### PR TITLE
Dataviews endpoint should not require auth for public dataviews.

### DIFF
--- a/onadata/apps/api/permissions.py
+++ b/onadata/apps/api/permissions.py
@@ -235,10 +235,18 @@ class DataViewViewsetPermissions(AlternateHasObjectPermissionMixin,
 
     model_classes = [Project]
 
+    def has_permission(self, request, view):
+        if request.user.is_anonymous() and view.action == 'list':
+            return False
+        else:
+            return True
+
     def has_object_permission(self, request, view, obj):
         model_cls = Project
         user = request.user
 
+        if obj.project.shared:
+            return True
         return self._has_object_permission(request, model_cls, user,
                                            obj.project)
 

--- a/onadata/apps/api/permissions.py
+++ b/onadata/apps/api/permissions.py
@@ -236,10 +236,10 @@ class DataViewViewsetPermissions(AlternateHasObjectPermissionMixin,
     model_classes = [Project]
 
     def has_permission(self, request, view):
-        if request.user.is_anonymous() and view.action == 'list':
-            return False
-        else:
-            return True
+        # To allow individual public dataviews to be visible on
+        # `api/v1/dataviews/<pk>` but stop retreival of all dataviews when
+        # the dataviews endpoint is queried `api/v1/dataviews`
+        return not (request.user.is_anonymous() and view.action == 'list')
 
     def has_object_permission(self, request, view, obj):
         model_cls = Project

--- a/onadata/apps/api/tests/viewsets/test_dataview_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_dataview_viewset.py
@@ -156,6 +156,22 @@ class TestDataViewViewSet(TestAbstractViewSet):
         self.assertEquals(response.data['last_submission_time'],
                           '2015-03-09T13:34:05')
 
+        # Public
+        self.project.shared = True
+        self.project.save()
+
+        anon_request = self.factory.get('/')
+        anon_response = self.view(anon_request, pk=self.data_view.pk)
+        self.assertEquals(anon_response.status_code, 200)
+
+        # Private
+        self.project.shared = False
+        self.project.save()
+
+        anon_request = self.factory.get('/')
+        anon_response = self.view(anon_request, pk=self.data_view.pk)
+        self.assertEquals(anon_response.status_code, 404)
+
     def test_update_dataview(self):
         self._create_dataview()
 
@@ -251,6 +267,10 @@ class TestDataViewViewSet(TestAbstractViewSet):
 
         self.assertEquals(response.status_code, 200)
         self.assertEquals(len(response.data), 2)
+
+        anon_request = request = self.factory.get('/')
+        anon_response = view(anon_request)
+        self.assertEquals(anon_response.status_code, 401)
 
     def test_get_dataview_no_perms(self):
         self._create_dataview()


### PR DESCRIPTION
The dataviews endpoint should not require auth for public dataviews, 
`api/v1/dataviews/<public-dataview-id>`, filtered by the dataview id but should require auth for a request for all dataviews, `api/v1/dataviews`.

closes #891 