### PR TITLE
Strip `uuid:` from `instance_id` before querying to the instance model.

### DIFF
--- a/onadata/libs/utils/csv_import.py
+++ b/onadata/libs/utils/csv_import.py
@@ -59,7 +59,8 @@ def get_submission_meta_dict(xform, instance_id):
 
     update = 0
 
-    if xform.instances.filter(uuid=instance_id).count() > 0:
+    if instance_id and xform.instances.filter(
+            uuid=instance_id.replace('uuid:', '')).count() > 0:
         uuid_arg = 'uuid:{}'.format(uuid.uuid4())
         meta.update({
             'instanceID': uuid_arg,


### PR DESCRIPTION
…ch is not the format in which the uuid is stored.

Strip this `uuid:` before making the query to the instance model.

Signed-off-by: Lincoln Simba <lincolncmba@gmail.com>