### PR TITLE
Use content_type to determin metadata content_object type

### DIFF
--- a/onadata/libs/serializers/fields/instance_related_field.py
+++ b/onadata/libs/serializers/fields/instance_related_field.py
@@ -1,15 +1,32 @@
-from onadata.apps.logger.models import Instance
+from django.contrib.contenttypes.models import ContentType
+from django.core.cache import cache
+
 from rest_framework import serializers
 from rest_framework.fields import SkipField
+
+from onadata.apps.logger.models import Instance
 
 
 class InstanceRelatedField(serializers.RelatedField):
     """A custom field to represent the content_object generic relationship"""
 
     def get_attribute(self, instance):
-        # xform is not an attribute of the MetaData object
-        if instance and isinstance(instance.content_object, Instance):
-            return instance.content_object
+        content_type_id = cache.get("instance_content_type_id")
+        if not content_type_id:
+            try:
+                content_type_id = ContentType.objects.get(
+                    app_label="logger", model="instance"
+                ).id
+            except ContentType.DoesNotExist:
+                pass
+            else:
+                cache.set("instance_content_type_id", content_type_id)
+        if not content_type_id:
+            if instance and isinstance(instance.content_object, Instance):
+                return instance.object_id
+        else:
+            if instance and instance.content_type_id == content_type_id:
+                return instance.object_id
 
         raise SkipField()
 
@@ -21,4 +38,4 @@ class InstanceRelatedField(serializers.RelatedField):
 
     def to_representation(self, instance):
         """Serialize project object"""
-        return instance.pk
+        return instance

--- a/onadata/libs/serializers/fields/instance_related_field.py
+++ b/onadata/libs/serializers/fields/instance_related_field.py
@@ -1,32 +1,19 @@
-from django.contrib.contenttypes.models import ContentType
-from django.core.cache import cache
-
+# -*- coding: utf-8 -*-
+"""InstanceRelatedField"""
 from rest_framework import serializers
 from rest_framework.fields import SkipField
 
 from onadata.apps.logger.models import Instance
+from onadata.libs.serializers.fields.utils import get_object_id_by_content_type
 
 
 class InstanceRelatedField(serializers.RelatedField):
     """A custom field to represent the content_object generic relationship"""
 
     def get_attribute(self, instance):
-        content_type_id = cache.get("instance_content_type_id")
-        if not content_type_id:
-            try:
-                content_type_id = ContentType.objects.get(
-                    app_label="logger", model="instance"
-                ).id
-            except ContentType.DoesNotExist:
-                pass
-            else:
-                cache.set("instance_content_type_id", content_type_id)
-        if not content_type_id:
-            if instance and isinstance(instance.content_object, Instance):
-                return instance.object_id
-        else:
-            if instance and instance.content_type_id == content_type_id:
-                return instance.object_id
+        val = get_object_id_by_content_type(instance, Instance)
+        if val:
+            return val
 
         raise SkipField()
 
@@ -34,8 +21,8 @@ class InstanceRelatedField(serializers.RelatedField):
         try:
             return Instance.objects.get(pk=data)
         except ValueError:
-            raise Exception("project id should be an integer")
+            raise Exception("instance id should be an integer")
 
-    def to_representation(self, instance):
-        """Serialize project object"""
-        return instance
+    def to_representation(self, value):
+        """Serialize instance object"""
+        return value

--- a/onadata/libs/serializers/fields/project_related_field.py
+++ b/onadata/libs/serializers/fields/project_related_field.py
@@ -1,32 +1,20 @@
-from django.contrib.contenttypes.models import ContentType
-from django.core.cache import cache
+# -*- coding: utf-8 -*-
+"""ProjectRelatedField"""
 
 from rest_framework import serializers
 from rest_framework.fields import SkipField
 
 from onadata.apps.logger.models import Project
+from onadata.libs.serializers.fields.utils import get_object_id_by_content_type
 
 
 class ProjectRelatedField(serializers.RelatedField):
     """A custom field to represent the content_object generic relationship"""
 
     def get_attribute(self, instance):
-        content_type_id = cache.get("project_content_type_id")
-        if not content_type_id:
-            try:
-                content_type_id = ContentType.objects.get(
-                    app_label="logger", model="project"
-                ).id
-            except ContentType.DoesNotExist:
-                pass
-            else:
-                cache.set("project_content_type_id", content_type_id)
-        if not content_type_id:
-            if instance and isinstance(instance.content_object, Project):
-                return instance.object_id
-        else:
-            if instance and instance.content_type_id == content_type_id:
-                return instance.object_id
+        val = get_object_id_by_content_type(instance, Project)
+        if val:
+            return val
 
         raise SkipField()
 
@@ -36,6 +24,6 @@ class ProjectRelatedField(serializers.RelatedField):
         except ValueError:
             raise Exception("project id should be an integer")
 
-    def to_representation(self, instance):
+    def to_representation(self, value):
         """Serialize project object"""
-        return instance
+        return value

--- a/onadata/libs/serializers/fields/project_related_field.py
+++ b/onadata/libs/serializers/fields/project_related_field.py
@@ -1,15 +1,32 @@
-from onadata.apps.logger.models import Project
+from django.contrib.contenttypes.models import ContentType
+from django.core.cache import cache
+
 from rest_framework import serializers
 from rest_framework.fields import SkipField
