### PR TITLE
Remove message attribute from Exceptions

### DIFF
--- a/onadata/apps/logger/views.py
+++ b/onadata/apps/logger/views.py
@@ -716,7 +716,7 @@ def form_upload(request, username):
         else:
             content = xform['text']
             if isinstance(content, Exception):
-                content = content.message
+                content = content
                 status = 500
             else:
                 status = 400

--- a/onadata/apps/sms_support/parser.py
+++ b/onadata/apps/sms_support/parser.py
@@ -129,7 +129,7 @@ def parse_sms_text(xform, identity, text):
                     # check that altitude is integer
                     int(geodata[2])
             except Exception as e:
-                raise SMSCastingError(e.message, xlsf_name)
+                raise SMSCastingError(e, xlsf_name)
             return " ".join(geodata)
 
         elif xlsf_type in MEDIA_TYPES:

--- a/onadata/libs/authentication.py
+++ b/onadata/libs/authentication.py
@@ -80,7 +80,7 @@ class DigestAuthentication(BaseAuthentication):
                 raise AuthenticationFailed(
                     _('Invalid username/password'))
         except (AttributeError, ValueError, DataError) as e:
-            raise AuthenticationFailed(e.message)
+            raise AuthenticationFailed(e)
 
     def authenticate_header(self, request):
         response = self.authenticator.build_challenge_response()

--- a/onadata/libs/serializers/stats_serializer.py
+++ b/onadata/libs/serializers/stats_serializer.py
@@ -47,7 +47,7 @@ class SubmissionStatsInstanceSerializer(serializers.Serializer):
             data = get_form_submissions_grouped_by_field(
                 obj, field, name)
         except ValueError as e:
-            raise exceptions.ParseError(detail=e.message)
+            raise exceptions.ParseError(detail=e)
         else:
             if data:
                 element = obj.get_survey_element(field)
@@ -93,6 +93,6 @@ class StatsInstanceSerializer(serializers.Serializer):
         try:
             data = stats_function(obj, field)
         except ValueError as e:
-            raise exceptions.ParseError(detail=e.message)
+            raise exceptions.ParseError(detail=e)
 
         return data

--- a/onadata/libs/serializers/xform_serializer.py
+++ b/onadata/libs/serializers/xform_serializer.py
@@ -49,7 +49,7 @@ def _create_enketo_url(request, xform):
         url = enketo_url(form_url, xform.id_string)
         MetaData.enketo_url(xform, url)
     except ConnectionError as e:
-        logging.exception("Connection Error: %s" % e.message)
+        logging.exception("Connection Error: %s" % e)
     except EnketoError as e:
         logging.exception("Enketo Error: %s" % e.message)
 

--- a/script/i18ntool.py
+++ b/script/i18ntool.py
@@ -216,7 +216,7 @@ def main():
         if lang not in LANGS:
             raise ValueError(u"Unknown lang code")
     except ValueError as e:
-        puts(colored.red(e.message))
+        puts(colored.red(e))
         usage()
     except IndexError:
         lang = None


### PR DESCRIPTION
In python 3, the Exceptions don't have the attribute message. It's been replaced by args. The Exception by itself is a string, and that's what I have decided to use as is.
fixes #1606

Signed-off-by: Lincoln Simba <lincolncmba@gmail.com>