### PR TITLE
Validate metadata Field on Project Serializer

### DIFF
--- a/onadata/libs/serializers/fields/json_field.py
+++ b/onadata/libs/serializers/fields/json_field.py
@@ -8,7 +8,6 @@ class JsonField(serializers.Field):
     def to_representation(self, value):
         if isinstance(value, basestring):
             return json.loads(value)
-
         return value
 
     def to_internal_value(self, value):
@@ -18,12 +17,10 @@ class JsonField(serializers.Field):
             except ValueError as e:
                 # invalid json
                 raise serializers.ValidationError(unicode(e))
-
         return value
 
     @classmethod
     def to_json(cls, data):
         if isinstance(data, basestring):
             return json.loads(data)
-
         return data


### PR DESCRIPTION
Validate metadata field on Project Serializer to reject invalid
inputs/values.

Additionally, ensure that metadata is always converted to valid JSON for
storage.

Fix: #977