+
+from onadata.apps.logger.models import Project
 
 
 class ProjectRelatedField(serializers.RelatedField):
     """A custom field to represent the content_object generic relationship"""
 
     def get_attribute(self, instance):
-        # xform is not an attribute of the MetaData object
-        if instance and isinstance(instance.content_object, Project):
-            return instance.content_object
+        content_type_id = cache.get("project_content_type_id")
+        if not content_type_id:
+            try:
+                content_type_id = ContentType.objects.get(
+                    app_label="logger", model="project"
+                ).id
+            except ContentType.DoesNotExist:
+                pass
+            else:
+                cache.set("project_content_type_id", content_type_id)
+        if not content_type_id:
+            if instance and isinstance(instance.content_object, Project):
+                return instance.object_id
+        else:
+            if instance and instance.content_type_id == content_type_id:
+                return instance.object_id
 
         raise SkipField()
 
@@ -21,4 +38,4 @@ class ProjectRelatedField(serializers.RelatedField):
 
     def to_representation(self, instance):
         """Serialize project object"""
-        return instance.pk
+        return instance

--- a/onadata/libs/serializers/fields/utils.py
+++ b/onadata/libs/serializers/fields/utils.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+"""Serializer fields utils module."""
+from django.contrib.contenttypes.models import ContentType
+from django.core.cache import cache
+
+
+def get_object_id_by_content_type(instance, model_class):
+    """Return instance.object_id from a cached model's content type"""
+    key = "{}-content_type_id".format(model_class.__name__)
+    content_type_id = cache.get(key)
+    if not content_type_id:
+        try:
+            content_type_id = ContentType.objects.get(
+                app_label=model_class._meta.app_label,
+                model=model_class.__name__.lower(),
+            ).id
+        except ContentType.DoesNotExist:
+            if instance and isinstance(instance.content_object, model_class):
+                return instance.object_id
+        else:
+            cache.set(key, content_type_id)
+
+    if instance and instance.content_type_id == content_type_id:
+        return instance.object_id
+
+    return None

--- a/onadata/libs/serializers/fields/xform_related_field.py
+++ b/onadata/libs/serializers/fields/xform_related_field.py
@@ -1,6 +1,10 @@
-from onadata.apps.logger.models import XForm
+from django.contrib.contenttypes.models import ContentType
+from django.core.cache import cache
+
 from rest_framework import serializers
 from rest_framework.fields import SkipField
+
+from onadata.apps.logger.models import XForm
 
 
 class XFormRelatedField(serializers.RelatedField):
@@ -8,8 +12,22 @@ class XFormRelatedField(serializers.RelatedField):
 
     def get_attribute(self, instance):
         # xform is not an attribute of the MetaData object
-        if instance and isinstance(instance.content_object, XForm):
-            return instance.content_object
+        content_type_id = cache.get("xform_content_type_id")
+        if not content_type_id:
+            try:
+                content_type_id = ContentType.objects.get(
+                    app_label="logger", model="xform"
+                ).id
+            except ContentType.DoesNotExist:
+                pass
+            else:
+                cache.set("xform_content_type_id", content_type_id)
+        if not content_type_id:
+            if instance and isinstance(instance.content_object, XForm):
+                return instance.object_id
+        else:
+            if instance and instance.content_type_id == content_type_id:
+                return instance.object_id
 
         raise SkipField()
 
@@ -23,4 +41,4 @@ class XFormRelatedField(serializers.RelatedField):
 
     def to_representation(self, instance):
         """Serialize xform object"""
-        return instance.pk
+        return instance

--- a/onadata/libs/serializers/fields/xform_related_field.py
+++ b/onadata/libs/serializers/fields/xform_related_field.py
@@ -1,33 +1,20 @@
-from django.contrib.contenttypes.models import ContentType
-from django.core.cache import cache
+# -*- coding: utf-8 -*-
+"""XFormRelatedField"""
 
 from rest_framework import serializers
 from rest_framework.fields import SkipField
 
 from onadata.apps.logger.models import XForm
+from onadata.libs.serializers.fields.utils import get_object_id_by_content_type
 
 
 class XFormRelatedField(serializers.RelatedField):
     """A custom field to represent the content_object generic relationship"""
 
     def get_attribute(self, instance):
-        # xform is not an attribute of the MetaData object
-        content_type_id = cache.get("xform_content_type_id")
-        if not content_type_id:
-            try:
-                content_type_id = ContentType.objects.get(
-                    app_label="logger", model="xform"
-                ).id
-            except ContentType.DoesNotExist:
-                pass
-            else:
-                cache.set("xform_content_type_id", content_type_id)
-        if not content_type_id:
-            if instance and isinstance(instance.content_object, XForm):
-                return instance.object_id
-        else:
-            if instance and instance.content_type_id == content_type_id:
-                return instance.object_id
+        val = get_object_id_by_content_type(instance, XForm)
+        if val:
+            return val
 
         raise SkipField()
 
@@ -39,6 +26,6 @@ class XFormRelatedField(serializers.RelatedField):
         except XForm.DoesNotExist:
             raise serializers.ValidationError("XForm does not exist")
 
-    def to_representation(self, instance):
+    def to_representation(self, value):
         """Serialize xform object"""
-        return instance
+        return value


### PR DESCRIPTION
This prevents running a query against the xform object which will
include all fields and for forms whose XML is at least 1MB it can dump
more than 5GB of data into memory resulting in processess being killed,
especially where a form has more than 5 metadata objects.