### PR TITLE
Pick passed format or default to json in GenericRelatedField serializer

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,13 @@
 Changelog for onadata
 =====================
 
+1.18.1 (2019-02-07)
+-----------------------
+
+- Pick passed format or default to json in GenericRelatedField serializer
+  `PR #1558 <https://github.com/onaio/onadata/pull/1558>`_
+  [lincmba]
+
 1.18.0 (2019-01-24)
 -----------------------
 

--- a/onadata/__init__.py
+++ b/onadata/__init__.py
@@ -6,7 +6,7 @@ visualization.
 """
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "1.18.0"
+__version__ = "1.18.1"
 
 
 # This will make sure the app is always imported when

--- a/onadata/libs/serializers/widget_serializer.py
+++ b/onadata/libs/serializers/widget_serializer.py
@@ -1,21 +1,19 @@
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.urlresolvers import resolve, get_script_prefix, Resolver404
+from django.http import Http404
 from django.utils.translation import ugettext as _
 from future.moves.urllib.parse import urlparse
-from django.http import Http404
-
 from guardian.shortcuts import get_users_with_perms
-
 from rest_framework import serializers
 from rest_framework.reverse import reverse
 
-from onadata.apps.logger.models.xform import XForm
 from onadata.apps.logger.models.data_view import DataView
 from onadata.apps.logger.models.widget import Widget
-from onadata.libs.utils.string import str2bool
-from onadata.libs.serializers.fields.json_field import JsonField
+from onadata.apps.logger.models.xform import XForm
 from onadata.libs.permissions import OwnerRole, is_organization
+from onadata.libs.serializers.fields.json_field import JsonField
 from onadata.libs.utils.chart_tools import get_field_from_field_xpath
+from onadata.libs.utils.string import str2bool
 
 
 class GenericRelatedField(serializers.HyperlinkedRelatedField):
@@ -27,6 +25,7 @@ class GenericRelatedField(serializers.HyperlinkedRelatedField):
         self.view_names = ['xform-detail', 'dataviews-detail']
         self.resolve = resolve
         self.reverse = reverse
+        self.format = kwargs.pop('format', 'json')
         super(serializers.RelatedField, self).__init__(*args, **kwargs)
 
     def _setup_field(self, view_name):


### PR DESCRIPTION
Widgets endpoint fail when .json is appended to the url and the format not specified
Here we get the format from kwargs or default to json

Signed-off-by: Lincoln Simba <lincolncmba@gmail.com>