### PR TITLE
firstname to first_name in docs for required sign up fields

### DIFF
--- a/docs/profiles.rst
+++ b/docs/profiles.rst
@@ -4,7 +4,7 @@ Profiles
 Register a new User
 -------------------
 
-``username, email, firstname`` Are required fields. \ ``username`` may
+``username, email, first_name`` Are required fields. \ ``username`` may
 contain alphanumeric, \_, @, +, . and - characters
 
 .. raw:: html
@@ -227,7 +227,7 @@ Example
 ::
 
     curl -X POST -d current_password=password1 -d new_password=password2 https://api.ona.io/api/v1/profile/demouser/change_password
-    
+
 Response
 ^^^^^^^^
 


### PR DESCRIPTION
Currently the docs are a little confusing right here https://api.ona.io/static/docs/profiles.html#register-a-new-user, which led me to try figure out the issue for a while. It's just a missing underscore.