### PR TITLE
Handle excel datetime in CSV Import

### DIFF
--- a/onadata/libs/tests/utils/fixtures/date.csv
+++ b/onadata/libs/tests/utils/fixtures/date.csv
@@ -1,3 +1,3 @@
-today,name,tdate,meta/instanceID,_id,_uuid,_submission_time,_tags,_notes,_version,_duration,_submitted_by,_total_media,_media_count,_media_all_received,_xform_id
-3/1/2019,olaf,3/1/2019,uuid:4ef3fadd-90b7-4aff-afcf-b2c600acd9b2,43009420,4ef3fadd-90b7-4aff-afcf-b2c600acd9b2,2019-03-01T08:13:03,,,2.02E+11,,bob,0,0,TRUE,1
-3/1/2019,Ella,2/26/2019,uuid:f6de1de0-256f-4320-8e61-9f972374459d,43009427,f6de1de0-256f-4320-8e61-9f972374459d,2019-03-01T08:13:15,,,2.02E+11,,bob,0,0,TRUE,1
+today,name,tdate,start,end,now,meta/instanceID,_id,_uuid,_submission_time,_tags,_notes,_version,_duration,_submitted_by,_total_media,_media_count,_media_all_received,_xform_id
+3/1/2019,olaf,3/1/2019,2/12/2018 13:20,5/12/2019 13:20,6/12/2020 13:20,uuid:4ef3fadd-90b7-4aff-afcf-b2c600acd9b2,43009420,4ef3fadd-90b7-4aff-afcf-b2c600acd9b2,2019-03-01T08:13:03,,,2.02E+11,,bob,0,0,TRUE,1
+3/1/2019,Ella,2/26/2019,2019-05-01T08:13:03.147+02:00,2018-03-01T08:13:03.147+02:00,2019-03-11T16:00:51.147+02:00,uuid:f6de1de0-256f-4320-8e61-9f972374459d,43009427,f6de1de0-256f-4320-8e61-9f972374459d,2019-03-01T08:13:15,,,2.02E+11,,bob,0,0,TRUE,1

--- a/onadata/libs/tests/utils/test_csv_import.py
+++ b/onadata/libs/tests/utils/test_csv_import.py
@@ -339,10 +339,13 @@ class CSVImportTestCase(TestBase):
         """Convert date from 01/01/1900 to 01-01-1900"""
         date_md_form = """
         | survey |
-        |        | type  | name  | label |
-        |        | today | today | Today |
-        |        | text  | name  | Name  |
-        |        | date  | tdate | Date  |
+        |        | type     | name  | label |
+        |        | today    | today | Today |
+        |        | text     | name  | Name  |
+        |        | date     | tdate | Date  |
+        |        | start    | start |       |
+        |        | end      | end   |       |
+        |        | dateTime | now   | Now   |
         | choices |
         |         | list name | name   | label  |
         | settings |
@@ -365,15 +368,26 @@ class CSVImportTestCase(TestBase):
 
         csv_reader = ucsv.DictReader(date_csv, encoding='utf-8-sig')
         xl_dates = []
+        xl_datetime = []
         # xl dates
         for row in csv_reader:
             xl_dates.append(row.get('tdate'))
+            xl_datetime.append(row.get('now'))
 
         csv_import.submit_csv(self.user.username, xform, date_csv)
         # converted dates
         conv_dates = [instance.json.get('tdate')
                       for instance in Instance.objects.filter(
                 xform=xform).order_by('date_created')]
+        conv_datetime = [instance.json.get('now')
+                         for instance in Instance.objects.filter(
+                xform=xform).order_by('date_created')]
 
         self.assertEqual(xl_dates, ['3/1/2019', '2/26/2019'])
+        self.assertEqual(
+            xl_datetime,
+            [u'6/12/2020 13:20', u'2019-03-11T16:00:51.147+02:00'])
+        self.assertEqual(
+            conv_datetime,
+            [u'2020-06-12T13:20:00.000000', u'2019-03-11T16:00:51.147+02:00'])
         self.assertEqual(conv_dates, ['2019-03-01', '2019-02-26'])

--- a/onadata/libs/utils/common_tags.py
+++ b/onadata/libs/utils/common_tags.py
@@ -135,3 +135,4 @@ EXCEL_FALSE = 0
 MEMBERS = 'members'
 XLS_DATE_FIELDS = ['date', 'today']
 SUBMISSION_REVIEW = 'submission_review'
+XLS_DATETIME_FIELDS = ['start', 'end', 'dateTime', '_submission_time']


### PR DESCRIPTION
Excel sometimes reformats the date to `mm/dd/YYYY HH:MM` which is not in line with how we store datetime.
 This addresses the conversion of the excel datetime to a string format that's consistent with Onadata and ODK.
fixes #1577 
Signed-off-by: Lincoln Simba <lincolncmba@gmail.com>