### PR TITLE
Limit the size of zip exports.

### DIFF
--- a/onadata/libs/utils/viewer_tools.py
+++ b/onadata/libs/utils/viewer_tools.py
@@ -264,7 +264,14 @@ def create_attachments_zipfile(attachments):
             if default_storage.exists(filename):
                 try:
                     with default_storage.open(filename) as f:
-                        z.writestr(attachment.media_file.name, f.read())
+                        if f.size > settings.ZIP_REPORT_ATTACHMENT_LIMMIT:
+                            report_exception(
+                                "Create attachment zip exception",
+                                "File is greater than {} bytes".format(
+                                    settings.ZIP_REPORT_ATTACHMENT_LIMMIT)
+                            )
+                        else:
+                            z.writestr(attachment.media_file.name, f.read())
                 except IOError as e:
                     report_exception("Create attachment zip exception", e)
 

--- a/onadata/settings/common.py
+++ b/onadata/settings/common.py
@@ -439,6 +439,7 @@ CELERY_IMPORTS = ('onadata.libs.utils.csv_import',)
 
 CSV_FILESIZE_IMPORT_ASYNC_THRESHOLD = 100000  # Bytes
 GOOGLE_SHEET_UPLOAD_BATCH = 1000
+ZIP_REPORT_ATTACHMENT_LIMMIT = 5242880000  # 500 MB in Bytes
 
 # duration to keep zip exports before deletion (in seconds)
 ZIP_EXPORT_COUNTDOWN = 3600  # 1 hour


### PR DESCRIPTION
Limit the size of the zip exports to avoid machines running out of space due to huge reports.