### PR TITLE
Fix failing csv bulk edits

### DIFF
--- a/onadata/libs/tests/utils/test_csv_import.py
+++ b/onadata/libs/tests/utils/test_csv_import.py
@@ -39,10 +39,10 @@ class CSVImportTestCase(TestBase):
         self.assertTrue('instanceID' in meta[0])
         self.assertEqual(meta[1], 0)
 
-        instance_id = '9118a3fc-ab99-44cf-9a97-1bb1482d8e2b'
+        instance_id = 'uuid:9118a3fc-ab99-44cf-9a97-1bb1482d8e2b'
         meta = get_submission_meta_dict(xform, instance_id)
         self.assertTrue('instanceID' in meta[0])
-        self.assertEqual(meta[0]['instanceID'], 'uuid:' + instance_id)
+        self.assertEqual(meta[0]['instanceID'], instance_id)
         self.assertEqual(meta[1], 0)
 
     def test_submit_csv_param_sanity_check(self):
@@ -311,8 +311,6 @@ class CSVImportTestCase(TestBase):
             open(os.path.join(self.fixtures_dir, 'single.xml'), 'rb').read())
         safe_create_args = list(safe_create_instance.call_args[0])
 
-        self.assertEqual(safe_create_args[0], self.user.username,
-                         'Wrong username passed')
         instance_xml = fromstring(safe_create_args[1].getvalue())
         single_instance_xml = fromstring(xml_file_param.getvalue())
 

--- a/onadata/libs/tests/utils/test_csv_import.py
+++ b/onadata/libs/tests/utils/test_csv_import.py
@@ -63,7 +63,6 @@ class CSVImportTestCase(TestBase):
 
         self.assertEqual(safe_create_args[0], self.user.username,
                          'Wrong username passed')
-        __import__('ipdb').set_trace()
         self.assertEqual(
             strip_xml_uuid(safe_create_args[1].getvalue()),
             strip_xml_uuid(xml_file_param.getvalue()),

--- a/onadata/libs/tests/utils/test_csv_import.py
+++ b/onadata/libs/tests/utils/test_csv_import.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 import os
 import re
 from io import BytesIO
+from xml.etree.ElementTree import fromstring
 
 import mock
 import unicodecsv as ucsv
@@ -62,6 +63,7 @@ class CSVImportTestCase(TestBase):
 
         self.assertEqual(safe_create_args[0], self.user.username,
                          'Wrong username passed')
+        __import__('ipdb').set_trace()
         self.assertEqual(
             strip_xml_uuid(safe_create_args[1].getvalue()),
             strip_xml_uuid(xml_file_param.getvalue()),
@@ -297,3 +299,29 @@ class CSVImportTestCase(TestBase):
 
         self.assertEqual(
             g_csv_reader.fieldnames[10], c_csv_reader.fieldnames[10])
+
+    @mock.patch('onadata.libs.utils.csv_import.safe_create_instance')
+    def test_submit_csv_instance_id_consistency(self, safe_create_instance):
+        self._publish_xls_file(self.xls_file_path)
+        self.xform = XForm.objects.get()
+
+        safe_create_instance.return_value = {}
+        single_csv = open(os.path.join(self.fixtures_dir, 'single.csv'), 'rb')
+        csv_import.submit_csv(self.user.username, self.xform, single_csv)
+        xml_file_param = BytesIO(
+            open(os.path.join(self.fixtures_dir, 'single.xml'), 'rb').read())
+        safe_create_args = list(safe_create_instance.call_args[0])
+
+        self.assertEqual(safe_create_args[0], self.user.username,
+                         'Wrong username passed')
+        instance_xml = fromstring(safe_create_args[1].getvalue())
+        single_instance_xml = fromstring(xml_file_param.getvalue())
+
+        instance_id = [
+            m.find('instanceID').text for m in instance_xml.findall('meta')][0]
+        single_instance_id = [m.find('instanceID').text for m in
+                              single_instance_xml.findall('meta')][0]
+
+        self.assertEqual(
+            len(instance_id), len(single_instance_id),
+            "Same uuid length in generated xml")

--- a/onadata/libs/utils/csv_import.py
+++ b/onadata/libs/utils/csv_import.py
@@ -54,7 +54,7 @@ def get_submission_meta_dict(xform, instance_id):
     :return: The metadata dict
     :rtype:  dict
     """
-    uuid_arg = 'uuid:{}'.format(instance_id or uuid.uuid4())
+    uuid_arg = instance_id or 'uuid:{}'.format(uuid.uuid4())
     meta = {'instanceID': uuid_arg}
 
     update = 0
@@ -63,7 +63,7 @@ def get_submission_meta_dict(xform, instance_id):
         uuid_arg = 'uuid:{}'.format(uuid.uuid4())
         meta.update({
             'instanceID': uuid_arg,
-            'deprecatedID': 'uuid:{}'.format(instance_id)
+            'deprecatedID': instance_id
         })
         update += 1
     return [meta, update]
@@ -248,8 +248,8 @@ def submit_csv(username, xform, csv_file, overwrite=False):
 
             # fetch submission uuid before purging row metadata
 
-            row_uuid = row.get('_uuid') or row.get(
-                'meta/instanceID').replace('uuid:', '')
+            row_uuid = row.get('meta/instanceID') or 'uuid:{}'.format(
+                row.get('_uuid'))
             submitted_by = row.get('_submitted_by')
             submission_date = row.get('_submission_time', submission_time)
 

--- a/onadata/libs/utils/csv_import.py
+++ b/onadata/libs/utils/csv_import.py
@@ -247,7 +247,9 @@ def submit_csv(username, xform, csv_file, overwrite=False):
                 del row[index]
 
             # fetch submission uuid before purging row metadata
-            row_uuid = row.get('meta/instanceID') or row.get('_uuid')
+
+            row_uuid = row.get('_uuid') or row.get(
+                'meta/instanceID').replace('uuid:', '')
             submitted_by = row.get('_submitted_by')
             submission_date = row.get('_submission_time', submission_time)
 


### PR DESCRIPTION

Get rid of extra `uuid` tag that get's appended to all instanceID rows. This extra tag made old instances be considered new instances.

fixes #1540