### PR TITLE
Prevent SAV Exports From Failing When Choices Lists Have Duplicate Names

### DIFF
--- a/onadata/apps/viewer/tests/test_export_builder.py
+++ b/onadata/apps/viewer/tests/test_export_builder.py
@@ -713,7 +713,7 @@ class TestExportBuilder(TestBase):
         |         | animals   | 4    | Sheep      |
         |         | animals   | 5    | Donkey     |
         |         | animals   | 6    | Hen        |
-        |         | animals   | 6    | Other      | <--- duplicate name
+        |         | animals   | 6    | Other      | # <--- duplicate name
         |         | animals   | 8    | None       |
         |         | animals   | 9    | Don't Know |
         """

--- a/onadata/apps/viewer/tests/test_export_builder.py
+++ b/onadata/apps/viewer/tests/test_export_builder.py
@@ -646,7 +646,7 @@ class TestExportBuilder(TestBase):
                        returnHeader=True) as reader:
             rows = [r for r in reader]
             self.assertTrue(len(rows) > 1)
-            self.assertEqual(rows[1][0],  "1")
+            self.assertEqual(rows[1][0], "1")
             # expensed.1 is selected hence True, 1.00 or 1 in SPSS
             self.assertEqual(rows[1][1], 1)
             # expensed.0 is not selected hence False, .00 or 0 in SPSS
@@ -698,6 +698,45 @@ class TestExportBuilder(TestBase):
             self.assertEqual(rows[1][6], '2016-11-21 03:43:43')
 
         shutil.rmtree(temp_dir)
+
+    def test_zipped_sav_export_with_duplicate_name_in_choice_list(self):
+        md = """
+        | survey |                         |      |                  |
+        |        | type                    | name | label            |
+        |        | select_multiple animals | q1   | Favorite animal? |
+
+        | choices |           |      |            |
+        |         | list_name | name | label      |
+        |         | animals   | 1    | Goat       |
+        |         | animals   | 2    | Camel      |
+        |         | animals   | 3    | Cow        |
+        |         | animals   | 4    | Sheep      |
+        |         | animals   | 5    | Donkey     |
+        |         | animals   | 6    | Hen        |
+        |         | animals   | 6    | Other      |
+        |         | animals   | 8    | None       |
+        |         | animals   | 9    | Don't Know |
+        """
+        survey = self.md_to_pyxform_survey(md, {'name': 'exp'})
+        data = [{"q1": "1",
+                '_submission_time': u'2016-11-21T03:43:43.000-08:00'},
+                {"q1": "6",
+                '_submission_time': u'2016-11-21T03:43:43.000-08:00'}
+                ]
+        export_builder = ExportBuilder()
+        export_builder.set_survey(survey)
+        temp_zip_file = NamedTemporaryFile(suffix='.zip')
+        export_builder.to_zipped_sav(temp_zip_file.name, data)
+        temp_zip_file.seek(0)
+        temp_dir = tempfile.mkdtemp()
+        zip_file = zipfile.ZipFile(temp_zip_file.name, "r")
+        zip_file.extractall(temp_dir)
+        zip_file.close()
+        temp_zip_file.close()
+        # check that the children's file (which has the unicode header) exists
+        self.assertTrue(
+            os.path.exists(
+                os.path.join(temp_dir, "exp.sav")))
 
     def test_xls_export_works_with_unicode(self):
         survey = create_survey_from_xls(_logger_fixture_path(

--- a/onadata/apps/viewer/tests/test_export_builder.py
+++ b/onadata/apps/viewer/tests/test_export_builder.py
@@ -713,7 +713,7 @@ class TestExportBuilder(TestBase):
         |         | animals   | 4    | Sheep      |
         |         | animals   | 5    | Donkey     |
         |         | animals   | 6    | Hen        |
-        |         | animals   | 6    | Other      |
+        |         | animals   | 6    | Other      | <--- duplicate name
         |         | animals   | 8    | None       |
         |         | animals   | 9    | Don't Know |
         """

--- a/onadata/libs/utils/common_tags.py
+++ b/onadata/libs/utils/common_tags.py
@@ -92,3 +92,9 @@ USER_ID = u'USER_ID'
 # tag group delimiter name
 GROUP_DELIMETER_TAG = 'group_delimiter'
 XFORM_META_PERMS = u'xform_meta_perms'
+
+# SAV
+# VarTyoes: 0 means 'numeric', and varType > 0 means 'character' of that length
+# (in bytes)
+SAV_NUMERIC_TYPE = 0
+SAV_255_BYTES_TYPE = 255

--- a/onadata/libs/utils/export_builder.py
+++ b/onadata/libs/utils/export_builder.py
@@ -207,22 +207,6 @@ def track_task_progress(additions, total=None):
         pass
 
 
-def get_parent_element(xpath, element_type, data_dictionary):
-    parent_xpath = '/'.join(xpath.split('/')[:-1])
-    return data_dictionary.get_element(parent_xpath)
-
-
-def get_element_from_xpath(xpath, elements):
-    return next((el for el in elements if el['xpath'] == xpath), None)
-
-
-def get_element_type_from_xpath(xpath, elements):
-    element = get_element_from_xpath(xpath, elements)
-    if element:
-        return element['type']
-    return ""
-
-
 class ExportBuilder(object):
     IGNORED_COLUMNS = [XFORM_ID_STRING, STATUS, ATTACHMENTS, GEOLOCATION,
                        BAMBOO_DATASET_ID, DELETEDAT]

