### PR TITLE
Optional manifest url

### DIFF
--- a/onadata/apps/api/tests/fixtures/formList.xml
+++ b/onadata/apps/api/tests/fixtures/formList.xml
@@ -1,2 +1,2 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xforms xmlns="http://openrosa.org/xforms/xformsList"><xform><formID>transportation_2011_07_25</formID><name>transportation_2011_07_25</name><version>2014111</version><hash>%(hash)s</hash><descriptionText></descriptionText><downloadUrl>http://testserver/bob/forms/%(pk)s/form.xml</downloadUrl><manifestUrl></manifestUrl></xform></xforms>
+<xforms xmlns="http://openrosa.org/xforms/xformsList"><xform><formID>transportation_2011_07_25</formID><name>transportation_2011_07_25</name><version>2014111</version><hash>%(hash)s</hash><descriptionText></descriptionText><downloadUrl>http://testserver/bob/forms/%(pk)s/form.xml</downloadUrl></xform></xforms>

--- a/onadata/apps/api/tests/viewsets/test_xform_list_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_xform_list_viewset.py
@@ -1,7 +1,7 @@
 import os
-from builtins import open
 from hashlib import md5
 
+from builtins import open
 from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.test import TransactionTestCase
@@ -894,9 +894,9 @@ class TestXFormListViewSet(TestAbstractViewSet, TransactionTestCase):
         # success with authentication
         self.assertEqual(response.status_code, 200)
 
-    def test_manifest_url_tag_is_empty_when_no_media(self):
+    def test_manifest_url_tag_is_not_present_when_no_media(self):
         """
-        Test that content contains an empty tag for manifest url
+        Test that content does not contain a manifest url
         only when the form has no media
         """
         request = self.factory.get('/')
@@ -905,7 +905,7 @@ class TestXFormListViewSet(TestAbstractViewSet, TransactionTestCase):
         self.assertEqual(response.status_code, 200)
         content = response.render().content.decode('utf-8')
         manifest_url = ('<manifestUrl></manifestUrl>')
-        self.assertTrue(manifest_url in content)
+        self.assertNotIn(manifest_url, content)
 
         # Add media and test that manifest url exists
         data_type = 'media'

--- a/onadata/apps/main/tests/test_process.py
+++ b/onadata/apps/main/tests/test_process.py
@@ -3,19 +3,19 @@ import fnmatch
 import json
 import os
 import re
+from datetime import datetime
+from hashlib import md5
+from xml.dom import minidom, Node
+
 import pytz
 from builtins import open
-from datetime import datetime
-from future.utils import iteritems
-from hashlib import md5
-from mock import patch
-
-from django.core.urlresolvers import reverse
 from django.conf import settings
-from django_digest.test import Client as DigestClient
 from django.core.files.uploadedfile import UploadedFile
+from django.core.urlresolvers import reverse
+from django_digest.test import Client as DigestClient
+from future.utils import iteritems
+from mock import patch
 from xlrd import open_workbook
-from xml.dom import minidom, Node
 
 from onadata.apps.logger.models import XForm
 from onadata.apps.logger.models.xform import XFORM_TITLE_LENGTH
@@ -25,7 +25,6 @@ from onadata.apps.main.tests.test_base import TestBase
 from onadata.apps.viewer.models.data_dictionary import DataDictionary
 from onadata.libs.utils.common_tags import MONGO_STRFTIME
 from onadata.libs.utils.common_tools import get_response_content
-
 
 uuid_regex = re.compile(
     r'(</instance>.*uuid[^//]+="\')([^\']+)(\'".*)', re.DOTALL)
@@ -217,7 +216,7 @@ class TestProcess(TestBase):
             % (self.user.username, self.xform.pk)
         md5_hash = md5(self.xform.xml.encode('utf-8')).hexdigest()
         expected_content = """<?xml version="1.0" encoding="utf-8"?>
-<xforms xmlns="http://openrosa.org/xforms/xformsList"><xform><formID>transportation_2011_07_25</formID><name>transportation_2011_07_25</name><version>2014111</version><hash>md5:%(hash)s</hash><descriptionText></descriptionText><downloadUrl>%(download_url)s</downloadUrl><manifestUrl></manifestUrl></xform></xforms>"""  # noqa
+<xforms xmlns="http://openrosa.org/xforms/xformsList"><xform><formID>transportation_2011_07_25</formID><name>transportation_2011_07_25</name><version>2014111</version><hash>md5:%(hash)s</hash><descriptionText></descriptionText><downloadUrl>%(download_url)s</downloadUrl></xform></xforms>"""  # noqa
         expected_content = expected_content % {
             'download_url': self.download_url,
             'hash': md5_hash

--- a/onadata/libs/renderers/renderers.py
+++ b/onadata/libs/renderers/renderers.py
@@ -7,13 +7,11 @@ import json
 import math
 from io import BytesIO
 
-from future.utils import iteritems
-
+import pytz
 from django.utils.dateparse import parse_datetime
 from django.utils.encoding import smart_text
 from django.utils.xmlutils import SimplerXMLGenerator
-
-import pytz
+from future.utils import iteritems
 from rest_framework import negotiation
 from rest_framework.compat import six
 from rest_framework.renderers import (BaseRenderer, JSONRenderer,
@@ -29,6 +27,14 @@ IGNORE_FIELDS = [
     'meta/deprecatedID',
     'meta/instanceID',
     'meta/sessionID',
+]
+
+FORMLIST_MANDATORY_FIELDS = [
+    'formID',
+    'name',
+    'version',
+    'hash',
+    'downloadUrl'
 ]
 
 
@@ -244,9 +250,12 @@ class XFormListRenderer(BaseRenderer):  # pylint: disable=R0903
 
         elif isinstance(data, dict):
             for (key, value) in iteritems(data):
-                xml.startElement(key, {})
-                self._to_xml(xml, value)
-                xml.endElement(key)
+                if key not in FORMLIST_MANDATORY_FIELDS and value is None:
+                    pass
+                else:
+                    xml.startElement(key, {})
+                    self._to_xml(xml, value)
+                    xml.endElement(key)
 
         elif data is None:
             # Don't output any value

--- a/onadata/libs/renderers/renderers.py
+++ b/onadata/libs/renderers/renderers.py
@@ -251,11 +251,10 @@ class XFormListRenderer(BaseRenderer):  # pylint: disable=R0903
         elif isinstance(data, dict):
             for (key, value) in iteritems(data):
                 if key not in FORMLIST_MANDATORY_FIELDS and value is None:
-                    pass
-                else:
-                    xml.startElement(key, {})
-                    self._to_xml(xml, value)
-                    xml.endElement(key)
+                    continue
+                xml.startElement(key, {})
+                self._to_xml(xml, value)
+                xml.endElement(key)
 
         elif data is None:
             # Don't output any value


### PR DESCRIPTION
Optional fields in formList such as manifestUrl should not be included in formList incase none exists.
fixes #1519 