### PR TITLE
Add organization teams permissions to xform.

### DIFF
--- a/onadata/apps/api/permissions.py
+++ b/onadata/apps/api/permissions.py
@@ -115,7 +115,7 @@ class ProjectPermissions(DjangoObjectPermissions):
     authenticated_users_only = False
 
     def has_permission(self, request, view):
-        # allow anonymous to view public projects
+        # allow anonymous users to view public projects
         if request.user.is_anonymous() and view.action == 'list':
             return True
 

--- a/onadata/apps/logger/models/project.py
+++ b/onadata/apps/logger/models/project.py
@@ -102,8 +102,8 @@ def set_object_permissions(sender, instance=None, created=False, **kwargs):
             owners = instance.organization.team_set\
                 .filter(name="{}#{}".format(instance.organization.username,
                         OWNER_TEAM_NAME), organization=instance.organization)
-            if owners:
-                assign_perm(perm.codename, owners[0], instance)
+            for owner in owners:
+                assign_perm(perm.codename, owner, instance)
 
             if instance.created_by:
                 assign_perm(perm.codename, instance.created_by, instance)

--- a/onadata/libs/permissions.py
+++ b/onadata/libs/permissions.py
@@ -331,7 +331,9 @@ def get_role_in_org(user, organization):
         return get_role(perms, organization) or MemberRole.name
 
 
-def get_object_users_with_permissions(obj, username=False):
+def get_object_users_with_permissions(obj,
+                                      username=False,
+                                      with_group_users=False):
     """
     Returns users, roles and permissions for an object.
 
@@ -342,7 +344,7 @@ def get_object_users_with_permissions(obj, username=False):
 
     if obj:
         users_with_perms = get_users_with_perms(
-            obj, attach_perms=True, with_group_users=False).items()
+            obj, attach_perms=True, with_group_users=with_group_users).items()
 
         result = [{
             'user': user.username if username else user,

--- a/onadata/libs/utils/project_utils.py
+++ b/onadata/libs/utils/project_utils.py
@@ -1,6 +1,7 @@
 from onadata.libs.permissions import get_object_users_with_permissions
 from onadata.libs.permissions import OwnerRole
 from onadata.libs.permissions import ROLES
+from onadata.libs.utils.common_tags import OWNER_TEAM_NAME
 
 
 def set_project_perms_to_xform(xform, project):
@@ -12,7 +13,15 @@ def set_project_perms_to_xform(xform, project):
         xform.shared_data = project.shared
         xform.save()
 
-    for perm in get_object_users_with_permissions(project):
+    owners = project.organization.team_set.filter(name="{}#{}".format(
+        project.organization.username, OWNER_TEAM_NAME),
+        organization=project.organization)
+
+    if owners:
+        OwnerRole.add(owners[0], xform)
+
+    for perm in get_object_users_with_permissions(project,
+                                                  with_group_users=True):
         user = perm['user']
         role_name = perm['role']
         role = ROLES.get(role_name)


### PR DESCRIPTION
Org members permissions are added to the project and transitively the xform.
However, this doesn't happen for org *teams* which has admins as the initial team (teams[0]) and every other element in teams. 

This adds the admins/owners team permissions to the xform permission.

