### PR TITLE
Ensure that >400 level HTTP errors are properly handled

### DIFF
--- a/onadata/apps/api/tests/viewsets/test_data_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_data_viewset.py
@@ -43,6 +43,14 @@ def enketo_mock(url, request):
     return response
 
 
+@urlmatch(netloc=r'(.*\.)?enketo\.ona\.io$')
+def enketo_mock_http_413(url, request):
+    response = requests.Response()
+    response.status_code = 413
+    response._content = ''
+    return response
+
+
 def _data_list(formid):
     return [{
         u'id': formid,
@@ -1127,6 +1135,11 @@ class TestDataViewSet(TestBase):
             self.assertEqual(
                 response.data['url'],
                 "https://hmh2a.enketo.ona.io")
+
+        with HTTMock(enketo_mock_http_413):
+            response = view(request, pk=formid, dataid=dataid)
+            self.assertEqual(response.status_code, 400)
+            self.assertEqual(response.get('Cache-Control'), None)
 
     def test_get_form_public_data(self):
         self._make_submissions()

--- a/onadata/apps/api/viewsets/data_viewset.py
+++ b/onadata/apps/api/viewsets/data_viewset.py
@@ -50,7 +50,7 @@ from onadata.libs.serializers.geojson_serializer import GeoJsonSerializer
 from onadata.libs import filters
 from onadata.libs.permissions import CAN_DELETE_SUBMISSION,\
     filter_queryset_xform_meta_perms, filter_queryset_xform_meta_perms_sql
-from onadata.libs.utils.viewer_tools import EnketoError
+from onadata.libs.exceptions import EnketoError
 from onadata.libs.utils.viewer_tools import get_enketo_edit_url
 from onadata.libs.utils.api_export_tools import custom_response_handler
 from onadata.libs.data import parse_int

--- a/onadata/apps/api/viewsets/data_viewset.py
+++ b/onadata/apps/api/viewsets/data_viewset.py
@@ -254,7 +254,7 @@ class DataViewSet(AnonymousUserPublicFormsMixin,
                     data["url"] = get_enketo_edit_url(
                         request, self.object, return_url)
                 except EnketoError as e:
-                    data['detail'] = "{}".format(e)
+                    raise ParseError(str(e))
             else:
                 raise PermissionDenied(_(u"You do not have edit permissions."))
 

--- a/onadata/apps/api/viewsets/xform_viewset.py
+++ b/onadata/apps/api/viewsets/xform_viewset.py
@@ -67,10 +67,11 @@ from onadata.libs.utils.csv_import import (get_async_csv_submission_status,
 from onadata.libs.utils.export_tools import parse_request_export_options
 from onadata.libs.utils.logger_tools import publish_form
 from onadata.libs.utils.string import str2bool
-from onadata.libs.utils.viewer_tools import (EnketoError, enketo_url,
+from onadata.libs.utils.viewer_tools import (enketo_url,
                                              generate_enketo_form_defaults,
                                              get_enketo_preview_url,
                                              get_form_url)
+from onadata.libs.exceptions import EnketoError
 
 BaseViewset = get_baseviewset_class()
 

--- a/onadata/apps/logger/tests/test_publish_xls.py
+++ b/onadata/apps/logger/tests/test_publish_xls.py
@@ -6,7 +6,7 @@ from django.core.management.base import CommandError
 
 from onadata.apps.main.tests.test_base import TestBase
 from onadata.apps.logger.models.xform import XForm
-from onadata.libs.utils.logger_tools import report_exception
+from onadata.libs.utils.common_tools import report_exception
 
 
 class TestPublishXLS(TestBase):

--- a/onadata/apps/main/views.py
+++ b/onadata/apps/main/views.py
@@ -56,8 +56,9 @@ from onadata.libs.utils.user_auth import (add_cors_headers, check_and_set_user,
                                           get_xform_users_with_perms,
                                           has_permission,
                                           helper_auth_helper, set_profile_data)
-from onadata.libs.utils.viewer_tools import (EnketoError, enketo_url,
+from onadata.libs.utils.viewer_tools import (enketo_url,
                                              get_enketo_preview_url, get_form)
+from onadata.libs.exceptions import EnketoError
 
 
 def home(request):

--- a/onadata/apps/viewer/tasks.py
+++ b/onadata/apps/viewer/tasks.py
@@ -7,11 +7,10 @@ from requests import ConnectionError
 
 from onadata.apps.viewer.models.export import Export
 from onadata.libs.exceptions import NoRecordsFoundError
-from onadata.libs.utils.common_tools import get_boolean_value
+from onadata.libs.utils.common_tools import get_boolean_value, report_exception
 from onadata.libs.utils.export_tools import (
     generate_attachments_zip_export, generate_export, generate_external_export,
     generate_kml_export, generate_osm_export)
-from onadata.libs.utils.logger_tools import report_exception
 
 EXPORT_QUERY_KEY = 'query'
 

--- a/onadata/libs/exceptions.py
+++ b/onadata/libs/exceptions.py
@@ -1,4 +1,21 @@
+from django.utils.translation import ugettext_lazy as _
+
 from rest_framework.exceptions import APIException
+
+
+class EnketoError(Exception):
+
+    default_message = _("There was a problem with your submissionor"
+                        " form. Please contact support.")
+
+    def __init__(self, message=None):
+        if message is None:
+            self.message = self.default_message
+        else:
+            self.message = message
+
+    def __str__(self):
+        return "{}".format(self.message)
 
 
 class NoRecordsFoundError(Exception):

--- a/onadata/libs/serializers/xform_serializer.py
+++ b/onadata/libs/serializers/xform_serializer.py
@@ -23,7 +23,8 @@ from onadata.libs.utils.cache_tools import (
 from onadata.libs.utils.common_tags import GROUP_DELIMETER_TAG
 from onadata.libs.utils.decorators import check_obj
 from onadata.libs.utils.viewer_tools import (
-    EnketoError, enketo_url, get_enketo_preview_url, get_form_url)
+    enketo_url, get_enketo_preview_url, get_form_url)
+from onadata.libs.exceptions import EnketoError
 
 
 def _create_enketo_url(request, xform):

--- a/onadata/libs/utils/csv_import.py
+++ b/onadata/libs/utils/csv_import.py
@@ -19,8 +19,8 @@ from onadata.libs.utils.async_status import (FAILED, async_status,
                                              celery_state_to_status)
 from onadata.libs.utils.common_tags import MULTIPLE_SELECT_TYPE
 from onadata.libs.utils.dict_tools import csv_dict_to_nested_dict
-from onadata.libs.utils.logger_tools import (dict2xml, report_exception,
-                                             safe_create_instance)
+from onadata.libs.utils.logger_tools import dict2xml, safe_create_instance
+from onadata.libs.utils.common_tools import report_exception
 
 DEFAULT_UPDATE_BATCH = 100
 PROGRESS_BATCH_UPDATE = getattr(settings, 'EXPORT_TASK_PROGRESS_UPDATE_BATCH',

--- a/onadata/libs/utils/project_utils.py
+++ b/onadata/libs/utils/project_utils.py
@@ -7,7 +7,7 @@ from onadata.apps.logger.models import Project, XForm
 from onadata.libs.permissions import (ROLES, OwnerRole,
                                       get_object_users_with_permissions)
 from onadata.libs.utils.common_tags import OWNER_TEAM_NAME
-from onadata.libs.utils.logger_tools import report_exception
+from onadata.libs.utils.common_tools import report_exception
 
 
 def set_project_perms_to_xform(xform, project):

--- a/onadata/libs/utils/viewer_tools.py
+++ b/onadata/libs/utils/viewer_tools.py
@@ -11,30 +11,16 @@ from django.core.files.storage import get_storage_class
 from django.core.files.uploadedfile import InMemoryUploadedFile
 from django.core.mail import mail_admins
 from django.utils.translation import ugettext as _
-from django.utils.translation import ugettext_lazy
 
 from onadata.libs.utils import common_tags
+from onadata.libs.exceptions import EnketoError
+
 
 SLASH = u"/"
 
 
 class MyError(Exception):
     pass
-
-
-class EnketoError(Exception):
-
-    default_message = ugettext_lazy("There was a problem with your submission"
-                                    " or form. Please contact support.")
-
-    def __init__(self, message=None):
-        if message is None:
-            self.message = self.default_message
-        else:
-            self.message = message
-
-    def __str__(self):
-        return "{}".format(self.message)
 
 
 def image_urls_for_form(xform):


### PR DESCRIPTION
Fixes: #1072

We discovered that the API endpoint to get an enketo edit url
encountered >400 level errors it did not properly set the HTTP
status code and instead returned the edit url as false.

This set of commits fixes that by raising an EnketoError exception
which has a friendly default error message that can be overridden.