### PR TITLE
Only generate hash for linked datasets

### DIFF
--- a/onadata/libs/serializers/xform_serializer.py
+++ b/onadata/libs/serializers/xform_serializer.py
@@ -1,21 +1,22 @@
-import os
 import logging
+import os
 from hashlib import md5
-from future.moves.urllib.parse import urlparse
-from future.utils import listvalues
 
-from django.core.exceptions import ValidationError
-from django.core.validators import URLValidator
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.cache import cache
+from django.core.exceptions import ValidationError
+from django.core.validators import URLValidator
 from django.db.models import Count
+from future.moves.urllib.parse import urlparse
+from future.utils import listvalues
 from requests.exceptions import ConnectionError
 from rest_framework import serializers
 from rest_framework.reverse import reverse
 
 from onadata.apps.logger.models import DataView, Instance, XForm
 from onadata.apps.main.models.meta_data import MetaData
+from onadata.libs.exceptions import EnketoError
 from onadata.libs.permissions import get_role, is_organization
 from onadata.libs.serializers.dataview_serializer import \
     DataViewMinimalSerializer
@@ -25,12 +26,11 @@ from onadata.libs.utils.cache_tools import (
     ENKETO_PREVIEW_URL_CACHE, ENKETO_URL_CACHE, XFORM_DATA_VERSIONS,
     XFORM_LINKED_DATAVIEWS, XFORM_METADATA_CACHE, XFORM_PERMISSIONS_CACHE,
     XFORM_COUNT)
+from onadata.libs.utils.common_tags import (GROUP_DELIMETER_TAG,
+                                            REPEAT_INDEX_TAGS)
 from onadata.libs.utils.decorators import check_obj
 from onadata.libs.utils.viewer_tools import (
     enketo_url, get_enketo_preview_url, get_form_url)
-from onadata.libs.exceptions import EnketoError
-from onadata.libs.utils.common_tags import (GROUP_DELIMETER_TAG,
-                                            REPEAT_INDEX_TAGS)
 
 
 def _create_enketo_url(request, xform):
@@ -394,7 +394,8 @@ class XFormManifestSerializer(serializers.Serializer):
         parts = filename.split(' ')
         # filtered dataset is of the form "xform PK name", xform pk is the
         # second item
-        if len(parts) > 2:
+        # other file uploads other than linked datasets have a data_file
+        if len(parts) > 2 and obj.data_file == '':
             dataset_type = parts[0]
             pk = parts[1]
             xform = None

--- a/onadata/libs/tests/serializers/test_xform_serializer.py
+++ b/onadata/libs/tests/serializers/test_xform_serializer.py
@@ -5,10 +5,11 @@ Test onadata.libs.serializers.xform_serializer
 from django.test import TestCase
 from mock import MagicMock
 
+from onadata.apps.main.tests.test_base import TestBase
 from onadata.libs.serializers.xform_serializer import XFormManifestSerializer
 
 
-class TestXFormManifestSerializer(TestCase):
+class TestXFormManifestSerializer(TestCase, TestBase):
     """
     Test XFormManifestSerializer
     """
@@ -36,3 +37,28 @@ class TestXFormManifestSerializer(TestCase):
 
         obj.data_value = "xform 1 clinics"
         self.assertEqual(serializer.get_filename(obj), 'clinics.csv')
+
+    def test_get_hash(self):
+        """
+        Test get hash for filtered dataset and unchanged hash for other
+        media files
+        """
+        # create xform and make submissions
+        self._create_user_and_login()
+        self._publish_transportation_form()
+        self._make_submissions()
+
+        # filtered dataset hash regenerated
+        obj = MagicMock()
+        serializer = XFormManifestSerializer()
+
+        obj.data_value = "xform 1 test_dataset"
+
+        obj.file_hash = u'md5:b9cc8695c526f3c7aaa882234f3b9484'
+        obj.data_file = ""
+        self.assertNotEqual(serializer.get_hash(obj), obj.file_hash)
+
+        # any other dataset with media files have their hashes unchanged
+        obj.data_value = "an image upload.png"
+        obj.data_file = "data file"
+        self.assertEqual(serializer.get_hash(obj), obj.file_hash)

--- a/onadata/libs/tests/serializers/test_xform_serializer.py
+++ b/onadata/libs/tests/serializers/test_xform_serializer.py
@@ -52,7 +52,7 @@ class TestXFormManifestSerializer(TestCase, TestBase):
         obj = MagicMock()
         serializer = XFormManifestSerializer()
 
-        obj.data_value = "xform 1 test_dataset"
+        obj.data_value = "xform {} test_dataset".format(self.xform.id)
 
         obj.file_hash = u'md5:b9cc8695c526f3c7aaa882234f3b9484'
         obj.data_file = ""


### PR DESCRIPTION
Only generate hash for linked datasets, not on any other form media files uploaded

fixes #1411

Signed-off-by: Lincoln Simba <lincolncmba@gmail.com>