### PR TITLE
Cancel or delete stale pending and failed exports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ build
 *~
 *orig
 celerybeat-schedule
+celerybeat.pid
 *.swp
 .venv
 *.ropeproject

--- a/onadata/apps/viewer/tasks.py
+++ b/onadata/apps/viewer/tasks.py
@@ -1,6 +1,8 @@
 import sys
+from datetime import datetime, timedelta
 
 from celery import task
+from celery.task.schedules import crontab
 from django.conf import settings
 from django.shortcuts import get_object_or_404
 from requests import ConnectionError
@@ -349,3 +351,39 @@ def delete_export(export_id):
         export.delete()
         return True
     return False
+
+
+@task.periodic_task(
+    run_every=(crontab(hour='*/7')),
+    ignore_result=True
+)
+def check_pending_exports():
+    """
+    Exports that have not completed within a set time should be marked as
+    failed
+    """
+    h = settings.EXPORT_TASK_LIFESPAN
+    time_threshold = datetime.now() - timedelta(hours=h)
+    exports = Export.objects.filter(internal_status=Export.PENDING,
+                                    created_on__lt=time_threshold)
+    for export in exports:
+        export.internal_status = Export.FAILED
+        export.save()
+    return True
+
+
+@task.periodic_task(
+    run_every=(crontab(hour='*/7')),
+    ignore_result=True
+)
+def delete_old_failed_exports():
+    """
+    Delete old failed exports
+    """
+    h = settings.EXPORT_TASK_LIFESPAN
+    time_threshold = datetime.now() - timedelta(hours=h)
+    exports = Export.objects.filter(internal_status=Export.FAILED,
+                                    created_on__lt=time_threshold)
+    for export in exports:
+        delete_export.delay(export.id)
+    return True

--- a/onadata/apps/viewer/tasks.py
+++ b/onadata/apps/viewer/tasks.py
@@ -375,7 +375,7 @@ def mark_expired_pending_exports_as_failed():
     run_every=(crontab(hour='*/7')),
     ignore_result=True
 )
-def delete_old_failed_exports():
+def delete_expired_failed_exports():
     """
     Delete old failed exports
     """
@@ -383,5 +383,4 @@ def delete_old_failed_exports():
     time_threshold = timezone.now() - timedelta(hours=task_lifespan)
     exports = Export.objects.filter(internal_status=Export.FAILED,
                                     created_on__lt=time_threshold)
-    for export in exports:
-        export.delete()
+    exports.delete()

--- a/onadata/apps/viewer/tests/test_tasks.py
+++ b/onadata/apps/viewer/tests/test_tasks.py
@@ -8,7 +8,7 @@ from onadata.apps.main.tests.test_base import TestBase
 from onadata.apps.viewer.models.export import Export
 from onadata.apps.viewer.tasks import create_async_export
 from onadata.apps.viewer.tasks import mark_expired_pending_exports_as_failed
-from onadata.apps.viewer.tasks import delete_old_failed_exports
+from onadata.apps.viewer.tasks import delete_expired_failed_exports
 
 
 class TestExportTasks(TestBase):
@@ -57,7 +57,7 @@ class TestExportTasks(TestBase):
         export = Export.objects.filter(pk=export.pk).first()
         self.assertEquals(export.internal_status, Export.FAILED)
 
