### PR TITLE
Change upload to location for attachments

### DIFF
--- a/onadata/apps/api/tests/viewsets/test_attachment_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_attachment_viewset.py
@@ -38,7 +38,7 @@ class TestAttachmentViewSet(TestAbstractViewSet):
 
         data = {
             'url': 'http://testserver/api/v1/media/%s' % pk,
-            'field_xpath': None,
+            'field_xpath': 'image1',
             'download_url': attachment_url(self.attachment),
             'small_download_url': attachment_url(self.attachment, 'small'),
             'medium_download_url': attachment_url(self.attachment, 'medium'),

--- a/onadata/apps/api/tests/viewsets/test_briefcase_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_briefcase_viewset.py
@@ -262,8 +262,10 @@ class TestBriefcaseViewSet(test_abstract_viewset.TestAbstractViewSet):
             'view', 'downloadSubmission.xml')
         with codecs.open(download_submission_path, encoding='utf-8') as f:
             text = f.read()
-            text = text.replace(u'{{submissionDate}}',
-                                instance.date_created.isoformat())
+            for var in ((u'{{submissionDate}}',
+                         instance.date_created.isoformat()),
+                        (u'{{form_id}}', str(self.xform.id))):
+                text = text.replace(*var)
             self.assertContains(response, instanceId, status_code=200)
             self.assertMultiLineEqual(response.content.decode('utf-8'), text)
 
@@ -425,8 +427,10 @@ class TestBriefcaseViewSet(test_abstract_viewset.TestAbstractViewSet):
             'view', 'downloadSubmission.xml')
         with codecs.open(download_submission_path, encoding='utf-8') as f:
             text = f.read()
-            text = text.replace(u'{{submissionDate}}',
-                                instance.date_created.isoformat())
+            for var in ((u'{{submissionDate}}',
+                         instance.date_created.isoformat()),
+                        (u'{{form_id}}', str(self.xform.id))):
+                text = text.replace(*var)
             self.assertContains(response, instanceId, status_code=200)
 
     def tearDown(self):

--- a/onadata/apps/api/tests/viewsets/test_dataview_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_dataview_viewset.py
@@ -95,7 +95,9 @@ class TestDataViewViewSet(TestAbstractViewSet):
         attachment_info = instance_with_attachment.get('_attachments')[0]
         self.assertEquals(u'image/png', attachment_info.get(u'mimetype'))
         self.assertEquals(
-            u'%s/attachments/%s' % (self.user.username, media_file),
+            u'{}/attachments/{}_{}/{}'.format(
+                self.user.username, self.xform.id, self.xform.id_string,
+                media_file),
             attachment_info.get(u'filename'))
         self.assertEquals(response.status_code, 200)
 

--- a/onadata/apps/api/tests/viewsets/test_xform_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_xform_viewset.py
@@ -3968,9 +3968,11 @@ class TestXFormViewSet(TestAbstractViewSet):
             response = view(request, pk=self.xform.pk, format='csv')
             self.assertEqual(response.status_code, 200)
 
-            expected_data = ['http://example.com/api/v1/files/%s?'
-                             'filename=bob/attachments/1442323232322.jpg' %
-                             attachment_id]
+            expected_data = ['http://example.com/api/v1/files/{}?'
+                             'filename=bob/attachments/{}_{}/'
+                             '1442323232322.jpg'.format(attachment_id,
+                                                        self.xform.id,
+                                                        self.xform.id_string)]
             key = 'photo'
             self._validate_csv_export(response, None, key, expected_data)
 

--- a/onadata/apps/logger/models/attachment.py
+++ b/onadata/apps/logger/models/attachment.py
@@ -26,8 +26,8 @@ def get_original_filename(filename):
 
 def upload_to(instance, filename):
     return os.path.join(
-        instance.instance.xform.user.username,
-        'attachments',
+        instance.instance.xform.user.username, 'attachments',
+        str(instance.instance.xform.id), instance.instance.xform.id_string,
         os.path.split(filename)[1])
 
 

--- a/onadata/apps/logger/models/attachment.py
+++ b/onadata/apps/logger/models/attachment.py
@@ -25,9 +25,10 @@ def get_original_filename(filename):
 
 
 def upload_to(instance, filename):
+    folder = "{}_{}".format(instance.instance.xform.id,
+                            instance.instance.xform.id_string)
     return os.path.join(
-        instance.instance.xform.user.username, 'attachments',
-        str(instance.instance.xform.id), instance.instance.xform.id_string,
+        instance.instance.xform.user.username, 'attachments', folder,
         os.path.split(filename)[1])
 
 

