### PR TITLE
Add team permissions to org owner role

### DIFF
--- a/onadata/apps/api/tests/models/test_organization_profile.py
+++ b/onadata/apps/api/tests/models/test_organization_profile.py
@@ -1,10 +1,15 @@
-from onadata.apps.main.tests.test_base import TestBase
+from django.core.cache import cache
+from django.db import IntegrityError
+
+from guardian.shortcuts import get_perms
+
 from onadata.apps.api import tools
 from onadata.apps.api.models.organization_profile import OrganizationProfile
 from onadata.apps.api.models.team import Team
-from django.db import IntegrityError
-from django.core.cache import cache
+from onadata.apps.main.tests.test_base import TestBase
 from onadata.libs.utils.cache_tools import IS_ORG, safe_delete
+
+from onadata.libs.permissions import OwnerRole
 
 
 class TestOrganizationProfile(TestBase):
@@ -47,3 +52,39 @@ class TestOrganizationProfile(TestBase):
         self.assertIsNone(cache.get('{}{}'.format(IS_ORG, profile_id)))
         self.assertEqual(count - 1,
                          OrganizationProfile.objects.all().count())
+
+    def test_org_admin_change_team_role(self):
+        """
+        Test that a user with org admin role can change members role
+        """
+        # create an organization
+        profile = tools.create_organization_object("onaorg", self.user)
+        profile.save()
+        self.assertIsInstance(profile, OrganizationProfile)
+        ona_org = OrganizationProfile.objects.get(
+            user__username="onaorg")
+        self.assertTrue(ona_org.is_organization)
+
+        # create a project and team, and add team to project
+        ona_project = tools.create_organization_project(
+            ona_org.user, 'ona_project', self.user)
+        team = tools.get_organization_members_team(ona_org)
+        tools.add_team_to_project(team, ona_project)
+
+        # add user to organization
+        ivy = self._create_user('ivy', 'ivy')
+        tools.add_user_to_organization(ona_org, ivy)
+
+        # assert that user cannot change team role
+        permissions = get_perms(ivy, team)
+        self.assertEqual(len(permissions), 1)
+        self.assertIn('view_team', permissions)
+
+        # make user (ivy) admin of org
+        OwnerRole.add(ivy, ona_org)
+        self.assertTrue(OwnerRole.user_has_role(ivy, ona_org))
+
+        # assert that user (ivy) can change team role
+        permissions = get_perms(ivy, team)
+        self.assertIn('change_team', permissions)
+        self.assertEqual(len(permissions), 4)


### PR DESCRIPTION
- Give team permissions to a user when they are given org owner role
- Add test for the above

Fix #1412 