### PR TITLE
Ensure that save_osm_data does not raise TransactionManagementError

### DIFF
--- a/onadata/apps/api/tests/viewsets/test_osm_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_osm_viewset.py
@@ -7,6 +7,7 @@ from django.test import RequestFactory
 from django.test.utils import override_settings
 from django.utils.dateparse import parse_datetime
 from django.db import IntegrityError, transaction
+from django.db.transaction import TransactionManagementError
 
 from onadata.apps.api.tests.viewsets.test_abstract_viewset import \
     TestAbstractViewSet
@@ -199,4 +200,7 @@ class TestOSMViewSet(TestAbstractViewSet):
             # excplicity use an atomic block
             with transaction.atomic():
                 mock.side_effect = _side_effect
-                save_osm_data(submission.id)
+                try:
+                    save_osm_data(submission.id)
+                except TransactionManagementError:
+                    self.fail("TransactionManagementError was raised")

--- a/onadata/libs/utils/osm.py
+++ b/onadata/libs/utils/osm.py
@@ -196,9 +196,8 @@ def save_osm_data(instance_id):
                 except IntegrityError:
                     with transaction.atomic():
                         osm_data = OsmData.objects.exclude(
-                                    xml=osm_xml).filter(
-                                        instance=instance,
-                                        field_name=field_name).first()
+                            xml=osm_xml).filter(
+                            instance=instance, field_name=field_name).first()
                         if osm_data:
                             osm_data.xml = osm_xml
                             osm_data.osm_id = osmd['osm_id']

--- a/onadata/libs/utils/osm.py
+++ b/onadata/libs/utils/osm.py
@@ -6,7 +6,7 @@ from celery import task
 from django.contrib.gis.geos import (GeometryCollection, LineString, Point,
                                      Polygon)
 from django.contrib.gis.geos.error import GEOSException
-from django.db import IntegrityError, models
+from django.db import IntegrityError, models, transaction
 from lxml import etree
 
 from onadata.apps.logger.models.attachment import Attachment
@@ -182,26 +182,31 @@ def save_osm_data(instance_id):
             osm_list = parse_osm(osm_xml, include_osm_id=True)
             for osmd in osm_list:
                 try:
-                    osm_data = OsmData(
-                        instance=instance,
-                        xml=osm_xml,
-                        osm_id=osmd['osm_id'],
-                        osm_type=osmd['osm_type'],
-                        tags=osmd['tags'],
-                        geom=GeometryCollection(osmd['geom']),
-                        filename=filename,
-                        field_name=field_name)
-                    osm_data.save()
+                    with transaction.atomic():
+                        osm_data = OsmData(
+                            instance=instance,
+                            xml=osm_xml,
+                            osm_id=osmd['osm_id'],
+                            osm_type=osmd['osm_type'],
+                            tags=osmd['tags'],
+                            geom=GeometryCollection(osmd['geom']),
+                            filename=filename,
+                            field_name=field_name)
+                        osm_data.save()
                 except IntegrityError:
-                    osm_data = OsmData.objects.get(
-                        instance=instance, field_name=field_name)
-                    osm_data.xml = osm_xml
-                    osm_data.osm_id = osmd['osm_id']
-                    osm_data.osm_type = osmd['osm_type']
-                    osm_data.tags = osmd['tags']
-                    osm_data.geom = GeometryCollection(osmd['geom'])
-                    osm_data.filename = filename
-                    osm_data.save()
+                    with transaction.atomic():
+                        osm_data = OsmData.objects.exclude(
+                                    xml=osm_xml).filter(
+                                        instance=instance,
+                                        field_name=field_name).first()
+                        if osm_data:
+                            osm_data.xml = osm_xml
+                            osm_data.osm_id = osmd['osm_id']
+                            osm_data.osm_type = osmd['osm_type']
+                            osm_data.tags = osmd['tags']
+                            osm_data.geom = GeometryCollection(osmd['geom'])
+                            osm_data.filename = filename
+                            osm_data.save()
         instance.save()
         trigger_webhook.send(sender=instance.__class__, instance=instance)
 


### PR DESCRIPTION
Use nexted transaction.atomic() blocks when doing new queries inside
save_osm_data so that a TransactionManagementError is not raised, especially
in cases where we catch an IntegrityError

Fix: #1202 