### PR TITLE
Add Instance Model Fields As Data Endpoints Filters

### DIFF
--- a/docs/data.rst
+++ b/docs/data.rst
@@ -367,6 +367,204 @@ Filter    Description
 **$i**    Case insensitive or partial search
 ========  ===================================
 
+Query submitted data of a specific form using date_created
+----------------------------------------------------------
+
+Filter submissions using the date_created field
+
+Example
+^^^^^^^^^
+::
+
+    curl -X GET https://api.ona.io/api/v1/data/22845?date_created__year=2017
+
+
+All Filters Options
+
+=============================     ===================================
+Filter                            Description
+=============================     ===================================
+**$date_created__year**           Exact year e.g. 2017
+**$date_created__year__lt**       year Less than
+**$date_created__year__lte**      year Less than or Equal to
+**$date_created__year__gt**       year Greater than
+**$date_created__year__gte**      year Greater than or Equal to
+**$date_created__month**          Exact month e.g. 11
+**$date_created__month__lt**      Month Less than
+**$date_created__month__lte**     Month Less than or Equal to
+**$date_created__month__gt**      Month Greater than
+**$date_created__month__gte**     Month Greater than or Equal to
+**$date_created__day**            Exact day e.g. 13
+**$date_created__day__lt**        Day Less than
+**$date_created__day__lte**       Day Less than or Equal to
+**$date_created__day__gt**        Day Greater than
+**$date_created__day__gte**       Day Greater than or Equal to
+=============================     ===================================
+
+Filter options can be chained to narrow results even further.
+
+
+Query submitted data of a specific form using date_modified
+-----------------------------------------------------------
+
+Filter submissions using the date_modified field
+
+Example
+^^^^^^^^^
+::
+
+    curl -X GET https://api.ona.io/api/v1/data/22845?date_modified__month=11
+
+All Filters Options
+
+=============================     ===================================
+Filter                            Description
+=============================     ===================================
+**$date_modified__year**          Exact year e.g. 2017
+**$date_modified__year__lt**      year Less than
+**$date_modified__year__lte**     year Less than or Equal to
+**$date_modified__year__gt**      year Greater than
+**$date_modified__year__gte**     year Greater than or Equal to
+**$date_modified__month**         Exact month e.g. 11
+**$date_modified__month__lt**     Month Less than
+**$date_modified__month__lte**    Month Less than or Equal to
+**$date_modified__month__gt**     Month Greater than
+**$date_modified__month__gte**    Month Greater than or Equal to
+**$date_modified__day**           Exact day e.g. 13
+**$date_modified__day__lt**       Day Less than
+**$date_modified__day__lte**      Day Less than or Equal to
+**$date_modified__day__gt**       Day Greater than
+**$date_modified__day__gte**      Day Greater than or Equal to
+=============================     ===================================
+
+Filter options can be chained to narrow results even further.
+
+
+Query submitted data of a specific form using last_edited
+---------------------------------------------------------
+
+Filter submissions using the last_edited field
+
+Example
+^^^^^^^^^
+::
+
+    curl -X GET https://api.ona.io/api/v1/data/22845?last_edited__year=2017&last_edited__month=2
+
+All Filters Options
+
+=============================     ===================================
+Filter                            Description
+=============================     ===================================
+**$last_edited__year**            Exact year e.g. 2017
+**$last_edited__year__lt**        year Less than
+**$last_edited__year__lte**       year Less than or Equal to
+**$last_edited__year__gt**        year Greater than
+**$last_edited__year__gte**       year Greater than or Equal to
+**$last_edited__month**           Exact month e.g. 11
+**$last_edited__month__lt**       Month Less than
+**$last_edited__month__lte**      Month Less than or Equal to
+**$last_edited__month__gt**       Month Greater than
+**$last_edited__month__gte**      Month Greater than or Equal to
+**$last_edited__day**             Exact day e.g. 13
+**$last_edited__day__lt**         Day Less than
+**$last_edited__day__lte**        Day Less than or Equal to
+**$last_edited__day__gt**         Day Greater than
+**$last_edited__day__gte**        Day Greater than or Equal to
+=============================     ===================================
+
+Filter options can be chained to narrow results even further.
+
+
+Query submitted data of a specific form using version
+-----------------------------------------------------
+
+Filter submissions using the version field
+
+Example
+^^^^^^^^^
+::
+
+    curl -X GET https://api.ona.io/api/v1/data/22845?version=2324243
+
+
+Query submitted data of a specific form using status
+----------------------------------------------------
+
+Filter submissions using the status field
+
+Example
+^^^^^^^^^
+::
+
+    curl -X GET https://api.ona.io/api/v1/data/22845?status=submitted_via_web
+
+
+Query submitted data of a specific form using uuid
+--------------------------------------------------
+
+Filter submissions using the uuid field
+
+Example
+^^^^^^^^^
+::
+
+    curl -X GET https://api.ona.io/api/v1/data/22845?uuid=9c6f3468-cfda-46e8-84c1-75458e72805d
+
+
+Query submitted data of a specific form using user
+--------------------------------------------------
+
+Filter submissions using the user field
+
+Example
+^^^^^^^^^
+::
+
+    curl -X GET https://api.ona.io/api/v1/data/22845?user__id=260
+
+All Filters Options
+
+===================     ===================================
+Filter                  Description
+===================     ===================================
+**$user__id**           user's id
+**$user__username**     user's username
+===================     ===================================
+
+
+Query submitted data of a specific form using submitted_by
+----------------------------------------------------------
+
+Filter submissions using the submitted_by field
+
+Example
+^^^^^^^^^
+::
+
+    curl -X GET https://api.ona.io/api/v1/data/22845?submitted_by__username=hunter2
+
+All Filters Options
+
+===========================     ===================================
+Filter                          Description
+===========================     ===================================
+**$submitted_by__id**           submitted_by user's id
+**$submitted_by__username**     submitted_by user's username
+===========================     ===================================
+
+
+Query submitted data of a specific form using survey_type
+---------------------------------------------------------
+
+Filter submissions using the survey_type field
+
+Example
+^^^^^^^^^
+::
+
+    curl -X GET https://api.ona.io/api/v1/data/22845?survey_type__slug=fortytwo
+
 
 Query submitted data of a specific form using Tags
 --------------------------------------------------

