### PR TITLE
KJ | JW: Test That SAV Exports With Duplicate Column Names Fail

### DIFF
--- a/onadata/apps/viewer/tests/test_tasks.py
+++ b/onadata/apps/viewer/tests/test_tasks.py
@@ -9,8 +9,6 @@ from onadata.apps.viewer.models.export import Export
 from onadata.apps.viewer.tasks import create_async_export
 from onadata.apps.viewer.tasks import mark_expired_pending_exports_as_failed
 from onadata.apps.viewer.tasks import delete_expired_failed_exports
-from onadata.apps.viewer.models import DataDictionary
-from onadata.libs.utils.user_auth import get_user_default_project
 
 
 class TestExportTasks(TestBase):
@@ -44,34 +42,6 @@ class TestExportTasks(TestBase):
             self.assertTrue(export.id)
             self.assertIn("username", options)
             self.assertEquals(options.get("id_string"), self.xform.id_string)
-
-    def test_zipped_sav_export_with_duplicate_column_name(self):
-        """
-        Test that SAV  exports with duplicate column names actually fail
-        """
-        md = """
-        | survey |              |          |                 |
-        |        | type         | name     | label           |
-        |        | text         | Sport    | Which Sport     |
-        |        | text         | sport    | Which sport     |
-        """
-        survey = self.md_to_pyxform_survey(md, {'name': 'sports'})
-
-        project = get_user_default_project(self.user)
-        xform = DataDictionary(created_by=self.user, user=self.user,
-                               xml=survey.to_xml(), json=survey.to_json(),
-                               project=project)
-        xform.save()
-
-        export_type = Export.SAV_ZIP_EXPORT
-
-        options = {"group_delimiter": "/",
-                   "remove_group_name": False,
-                   "split_select_multiples": True}
-
-        result = create_async_export(xform, export_type, None, False, options)
-        export = result[0]
-        self.assertEquals(export.internal_status, Export.FAILED)
 
     def test_mark_expired_pending_exports_as_failed(self):
         self._publish_transportation_form_and_submit_instance()

--- a/onadata/libs/utils/export_builder.py
+++ b/onadata/libs/utils/export_builder.py
@@ -961,7 +961,7 @@ class ExportBuilder(object):
             col_len_diff = len(column) - 64
             column = column[:-col_len_diff]
 
-        if column in columns:
+        if column.lower() in (t.lower() for t in columns):
             if len(column) > 59:
                 column = column[:-5]
             column = column + "@" + str(uuid.uuid4()).split("-")[1]

--- a/onadata/libs/utils/export_tools.py
+++ b/onadata/libs/utils/export_tools.py
@@ -3,6 +3,7 @@ import json
 import math
 import os
 import re
+import sys
 import time
 from datetime import datetime
 from datetime import timedelta
@@ -29,7 +30,7 @@ from onadata.apps.viewer.models.parsed_instance import query_data
 from onadata.libs.exceptions import J2XException, NoRecordsFoundError
 from onadata.libs.utils.common_tags import (DATAVIEW_EXPORT,
                                             GROUPNAME_REMOVED_FLAG)
-from onadata.libs.utils.common_tools import str_to_bool
+from onadata.libs.utils.common_tools import str_to_bool, report_exception
 from onadata.libs.utils.export_builder import ExportBuilder
 from onadata.libs.utils.model_tools import (get_columns_with_hxl,
                                             queryset_iterator)
@@ -233,7 +234,7 @@ def generate_export(export_type, xform, export_id=None, options=None,
         export.error_message = str(e)
         export.internal_status = Export.FAILED
         export.save()
-
+        report_exception("SAV Export Failure", e, sys.exc_info())
         return export
 
     # generate filename


### PR DESCRIPTION
Add a test to ascertain that SAV exports fail when the form has duplicate column names.

Fix: #1216 