--- a/onadata/libs/utils/export_builder.py
+++ b/onadata/libs/utils/export_builder.py
@@ -212,6 +212,17 @@ def get_parent_element(xpath, element_type, data_dictionary):
     return data_dictionary.get_element(parent_xpath)
 
 
+def get_element_from_xpath(xpath, elements):
+    return next((el for el in elements if el['xpath'] == xpath), None)
+
+
+def get_element_type_from_xpath(xpath, elements):
+    element = get_element_from_xpath(xpath, elements)
+    if element:
+        return element['type']
+    return ""
+
+
 class ExportBuilder(object):
     IGNORED_COLUMNS = [XFORM_ID_STRING, STATUS, ATTACHMENTS, GEOLOCATION,
                        BAMBOO_DATASET_ID, DELETEDAT]
@@ -931,7 +942,7 @@ class ExportBuilder(object):
             [(x[1],
               SAV_NUMERIC_TYPE if _is_numeric(
                 x[0],
-                self.dd.get_element(x[0]),
+                self.dd.get_element(x[0]).type,
                 self.dd) else SAV_255_BYTES_TYPE)
                 for x in duplicate_names]
         )

--- a/onadata/libs/utils/export_builder.py
+++ b/onadata/libs/utils/export_builder.py
@@ -22,9 +22,9 @@ from onadata.apps.logger.models.xform import _encode_for_mongo,\
 from onadata.apps.viewer.models.data_dictionary import DataDictionary
 from onadata.libs.utils.common_tags import (
     ID, XFORM_ID_STRING, STATUS, ATTACHMENTS, GEOLOCATION, BAMBOO_DATASET_ID,
-    DELETEDAT, INDEX, PARENT_INDEX, PARENT_TABLE_NAME,
+    DELETEDAT, INDEX, PARENT_INDEX, PARENT_TABLE_NAME, MULTIPLE_SELECT_TYPE,
     SUBMISSION_TIME, UUID, TAGS, NOTES, VERSION, SUBMITTED_BY, DURATION,
-    MULTIPLE_SELECT_TYPE)
+    SAV_255_BYTES_TYPE, SAV_NUMERIC_TYPE)
 from onadata.libs.utils.mongo import _is_invalid_for_mongo,\
     _decode_from_mongo
 
@@ -220,7 +220,7 @@ def get_element_type_from_xpath(xpath, elements):
     element = get_element_from_xpath(xpath, elements)
     if element:
         return element['type']
-    return "unknown"
+    return ""
 
 
 class ExportBuilder(object):
@@ -929,17 +929,21 @@ class ExportBuilder(object):
 
         var_types = dict(
             [(_var_types[element['xpath']],
-                0 if _is_numeric(element['xpath'], element['type'],
-                                 self.dd) else 255)
+                SAV_NUMERIC_TYPE if _is_numeric(element['xpath'],
+                                                element['type'],
+                                                self.dd) else
+                SAV_255_BYTES_TYPE)
                 for element in elements] +
             [(_var_types[item],
-                0 if item in ['_id', '_index', '_parent_index',
-                              SUBMISSION_TIME] else 255)
+                SAV_NUMERIC_TYPE if item in [
+                    '_id', '_index', '_parent_index', SUBMISSION_TIME]
+                else SAV_255_BYTES_TYPE)
                 for item in self.EXTRA_FIELDS] +
             [(x[1],
-              0 if _is_numeric(x[0],
-                               get_element_type_from_xpath(x[0], elements),
-                               self.dd) else 255)
+              SAV_NUMERIC_TYPE if _is_numeric(
+                x[0],
+                get_element_type_from_xpath(x[0], elements),
+                self.dd) else SAV_255_BYTES_TYPE)
                 for x in duplicate_names]
         )
         dates = [_var_types[element['xpath']] for element in elements

--- a/onadata/libs/utils/export_builder.py
+++ b/onadata/libs/utils/export_builder.py
@@ -212,17 +212,6 @@ def get_parent_element(xpath, element_type, data_dictionary):
     return data_dictionary.get_element(parent_xpath)
 
 
-def get_element_from_xpath(xpath, elements):
-    return next((el for el in elements if el['xpath'] == xpath), None)
-
-
-def get_element_type_from_xpath(xpath, elements):
-    element = get_element_from_xpath(xpath, elements)
-    if element:
-        return element['type']
-    return ""
-
-
 class ExportBuilder(object):
     IGNORED_COLUMNS = [XFORM_ID_STRING, STATUS, ATTACHMENTS, GEOLOCATION,
                        BAMBOO_DATASET_ID, DELETEDAT]
@@ -942,7 +931,7 @@ class ExportBuilder(object):
             [(x[1],
               SAV_NUMERIC_TYPE if _is_numeric(
                 x[0],
-                get_element_type_from_xpath(x[0], elements),
+                self.dd.get_element(x[0]),
                 self.dd) else SAV_255_BYTES_TYPE)
                 for x in duplicate_names]
         )


### PR DESCRIPTION
Prevent the export builder from failing when data from a form with
multiple choices that have duplicate names by ignoring all but one of the
choices that have a duplicated names.

Fix: #983