### PR TITLE
Use File Size to Determine Whether To Do csv_import Asynchronously

### DIFF
--- a/onadata/apps/api/tests/viewsets/test_xform_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_xform_viewset.py
@@ -1850,7 +1850,7 @@ class TestXFormViewSet(TestAbstractViewSet):
             self.assertEqual(response.data.get('updates'), 0)
 
     @override_settings(CELERY_ALWAYS_EAGER=True)
-    @override_settings(CSV_ROW_IMPORT_ASYNC_THRESHOLD=5)
+    @override_settings(CSV_FILESIZE_IMPORT_ASYNC_THRESHOLD=20)
     def test_csv_import_async(self):
         with HTTMock(enketo_mock):
             xls_path = os.path.join(settings.PROJECT_ROOT, "apps", "main",
@@ -1902,7 +1902,7 @@ class TestXFormViewSet(TestAbstractViewSet):
     @patch('onadata.apps.api.viewsets.xform_viewset.submit_csv_async')
     def test_raise_error_when_task_is_none(self, mock_submit_csv_async):
         with HTTMock(enketo_mock):
-            settings.CSV_ROW_IMPORT_ASYNC_THRESHOLD = 5
+            settings.CSV_FILESIZE_IMPORT_ASYNC_THRESHOLD = 20
             mock_submit_csv_async.delay.return_value = None
             self._publish_xls_form_to_project()
             view = XFormViewSet.as_view({'post': 'csv_import'})
@@ -1917,7 +1917,7 @@ class TestXFormViewSet(TestAbstractViewSet):
     @patch('onadata.apps.api.viewsets.xform_viewset.submit_csv_async')
     def test_import_csv_asynchronously(self, mock_submit_csv_async):
         with HTTMock(enketo_mock):
-            settings.CSV_ROW_IMPORT_ASYNC_THRESHOLD = 5
+            settings.CSV_FILESIZE_IMPORT_ASYNC_THRESHOLD = 20
             self._publish_xls_form_to_project()
             view = XFormViewSet.as_view({'post': 'csv_import'})
             csv_import = fixtures_path('good.csv')

--- a/onadata/apps/api/viewsets/xform_viewset.py
+++ b/onadata/apps/api/viewsets/xform_viewset.py
@@ -569,8 +569,8 @@ class XFormViewSet(AnonymousUserPublicFormsMixin,
             if csv_file is None:
                 resp.update({u'error': u'csv_file field empty'})
             else:
-                num_rows = sum(1 for row in csv_file) - 1
-                if num_rows < settings.CSV_ROW_IMPORT_ASYNC_THRESHOLD:
+                size_threshold = settings.CSV_FILESIZE_IMPORT_ASYNC_THRESHOLD
+                if csv_file.size < size_threshold:
                     resp.update(submit_csv(request.user.username,
                                            self.object, csv_file))
                 else:

--- a/onadata/settings/common.py
+++ b/onadata/settings/common.py
@@ -427,7 +427,7 @@ BROKER_URL = 'amqp://guest:guest@localhost:5672/'
 CELERY_RESULT_BACKEND = "amqp"  # telling Celery to report results to RabbitMQ
 CELERY_ALWAYS_EAGER = False
 CELERY_IMPORTS = ('onadata.libs.utils.csv_import',)
-CSV_ROW_IMPORT_ASYNC_THRESHOLD = 100
+CSV_FILESIZE_IMPORT_ASYNC_THRESHOLD = 100000  # Bytes
 GOOGLE_SHEET_UPLOAD_BATCH = 1000
 
 # duration to keep zip exports before deletion (in seconds)


### PR DESCRIPTION
Use file size because it represents a better estimate of how long
processing the file would take than simply counting the number of
rows in the csv.

Set default file size threshold at 100kB loosely based on:
https://www.postgresql.org/message-id/4D2F2C71.8080805%40dndg.it

Fix: #1224