### PR TITLE
Remove link expiration message on verification email

### DIFF
--- a/onadata/libs/templates/registration/verification_email.txt
+++ b/onadata/libs/templates/registration/verification_email.txt
@@ -4,10 +4,9 @@ Hi {{ username }},
 
 You're almost done! Please make sure to verify your email address and we'll finish setting up your account on Ona for you.
 {{ verification_url }}
-The link above is valid for {{ expiration_days }} day{{ expiration_days_p }}.
 Thank you for choosing Ona!
 Please contact us with any questions, we're always happy to help.
 
 Thanks,
-The team at Ona
+The Team at Ona
 {% endblocktrans %}


### PR DESCRIPTION
Remove link validity duration on email message.
Links no longer expire after a day

fixes #1489

Signed-off-by: Lincoln Simba <lincolncmba@gmail.com>