--- a/onadata/apps/logger/tests/models/test_attachment.py
+++ b/onadata/apps/logger/tests/models/test_attachment.py
@@ -9,7 +9,8 @@ from django.db.utils import DataError
 
 from onadata.apps.main.tests.test_base import TestBase
 from onadata.apps.logger.models import Attachment, Instance
-from onadata.apps.logger.models.attachment import get_original_filename
+from onadata.apps.logger.models.attachment import (get_original_filename,
+                                                   upload_to)
 from onadata.libs.utils.image_tools import image_url
 
 
@@ -115,3 +116,10 @@ class TestAttachment(TestBase):
             get_original_filename('submission_random.enc'),
             'submission_random.enc'
         )
+
+    def test_upload_to(self):
+        """
+        Test that upload to returns the correct path
+        """
+        path = upload_to(self.attachment, self.attachment.filename)
+        self.assertEqual(path, 'bob/attachments/1/transportation_2011_07_25/1335783522563.jpg')  # noqa

--- a/onadata/apps/logger/tests/models/test_attachment.py
+++ b/onadata/apps/logger/tests/models/test_attachment.py
@@ -122,4 +122,6 @@ class TestAttachment(TestBase):
         Test that upload to returns the correct path
         """
         path = upload_to(self.attachment, self.attachment.filename)
-        self.assertEqual(path, 'bob/attachments/1/transportation_2011_07_25/1335783522563.jpg')  # noqa
+        self.assertEqual(path,
+                         'bob/attachments/{}_{}/1335783522563.jpg'.format(
+                             self.xform.id, self.xform.id_string))

--- a/onadata/apps/logger/tests/test_briefcase_api.py
+++ b/onadata/apps/logger/tests/test_briefcase_api.py
@@ -199,8 +199,11 @@ class TestBriefcaseAPI(TestBase):
             'view', 'downloadSubmission.xml')
         with open(download_submission_path, encoding='utf-8') as f:
             text = f.read()
-            text = text.replace(u'{{submissionDate}}',
-                                instance.date_created.isoformat())
+            for var in ((u'{{submissionDate}}',
+                         instance.date_created.isoformat()),
+                        (u'{{form_id}}', str(self.xform.id))):
+                text = text.replace(*var)
+
             self.assertContains(response, instanceId, status_code=200)
             self.assertMultiLineEqual(response.content.decode('utf-8'), text)
 

--- a/onadata/apps/logger/tests/test_importing_database.py
+++ b/onadata/apps/logger/tests/test_importing_database.py
@@ -16,7 +16,7 @@ DB_FIXTURES_PATH = os.path.join(CUR_DIR, 'data_from_sdcard')
 
 def images_count(username="bob"):
     images = glob.glob(
-        os.path.join(settings.MEDIA_ROOT, username, 'attachments', '*'))
+        os.path.join(settings.MEDIA_ROOT, username, 'attachments', '*', '*'))
     return len(images)
 
 
@@ -35,7 +35,7 @@ class TestImportingDatabase(TestBase):
         if settings.TESTING_MODE:
             images = glob.glob(
                 os.path.join(settings.MEDIA_ROOT, self.user.username,
-                             'attachments', '*'))
+                             'attachments', '*', '*'))
             for image in images:
                 os.remove(image)
 

--- a/onadata/apps/main/tests/fixtures/transportation/view/downloadSubmission.xml
+++ b/onadata/apps/main/tests/fixtures/transportation/view/downloadSubmission.xml
@@ -6,6 +6,6 @@
     <mediaFile>
         <filename>1335783522563.jpg</filename>
         <hash>md5:2ca0d22073a9b6b4ebe51368b08da60c</hash>
-        <downloadUrl>http://testserver/attachment/original?media_file=bob/attachments/1335783522563.jpg</downloadUrl>
+        <downloadUrl>http://testserver/attachment/original?media_file=bob/attachments/{{form_id}}_transportation_2011_07_25/1335783522563.jpg</downloadUrl>
     </mediaFile>
 </submission>

--- a/onadata/libs/tests/utils/test_export_builder.py
+++ b/onadata/libs/tests/utils/test_export_builder.py
@@ -953,7 +953,7 @@ class TestExportBuilder(TestBase):
         rows = [row for row in children_sheet.rows]
         row = [a.value for a in rows[1]]
         attachment_id = xdata[0]['_attachments'][0]['id']
-        attachment_url = 'http://example.com/api/v1/files/{}?filename=bob/attachments/1300221157303.jpg'.format(attachment_id)  # noqa
+        attachment_url = 'http://example.com/api/v1/files/{}?filename=bob/attachments/{}_{}/1300221157303.jpg'.format(attachment_id, self.xform.id, self.xform.id_string)  # noqa
         self.assertIn(attachment_url, row)
         temp_xls_file.close()
 


### PR DESCRIPTION
- Store attachments in a form specific folder

Fix #961 