### PR TITLE
Confirm that deleted osm data does not exist in export

### DIFF
--- a/onadata/libs/tests/utils/test_export_tools.py
+++ b/onadata/libs/tests/utils/test_export_tools.py
@@ -95,7 +95,7 @@ class TestExportTools(TestBase):
                 content = f2.read()
                 self.assertMultiLineEqual(content.strip(), osm.strip())
 
-        # deleted submission
+        # delete submission and check that content is no longer in export
         submission = self.xform.instances.filter().first()
         submission.deleted_at = timezone.now()
         submission.save()
@@ -105,6 +105,7 @@ class TestExportTools(TestBase):
         self.assertTrue(export.is_successful)
         with default_storage.open(export.filepath) as f2:
             content = f2.read()
+            self.assertEqual(content, '')
 
     def test_generate_attachments_zip_export(self):
         filenames = [


### PR DESCRIPTION
Add assert statement to confirm that deleted osm content is not shown in generated export

Fix #776