### PR TITLE
DO NOT MERGE: mysql to postgressql

### DIFF
--- a/onadata/apps/odk_logger/migrations/0035_fill_json.py
+++ b/onadata/apps/odk_logger/migrations/0035_fill_json.py
@@ -1,13 +1,15 @@
 # -*- coding: utf-8 -*-
 from django.core.exceptions import ValidationError
 from south.v2 import DataMigration
+from onadata.libs.utils.model_tools import queryset_iterator
+from onadata.apps.odk_logger.models import Instance
 
 class Migration(DataMigration):
 
     def forwards(self, orm):
         """Add parsed JSON to JSON instance column."""
-        for instance in orm.Instance.objects.all():
-            json = instance.get_dict()
+        for instance in queryset_iterator(orm.Instance.objects.all()):
+            json = Instance.objects.get(pk=instance.pk).get_dict()
             instance.json = json
             instance.save()
 


### PR DESCRIPTION
# The Plan

create onadata user and db in psql

``` bash
createuser -d -e -P -s onadata
createdb -E UTF8 -T template0 --locale=en_US.utf8 -O onadata onadata
```

with mysql settings dumpdata

``` bash
python manage.py dumpdata --settings=formhub.settings > all.json
```

with postgresql settings, and a blank database
- edit local_settings DATABASE to point to postgresql backend
- syncdb, migrate

``` bash
python manage.py syncdb --noinput --settings=formhub.settings
python manage.py migrate --settings=formhub.settings
```

set psql password in .pgpass

``` bash
echo "*:*:*:onadata:onadatapasswd" > ~/.pgpass
chmod 600 ~/.pgpass
```

truncate tables

``` bash
python manage.py sqlflush --settings=formhub.settings | psql -U onadata onadata
```

disable post_save, comment out the post_save.connect lines

``` bash
find  . -name '*.pyc' -type f -exec rm {} \;
grep -r post_save
```

loaddata

``` bash
python manage.py loaddata --settings=formhub.settings  all.json
```

Update to latest

``` bash
git checkout origin/master
find  . -name '*.pyc' -type f -exec rm {} \;
find * -empty -exec rmdir {} \;

cp formhub/local_settings.py onadata/settings/local_settings.py
```

edit local_settings to import from .common instead of from .settings
edit .bashrc

``` bash
export DJANGO_SETTINGS_MODULE=onadata.settings.common
echo "export DJANGO_SETTINGS_MODULE=onadata.settings.common" >> ~/.bashrc

python manage syncdb
python manage migrate

python manage.py sqlsequencereset auth | tail -n +4 | psql -U onadata -d onadata;
python manage.py sqlsequencereset contenttypes | tail -n +4 | psql -U onadata -d onadata;
python manage.py sqlsequencereset sessions | tail -n +4 | psql -U onadata -d onadata;
python manage.py sqlsequencereset sites | tail -n +4 | psql -U onadata -d onadata;
python manage.py sqlsequencereset messages | tail -n +4 | psql -U onadata -d onadata;
python manage.py sqlsequencereset staticfiles | tail -n +4 | psql -U onadata -d onadata;
python manage.py sqlsequencereset humanize | tail -n +4 | psql -U onadata -d onadata;
python manage.py sqlsequencereset admin | tail -n +4 | psql -U onadata -d onadata;
python manage.py sqlsequencereset admindocs | tail -n +4 | psql -U onadata -d onadata;
python manage.py sqlsequencereset registration | tail -n +4 | psql -U onadata -d onadata;
python manage.py sqlsequencereset south | tail -n +4 | psql -U onadata -d onadata;
python manage.py sqlsequencereset django_digest | tail -n +4 | psql -U onadata -d onadata;
python manage.py sqlsequencereset corsheaders | tail -n +4 | psql -U onadata -d onadata;
python manage.py sqlsequencereset oauth2_provider | tail -n +4 | psql -U onadata -d onadata;
python manage.py sqlsequencereset rest_framework | tail -n +4 | psql -U onadata -d onadata;
python manage.py sqlsequencereset authtoken | tail -n +4 | psql -U onadata -d onadata;
python manage.py sqlsequencereset taggit | tail -n +4 | psql -U onadata -d onadata;
python manage.py sqlsequencereset odk_logger | tail -n +4 | psql -U onadata -d onadata;
python manage.py sqlsequencereset odk_viewer | tail -n +4 | psql -U onadata -d onadata;
python manage.py sqlsequencereset main | tail -n +4 | psql -U onadata -d onadata;
python manage.py sqlsequencereset restservice | tail -n +4 | psql -U onadata -d onadata;
python manage.py sqlsequencereset api | tail -n +4 | psql -U onadata -d onadata;
python manage.py sqlsequencereset guardian | tail -n +4 | psql -U onadata -d onadata;
python manage.py sqlsequencereset djcelery | tail -n +4 | psql -U onadata -d onadata;
python manage.py sqlsequencereset stats | tail -n +4 | psql -U onadata -d onadata;
python manage.py sqlsequencereset sms_support | tail -n +4 | psql -U onadata -d onadata;
```

clear sessions

``` bash
python manage.py clearsessions
```