--- a/onadata/apps/api/tests/viewsets/test_data_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_data_viewset.py
@@ -1954,6 +1954,18 @@ class TestDataViewSet(TestBase):
         response = view(request, pk=formid, format='json')
         self.assertEqual(len(response.data),
                          Instance.objects.filter(version=777).count())
+        # ## Test Status
+        # all the instanced created have the same status i.e.
+        # 'submitted_via_web' .  We now set one instance to have a different
+        # status and filter for it
+        instance = Instance.objects.last()
+        instance.status = 'fortytwo'
+        instance.save()
+        request = self.factory.get('/', {'status': 'fortytwo'}, **self.extra)
+        view = DataViewSet.as_view({'get': 'list'})
+        response = view(request, pk=formid, format='json')
+        self.assertEqual(len(response.data),
+                         Instance.objects.filter(status='fortytwo').count())
         # ## Test date_created
         # all the instances created have the same date_created i.e. the
         # datetime at the time of creation

--- a/onadata/apps/api/viewsets/data_viewset.py
+++ b/onadata/apps/api/viewsets/data_viewset.py
@@ -116,7 +116,7 @@ class DataViewSet(AnonymousUserPublicFormsMixin,
     public_data_endpoint = 'public'
     pagination_class = StandardPageNumberPagination
 
-    queryset = XForm.objects.filter()
+    queryset = XForm.objects.filter(deleted_at__isnull=True)
 
     def get_serializer_class(self):
         pk_lookup, dataid_lookup = self.lookup_fields
@@ -357,6 +357,12 @@ class DataViewSet(AnonymousUserPublicFormsMixin,
             tags = self.request.query_params.get('tags')
             not_tagged = self.request.query_params.get('not_tagged')
 
+            self.object_list = filters.InstanceFilter(
+                self.request.query_params,
+                queryset=self.object_list,
+                request=request
+            ).qs
+
             if tags and isinstance(tags, six.string_types):
                 tags = tags.split(',')
                 self.object_list = self.object_list.filter(tags__name__in=tags)
@@ -443,9 +449,9 @@ class DataViewSet(AnonymousUserPublicFormsMixin,
                     limit=limit, fields=fields
                 )
                 self.etag_hash = get_etag_hash_from_query(records, sql, params)
-        except ValueError, e:
+        except ValueError as e:
             raise ParseError(unicode(e))
-        except DataError, e:
+        except DataError as e:
             raise ParseError(unicode(e))
 
     def _get_data(self, query, fields, sort, start, limit, is_public_request):

--- a/onadata/libs/filters.py
+++ b/onadata/libs/filters.py
@@ -105,6 +105,16 @@ class InstanceFilter(django_filter_filters.FilterSet):
     """
     Instance FilterSet implemented using django-filter
     """
+    submitted_by__id = django_filter_filters.ModelChoiceFilter(
+        name='user',
+        queryset=User.objects.all(),
+        to_field_name='id',
+    )
+    submitted_by__username = django_filter_filters.ModelChoiceFilter(
+        name='user',
+        queryset=User.objects.all(),
+        to_field_name='username',
+    )
 
     class Meta:
         model = Instance
@@ -116,7 +126,14 @@ class InstanceFilter(django_filter_filters.FilterSet):
         generic_field_lookups = ['exact', 'gt', 'lt', 'gte', 'lte']
         fields = {'date_created': date_field_lookups,
                   'date_modified': date_field_lookups,
+                  'last_edited': date_field_lookups,
                   'status': ['exact'],
+                  'submitted_by__id': ['exact'],
+                  'submitted_by__username': ['exact'],
+                  'survey_type__slug': ['exact'],
+                  'user__id': ['exact'],
+                  'user__username': ['exact'],
+                  'uuid': ['exact'],
                   'version': generic_field_lookups}
 
 

--- a/onadata/libs/filters.py
+++ b/onadata/libs/filters.py
@@ -6,7 +6,7 @@ from django.contrib.auth.models import User
 from django.http import Http404
 from django.utils import six
 from rest_framework import filters
-
+from django_filters import rest_framework as django_filter_filters
 
 from onadata.apps.api.models import Team, OrganizationProfile
 from onadata.apps.logger.models import Project, XForm, Instance
@@ -99,6 +99,25 @@ class DataFilter(filters.DjangoObjectPermissionsFilter):
         if request.user.is_anonymous():
             return queryset.filter(Q(shared_data=True))
         return queryset
+
+
+class InstanceFilter(django_filter_filters.FilterSet):
+    """
+    Instance FilterSet implemented using django-filter
+    """
+
+    class Meta:
+        model = Instance
+        date_field_lookups = ['exact', 'gt', 'lt', 'gte', 'lte', 'year',
+                              'year__gt', 'year__lt', 'year__gte', 'year__lte',
+                              'month', 'month__gt', 'month__lt', 'month__gte',
+                              'month__lte', 'day', 'day__gt', 'day__lt',
+                              'day__gte', 'day__lte']
+        generic_field_lookups = ['exact', 'gt', 'lt', 'gte', 'lte']
+        fields = {'date_created': date_field_lookups,
+                  'date_modified': date_field_lookups,
+                  'status': ['exact'],
+                  'version': generic_field_lookups}
 
 
 class ProjectOwnerFilter(filters.BaseFilterBackend):


### PR DESCRIPTION
Add the ability to filter data endpoints using Instance model fields.
Done through a django-filter FilterSet. Implement filters for the
following fields:

- version
- date_created
- date_modified
- status
- submitted_by
- user
- uuid

Fix: #1048