### PR TITLE
[DNM]: Update Dockerfile to use python3.6 an ubuntu 18.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 ENV DEBIAN_FRONTEND noninteractive
 ENV PYTHONUNBUFFERED 1
@@ -10,9 +10,8 @@ RUN apt-get update \
     memcached \
     libmemcached-dev \
     build-essential \
-    python-pip \
-    python-virtualenv \
-    python-dev \
+    python3.6-dev \
+    python3.6-venv \
     git \
     libssl-dev \
     libpq-dev \
@@ -22,48 +21,30 @@ RUN apt-get update \
     libxml2-dev \
     libxslt-dev \
     zlib1g-dev \
-    python-software-properties \
     ghostscript \
     python-celery \
     python-sphinx \
-    openjdk-9-jre-headless \
-    python-virtualenv \
+    openjdk-8-jre-headless \
     locales \
     pkg-config \
     gcc \
     libtool \
     automake
 
-RUN  locale-gen en_US.UTF-8
+RUN locale-gen en_US.UTF-8
+ENV LANG en_US.UTF-8
 
 RUN useradd -m onadata
-RUN mkdir -p /srv/onadata && chown -R onadata:onadata /srv/onadata
+RUN mkdir -p /srv/onadata && chown -R onadata:onadata /srv
 USER onadata
-RUN mkdir -p /srv/onadata/requirements
 
-ADD requirements /srv/onadata/requirements/
-
+COPY . /srv/onadata
 WORKDIR /srv/onadata
 
-RUN virtualenv /srv/onadata/.virtualenv
-RUN . /srv/onadata/.virtualenv/bin/activate; \
-    pip install pip --upgrade && pip install -r requirements/base.pip
-
-ADD . /srv/onadata/
+RUN python3.6 -m venv /srv/.virtualenv \
+  && /srv/.virtualenv/bin/pip install pip --upgrade  \
+  && /srv/.virtualenv/bin/pip install -r requirements/base.pip
 
 ENV DJANGO_SETTINGS_MODULE onadata.settings.docker
-
-USER root
-
-# for local development tmux is a nice to have
-RUN apt-get install -y tmux
-
-RUN rm -rf /var/lib/apt/lists/* \
-  && find . -name '*.pyc' -type f -delete
-
-USER onadata
-
-# Run tmux to use bash shell.
-RUN echo "set-option -g default-shell /bin/bash" > ~/.tmux.conf
 
 CMD ["/srv/onadata/docker/docker-entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update \
     ghostscript \
     python-celery \
     python-sphinx \
-    openjdk-8-jre-headless \
+    openjdk-8-jre \
     locales \
     pkg-config \
     gcc \

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -6,11 +6,8 @@ psql -h db -U postgres -c "CREATE ROLE onadata WITH SUPERUSER LOGIN PASSWORD 'on
 psql -h db -U postgres -c "CREATE DATABASE onadata OWNER onadata;"
 psql -h db -U postgres onadata -c "CREATE EXTENSION postgis; CREATE EXTENSION postgis_topology;"
 
-virtualenv /srv/onadata/.virtualenv
-. /srv/onadata/.virtualenv/bin/activate
-
+source /srv/.virtualenv/bin/activate
 cd /srv/onadata
-pip install -r requirements/base.pip
 python manage.py migrate --noinput
 python manage.py collectstatic --noinput
 python manage.py runserver 0.0.0.0:8000


### PR DESCRIPTION
Using an Ubuntu 18.04 base image
Using python 3.6.x
Removed tmux and other dev tools
Using java8 which is LTS and distributed with ubuntu 18.04

Also related problem that took long to figure out https://bitbucket.org/fomcl/savreaderwriter/issues/73/pip-install-fails-for-non-utf-8-encoding