-    def test_delete_old_failed_exports(self):
+    def test_delete_expired_failed_exports(self):
         self._publish_transportation_form_and_submit_instance()
         over_threshold = settings.EXPORT_TASK_LIFESPAN + 2
         export = Export.objects.create(xform=self.xform,
@@ -68,5 +68,5 @@ class TestExportTasks(TestBase):
         export.created_on = timezone.now() - timedelta(hours=over_threshold)
         export.save()
         pk = export.pk
-        delete_old_failed_exports()
+        delete_expired_failed_exports()
         self.assertEquals(Export.objects.filter(pk=pk).first(), None)

--- a/onadata/apps/viewer/tests/test_tasks.py
+++ b/onadata/apps/viewer/tests/test_tasks.py
@@ -3,12 +3,11 @@ from datetime import timedelta
 from celery import current_app
 from django.conf import settings
 from django.utils import timezone
-from django.core.files.storage import get_storage_class
 
 from onadata.apps.main.tests.test_base import TestBase
 from onadata.apps.viewer.models.export import Export
 from onadata.apps.viewer.tasks import create_async_export
-from onadata.apps.viewer.tasks import check_pending_exports
+from onadata.apps.viewer.tasks import mark_expired_pending_exports_as_failed
 from onadata.apps.viewer.tasks import delete_old_failed_exports
 
 
@@ -18,11 +17,6 @@ class TestExportTasks(TestBase):
         super(TestExportTasks, self).setUp()
         settings.CELERY_ALWAYS_EAGER = True
         current_app.conf.CELERY_ALWAYS_EAGER = True
-
-    def delete_export_file(self, filepath):
-        storage = get_storage_class()()
-        if filepath and storage.exists(filepath):
-            storage.delete(filepath)
 
     def test_create_async(self):
 
@@ -49,42 +43,30 @@ class TestExportTasks(TestBase):
             self.assertIn("username", options)
             self.assertEquals(options.get("id_string"), self.xform.id_string)
 
-    def test_check_pending_exports(self):
+    def test_mark_expired_pending_exports_as_failed(self):
         self._publish_transportation_form_and_submit_instance()
-        options = {"group_delimiter": "/",
-                   "remove_group_name": False,
-                   "split_select_multiples": True}
-        result = create_async_export(
-            self.xform, Export.CSV_EXPORT, None, False, options)
-        export = result[0]
-        filepath = export.filepath
-        export.filename = ""
         over_threshold = settings.EXPORT_TASK_LIFESPAN + 2
-        export.internal_status = Export.PENDING
+        export = Export.objects.create(xform=self.xform,
+                                       export_type=Export.CSV_EXPORT,
+                                       internal_status=Export.PENDING,
+                                       filename="")
+        # we set created_on here because Export.objects.create() overrides it
         export.created_on = timezone.now() - timedelta(hours=over_threshold)
         export.save()
-        final_result = check_pending_exports.delay()
-        self.delete_export_file(filepath)
-        self.assertTrue(final_result)
+        mark_expired_pending_exports_as_failed()
         export = Export.objects.filter(pk=export.pk).first()
         self.assertEquals(export.internal_status, Export.FAILED)
 
     def test_delete_old_failed_exports(self):
         self._publish_transportation_form_and_submit_instance()
-        options = {"group_delimiter": "/",
-                   "remove_group_name": False,
-                   "split_select_multiples": True}
-        result = create_async_export(
-            self.xform, Export.CSV_EXPORT, None, False, options)
-        export = result[0]
-        pk = export.pk
-        filepath = export.filepath
-        export.filename = ""
         over_threshold = settings.EXPORT_TASK_LIFESPAN + 2
-        export.internal_status = Export.FAILED
+        export = Export.objects.create(xform=self.xform,
+                                       export_type=Export.CSV_EXPORT,
+                                       internal_status=Export.FAILED,
+                                       filename="")
+        # we set created_on here because Export.objects.create() overrides it
         export.created_on = timezone.now() - timedelta(hours=over_threshold)
         export.save()
-        final_result = delete_old_failed_exports.delay()
-        self.delete_export_file(filepath)
-        self.assertTrue(final_result)
+        pk = export.pk
+        delete_old_failed_exports()
         self.assertEquals(Export.objects.filter(pk=pk).first(), None)

--- a/onadata/apps/viewer/tests/test_tasks.py
+++ b/onadata/apps/viewer/tests/test_tasks.py
@@ -4,6 +4,8 @@ from django.conf import settings
 from onadata.apps.main.tests.test_base import TestBase
 from onadata.apps.viewer.models.export import Export
 from onadata.apps.viewer.tasks import create_async_export
+from onadata.apps.viewer.tasks import check_pending_exports
+from onadata.apps.viewer.tasks import delete_old_failed_exports
 
 
 class TestExportTasks(TestBase):
@@ -38,3 +40,11 @@ class TestExportTasks(TestBase):
             self.assertTrue(export.id)
             self.assertIn("username", options)
             self.assertEquals(options.get("id_string"), self.xform.id_string)
+
+    def test_check_pending_exports(self):
+        result = check_pending_exports.delay()
+        self.assertTrue(result)
+
+    def test_delete_old_failed_exports(self):
+        result = delete_old_failed_exports.delay()
+        self.assertTrue(result)

--- a/onadata/settings/common.py
+++ b/onadata/settings/common.py
@@ -435,6 +435,7 @@ ZIP_EXPORT_COUNTDOWN = 3600  # 1 hour
 
 # number of records on export or CSV import before a progress update
 EXPORT_TASK_PROGRESS_UPDATE_BATCH = 1000
+EXPORT_TASK_LIFESPAN = 6  # six hours
 
 # default content length for submission requests
 DEFAULT_CONTENT_LENGTH = 10000000


### PR DESCRIPTION
Fixes: #1068

Create periodic tasks which:

- Find old pending exports and mark them as failed.

- Find old failed exports and delete them

The 'oldness' is determined by a configurable setting.