### PR TITLE
Add share users to users when projects filtered by username

### DIFF
--- a/docs/projects.rst
+++ b/docs/projects.rst
@@ -70,6 +70,10 @@ List of Projects filter by owner/organization
 	<b>GET</b> /api/v1/projects?<code>owner</code>=<code>owner_username</code>
 	</pre>
 
+You can use this to get both members and collaborators of an organization.
+In the case of organizations, this gives you both members and collaborators under "users".
+Under "teams" key we list only the members of the organization.
+
 Example
 ^^^^^^^^
 ::
@@ -460,4 +464,3 @@ Get user profiles that have starred a project
 
 	<pre class="prettyprint">
 	<b>GET</b> /api/v1/projects/<code>{pk}</code>/star</pre>
-    

--- a/onadata/apps/api/tests/viewsets/test_project_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_project_viewset.py
@@ -1,4 +1,3 @@
-
 import os
 import json
 import requests

--- a/onadata/apps/api/tests/viewsets/test_project_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_project_viewset.py
@@ -2060,4 +2060,4 @@ class TestProjectViewSet(TestAbstractViewSet):
         self.assertEqual(response.status_code, 200)
         self.assertNotIn({'first_name': u'Bob', 'last_name': u'erama',
                           'is_org': False, 'role': 'readonly',
-                          'user': u'alice','metadata': {}}, users)
+                          'user': u'alice', 'metadata': {}}, users)

--- a/onadata/apps/api/tests/viewsets/test_project_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_project_viewset.py
@@ -866,7 +866,7 @@ class TestProjectViewSet(TestAbstractViewSet):
         view = ProjectViewSet.as_view({
             'get': 'retrieve'
         })
-        request = self.factory.get('/', **self.extra)
+        request = self.factory.get('/', {'owner': 'bob'}, **self.extra)
         response = view(request, pk=self.project.pk)
         request.user = self.user
         self.project.reload()

--- a/onadata/apps/api/tests/viewsets/test_project_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_project_viewset.py
@@ -880,6 +880,7 @@ class TestProjectViewSet(TestAbstractViewSet):
         request = self.factory.get('/', **self.extra)
         response = self.view(request)
         self.assertEqual(response.status_code, 200)
+        request = self.factory.get('/', {'owner': 'alice'}, **self.extra)
         request.user = self.user
         self.project_data = BaseProjectSerializer(
             self.project, context={'request': request}).data

--- a/onadata/apps/api/tests/viewsets/test_project_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_project_viewset.py
@@ -2017,9 +2017,14 @@ class TestProjectViewSet(TestAbstractViewSet):
 
     def test_project_list_by_owner(self):
         # create project and publish form to project
+        sluggie_data = {'username': 'sluggie',
+                        'email': 'sluggie@localhost.com'}
+        self._login_user_and_profile(sluggie_data)
         self._publish_xls_form_to_project()
+
         alice_data = {'username': 'alice', 'email': 'alice@localhost.com'}
         alice_profile = self._create_user_profile(alice_data)
+
         projectid = self.project.pk
 
         self.assertFalse(ReadOnlyRole.user_has_role(alice_profile.user,
@@ -2042,7 +2047,7 @@ class TestProjectViewSet(TestAbstractViewSet):
                                                    self.xform))
 
         # Should list collaborators
-        data = {"owner": "bob"}
+        data = {"owner": "sluggie"}
         request = self.factory.get('/', data=data, **self.extra)
         response = view(request)
 

--- a/onadata/apps/api/tests/viewsets/test_project_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_project_viewset.py
@@ -884,8 +884,14 @@ class TestProjectViewSet(TestAbstractViewSet):
         request.user = self.user
         self.project_data = BaseProjectSerializer(
             self.project, context={'request': request}).data
