### PR TITLE
xform metadata perms

### DIFF
--- a/docs/projects.rst
+++ b/docs/projects.rst
@@ -131,6 +131,21 @@ Response
         "date_modified": "2013-07-24T13:37:39Z"
     }
 
+Available Permission Roles
+--------------------------
+The following are the available roles in onadata:
+
+- ``member`` Default role for user with no permission
+- ``readonly-no-download`` Role for a user able to view data but not export it
+- ``readonly`` Role for a user able to view and download data
+- ``dataentry-only`` Role for a user able to submit data only
+- ``dataentry-minor`` Role for a user able to submit and view only data he/she submitted
+- ``dataentry`` Role for a user able to submit and view all data
+- ``editor-minor`` Role for a user able to view and edit data he/she submitted
+- ``editor`` Role for a user able to view and edit all data
+- ``manager`` Role for a user with administrative privileges
+- ``owner`` Role for an owner of a data-set, organization, or project.
+
 Share a project with a specific user
 -------------------------------------
 

--- a/onadata/apps/api/tests/models/test_team.py
+++ b/onadata/apps/api/tests/models/test_team.py
@@ -12,6 +12,8 @@ from onadata.libs.permissions import (
     CAN_ADD_XFORM,
     CAN_ADD_SUBMISSIONS_PROJECT,
     CAN_EXPORT_PROJECT,
+    CAN_VIEW_PROJECT_DATA,
+    CAN_VIEW_PROJECT_ALL,
     get_team_project_default_permissions)
 
 
@@ -74,7 +76,9 @@ class TestTeam(TestAbstractModels):
         DataEntryRole.add(team, project)
 
         self.assertEqual([CAN_EXPORT_PROJECT, CAN_ADD_SUBMISSIONS_PROJECT,
-                          CAN_VIEW_PROJECT], sorted(get_perms(team, project)))
+                          CAN_VIEW_PROJECT, CAN_VIEW_PROJECT_ALL,
+                          CAN_VIEW_PROJECT_DATA],
+                         sorted(get_perms(team, project)))
 
         self.assertEqual(get_team_project_default_permissions(team, project),
                          DataEntryRole.name)

--- a/onadata/apps/api/tests/viewsets/test_data_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_data_viewset.py
@@ -25,8 +25,8 @@ from onadata.apps.logger.models import Attachment
 from onadata.apps.logger.models import Instance
 from onadata.apps.logger.models.instance import InstanceHistory
 from onadata.apps.logger.models import XForm
-from onadata.libs.permissions import ReadOnlyRole, EditorRole, EditorMinorRole, \
-    DataEntryOnlyRole, DataEntryRole
+from onadata.libs.permissions import ReadOnlyRole, EditorRole, \
+    EditorMinorRole, DataEntryOnlyRole
 from onadata.libs import permissions as role
 from onadata.libs.utils.common_tags import MONGO_STRFTIME
 from onadata.apps.logger.models.instance import get_attachment_url
@@ -244,16 +244,16 @@ class TestDataViewSet(TestBase):
         profile.require_auth = False
         profile.save()
 
-        # self._assign_user_role(user_alice, DataEntryRole)
+        self._assign_user_role(user_alice, DataEntryOnlyRole)
 
         alices_extra = {
             'HTTP_AUTHORIZATION': 'Token %s' % user_alice.auth_token.key
         }
 
-        # request = self.factory.get('/', **alices_extra)
-        # response = view(request, pk=formid)
-        # self.assertEqual(response.status_code, 200)
-        # self.assertEqual(len(response.data), 0)
+        request = self.factory.get('/', **alices_extra)
+        response = view(request, pk=formid)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 0)
 
         self._assign_user_role(user_alice, EditorMinorRole)
         # check that by default, alice can be able to access all the data
@@ -290,7 +290,6 @@ class TestDataViewSet(TestBase):
         response = view(request, pk=formid)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 4)
-
 
     def test_data_pagination(self):
         self._make_submissions()

--- a/onadata/apps/api/tests/viewsets/test_data_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_data_viewset.py
@@ -24,7 +24,7 @@ from onadata.apps.logger.models import Attachment
 from onadata.apps.logger.models import Instance
 from onadata.apps.logger.models.instance import InstanceHistory
 from onadata.apps.logger.models import XForm
-from onadata.libs.permissions import ReadOnlyRole, EditorRole
+from onadata.libs.permissions import ReadOnlyRole, EditorRole, EditorMinorRole
 from onadata.libs import permissions as role
 from onadata.libs.utils.common_tags import MONGO_STRFTIME
 from onadata.apps.logger.models.instance import get_attachment_url
