### PR TITLE
Fix get XForm messaging metadata

### DIFF
--- a/onadata/apps/messaging/backends/mqtt.py
+++ b/onadata/apps/messaging/backends/mqtt.py
@@ -22,7 +22,7 @@ def get_target_metadata(target_obj):
     if target_obj_type == PROJECT:
         metadata['name'] = target_obj.name
     elif target_obj_type == XFORM:
-        metadata['name'] = target_obj.name
+        metadata['name'] = target_obj.title
         metadata['form_id'] = target_obj.id_string
     elif target_obj_type == USER:
         metadata['name'] = target_obj.get_full_name()

--- a/onadata/apps/messaging/tests/test_backends_mqtt.py
+++ b/onadata/apps/messaging/tests/test_backends_mqtt.py
@@ -51,7 +51,7 @@ class TestMQTTBackend(TestCase):
         # XForm objects
         xform = MagicMock()
         xform.pk = 1337
-        xform.name = 'Test Form'
+        xform.title = 'Test Form'
         xform.id_string = 'Test_Form_ID'
         xform._meta.model_name = XFORM
         xform_metadata = {


### PR DESCRIPTION
XForm objects dont have a `name` attribute, they have a `title`.