### PR TITLE
Return correct response for HEAD requests on submission endpoint

### DIFF
--- a/onadata/apps/api/permissions.py
+++ b/onadata/apps/api/permissions.py
@@ -426,7 +426,7 @@ class IsAuthenticatedSubmission(BasePermission):
     """
     def has_permission(self, request, view):
         username = view.kwargs.get('username')
-        if request.method == 'POST' and request.user.is_anonymous():
+        if request.method in ['HEAD', 'POST'] and request.user.is_anonymous():
             if username is None:
                 # raises a permission denied exception, forces authentication
                 return False

--- a/onadata/apps/api/viewsets/xform_submission_viewset.py
+++ b/onadata/apps/api/viewsets/xform_submission_viewset.py
@@ -3,10 +3,11 @@
 XFormSubmissionViewSet module
 """
 from django.conf import settings
-from rest_framework import mixins, permissions, viewsets
+from rest_framework import mixins, permissions, status, viewsets
 from rest_framework.authentication import (BasicAuthentication,
                                            TokenAuthentication)
 from rest_framework.renderers import BrowsableAPIRenderer, JSONRenderer
+from rest_framework.response import Response
 
 from onadata.apps.api.permissions import IsAuthenticatedSubmission
 from onadata.apps.api.tools import get_baseviewset_class
@@ -60,6 +61,15 @@ class XFormSubmissionViewSet(AuthenticateHeaderMixin,  # pylint: disable=R0901
             return RapidProSubmissionSerializer
 
         return SubmissionSerializer
+
+    def create(self, request, *args, **kwargs):
+        if request.method.upper() == 'HEAD':
+            return Response(
+                status=status.HTTP_204_NO_CONTENT,
+                template_name=self.template_name)
+
+        return super(XFormSubmissionViewSet, self).create(
+            request, *args, **kwargs)
 
     def handle_exception(self, exc):
         if hasattr(exc, 'response'):


### PR DESCRIPTION
- Add tests for HEAD requests to submission endpoint.