@@ -228,7 +228,7 @@ class TestDataViewSet(TestBase):
         )
 
         # share bob's project with alice and give alice an editor role
-        data = {'username': 'alice', 'role': EditorRole.name}
+        data = {'username': 'alice', 'role': EditorMinorRole.name}
         request = self.factory.put('/', data=data, **self.extra)
         project_view = ProjectViewSet.as_view({
             'put': 'share'
@@ -238,10 +238,10 @@ class TestDataViewSet(TestBase):
 
         # check that alice has an editor role on both bob's project and form
         self.assertTrue(
-            EditorRole.user_has_role(user_alice, self.project)
+            EditorMinorRole.user_has_role(user_alice, self.project)
         )
         self.assertTrue(
-            EditorRole.user_has_role(user_alice, self.xform)
+            EditorMinorRole.user_has_role(user_alice, self.xform)
         )
 
         # check that by default, alice can be able to access all the data
@@ -255,7 +255,6 @@ class TestDataViewSet(TestBase):
 
         # change xform permission for users with editor role - they should
         # only view data that they submitted
-        self.xform.permissions['can_edit'] = 'own'
         self.xform.save()
 
         # change user in 2 instances to be owned by alice - they should appear
@@ -280,7 +279,6 @@ class TestDataViewSet(TestBase):
 
         # change xform permission for users with editor role - they should not
         # view any data
-        self.xform.permissions['can_edit'] = 'none'
         self.xform.save()
 
         # check taht alice won't be able to see any data

--- a/onadata/apps/api/viewsets/data_viewset.py
+++ b/onadata/apps/api/viewsets/data_viewset.py
@@ -47,7 +47,8 @@ from onadata.libs.serializers.data_serializer import JsonDataSerializer
 from onadata.libs.serializers.data_serializer import OSMSerializer
 from onadata.libs.serializers.geojson_serializer import GeoJsonSerializer
 from onadata.libs import filters
-from onadata.libs.permissions import CAN_DELETE_SUBMISSION
+from onadata.libs.permissions import CAN_DELETE_SUBMISSION,\
+    filter_queryset_xform_meta_perms
 from onadata.libs.utils.viewer_tools import EnketoError
 from onadata.libs.utils.viewer_tools import get_enketo_edit_url
 from onadata.libs.utils.api_export_tools import custom_response_handler
@@ -336,6 +337,10 @@ class DataViewSet(AnonymousUserPublicFormsMixin,
             xform_id = qs[0] if qs else lookup
             self.object_list = Instance.objects.filter(xform_id=xform_id,
                                                        deleted_at=None)
+            xform = self.get_object()
+            self.object_list = \
+                filter_queryset_xform_meta_perms(xform, request.user,
+                                                 self.object_list)
             tags = self.request.query_params.get('tags')
             not_tagged = self.request.query_params.get('not_tagged')
 

--- a/onadata/apps/logger/models/project.py
+++ b/onadata/apps/logger/models/project.py
@@ -61,6 +61,8 @@ class Project(BaseModel):
             ("report_project_xform", "Can make submissions to the project"),
             ('transfer_project', "Can transfer project to different owner"),
             ('can_export_project_data', "Can export data in project"),
+            ("view_project_all", "Can view all associated data"),
+            ("view_project_data", "Can view submitted data"),
         )
 
     name = models.CharField(max_length=255)

--- a/onadata/apps/logger/models/xform.py
+++ b/onadata/apps/logger/models/xform.py
@@ -658,6 +658,7 @@ class XForm(XFormMixin, BaseModel):
         permissions = (
             ("view_xform", _("Can view associated data")),
             ("view_xform_all", _("Can view all associated data")),
+            ("view_xform_data", _("Can view submitted data")),
             ("report_xform", _("Can make submissions to the form")),
             ("move_xform", _(u"Can move form between projects")),
             ("transfer_xform", _(u"Can transfer form ownership.")),

--- a/onadata/apps/logger/models/xform.py
+++ b/onadata/apps/logger/models/xform.py
@@ -657,6 +657,7 @@ class XForm(XFormMixin, BaseModel):
         ordering = ("id_string",)
         permissions = (
             ("view_xform", _("Can view associated data")),
+            ("view_xform_all", _("Can view all associated data")),
             ("report_xform", _("Can make submissions to the form")),
             ("move_xform", _(u"Can move form between projects")),
             ("transfer_xform", _(u"Can transfer form ownership.")),

--- a/onadata/libs/permissions.py
+++ b/onadata/libs/permissions.py
@@ -42,6 +42,8 @@ CAN_EXPORT_XFORM = 'can_export_xform_data'
 # Project Permissions
 CAN_ADD_PROJECT = 'add_project'
 CAN_VIEW_PROJECT = 'view_project'
+CAN_VIEW_PROJECT_DATA = 'view_project_data'
+CAN_VIEW_PROJECT_ALL = 'view_project_all'
 CAN_CHANGE_PROJECT = 'change_project'
 CAN_TRANSFER_PROJECT_OWNERSHIP = 'transfer_project'
 CAN_DELETE_PROJECT = 'delete_project'
@@ -67,7 +69,6 @@ class Role(object):
     @classmethod
     def add(cls, user, obj):
         cls._remove_obj_permissions(user, obj)
-
         for codename, klass in cls.permissions:
             if type(obj) == klass:
                 assign_perm(codename, user, obj)
@@ -137,6 +138,7 @@ class DataEntryMinorRole(Role):
         (CAN_EXPORT_XFORM, XForm),
         (CAN_EXPORT_PROJECT, Project),
         (CAN_VIEW_XFORM_DATA, XForm),
+        (CAN_VIEW_PROJECT_DATA, Project),
     )
 
 
@@ -152,6 +154,8 @@ class DataEntryRole(Role):
         (CAN_EXPORT_PROJECT, Project),
         (CAN_VIEW_XFORM_ALL, XForm),
         (CAN_VIEW_XFORM_DATA, XForm),
+        (CAN_VIEW_PROJECT_DATA, Project),
+        (CAN_VIEW_PROJECT_ALL, Project),
     )
 
 
@@ -169,6 +173,7 @@ class EditorMinorRole(Role):
         (CAN_EXPORT_XFORM, XForm),
         (CAN_EXPORT_PROJECT, Project),
         (CAN_VIEW_XFORM_DATA, XForm),
+        (CAN_VIEW_PROJECT_DATA, Project),
     )
 
 
@@ -187,6 +192,8 @@ class EditorRole(Role):
         (CAN_EXPORT_PROJECT, Project),
         (CAN_VIEW_XFORM_ALL, XForm),
         (CAN_VIEW_XFORM_DATA, XForm),
+        (CAN_VIEW_PROJECT_DATA, Project),
+        (CAN_VIEW_PROJECT_ALL, Project),
     )
 
 