-        self.assertIn(updated_project_data, response.data)
-        self.assertIn(self.project_data, response.data)
+        result = [{'owner': p.get('owner'),
+                  'projectid': p.get('projectid')} for p in response.data]
+        bob_data = {'owner': 'http://testserver/api/v1/users/bob',
+                    'projectid': updated_project_data.get('projectid')}
+        alice_data = {'owner': 'http://testserver/api/v1/users/alice',
+                      'projectid': self.project_data.get('projectid')}
+        self.assertIn(bob_data, result)
+        self.assertIn(alice_data, result)
 
         # only bob's project
         request = self.factory.get('/', {'owner': 'bob'}, **self.extra)

--- a/onadata/libs/serializers/project_serializer.py
+++ b/onadata/libs/serializers/project_serializer.py
@@ -209,11 +209,11 @@ class BaseProjectSerializer(serializers.HyperlinkedModelSerializer):
         return get_starred(obj, self.context['request'])
 
     def get_users(self, obj):
-        if 'request' in self.context \
-                and "owner" in self.context['request'].GET:
-            return get_users(obj, self.context)
-        else:
-            return get_users(obj, self.context, False)
+        owner_query_param_in_request = \
+          'request' in self.context and "owner" in self.context['request'].GET
+        return get_users(obj,
+                         self.context,
+                         owner_query_param_in_request)
 
     @profile("get_project_forms.prof")
     @check_obj

--- a/onadata/libs/serializers/project_serializer.py
+++ b/onadata/libs/serializers/project_serializer.py
@@ -209,11 +209,9 @@ class BaseProjectSerializer(serializers.HyperlinkedModelSerializer):
         return get_starred(obj, self.context['request'])
 
     def get_users(self, obj):
-        if 'request' in self.context:
-            all_perms = "owner" in self.context['request'].GET
-            return get_users(obj,
-                             self.context,
-                             all_perms=all_perms)
+        if 'request' in self.context \
+                and "owner" in self.context['request'].GET:
+            return get_users(obj, self.context)
         else:
             return get_users(obj, self.context, False)
 

--- a/onadata/libs/serializers/project_serializer.py
+++ b/onadata/libs/serializers/project_serializer.py
@@ -209,7 +209,13 @@ class BaseProjectSerializer(serializers.HyperlinkedModelSerializer):
         return get_starred(obj, self.context['request'])
 
     def get_users(self, obj):
-        return get_users(obj, self.context, False)
+        if 'request' in self.context:
+            all_perms = "owner" in self.context['request'].GET
+            return get_users(obj,
+                             self.context,
+                             all_perms=all_perms)
+        else:
+            return get_users(obj, self.context, False)
 
     @profile("get_project_forms.prof")
     @check_obj

--- a/onadata/libs/tests/serializers/test_project_serializer.py
+++ b/onadata/libs/tests/serializers/test_project_serializer.py
@@ -5,7 +5,6 @@ from onadata.apps.api.tests.viewsets.test_abstract_viewset import \
     TestAbstractViewSet
 from onadata.libs.serializers.project_serializer import\
     ProjectSerializer, BaseProjectSerializer
-from onadata.libs.models.share_project import ShareProject
 
 
 class TestBaseProjectSerializer(TestAbstractViewSet):
@@ -18,13 +17,14 @@ class TestBaseProjectSerializer(TestAbstractViewSet):
         data = {
                 'name': u'demo',
                 'owner':
-                'http://testserver/api/v1/users/%s' % self.organization.user.username,
+                'http://testserver/api/v1/users/%s'
+                % self.organization.user.username,
                 'metadata': {'description': 'Some description',
                              'location': 'Naivasha, Kenya',
                              'category': 'governance'},
                 'public': False
             }
-        #create the project
+        # Create the project
         self._project_create(data)
 
     def test_get_users(self):
@@ -32,11 +32,6 @@ class TestBaseProjectSerializer(TestAbstractViewSet):
         # Is none when request to get users lacks a project
         users = self.serializer.get_users(None)
         self.assertEqual(users, None)
-
-        # create users. Returns a user-profile object.
-        alice = self._create_user_profile({'username': 'alice'})
-
-        ShareProject(self.project, 'alice', 'manager').save()
 
         # Has members and NOT collaborators when NOT passed 'owner'
         request = self.factory.get('/', **self.extra)
