### PR TITLE
Include 'report_xform' when removing permissions

### DIFF
--- a/onadata/apps/main/tests/test_form_permissions.py
+++ b/onadata/apps/main/tests/test_form_permissions.py
@@ -119,6 +119,24 @@ class TestFormPermissions(TestBase):
         response = alice.post(self.edit_url)
         self.assertEqual(response.status_code, 302)
 
+    def test_remove_permissions_from_user(self):
+        user = self._create_user('alice', 'alice')
+        # Grant all permissions
+        for perm_type in ('view', 'edit', 'report'):
+            response = self.client.post(self.perm_url, {
+                'for_user': user.username, 'perm_type': perm_type})
+            self.assertEqual(response.status_code, 302)
+        self.assertEqual(user.has_perm('view_xform', self.xform), True)
+        self.assertEqual(user.has_perm('change_xform', self.xform), True)
+        self.assertEqual(user.has_perm('report_xform', self.xform), True)
+        # Revoke all permissions
+        response = self.client.post(self.perm_url, {
+            'for_user': user.username, 'perm_type': 'remove'})
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(user.has_perm('view_xform', self.xform), False)
+        self.assertEqual(user.has_perm('change_xform', self.xform), False)
+        self.assertEqual(user.has_perm('report_xform', self.xform), False)
+
     def test_public_with_link_to_share(self):
         response = self.client.post(self.perm_url, {
             'for_user': 'all', 'perm_type': 'link'})

--- a/onadata/apps/main/views.py
+++ b/onadata/apps/main/views.py
@@ -1104,6 +1104,7 @@ def set_perm(request, username, id_string):
                     }, audit, request)
                 remove_perm('change_xform', user, xform)
                 remove_perm('view_xform', user, xform)
+                remove_perm('report_xform', user, xform)
     elif perm_type == 'link':
         current = MetaData.public_link(xform)
         if for_user == 'all':


### PR DESCRIPTION
Hello, this fixes `onadata.apps.main.views.set_perm()` so that it becomes possible to remove the `report_xform` permission. Thanks for your consideration.
