### PR TITLE
Floip handle publishing exceptions

### DIFF
--- a/onadata/apps/api/tests/fixtures/flow-results-missing-resource-name.json
+++ b/onadata/apps/api/tests/fixtures/flow-results-missing-resource-name.json
@@ -1,0 +1,93 @@
+{
+   "data":{
+      "type":"packages",
+      "attributes":{
+         "profile":"flow-results-package",
+         "name":"standard_test_survey",
+         "flow-results-specification":"1.0.0-rc1",
+         "created":"2015-11-26 02:59:24+00:00",
+         "modified":"2017-12-04 15:54:44+00:00",
+         "id":null,
+         "title":"Standard Test Survey",
+         "resources":[
+            {
+               "path":null,
+               "api-data-url":null,
+               "mediatype":"application/json",
+               "encoding":"utf-8",
+               "schema":{
+                  "language":"eng",
+                  "fields":[
+                     {
+                        "name":"timestamp",
+                        "title":"Timestamp",
+                        "type":"datetime"
+                     },
+                     {
+                        "name":"row_id",
+                        "title":"Row ID",
+                        "type":"string"
+                     },
+                     {
+                        "name":"contact_id",
+                        "title":"Contact ID",
+                        "type":"string"
+                     },
+                     {
+                        "name":"question_id",
+                        "title":"Question ID",
+                        "type":"string"
+                     },
+                     {
+                        "name":"response_id",
+                        "title":"Response ID",
+                        "type":"any"
+                     },
+                     {
+                        "name":"response_metadata",
+                        "title":"Response Metadata",
+                        "type":"object"
+                     }
+                  ],
+                  "questions":[
+                     {
+                        "1448506769745_42":{
+                           "type":"select_one",
+                           "label":"Are you a woman or a man?",
+                           "type_options":{
+                              "choices":[
+                                 "Woman",
+                                 "Man",
+                                 "Other"
+                              ]
+                           }
+                        }
+                     },
+                     {
+                        "1448506773018_89":{
+                           "type":"numeric",
+                           "label":"How old are you? Please enter your age in years.",
+                           "type_options":{
+                              "range":[
+                                 -99,
+                                 99
+                              ]
+                           }
+                        }
+                     },
+                     {
+                        "1448506774930_30":{
+                           "type":"open",
+                           "label":"What was the best thing that happened to you today?",
+                           "type_options":{
+
+                           }
+                        }
+                     }
+                  ]
+               }
+            }
+         ]
+      }
+   }
+}

--- a/onadata/apps/api/tests/fixtures/flow-results-number-question-names.json
+++ b/onadata/apps/api/tests/fixtures/flow-results-number-question-names.json
@@ -1,0 +1,88 @@
+{
+   "data":{
+      "type":"packages",
+      "attributes":{
+         "profile":"flow-results-package",
+         "name":"standard_test_survey",
+         "flow-results-specification":"1.0.0-rc1",
+         "created":"2015-11-26 02:59:24+00:00",
+         "modified":"2017-12-04 15:54:44+00:00",
+         "id":null,
+         "title":"Standard Test Survey",
+         "resources":[
+            {
+               "path":null,
+               "api-data-url":null,
+               "name":"standard_test_survey-data",
+               "mediatype":"application/json",
+               "encoding":"utf-8",
+               "schema":{
+                  "language":"eng",
+                  "fields":[
+                     {
+                        "name":"timestamp",
+                        "title":"Timestamp",
+                        "type":"datetime"
+                     },
+                     {
+                        "name":"row_id",
+                        "title":"Row ID",
+                        "type":"string"
+                     },
+                     {
+                        "name":"contact_id",
+                        "title":"Contact ID",
+                        "type":"string"
+                     },
+                     {
+                        "name":"question_id",
+                        "title":"Question ID",
+                        "type":"string"
+                     },
+                     {
+                        "name":"response_id",
+                        "title":"Response ID",
+                        "type":"any"
+                     },
+                     {
+                        "name":"response_metadata",
+                        "title":"Response Metadata",
+                        "type":"object"
+                     }
+                  ],
+                  "questions":{
+                        "1448506769745_42":{
+                           "type":"select_one",
+                           "label":"Are you a woman or a man?",
+                           "type_options":{
+                              "choices":[
+                                 "Woman",
+                                 "Man",
+                                 "Other"
+                              ]
+                           }
+                     },
+                        "1448506773018_89":{
+                           "type":"numeric",
+                           "label":"How old are you? Please enter your age in years.",
+                           "type_options":{
+                              "range":[
+                                 -99,
+                                 99
+                              ]
+                           }
+                     },
+                        "1448506774930_30":{
+                           "type":"open",
+                           "label":"What was the best thing that happened to you today?",
+                           "type_options":{
+
+                           }
+                     }
+                  }
+               }
+            }
+         ]
+      }
+   }
+}