@@ -55,6 +50,7 @@ class TestBaseProjectSerializer(TestAbstractViewSet):
                                   'role': 'owner',
                                   'user': u'denoinc',
                                   'metadata': {}}])
+
 
 class TestProjectSerializer(TestAbstractViewSet):
 

--- a/onadata/libs/tests/serializers/test_project_serializer.py
+++ b/onadata/libs/tests/serializers/test_project_serializer.py
@@ -5,9 +5,6 @@ from onadata.apps.api.tests.viewsets.test_abstract_viewset import \
     TestAbstractViewSet
 from onadata.libs.serializers.project_serializer import\
     ProjectSerializer, BaseProjectSerializer
-from onadata.libs.permissions import (
-    OwnerRole, ReadOnlyRole, ManagerRole, DataEntryRole, EditorMinorRole,
-    EditorRole, ReadOnlyRoleNoDownload,  DataEntryMinorRole, DataEntryOnlyRole)
 from onadata.libs.models.share_project import ShareProject
 
 
@@ -32,46 +29,16 @@ class TestBaseProjectSerializer(TestAbstractViewSet):
 
     def test_get_users(self):
         ""
-        # Is none when request lacks a project
+        # Is none when request to get users lacks a project
         users = self.serializer.get_users(None)
         self.assertEqual(users, None)
 
-        # create users
-        # returns a user profile object
+        # create users. Returns a user-profile object.
         alice = self._create_user_profile({'username': 'alice'})
-
-        import ipdb
-        ipdb.set_trace()
 
         ShareProject(self.project, 'alice', 'manager').save()
 
-        # Assert list has members and collaborators when passed 'owner'
-        request = self.factory.get('/',
-                                   data={'owner': self.organization.user.username},
-                                   **self.extra)
-        self.serializer.context['request'] = request
-        users = self.serializer.get_users(self.project)
-        self.assertEqual(users, [{'first_name': u'Bob',
-                                  'last_name': u'erama',
-                                  'is_org': False,
-                                  'role': 'owner',
-                                  'user': u'bob'
-                                  , 'metadata': {}},
-                                 {'first_name': u'Dennis',
-                                  'last_name': u'',
-                                  'is_org': True,
-                                  'role': 'owner',
-                                  'user': u'denoinc',
-                                  'metadata': {}},
-                                 {'first_name': u'',
-                                  'last_name': u'',
-                                  'is_org': False,
-                                  'role': 'readonly',
-                                  'user': u'alice',
-                                  'metadata': {}}])
-
-
-        # Assert list has members and NOT collaborators when NOT passed 'owner'
+        # Has members and NOT collaborators when NOT passed 'owner'
         request = self.factory.get('/', **self.extra)
         request.user = self.user
         self.serializer.context['request'] = request

--- a/onadata/libs/tests/serializers/test_project_serializer.py
+++ b/onadata/libs/tests/serializers/test_project_serializer.py
@@ -10,6 +10,7 @@ from onadata.libs.permissions import (
     EditorRole, ReadOnlyRoleNoDownload,  DataEntryMinorRole, DataEntryOnlyRole)
 from onadata.libs.models.share_project import ShareProject
 
+
 class TestBaseProjectSerializer(TestAbstractViewSet):
     def setUp(self):
         self.factory = APIRequestFactory()
@@ -29,17 +30,20 @@ class TestBaseProjectSerializer(TestAbstractViewSet):
         #create the project
         self._project_create(data)
 
-        # create users
-        # returns a user profile object
-        alice = self._create_user_profile({'username': 'alice'})
-
-        ShareProject(self.project, 'alice', 'readonly').save()
-
     def test_get_users(self):
         ""
         # Is none when request lacks a project
         users = self.serializer.get_users(None)
         self.assertEqual(users, None)
