### PR TITLE
Deal With Duplicate Fields in Different SAV Sections

### DIFF
--- a/onadata/apps/viewer/tests/test_export_builder.py
+++ b/onadata/apps/viewer/tests/test_export_builder.py
@@ -838,7 +838,7 @@ class TestExportBuilder(TestBase):
         temp_xls_file.seek(0)
         # check that values for red\'s and blue\'s are set to true
         wb = load_workbook(temp_xls_file.name)
-        children_sheet = wb.get_sheet_by_name("children.info")
+        children_sheet = wb["children.info"]
         data = dict([(r[0].value, r[1].value) for r in children_sheet.columns])
         self.assertTrue(data[u'children.info/fav_colors/red\'s'])
         self.assertTrue(data[u'children.info/fav_colors/blue\'s'])
@@ -871,7 +871,7 @@ class TestExportBuilder(TestBase):
             columns_with_hxl=columns_with_hxl)
         temp_xls_file.seek(0)
         wb = load_workbook(temp_xls_file.name)
-        children_sheet = wb.get_sheet_by_name("hxl_example")
+        children_sheet = wb["hxl_example"]
         self.assertTrue(children_sheet)
 
         # we pick the second row because the first row has xform fieldnames
@@ -1331,7 +1331,7 @@ class TestExportBuilder(TestBase):
         wb = load_workbook(filename)
 
         # get the children's sheet
-        ws1 = wb.get_sheet_by_name('childrens_survey_with_a_very_l1')
+        ws1 = wb['childrens_survey_with_a_very_l1']
 
         # parent_table is in cell K2
         parent_table_name = ws1['K2'].value
@@ -1339,7 +1339,7 @@ class TestExportBuilder(TestBase):
         self.assertEqual(parent_table_name, expected_parent_table_name)
 
         # get cartoons sheet
-        ws2 = wb.get_sheet_by_name('childrens_survey_with_a_very_l2')
+        ws2 = wb['childrens_survey_with_a_very_l2']
         parent_table_name = ws2['G2'].value
         expected_parent_table_name = 'childrens_survey_with_a_very_l1'
         self.assertEqual(parent_table_name, expected_parent_table_name)
@@ -1587,7 +1587,7 @@ class TestExportBuilder(TestBase):
         temp_xls_file.seek(0)
         # check that values for red\'s and blue\'s are set to true
         wb = load_workbook(temp_xls_file.name)
-        children_sheet = wb.get_sheet_by_name("children.info")
+        children_sheet = wb["children.info"]
         data = dict([(r[0].value, r[1].value) for r in children_sheet.columns])
         self.assertTrue(data[u"fav_colors/red's"])
         self.assertTrue(data[u"fav_colors/blue's"])
@@ -1660,7 +1660,7 @@ class TestExportBuilder(TestBase):
         temp_xls_file.seek(0)
         # check that values for red\'s and blue\'s are set to true
         wb = load_workbook(temp_xls_file.name)
-        children_sheet = wb.get_sheet_by_name("children.info")
+        children_sheet = wb["children.info"]
         labels = dict([(r[0].value, r[1].value)
                        for r in children_sheet.columns])
         self.assertEqual(labels[u'name.first'], '3.1 Childs name')
@@ -1689,7 +1689,7 @@ class TestExportBuilder(TestBase):
         temp_xls_file.seek(0)
         # check that values for red\'s and blue\'s are set to true
         wb = load_workbook(temp_xls_file.name)
-        children_sheet = wb.get_sheet_by_name("children.info")
+        children_sheet = wb["children.info"]
         data = dict([(r[0].value, r[1].value) for r in children_sheet.columns])
         self.assertEqual(data['3.1 Childs name'], 'Mike')
         self.assertEqual(data['3.2 Child age'], 5)
@@ -1912,13 +1912,13 @@ class TestExportBuilder(TestBase):
         export_builder.to_xls_export(temp_xls_file.name, self.data)
         temp_xls_file.seek(0)
         wb = load_workbook(temp_xls_file.name)
-        childrens_survey_sheet = wb.get_sheet_by_name("childrens_survey_en")
+        childrens_survey_sheet = wb["childrens_survey_en"]
         labels = dict([(r[0].value, r[1].value)
                        for r in childrens_survey_sheet.columns])
         self.assertEqual(labels[u'name'], '1. What is your name?')
         self.assertEqual(labels[u'age'], '2. How old are you?')
 
-        children_sheet = wb.get_sheet_by_name("children")
+        children_sheet = wb["children"]
         labels = dict([(r[0].value, r[1].value)
                        for r in children_sheet.columns])
         self.assertEqual(labels['fav_colors/red'], 'fav_colors/Red')
@@ -1940,13 +1940,13 @@ class TestExportBuilder(TestBase):
         export_builder.to_xls_export(temp_xls_file.name, self.data)
         temp_xls_file.seek(0)
         wb = load_workbook(temp_xls_file.name)
-        childrens_survey_sheet = wb.get_sheet_by_name("childrens_survey_sw")
+        childrens_survey_sheet = wb["childrens_survey_sw"]
         labels = dict([(r[0].value, r[1].value)
                        for r in childrens_survey_sheet.columns])
         self.assertEqual(labels[u'name'], '1. Jina lako ni?')
         self.assertEqual(labels[u'age'], '2. Umri wako ni?')
 
-        children_sheet = wb.get_sheet_by_name("children")
+        children_sheet = wb["children"]
         labels = dict([(r[0].value, r[1].value)
                        for r in children_sheet.columns])
         self.assertEqual(labels['fav_colors/red'], 'fav_colors/Nyekundu')

