### PR TITLE
WRAP PROJECT AND FORMS SOFT_DELETE IN TRANSACTION.ATOMIC

### DIFF
--- a/onadata/apps/logger/models/project.py
+++ b/onadata/apps/logger/models/project.py
@@ -6,7 +6,7 @@ from django.conf import settings
 from django.contrib.auth.models import User
 from django.contrib.postgres.fields import JSONField
 from django.core.exceptions import ValidationError
-from django.db import models
+from django.db import models, transaction
 from django.db.models import Prefetch
 from django.db.models.signals import post_save
 from django.utils import timezone
@@ -113,6 +113,7 @@ class Project(BaseModel):
     def user(self):
         return self.created_by
 
+    @transaction.atomic()
     def soft_delete(self, user=None):
         """
         Soft deletes a project by adding a deleted_at timestamp and renaming

--- a/onadata/apps/logger/models/xform.py
+++ b/onadata/apps/logger/models/xform.py
@@ -12,7 +12,7 @@ from django.contrib.auth.models import User
 from django.contrib.contenttypes.fields import GenericRelation
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.urlresolvers import reverse
-from django.db import models
+from django.db import models, transaction
 from django.db.models import Sum
 from django.db.models.signals import post_delete, post_save, pre_save
 from django.utils import timezone
@@ -874,6 +874,7 @@ class XForm(XFormMixin, BaseModel):
     def __str__(self):
         return getattr(self, "id_string", "")
 
+    @transaction.atomic()
     def soft_delete(self, user=None):
         """
         Return the soft deletion timestamp


### PR DESCRIPTION
Ensure that no project forms are left undeleted when the project is deleted. Fixes https://github.com/onaio/onadata/issues/1494