### PR TITLE
Use correct endpoints for cURL examples

### DIFF
--- a/onadata/apps/api/urls.py
+++ b/onadata/apps/api/urls.py
@@ -180,13 +180,13 @@ and API Token Authentication through the `Authorization` header.
 
 Example using curl:
 
-    curl -X GET http://ona.io/api/v1/ -u username:password
+    curl -X GET https://ona.io/api/v1/ -u username:password
 
 ### Token Authentication
 
 Example using curl:
 
-    curl -X GET http://ona.io/api/v1/ -H "Authorization: Token TOKEN_KEY"
+    curl -X GET https://ona.io/api/v1/ -H "Authorization: Token TOKEN_KEY"
 
 ### Ona Tagging API
 


### PR DESCRIPTION
Requests to the https://ona.io/api/v1 endpoint are redirected to http://ona.io/api/v1, which is subsequently redirected to http://ona.io/api/v1/. An out-of-the-box cURL configuration won't show you the 301 status code, and doesn't follow redirects by default.
