### PR TITLE
Set xform permissions async.

### DIFF
--- a/onadata/apps/api/tools.py
+++ b/onadata/apps/api/tools.py
@@ -42,7 +42,7 @@ from onadata.libs.utils.api_export_tools import custom_response_handler
 from onadata.libs.utils.cache_tools import safe_delete, PROJ_FORMS_CACHE
 from onadata.libs.utils.logger_tools import publish_form
 from onadata.libs.utils.logger_tools import response_with_mimetype_and_name
-from onadata.libs.utils.project_utils import set_project_perms_to_xform
+from onadata.libs.utils.project_utils import set_project_perms_to_xform_async
 from onadata.libs.utils.user_auth import check_and_set_form_by_id
 from onadata.libs.utils.user_auth import check_and_set_form_by_id_string
 from onadata.libs.permissions import ROLES
@@ -358,7 +358,7 @@ def publish_project_xform(request, project):
                 xform.save()
         except IntegrityError:
             raise exceptions.ParseError(_(msg))
-        set_project_perms_to_xform(xform, project)
+        set_project_perms_to_xform_async.delay(xform.pk, project.pk)
     else:
         xform = publish_form(set_form)
 

--- a/onadata/apps/viewer/models/data_dictionary.py
+++ b/onadata/apps/viewer/models/data_dictionary.py
@@ -153,8 +153,8 @@ def set_object_permissions(sender, instance=None, created=False, **kwargs):
         if instance.created_by and instance.user != instance.created_by:
             OwnerRole.add(instance.created_by, xform)
 
-        from onadata.libs.utils.project_utils import set_project_perms_to_xform
-        set_project_perms_to_xform(xform, instance.project)
+        from onadata.libs.utils.project_utils import set_project_perms_to_xform_async  # noqa
+        set_project_perms_to_xform_async.delay(xform.pk, instance.project.pk)
 
     if hasattr(instance, 'has_external_choices') \
             and instance.has_external_choices:

--- a/onadata/libs/utils/project_utils.py
+++ b/onadata/libs/utils/project_utils.py
@@ -1,3 +1,6 @@
+from celery import task
+
+from onadata.apps.logger.models import Project, XForm
 from onadata.libs.permissions import (ROLES, OwnerRole,
                                       get_object_users_with_permissions)
 from onadata.libs.utils.common_tags import OWNER_TEAM_NAME
@@ -40,3 +43,14 @@ def set_project_perms_to_xform(xform, project):
         else:
             if role:
                 role.add(user, xform)
+
+
+@task
+def set_project_perms_to_xform_async(xform_id, project_id):
+    try:
+        xform = XForm.objects.get(id=xform_id)
+        project = Project.objects.get(id=project_id)
+    except (Project.DoesNotExist, XForm.DoesNotExist):
+        pass
+    else:
+        set_project_perms_to_xform(xform, project)

--- a/onadata/libs/utils/project_utils.py
+++ b/onadata/libs/utils/project_utils.py
@@ -1,3 +1,5 @@
+import sys
+
 from celery import task
 from django.conf import settings
 
@@ -5,6 +7,7 @@ from onadata.apps.logger.models import Project, XForm
 from onadata.libs.permissions import (ROLES, OwnerRole,
                                       get_object_users_with_permissions)
 from onadata.libs.utils.common_tags import OWNER_TEAM_NAME
+from onadata.libs.utils.logger_tools import report_exception
 
 
 def set_project_perms_to_xform(xform, project):
@@ -54,9 +57,14 @@ def set_project_perms_to_xform_async(xform_id, project_id):
     except (Project.DoesNotExist, XForm.DoesNotExist):
         pass
     else:
-        if len(getattr(settings, 'SLAVE_DATABASES', [])):
-            from multidb.pinning import use_master
-            with use_master:
+        try:
+            if len(getattr(settings, 'SLAVE_DATABASES', [])):
+                from multidb.pinning import use_master
+                with use_master:
+                    set_project_perms_to_xform(xform, project)
+            else:
                 set_project_perms_to_xform(xform, project)
-        else:
-            set_project_perms_to_xform(xform, project)
+        except Exception as e:
+            msg = '%s: Setting project %d permissions to form %d failed.' % (
+                type(e), project_id, xform_id)
+            report_exception(msg, e, sys.exc_info())

--- a/onadata/libs/utils/project_utils.py
+++ b/onadata/libs/utils/project_utils.py
@@ -1,4 +1,5 @@
 from celery import task
+from django.conf import settings
 
 from onadata.apps.logger.models import Project, XForm
 from onadata.libs.permissions import (ROLES, OwnerRole,
@@ -53,4 +54,9 @@ def set_project_perms_to_xform_async(xform_id, project_id):
     except (Project.DoesNotExist, XForm.DoesNotExist):
         pass
     else:
-        set_project_perms_to_xform(xform, project)
+        if len(getattr(settings, 'SLAVE_DATABASES', [])):
+            from multidb.pinning import use_master
+            with use_master:
+                set_project_perms_to_xform(xform, project)
+        else:
+            set_project_perms_to_xform(xform, project)


### PR DESCRIPTION
Reduce time in adding forms to projects by performing permission assignment in async tasks.