--- a/onadata/libs/tests/utils/test_export_tools.py
+++ b/onadata/libs/tests/utils/test_export_tools.py
@@ -508,7 +508,6 @@ class TestExportTools(TestBase):
         expected_data = {'fruit': {'orange': 'Orange', 'mango': 'Mango'}}
         self.assertEqual(export_builder._get_sav_value_labels(), expected_data)
 
-        del export_builder._sav_value_labels
         export_builder.dd._default_language = 'Swahili'
         expected_data = {'fruit': {'orange': 'Chungwa', 'mango': 'Maembe'}}
         self.assertEqual(export_builder._get_sav_value_labels(), expected_data)

--- a/onadata/libs/utils/export_builder.py
+++ b/onadata/libs/utils/export_builder.py
@@ -795,7 +795,8 @@ class ExportBuilder(object):
         self._sav_value_labels = {}
 
         for q in choice_questions:
-            if q.get_abbreviated_xpath() not in xpath_var_names:
+            if (xpath_var_names and
+                    q.get_abbreviated_xpath() not in xpath_var_names):
                 continue
             var_name = xpath_var_names.get(q.get_abbreviated_xpath()) if \
                 xpath_var_names else q['name']

--- a/onadata/libs/utils/export_builder.py
+++ b/onadata/libs/utils/export_builder.py
@@ -814,8 +814,7 @@ class ExportBuilder(object):
                 if q.type != u'select all that apply' and is_numeric:
                     try:
                         name = float(name) \
-                            if (not name.startswith('0') and
-                                float(name) > int(name)) else int(name)
+                            if (float(name) > int(name)) else int(name)
                     except ValueError:
                         pass
                 label = self.get_choice_label_from_dict(choice['label'])

--- a/onadata/libs/utils/export_builder.py
+++ b/onadata/libs/utils/export_builder.py
@@ -791,34 +791,35 @@ class ExportBuilder(object):
                 'available': {0: 'No', 1: 'Yes'}
             }
         """
-        if not hasattr(self, '_sav_value_labels'):
-            choice_questions = self.dd.get_survey_elements_with_choices()
-            self._sav_value_labels = {}
+        choice_questions = self.dd.get_survey_elements_with_choices()
+        self._sav_value_labels = {}
 
-            for q in choice_questions:
-                var_name = xpath_var_names.get(q.get_abbreviated_xpath()) if \
-                    xpath_var_names else q['name']
-                choices = q.to_json_dict().get('children')
-                if choices is None:
-                    choices = self.survey.get('choices')
-                    if choices is not None and q.get('itemset'):
-                        choices = choices.get(q.get('itemset'))
-                _value_labels = {}
-                is_numeric = is_all_numeric([c['name'] for c in choices])
-                for choice in choices:
-                    name = choice['name'].strip()
-                    # should skip select multiple and zero padded numbers e.g
-                    # 009 or 09, they should be treated as strings
-                    if q.type != u'select all that apply' and is_numeric:
-                        try:
-                            name = float(name) \
-                                if (not name.startswith('0') and
-                                    float(name) > int(name)) else int(name)
-                        except ValueError:
-                            pass
-                    label = self.get_choice_label_from_dict(choice['label'])
-                    _value_labels[name] = label.strip()
-                self._sav_value_labels[var_name or q['name']] = _value_labels
+        for q in choice_questions:
+            if q.get_abbreviated_xpath() not in xpath_var_names:
+                continue
+            var_name = xpath_var_names.get(q.get_abbreviated_xpath()) if \
+                xpath_var_names else q['name']
+            choices = q.to_json_dict().get('children')
+            if choices is None:
+                choices = self.survey.get('choices')
+                if choices is not None and q.get('itemset'):
+                    choices = choices.get(q.get('itemset'))
+            _value_labels = {}
+            is_numeric = is_all_numeric([c['name'] for c in choices])
+            for choice in choices:
+                name = choice['name'].strip()
+                # should skip select multiple and zero padded numbers e.g
+                # 009 or 09, they should be treated as strings
+                if q.type != u'select all that apply' and is_numeric:
+                    try:
+                        name = float(name) \
+                            if (not name.startswith('0') and
+                                float(name) > int(name)) else int(name)
+                    except ValueError:
+                        pass
+                label = self.get_choice_label_from_dict(choice['label'])
+                _value_labels[name] = label.strip()
+            self._sav_value_labels[var_name or q['name']] = _value_labels
 
         return self._sav_value_labels
 
@@ -899,6 +900,7 @@ class ExportBuilder(object):
         xpath_var_names = dict([(xpath, var_name)
                                 for field, label, xpath, var_name
                                 in fields_and_labels])
+
         all_value_labels = self._get_sav_value_labels(xpath_var_names)
 
         duplicate_names = []  # list of (xpath, var_name)

--- a/onadata/libs/utils/export_builder.py
+++ b/onadata/libs/utils/export_builder.py
@@ -792,7 +792,7 @@ class ExportBuilder(object):
             }
         """
         choice_questions = self.dd.get_survey_elements_with_choices()
-        self._sav_value_labels = {}
+        sav_value_labels = {}
 
         for q in choice_questions:
             if (xpath_var_names and
@@ -820,9 +820,9 @@ class ExportBuilder(object):
                         pass
                 label = self.get_choice_label_from_dict(choice['label'])
                 _value_labels[name] = label.strip()
-            self._sav_value_labels[var_name or q['name']] = _value_labels
+            sav_value_labels[var_name or q['name']] = _value_labels
 
-        return self._sav_value_labels
+        return sav_value_labels
 
     def _get_var_name(self, title, var_names):
         """GET valid SPSS varName.


### PR DESCRIPTION
- Get correct value labels for select questions with the same name across different SAV sections.
- Ensure that we do not attempt to handle duplicate fields that appear across SAV sections.  They are not an issue because they represent different SPSS 'sheets'.

Fix: #1226 