--- a/onadata/apps/api/tests/viewsets/test_floip_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_floip_viewset.py
@@ -70,3 +70,28 @@ class TestFloipViewSet(TestAbstractViewSet):
             self.assertEqual(response['Location'],
                              'http://testserver/api/v1/flow-results/packages/'
                              + floip_data['id'] + '/responses')
+
+    def test_publish_missing_resource_name(self):  # pylint: disable=C0103
+        """
+        Test publishing a descriptor with missing resource name.
+        """
+        view = FloipViewSet.as_view({'post': 'create'})
+        path = os.path.join(
+            os.path.dirname(__file__), "../", "fixtures",
+            "flow-results-missing-resource-name.json")
+        with open(path) as json_file:
+            post_data = json_file.read()
+            request = self.factory.post(
+                '/',
+                data=post_data,
+                content_type='application/vnd.api+json',
+                **self.extra)
+            response = view(request)
+            response.render()
+            self.assertEqual(response.status_code, 400)
+            self.assertEqual(response['Content-Type'],
+                             'application/vnd.api+json')
+            self.assertEqual(
+                response.data['text'],
+                "The data resource 'standard_test_survey-data'"
+                " is not defined.")

--- a/onadata/apps/api/tests/viewsets/test_floip_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_floip_viewset.py
@@ -95,3 +95,28 @@ class TestFloipViewSet(TestAbstractViewSet):
                 response.data['text'],
                 "The data resource 'standard_test_survey-data'"
                 " is not defined.")
+
+    def test_publish_number_question_names(self):  # pylint: disable=C0103
+        """
+        Test publishing a descriptor with question identifiers that start with
+        a number.
+        """
+        view = FloipViewSet.as_view({'post': 'create'})
+        path = os.path.join(
+            os.path.dirname(__file__), "../", "fixtures",
+            "flow-results-number-question-names.json")
+        with open(path) as json_file:
+            post_data = json_file.read()
+            request = self.factory.post(
+                '/',
+                data=post_data,
+                content_type='application/vnd.api+json',
+                **self.extra)
+            response = view(request)
+            response.render()
+            self.assertEqual(response.status_code, 400)
+            self.assertEqual(response['Content-Type'],
+                             'application/vnd.api+json')
+            self.assertIn(
+                u"The name '1448506769745_42' is an invalid xml tag",
+                response.data['text'])

--- a/onadata/libs/serializers/floip_serializer.py
+++ b/onadata/libs/serializers/floip_serializer.py
@@ -147,7 +147,7 @@ class FloipSerializer(serializers.HyperlinkedModelSerializer):
         if isinstance(instance, XForm):
             return instance
 
-        raise ValidationError(instance)
+        raise serializers.ValidationError(instance)
 
     def to_representation(self, instance):
         request = self.context['request']

--- a/onadata/libs/utils/logger_tools.py
+++ b/onadata/libs/utils/logger_tools.py
@@ -464,16 +464,14 @@ def store_temp_file(data):
 
 
 def publish_form(callback):
+    """
+    Calls the callback function to publish a XLSForm and returns appropriate
+    message depending on exception throw during publishing of a XLSForm.
+    """
     try:
         return callback()
     except (PyXFormError, XLSFormError) as e:
-        msg = unicode(e)
-
-        if 'invalid xml tag' in msg:
-            msg = _(u"Invalid file name; Names must begin with a letter, "
-                    u"colon, or underscore, subsequent characters can include"
-                    u" numbers, dashes,periods and with no spacing.")
-        return {'type': 'alert-error', 'text': msg}
+        return {'type': 'alert-error', 'text': unicode(e)}
     except IntegrityError as e:
         return {
             'type': 'alert-error',


### PR DESCRIPTION
Ensures we only return 400 error - raising `serializer.ValidationError` ensures that on form publishing any errors that occur are reported to the user in a manner they can understand and address.