### PR TITLE
Add org admins as owners in all projects

### DIFF
--- a/onadata/apps/api/tests/viewsets/test_organization_profile_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_organization_profile_viewset.py
@@ -455,8 +455,9 @@ class TestOrganizationProfileViewSet(TestAbstractViewSet):
         self._project_create(project_data)
 
         # Create alice
-        self.profile_data['username'] = "alice"
-        alice_data = {'username': 'alice',
+        alice = 'alice'
+        self._create_user_profile(extra_post_data={'username': alice})
+        alice_data = {'username': alice,
                       'role': 'owner'}
         request = self.factory.post(
             '/', data=json.dumps(alice_data),
@@ -473,11 +474,11 @@ class TestOrganizationProfileViewSet(TestAbstractViewSet):
         project_users = response.data.get('users')
         users_in_users = [user['user'] for user in project_users]
 
-        self.assertIn('alice', users_in_users)
+        self.assertIn(alice, users_in_users)
 
         # remove alice from org
         request = self.factory.delete(
-            '/?username={}'.format('alice'), **self.extra)
+            '/?username={}'.format(alice), **self.extra)
 
         response = view(request, user='denoinc')
         self.assertEqual(response.status_code, 200)
@@ -492,7 +493,7 @@ class TestOrganizationProfileViewSet(TestAbstractViewSet):
         project_users = response.data.get('users')
         users_in_users = [user['user'] for user in project_users]
 
-        self.assertNotIn('alice', users_in_users)
+        self.assertNotIn(alice, users_in_users)
 
     def test_orgs_create_with_mixed_case(self):
         data = {

--- a/onadata/apps/api/tools.py
+++ b/onadata/apps/api/tools.py
@@ -27,6 +27,7 @@ from registration.models import RegistrationProfile
 from rest_framework import exceptions
 from taggit.forms import TagField
 
+from onadata.libs.models.share_project import ShareProject
 from onadata.libs.permissions import get_role
 from onadata.libs.permissions import is_organization
 from onadata.apps.api.models.organization_profile import OrganizationProfile
@@ -171,6 +172,11 @@ def remove_user_from_organization(organization, user):
     remove_user_from_team(team, user)
     owners_team = get_organization_owners_team(organization)
     remove_user_from_team(owners_team, user)
+
+    role = get_role_in_org(user, organization)
+    # Remove user from all org projects
+    for project in organization.user.project_org.all():
+        ShareProject(project, user.username, role, remove=True).remove_user()
 
 
 def remove_user_from_team(team, user):

--- a/onadata/apps/api/tools.py
+++ b/onadata/apps/api/tools.py
@@ -176,7 +176,7 @@ def remove_user_from_organization(organization, user):
     role = get_role_in_org(user, organization)
     # Remove user from all org projects
     for project in organization.user.project_org.all():
-        ShareProject(project, user.username, role, remove=True).remove_user()
+        ShareProject(project, user.username, role, remove=True).save()
 
 
 def remove_user_from_team(team, user):

--- a/onadata/apps/logger/models/project.py
+++ b/onadata/apps/logger/models/project.py
@@ -105,6 +105,9 @@ def set_object_permissions(sender, instance=None, created=False, **kwargs):
             for owner in owners:
                 assign_perm(perm.codename, owner, instance)
 
+            if owners:
+                for user in owners[0].user_set.all():
+                    assign_perm(perm.codename, user, instance)
             if instance.created_by:
                 assign_perm(perm.codename, instance.created_by, instance)
 

--- a/onadata/libs/models/share_project.py
+++ b/onadata/libs/models/share_project.py
@@ -34,7 +34,7 @@ class ShareProject(object):
     def save(self, **kwargs):
 
         if self.remove:
-            self.remove_user()
+            self.__remove_user()
         else:
             role = ROLES.get(self.role)
 
@@ -66,7 +66,7 @@ class ShareProject(object):
         safe_delete('{}{}'.format(PROJ_PERM_CACHE, self.project.pk))
 
     @transaction.atomic()
-    def remove_user(self):
+    def __remove_user(self):
         role = ROLES.get(self.role)
 
         if role and self.user and self.project:

--- a/onadata/libs/serializers/organization_member_serializer.py
+++ b/onadata/libs/serializers/organization_member_serializer.py
@@ -17,6 +17,7 @@ from onadata.apps.api.tools import _get_owners
 from onadata.apps.api.tools import get_organization_members
 from onadata.apps.api.tools import remove_user_from_organization
 from onadata.settings.common import (DEFAULT_FROM_EMAIL, SHARE_ORG_SUBJECT)
+from onadata.libs.models.share_project import ShareProject
 
 
 def _compose_send_email(organization, user, email_msg, email_subject=None):
@@ -43,7 +44,7 @@ def _set_organization_role_to_user(organization, user, role):
         add_user_to_team(owners_team, user)
         # add user to org projects
         for project in organization.user.project_org.all():
-            OwnerRole.add(user, project)
+            ShareProject(project, user.username, role).save()
 
     if role != OwnerRole.name:
         remove_user_from_team(owners_team, user)

--- a/onadata/libs/serializers/organization_member_serializer.py
+++ b/onadata/libs/serializers/organization_member_serializer.py
@@ -41,6 +41,9 @@ def _set_organization_role_to_user(organization, user, role):
     # add the owner to owners team
     if role == OwnerRole.name:
         add_user_to_team(owners_team, user)
+        # add user to org projects
+        for project in organization.user.project_org.all():
+            OwnerRole.add(user, project)
 
     if role != OwnerRole.name:
         remove_user_from_team(owners_team, user)


### PR DESCRIPTION
Adding a person as an admin to an org should add them as an owner in all all org projects and removing them from the org should remove them as owners in all org projects.

closes #924 