@@ -212,6 +219,8 @@ class ManagerRole(Role):
         (CAN_EXPORT_PROJECT, Project),
         (CAN_VIEW_XFORM_ALL, XForm),
         (CAN_VIEW_XFORM_DATA, XForm),
+        (CAN_VIEW_PROJECT_DATA, Project),
+        (CAN_VIEW_PROJECT_ALL, Project),
     )
 
 
@@ -263,6 +272,8 @@ class OwnerRole(Role):
         (CAN_EXPORT_PROJECT, Project),
         (CAN_VIEW_XFORM_ALL, XForm),
         (CAN_VIEW_XFORM_DATA, XForm),
+        (CAN_VIEW_PROJECT_DATA, Project),
+        (CAN_VIEW_PROJECT_ALL, Project),
     )
 
 ROLES_ORDERED = [ReadOnlyRoleNoDownload,
@@ -270,8 +281,8 @@ ROLES_ORDERED = [ReadOnlyRoleNoDownload,
                  DataEntryOnlyRole,
                  DataEntryMinorRole,
                  DataEntryRole,
-                 EditorRole,
                  EditorMinorRole,
+                 EditorRole,
                  ManagerRole,
                  OwnerRole]
 
@@ -343,7 +354,7 @@ def get_team_project_default_permissions(team, project):
 
 def filter_queryset_xform_meta_perms(xform, user, instance_queryset):
 
-    if user.has_perm(CAN_VIEW_XFORM_ALL, xform):
+    if user.has_perm(CAN_VIEW_XFORM_ALL, xform) or xform.shared_data:
         return instance_queryset
     elif user.has_perm(CAN_VIEW_XFORM_DATA, xform):
         return instance_queryset.filter(user=user)


### PR DESCRIPTION
closes #811

New roles added
 - ``dataentry-only`` Role for a user able to submit data only
 - ``dataentry-minor`` Role for a user able to submit and view only data he/she submitted
 - ``editor-minor`` Role for a user able to view and edit data he/she submitted