### PR TITLE
Track password edits:

### DIFF
--- a/onadata/apps/api/tests/viewsets/test_user_profile_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_user_profile_viewset.py
@@ -8,6 +8,7 @@ from django.contrib.auth.models import User
 from django.db.models import signals
 from django.test.utils import override_settings
 from django.utils.dateparse import parse_datetime
+from django.utils import timezone
 
 import requests
 from django_digest.test import DigestAuth
@@ -252,6 +253,8 @@ class TestUserProfileViewSet(TestAbstractViewSet):
         data['url'] = 'http://testserver/api/v1/profiles/deno'
         data['user'] = 'http://testserver/api/v1/users/deno'
         data['metadata'] = {}
+        data['metadata']['last_password_edit'] = \
+            profile.metadata['last_password_edit']
         data['joined_on'] = profile.user.date_joined
         data['name'] = "%s %s" % ('Dennis', 'erama')
         self.assertEqual(response.data, data)
@@ -452,6 +455,8 @@ class TestUserProfileViewSet(TestAbstractViewSet):
         data['url'] = 'http://testserver/api/v1/profiles/nguyenquynh'
         data['user'] = 'http://testserver/api/v1/users/nguyenquynh'
         data['metadata'] = {}
+        data['metadata']['last_password_edit'] = \
+            profile.metadata['last_password_edit']
         data['joined_on'] = profile.user.date_joined
         data['name'] = "%s %s" % (
             u'Nguy\u1ec5n Th\u1ecb', u'Di\u1ec5m Qu\u1ef3nh')
@@ -492,6 +497,8 @@ class TestUserProfileViewSet(TestAbstractViewSet):
         data['url'] = 'http://testserver/api/v1/profiles/deno'
         data['user'] = 'http://testserver/api/v1/users/deno'
         data['metadata'] = {}
+        data['metadata']['last_password_edit'] = \
+            profile.metadata['last_password_edit']
         data['joined_on'] = profile.user.date_joined
         self.assertEqual(response.data, data)
         self.assertNotIn('email', response.data)
@@ -681,6 +688,8 @@ class TestUserProfileViewSet(TestAbstractViewSet):
         data['user'] = 'http://testserver/api/v1/users/deno'
         data['username'] = u'deno'
         data['metadata'] = {}
+        data['metadata']['last_password_edit'] = \
+            profile.metadata['last_password_edit']
         data['joined_on'] = profile.user.date_joined
         self.assertEqual(response.data, data)
 
@@ -704,8 +713,12 @@ class TestUserProfileViewSet(TestAbstractViewSet):
 
         request = self.factory.post('/', data=post_data, **self.extra)
         response = view(request, user='bob')
+        now = timezone.now().isoformat()
         user = User.objects.get(username__iexact=self.user.username)
+        user_profile = UserProfile.objects.get(user_id=user.id)
         self.assertEqual(response.status_code, 204)
+        self.assertEqual(type(user_profile.metadata['last_password_edit']),
+                         type(parse_datetime(now)))
         self.assertTrue(user.check_password(new_password))
 
     def test_change_password_wrong_current_password(self):
@@ -751,6 +764,8 @@ class TestUserProfileViewSet(TestAbstractViewSet):
         data['url'] = 'http://testserver/api/v1/profiles/deno'
         data['user'] = 'http://testserver/api/v1/users/deno'
         data['metadata'] = {}
+        data['metadata']['last_password_edit'] = \
+            profile.metadata['last_password_edit']
         data['joined_on'] = profile.user.date_joined
 
         self.assertEqual(response.data, data)

--- a/onadata/apps/api/tests/viewsets/test_user_profile_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_user_profile_viewset.py
@@ -717,8 +717,9 @@ class TestUserProfileViewSet(TestAbstractViewSet):
         user = User.objects.get(username__iexact=self.user.username)
         user_profile = UserProfile.objects.get(user_id=user.id)
         self.assertEqual(response.status_code, 204)
-        self.assertEqual(type(user_profile.metadata['last_password_edit']),
-                         type(parse_datetime(now)))
+        self.assertEqual(
+            type(parse_datetime(user_profile.metadata['last_password_edit'])),
+            type(parse_datetime(now)))
         self.assertTrue(user.check_password(new_password))
 
     def test_change_password_wrong_current_password(self):

--- a/onadata/apps/api/viewsets/user_profile_viewset.py
+++ b/onadata/apps/api/viewsets/user_profile_viewset.py
@@ -14,6 +14,7 @@ from django.core.validators import ValidationError
 from django.db.models import Count
 from django.http import HttpResponseRedirect, HttpResponseBadRequest
 from django.utils.translation import ugettext as _
+from django.utils import timezone
 
 from registration.models import RegistrationProfile
 from rest_framework import serializers, status
@@ -154,10 +155,14 @@ class UserProfileViewSet(
         current_password = request.data.get('current_password', None)
         new_password = request.data.get('new_password', None)
 
+        metadata = user_profile.metadata or {}
+        metadata['last_password_edit'] = timezone.now().isoformat()
         if new_password:
             if user_profile.user.check_password(current_password):
                 user_profile.user.set_password(new_password)
+                user_profile.metadata = metadata
                 user_profile.user.save()
+                user_profile.save()
 
                 return Response(status=status.HTTP_204_NO_CONTENT)
 

--- a/onadata/apps/api/viewsets/user_profile_viewset.py
+++ b/onadata/apps/api/viewsets/user_profile_viewset.py
@@ -155,10 +155,10 @@ class UserProfileViewSet(
         current_password = request.data.get('current_password', None)
         new_password = request.data.get('new_password', None)
 
-        metadata = user_profile.metadata or {}
-        metadata['last_password_edit'] = timezone.now().isoformat()
         if new_password:
             if user_profile.user.check_password(current_password):
+                metadata = user_profile.metadata or {}
+                metadata['last_password_edit'] = timezone.now().isoformat()
                 user_profile.user.set_password(new_password)
                 user_profile.metadata = metadata
                 user_profile.user.save()


### PR DESCRIPTION
 Introduce last_password_edit field in the metadata json field
 Upon creation of an account add the last_password_edit time
 Upon password change update last_password_edit
 fixes #1454 
 fixes #1467