### PR TITLE
Check for and handle cases where created_by is None for a Note object

### DIFF
--- a/onadata/apps/logger/models/instance.py
+++ b/onadata/apps/logger/models/instance.py
@@ -358,12 +358,7 @@ class InstanceBaseClass(object):
         return self.numeric_converter(instance_dict)
 
     def get_notes(self):
-        return [{"id": note.id,
-                 "owner": note.created_by.username,
-                 "note": note.note,
-                 "instance_field": note.instance_field,
-                 "created_by": note.created_by.id}
-                for note in self.notes.all()]
+        return [note.get_data() for note in self.notes.all()]
 
     def get_root_node(self):
         self._set_parser()

--- a/onadata/apps/logger/models/note.py
+++ b/onadata/apps/logger/models/note.py
@@ -17,3 +17,16 @@ class Note(models.Model):
         permissions = (
             ('view_note', 'View note'),
         )
+
+    def get_data(self):
+        owner = ""
+        created_by_id = ""
+        if self.created_by:
+            owner = self.created_by.username
+            created_by_id = self.created_by.id
+        return {"id": self.id,
+                "owner": owner,
+                "note": self.note,
+                "instance_field": self.instance_field,
+                "created_by": created_by_id
+                }

--- a/onadata/apps/logger/tests/models/test_note.py
+++ b/onadata/apps/logger/tests/models/test_note.py
@@ -1,0 +1,22 @@
+from onadata.apps.main.tests.test_base import TestBase
+from onadata.apps.logger.models import Instance, Note
+
+
+class TestNote(TestBase):
+
+    def setUp(self):
+        super(self.__class__, self).setUp()
+
+    def test_no_created_by(self):
+        self._publish_transportation_form_and_submit_instance()
+        instance = Instance.objects.first()
+        note = Note(
+            instance=instance,
+            instance_field="",
+            created_by=None,
+        )
+        note.save()
+        try:
+            note.get_data()
+        except AttributeError:
+            self.fail("note.get_data() raised AttributeError unexpectedly!")

--- a/onadata/apps/logger/tests/models/test_note.py
+++ b/onadata/apps/logger/tests/models/test_note.py
@@ -16,7 +16,6 @@ class TestNote(TestBase):
             created_by=None,
         )
         note.save()
-        try:
-            note.get_data()
-        except AttributeError:
-            self.fail("note.get_data() raised AttributeError unexpectedly!")
+        note_data = note.get_data()
+        self.assertEqual(note_data['owner'], "")
+        self.assertEqual(note_data['created_by'], "")


### PR DESCRIPTION
Fixes: #1069

We now return an empty string in place of created_by when a Note is not
linked to any user.