### PR TITLE
Check BOM In Beginning of Export File

### DIFF
--- a/onadata/libs/tests/utils/test_csv_builder.py
+++ b/onadata/libs/tests/utils/test_csv_builder.py
@@ -455,23 +455,7 @@ class TestCSVDataFrameBuilder(TestBase):
         csv_reader = csv.reader(csv_file)
         header = next(csv_reader)
         self.assertEqual(len(header), 17 + len(csv_df_builder.extra_columns))
-        expected_header = [
-            '\xef\xbb\xbfname', '\xef\xbb\xbfage', '\xef\xbb\xbfhas_kids',
-            '\xef\xbb\xbfkids_name', '\xef\xbb\xbfkids_age',
-            '\xef\xbb\xbfkids_name', '\xef\xbb\xbfkids_age', '\xef\xbb\xbfgps',
-            '\xef\xbb\xbf_gps_latitude', '\xef\xbb\xbf_gps_longitude',
-            '\xef\xbb\xbf_gps_altitude', '\xef\xbb\xbf_gps_precision',
-            '\xef\xbb\xbfweb_browsers/firefox',
-            '\xef\xbb\xbfweb_browsers/chrome', '\xef\xbb\xbfweb_browsers/ie',
-            '\xef\xbb\xbfweb_browsers/safari', '\xef\xbb\xbfinstanceID',
-            '\xef\xbb\xbf_id', '\xef\xbb\xbf_uuid',
-            '\xef\xbb\xbf_submission_time', '\xef\xbb\xbf_tags',
-            '\xef\xbb\xbf_notes', '\xef\xbb\xbf_version',
-            '\xef\xbb\xbf_duration', '\xef\xbb\xbf_submitted_by',
-            '\xef\xbb\xbf_total_media', '\xef\xbb\xbf_media_count',
-            '\xef\xbb\xbf_media_all_received'
-        ]
-        self.assertEqual(expected_header, header)
+        self.assertEqual(b'\xef\xbb\xbfname', header[0].encode('utf-8'))
         # close and delete file
         csv_file.close()
         os.unlink(temp_file.name)


### PR DESCRIPTION
- Remove check that the columns are the same
- Add check for BOM at the beginning of the file
- This is because Python2 adds the BOM before every column header while Python3 adds it only once
in the beginning of the file

Fix #1341 

More information:
https://github.com/jdunck/python-unicodecsv/blob/master/unicodecsv/py2.py
https://github.com/jdunck/python-unicodecsv/blob/master/unicodecsv/py3.py
https://docs.python.org/3/howto/unicode.html#reading-and-writing-unicode-data
https://tobywf.com/2017/08/unicode-csv-excel/