+
+        # create users
+        # returns a user profile object
+        alice = self._create_user_profile({'username': 'alice'})
+
+        import ipdb
+        ipdb.set_trace()
+
+        ShareProject(self.project, 'alice', 'manager').save()
 
         # Assert list has members and collaborators when passed 'owner'
         request = self.factory.get('/',

--- a/onadata/libs/tests/serializers/test_project_serializer.py
+++ b/onadata/libs/tests/serializers/test_project_serializer.py
@@ -4,8 +4,86 @@ from onadata.apps.logger.models import Project
 from onadata.apps.api.tests.viewsets.test_abstract_viewset import \
     TestAbstractViewSet
 from onadata.libs.serializers.project_serializer import\
-    ProjectSerializer
+    ProjectSerializer, BaseProjectSerializer
+from onadata.libs.permissions import (
+    OwnerRole, ReadOnlyRole, ManagerRole, DataEntryRole, EditorMinorRole,
+    EditorRole, ReadOnlyRoleNoDownload,  DataEntryMinorRole, DataEntryOnlyRole)
+from onadata.libs.models.share_project import ShareProject
 
+class TestBaseProjectSerializer(TestAbstractViewSet):
+    def setUp(self):
+        self.factory = APIRequestFactory()
+        self._login_user_and_profile()
+        self.serializer = BaseProjectSerializer()
+
+        self._org_create()
+        data = {
+                'name': u'demo',
+                'owner':
+                'http://testserver/api/v1/users/%s' % self.organization.user.username,
+                'metadata': {'description': 'Some description',
+                             'location': 'Naivasha, Kenya',
+                             'category': 'governance'},
+                'public': False
+            }
+        #create the project
+        self._project_create(data)
+
+        # create users
+        # returns a user profile object
+        alice = self._create_user_profile({'username': 'alice'})
+
+        ShareProject(self.project, 'alice', 'readonly').save()
+
+    def test_get_users(self):
+        ""
+        # Is none when request lacks a project
+        users = self.serializer.get_users(None)
+        self.assertEqual(users, None)
+
+        # Assert list has members and collaborators when passed 'owner'
+        request = self.factory.get('/',
+                                   data={'owner': self.organization.user.username},
+                                   **self.extra)
+        self.serializer.context['request'] = request
+        users = self.serializer.get_users(self.project)
+        self.assertEqual(users, [{'first_name': u'Bob',
+                                  'last_name': u'erama',
+                                  'is_org': False,
+                                  'role': 'owner',
+                                  'user': u'bob'
+                                  , 'metadata': {}},
+                                 {'first_name': u'Dennis',
+                                  'last_name': u'',
+                                  'is_org': True,
+                                  'role': 'owner',
+                                  'user': u'denoinc',
+                                  'metadata': {}},
+                                 {'first_name': u'',
+                                  'last_name': u'',
+                                  'is_org': False,
+                                  'role': 'readonly',
+                                  'user': u'alice',
+                                  'metadata': {}}])
+
+
+        # Assert list has members and NOT collaborators when NOT passed 'owner'
+        request = self.factory.get('/', **self.extra)
+        request.user = self.user
+        self.serializer.context['request'] = request
+        users = self.serializer.get_users(self.project)
+        self.assertEqual(users, [{'first_name': u'Bob',
+                                  'last_name': u'erama',
+                                  'is_org': False,
+                                  'role': 'owner',
+                                  'user': u'bob',
+                                  'metadata': {}},
+                                 {'first_name': u'Dennis',
+                                  'last_name': u'',
+                                  'is_org': True,
+                                  'role': 'owner',
+                                  'user': u'denoinc',
+                                  'metadata': {}}])
 
 class TestProjectSerializer(TestAbstractViewSet):
 


### PR DESCRIPTION
List the collaborators when the projects endpoint is filtered by owner.

For example: `/api/v1/projects?owner=<username>` could have among it's users non-owners i.e collaborators
```
{...
 "projectid": 5
 "users": [{...}
           {"user": "sluggie"
            "role":   "readonly"}
           {...}]
...}
```

Compared to `api/v1/projects/<project-id>` which will not list collaborators.

closes #869 