### PR TITLE
Display Links To Images With Spaces In Filenames Correctly

### DIFF
--- a/onadata/apps/api/tests/viewsets/test_data_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_data_viewset.py
@@ -1239,6 +1239,7 @@ class TestDataViewSet(TestBase):
                 u'mimetype': attachment.mimetype,
                 u'instance': attachment.instance.pk,
                 u'filename': attachment.media_file.name,
+                u'name': attachment.name,
                 u'id': attachment.pk,
                 u'xform': xform.id}
             ],
@@ -1270,6 +1271,7 @@ class TestDataViewSet(TestBase):
                 u'mimetype': attachment.mimetype,
                 u'instance': attachment.instance.pk,
                 u'filename': attachment.media_file.name,
+                u'name': attachment.name,
                 u'id': attachment.pk,
                 u'xform': xform.id
             }]
@@ -1308,6 +1310,7 @@ class TestDataViewSet(TestBase):
                 u'mimetype': self.attachment.mimetype,
                 u'instance': self.attachment.instance.pk,
                 u'filename': self.attachment.media_file.name,
+                u'name': self.attachment.name,
                 u'id': self.attachment.pk,
                 u'xform': self.xform.id}
             ],

--- a/onadata/apps/logger/models/instance.py
+++ b/onadata/apps/logger/models/instance.py
@@ -62,6 +62,7 @@ def _get_attachments_from_instance(instance):
         attachment['medium_download_url'] = get_attachment_url(a, 'medium')
         attachment['mimetype'] = a.mimetype
         attachment['filename'] = a.media_file.name
+        attachment['name'] = a.name
         attachment['instance'] = a.instance.pk
         attachment['xform'] = instance.xform.id
         attachment['id'] = a.id

--- a/onadata/libs/tests/utils/test_export_tools.py
+++ b/onadata/libs/tests/utils/test_export_tools.py
@@ -268,7 +268,7 @@ class TestExportTools(TestBase):
             'photo_type_in_repeat_group.xlsx')
         self._publish_xls_file_and_set_xform(path)
 
-        filename = u'bob/attachments/1 2 3.jpg'
+        filename = u'bob/attachments/1_2_3.jpg'
         download_url = u'/api/v1/files/1?filename=%s' % filename
 
         # used a smaller version of row because we only using _attachmets key
@@ -298,7 +298,7 @@ class TestExportTools(TestBase):
 
         current_site = Site.objects.get_current()
         url = 'http://%s%s' % (current_site.domain, download_url)
-        self.assertNotEqual(url, val_or_url)
+        self.assertEqual(url, val_or_url)
 
     def test_parse_request_export_options(self):
         request = self.factory.get(

--- a/onadata/libs/tests/utils/test_export_tools.py
+++ b/onadata/libs/tests/utils/test_export_tools.py
@@ -223,6 +223,7 @@ class TestExportTools(TestBase):
                 u'medium_download_url': u'%s&suffix=medium' % download_url,
                 u'download_url': download_url,
                 u'filename': filename,
+                u'name': '123.jpg',
                 u'instance': 1,
                 u'small_download_url': u'%s&suffix=small' % download_url,
                 u'id': 1,
@@ -260,6 +261,44 @@ class TestExportTools(TestBase):
                                                  media_xpaths, attachment_list)
         self.assertTrue(val_or_url)
         self.assertEqual(value, val_or_url)
+
+    def test_get_attachment_uri_for_filename_with_space(self):
+        path = os.path.join(
+            os.path.dirname(__file__), 'fixtures',
+            'photo_type_in_repeat_group.xlsx')
+        self._publish_xls_file_and_set_xform(path)
+
+        filename = u'bob/attachments/1 2 3.jpg'
+        download_url = u'/api/v1/files/1?filename=%s' % filename
+
+        # used a smaller version of row because we only using _attachmets key
+        row = {
+            u'_attachments': [{
+                u'mimetype': u'image/jpeg',
+                u'medium_download_url': u'%s&suffix=medium' % download_url,
+                u'download_url': download_url,
+                u'filename': filename,
+                u'name': '1 2 3.jpg',
+                u'instance': 1,
+                u'small_download_url': u'%s&suffix=small' % download_url,
+                u'id': 1,
+                u'xform': 1
+            }]
+        }  # yapf: disable
+
+        # when include_images is True, you get the attachment url
+        media_xpaths = ['photo']
+        attachment_list = None
+        key = 'photo'
+        value = u'1 2 3.jpg'
+        val_or_url = get_value_or_attachment_uri(key, value, row, self.xform,
+                                                 media_xpaths, attachment_list)
+
+        self.assertTrue(val_or_url)
+
+        current_site = Site.objects.get_current()
+        url = 'http://%s%s' % (current_site.domain, download_url)
+        self.assertNotEqual(url, val_or_url)
 
     def test_parse_request_export_options(self):
         request = self.factory.get(

--- a/onadata/libs/utils/export_builder.py
+++ b/onadata/libs/utils/export_builder.py
@@ -77,10 +77,8 @@ def get_value_or_attachment_uri(
             if a.get('filename') and a.get('filename').endswith(value)
         ]
         if attachments:
-            value = current_site_url(
-                attachments[0].get('download_url', '')
-            )
-
+            value = current_site_url(attachments[0].get('download_url', ''))
+            value = value.replace(" ", "_")
     return value
 
 

--- a/onadata/libs/utils/export_builder.py
+++ b/onadata/libs/utils/export_builder.py
@@ -74,11 +74,11 @@ def get_value_or_attachment_uri(
         attachments = [
             a
             for a in row.get(ATTACHMENTS, attachment_list or [])
-            if a.get('filename') and a.get('filename').endswith(value)
+            if a.get('name') == value
         ]
         if attachments:
             value = current_site_url(attachments[0].get('download_url', ''))
-            value = value.replace(" ", "_")
+
     return value
 
 

--- a/onadata/libs/utils/logger_tools.py
+++ b/onadata/libs/utils/logger_tools.py
@@ -196,7 +196,7 @@ def update_attachment_tracking(instance):
     instance.media_count = instance.attachments_count
     instance.media_all_received = instance.media_count == instance.total_media
     instance.save(update_fields=['total_media', 'media_count',
-                                 'media_all_received'])
+                                 'media_all_received', 'json'])
 
 
 def save_attachments(xform, instance, media_files):


### PR DESCRIPTION
- Added 'name' to attachment
- Edited function that returns attachment uri to replace
 spaces with underscores