### PR TITLE
Add slack support

### DIFF
--- a/onadata/apps/restservice/__init__.py
+++ b/onadata/apps/restservice/__init__.py
@@ -1,4 +1,5 @@
 SERVICE_CHOICES = ((u'f2dhis2', u'f2dhis2'), (u'generic_json', u'JSON POST'),
                    (u'generic_xml', u'XML POST'), (u'bamboo', u'bamboo'),
                    (u'textit', u'TextIt POST'),
-                   (u'google_sheets', u'Google Sheet'))
+                   (u'google_sheets', u'Google Sheet'),
+                   (u'slack', u'slack'))

--- a/onadata/apps/restservice/services/slack.py
+++ b/onadata/apps/restservice/services/slack.py
@@ -1,0 +1,35 @@
+import json
+
+import requests
+from six import string_types
+
+from onadata.apps.main.models import MetaData
+from onadata.apps.restservice.RestServiceInterface import RestServiceInterface
+from onadata.libs.utils.common_tags import TEXTIT
+from onadata.settings.common import METADATA_SEPARATOR
+
+
+class ServiceDefinition(RestServiceInterface):
+    id = SLACK
+    verbose_name = u'Slack Webhook'
+    channel = "#general"
+    username = "Ona Bot"
+    avatar = 'https://ona.io/img/favicon-32x32.png'
+
+    def send(self, url, submission_instance):
+        """
+        Sends the submission to the configured rest service
+        :param url:
+        :param submission_instance:
+        :return:
+        """
+        
+        ona_data = json.dumps(submission_instance.json)
+        post_data = {
+            "channel": self.channel
+            "username": self.username
+            "icon_url": self.avatar
+            "text": "A new form {form_name} has been submitted by {form_user}".format(form_name=ona_data[], form_user=ona_data[])
+        }
+        headers = {"Content-Type": "application/json"}
+        requests.post(url, headers=headers, data=post_data)

--- a/onadata/apps/restservice/tests/test_restservice.py
+++ b/onadata/apps/restservice/tests/test_restservice.py
@@ -165,3 +165,11 @@ class RestServiceTest(TestBase):
 
         self.assertEquals(expected_data,
                           service.clean_keys_of_slashes(test_data))
+
+
+    @override_settings(CELERY_ALWAYS_EAGER=True)
+    @patch('requests.post')
+    def test_slack(self, mock_http):
+        service_url = 'https://hooks.slack.com/services/This/Is/Test'
+        self._add_rest_service(service_url, 'slack')
+        


### PR DESCRIPTION
This is a WIP. Implementation is incomplete. 

Ressources for slack : https://api.slack.com/docs/message-formatting
https://api.slack.com/docs/messages/builder?msg=%7B"text"%3A"I%20am%20a%20test%20message%20http%3A%2F%2Fslack.com"%2C"username"%3A"Ona%20Bot"%2C"channel"%3A"%23general"%2C"icon_url"%3A"https%3A%2F%2Fona.io%2Fimg%2Ffavicon-32x32.png"%2C"attachments"%3A%5B%7B"text"%3A"And%20here’s%20an%20attachment!"%7D%5D%7D
