### PR TITLE
Handle XLSFormError exceptions on form parial_update

### DIFF
--- a/onadata/apps/api/tests/viewsets/test_xform_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_xform_viewset.py
@@ -1389,7 +1389,7 @@ class TestXFormViewSet(TestAbstractViewSet):
             view = XFormViewSet.as_view({
                 'patch': 'partial_update'
             })
-            title = u'مرحب'
+            title = u'Hello & World!'
             description = 'DESCRIPTION'
             data = {'public': True, 'description': description, 'title': title,
                     'downloadable': True}
@@ -1398,6 +1398,13 @@ class TestXFormViewSet(TestAbstractViewSet):
 
             request = self.factory.patch('/', data=data, **self.extra)
             response = view(request, pk=self.xform.id)
+            self.assertEqual(response.status_code, 400)
+
+            title = u'Hello and World!'
+            data['title'] = title
+            request = self.factory.patch('/', data=data, **self.extra)
+            response = view(request, pk=self.xform.id)
+            self.assertEqual(response.status_code, 200)
 
             self.xform.reload()
             self.assertTrue(self.xform.downloadable)

--- a/onadata/apps/api/viewsets/xform_viewset.py
+++ b/onadata/apps/api/viewsets/xform_viewset.py
@@ -579,8 +579,11 @@ class XFormViewSet(AnonymousUserPublicFormsMixin,
                                  'text_xls_form']) & set(request.data.keys()):
             return _try_update_xlsform(request, self.object, owner)
 
-        return super(XFormViewSet, self).partial_update(request, *args,
-                                                        **kwargs)
+        try:
+            return super(XFormViewSet, self).partial_update(request, *args,
+                                                            **kwargs)
+        except XLSFormError as e:
+            raise ParseError(str(e))
 
     @detail_route(methods=['DELETE', 'GET'])
     def delete_async(self, request, *args, **kwargs):

--- a/onadata/libs/serializers/xform_serializer.py
+++ b/onadata/libs/serializers/xform_serializer.py
@@ -358,6 +358,7 @@ class XFormManifestSerializer(serializers.Serializer):
         if len(parts) > 2:
             dataset_type = parts[0]
             pk = parts[1]
+            xform = None
             if dataset_type == 'xform':
                 xform = XForm.objects.filter(pk=pk)\
                     .only('last_submission_time').first()

--- a/onadata/libs/utils/project_utils.py
+++ b/onadata/libs/utils/project_utils.py
@@ -35,7 +35,8 @@ def set_project_perms_to_xform(xform, project):
         role_name = perm['role']
         role = ROLES.get(role_name)
 
-        if user != xform.created_by:
-            role.add(user, xform)
-        else:
+        if user == xform.created_by:
             OwnerRole.add(user, xform)
+        else:
+            if role:
+                role.add(user, xform)


### PR DESCRIPTION
Catching `XLSFormError` exception and raising `ParseError` allows rest-framework to return a response with `status_code` 400 instead of failing with a `500` `status_code`.

Fixes #953