### PR TITLE
Limit ZIP Exports Size

### DIFF
--- a/onadata/libs/tests/utils/test_viewer_tools.py
+++ b/onadata/libs/tests/utils/test_viewer_tools.py
@@ -155,7 +155,7 @@ class TestViewerTools(TestBase):
         url = get_form_url(request, username='bob', xform_pk=1)
         self.assertEqual(url, 'https://ona.io/bob/1')
 
-    @override_settings(ZIP_REPORT_ATTACHMENT_LIMMIT=8)
+    @override_settings(ZIP_REPORT_ATTACHMENT_LIMIT=8)
     @patch('onadata.libs.utils.viewer_tools.report_exception')
     def test_create_attachments_zipfile_file_too_big(self, rpt_mock):
         """

--- a/onadata/libs/utils/viewer_tools.py
+++ b/onadata/libs/utils/viewer_tools.py
@@ -5,18 +5,16 @@ import os
 import sys
 import zipfile
 from builtins import open
-from future.utils import iteritems
 from tempfile import NamedTemporaryFile
 from xml.dom import minidom
 
-from future.moves.urllib.parse import urljoin
-
+import requests
 from django.conf import settings
 from django.core.files.storage import get_storage_class
 from django.core.files.uploadedfile import InMemoryUploadedFile
 from django.utils.translation import ugettext as _
-
-import requests
+from future.moves.urllib.parse import urljoin
+from future.utils import iteritems
 
 from onadata.libs.exceptions import EnketoError
 from onadata.libs.utils import common_tags
@@ -254,16 +252,18 @@ def create_attachments_zipfile(attachments):
             if default_storage.exists(filename):
                 try:
                     with default_storage.open(filename) as f:
-                        if f.size > settings.ZIP_REPORT_ATTACHMENT_LIMMIT:
+                        if f.size > settings.ZIP_REPORT_ATTACHMENT_LIMIT:
                             report_exception(
                                 "Create attachment zip exception",
                                 "File is greater than {} bytes".format(
                                     settings.ZIP_REPORT_ATTACHMENT_LIMMIT)
                             )
+                            break
                         else:
                             z.writestr(attachment.media_file.name, f.read())
                 except IOError as e:
                     report_exception("Create attachment zip exception", e)
+                    break
 
     return tmp
 

--- a/onadata/libs/utils/viewer_tools.py
+++ b/onadata/libs/utils/viewer_tools.py
@@ -256,7 +256,7 @@ def create_attachments_zipfile(attachments):
                             report_exception(
                                 "Create attachment zip exception",
                                 "File is greater than {} bytes".format(
-                                    settings.ZIP_REPORT_ATTACHMENT_LIMMIT)
+                                    settings.ZIP_REPORT_ATTACHMENT_LIMIT)
                             )
                             break
                         else:

--- a/onadata/settings/common.py
+++ b/onadata/settings/common.py
@@ -16,15 +16,11 @@ import subprocess  # noqa, used by included files
 import sys
 from imp import reload
 
-from future.moves.urllib.parse import urljoin
-
-from past.builtins import basestring
-
+from celery.signals import after_setup_logger
 from django.core.exceptions import SuspiciousOperation
 from django.utils.log import AdminEmailHandler
-
-from celery.signals import after_setup_logger
-
+from future.moves.urllib.parse import urljoin
+from past.builtins import basestring
 
 # setting default encoding to utf-8
 if sys.version[0] == '2':
@@ -439,7 +435,7 @@ CELERY_IMPORTS = ('onadata.libs.utils.csv_import',)
 
 CSV_FILESIZE_IMPORT_ASYNC_THRESHOLD = 100000  # Bytes
 GOOGLE_SHEET_UPLOAD_BATCH = 1000
-ZIP_REPORT_ATTACHMENT_LIMMIT = 5242880000  # 500 MB in Bytes
+ZIP_REPORT_ATTACHMENT_LIMIT = 5242880000  # 500 MB in Bytes
 
 # duration to keep zip exports before deletion (in seconds)
 ZIP_EXPORT_COUNTDOWN = 3600  # 1 hour


### PR DESCRIPTION
This is an improvement to #1556 which fixes #1370.
The size of exports is limited to `ZIP_REPORT_ATTACHMENT_LIMMIT` which is currently set to 500mb

Signed-off-by: Lincoln Simba <lincolncmba@gmail.com>