### PR TITLE
Validate presence of the xml_submission_file

### DIFF
--- a/onadata/apps/api/tests/viewsets/test_xform_submission_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_xform_submission_viewset.py
@@ -393,3 +393,14 @@ class TestXFormSubmissionViewSet(TestAbstractViewSet, TransactionTestCase):
         self.assertContains(response, 'Successful submission', status_code=201)
         self.assertTrue(response.has_header('Date'))
         self.assertEqual(response['Location'], 'http://testserver/submission')
+
+    def test_post_empty_submission(self):
+        """
+        Test empty submission fails.
+        """
+        request = self.factory.post(
+            '/%s/submission' % self.user.username, {})
+        request.user = AnonymousUser()
+        response = self.view(request, username=self.user.username)
+        self.assertContains(response, 'No XML submission file.',
+                            status_code=400)

--- a/onadata/libs/serializers/data_serializer.py
+++ b/onadata/libs/serializers/data_serializer.py
@@ -134,6 +134,13 @@ class SubmissionSerializer(SubmissionSuccessMixin, serializers.Serializer):
     XML SubmissionSerializer - handles creating a submission from XML.
     """
 
+    def validate(self, attrs):
+        request, __ = get_request_and_username(self.context)
+        if not request.FILES or 'xml_submission_file' not in request.FILES:
+            raise serializers.ValidationError(_("No XML submission file."))
+
+        return super(SubmissionSerializer, self).validate(attrs)
+
     def create(self, validated_data):
         """
         Returns object instances based on the validated data


### PR DESCRIPTION
Handles the exception
```python
AttributeError: 'NoneType' object has no attribute 'read'
```

It used to be handled by https://github.com/onaio/onadata/commit/2615055be40481da08d73d346f0592228ba2c4ea#diff-edf7b0b4bd8a5b8676bf0c6c7badabd4L150, but after the refactor it is best handled in the validate phase of the `SubmissionSerializer`.