### PR TITLE
ODK Briefcase downloadSubmission endpoint should use the original filename

### DIFF
--- a/onadata/apps/logger/models/attachment.py
+++ b/onadata/apps/logger/models/attachment.py
@@ -7,6 +7,25 @@ from django.db import models
 from instance import Instance
 
 
+def get_original_filename(filename):
+    # https://docs.djangoproject.com/en/1.8/ref/files/storage/
+    # #django.core.files.storage.Storage.get_available_name
+    # If a file with name already exists, an underscore plus a random
+    # 7 character alphanumeric string is appended to the filename
+    # before the extension.
+    # this code trys to reverse this effect to derive the original name
+    if filename:
+        parts = filename.split('_')
+        if len(parts) > 1:
+            ext_parts = parts[-1].split('.')
+            if len(ext_parts[0]) == 7 and len(ext_parts) == 2:
+                ext = ext_parts[1]
+
+                return u'.'.join([u'_'.join(parts[:-1]), ext])
+
+    return filename
+
+
 def upload_to(instance, filename):
     return os.path.join(
         instance.instance.xform.user.username,
@@ -59,3 +78,7 @@ class Attachment(models.Model):
     def filename(self):
         if self.media_file:
             return os.path.basename(self.media_file.name)
+
+    @property
+    def name(self):
+        return get_original_filename(self.filename)

--- a/onadata/apps/logger/templates/downloadSubmission.xml
+++ b/onadata/apps/logger/templates/downloadSubmission.xml
@@ -4,7 +4,7 @@
         {{ submission_data|safe }}
     </data>
     {% for media in media_files %}<mediaFile>
-        <filename>{{ media.filename|safe }}</filename>
+        <filename>{{ media.name|safe }}</filename>
         <hash>md5:{{ media.file_hash }}</hash>
         <downloadUrl>{{ host }}{% url "onadata.apps.viewer.views.attachment_url" 'original' %}?media_file={{ media.media_file.name|safe }}</downloadUrl>
     </mediaFile>{% endfor %}

--- a/onadata/apps/logger/tests/models/test_attachment.py
+++ b/onadata/apps/logger/tests/models/test_attachment.py
@@ -8,6 +8,7 @@ from django.db.utils import DataError
 
 from onadata.apps.main.tests.test_base import TestBase
 from onadata.apps.logger.models import Attachment, Instance
+from onadata.apps.logger.models.attachment import get_original_filename
 from onadata.libs.utils.image_tools import image_url
 
 
@@ -95,3 +96,21 @@ class TestAttachment(TestBase):
                 self.assertTrue(
                     default_storage.modified_time(thumbnail) > check_datetime)
                 default_storage.delete(thumbnail)
+
+    def test_get_original_filename(self):
+        self.assertEqual(
+            get_original_filename('submission.xml_K337n8u.enc'),
+            'submission.xml.enc'
+        )
+        self.assertEqual(
+            get_original_filename('submission.xml.enc'),
+            'submission.xml.enc'
+        )
+        self.assertEqual(
+            get_original_filename('submission_test.xml_K337n8u.enc'),
+            'submission_test.xml.enc'
+        )
+        self.assertEqual(
+            get_original_filename('submission_random.enc'),
+            'submission_random.enc'
+        )

--- a/onadata/apps/viewer/tests/test_attachment_url.py
+++ b/onadata/apps/viewer/tests/test_attachment_url.py
@@ -26,6 +26,14 @@ class TestAttachmentUrl(TestBase):
             self.url, {"media_file": self.attachment_media_file})
         self.assertEqual(response.status_code, 302)  # redirects to amazon
 
+    def test_attachment_url_no_redirect(self):
+        self.assertEqual(
+            Attachment.objects.count(), self.attachment_count + 1)
+        response = self.client.get(
+            self.url, {"media_file": self.attachment_media_file,
+                       'no_redirect': 'true'})
+        self.assertEqual(response.status_code, 200)  # no redirects to amazon
+
     def test_attachment_not_found(self):
         response = self.client.get(
             self.url, {"media_file": "non_existent_attachment.jpg"})

--- a/onadata/apps/viewer/views.py
+++ b/onadata/apps/viewer/views.py
@@ -744,12 +744,23 @@ def data_view(request, username, id_string):
 
 def attachment_url(request, size='medium'):
     media_file = request.GET.get('media_file')
+    no_redirect = request.GET.get('no_redirect')
     # TODO: how to make sure we have the right media file,
     # this assumes duplicates are the same file
     result = Attachment.objects.filter(media_file=media_file)[0:1]
     if result.count() == 0:
         return HttpResponseNotFound(_(u'Attachment not found'))
     attachment = result[0]
+
+    if size == 'original' and no_redirect == 'true':
+        response = response_with_mimetype_and_name(
+            attachment.mimetype,
+            attachment.name,
+            extension=attachment.extension,
+            file_path=attachment.media_file.name
+        )
+
+        return response
     if not attachment.mimetype.startswith('image'):
         return redirect(attachment.media_file.url)
     try:


### PR DESCRIPTION
- Filename uses original filename on the `/view/downloadSubmission` briefcase api endpoint
- support for serving attachment files directly with no redirect to s3

closes #853