### PR TITLE
Use strings instead of binary strings in reset_url generation

### DIFF
--- a/onadata/libs/serializers/password_reset_serializer.py
+++ b/onadata/libs/serializers/password_reset_serializer.py
@@ -21,13 +21,13 @@ def get_password_reset_email(user, reset_url,
     result = urlparse(reset_url)
     site_name = domain = result.hostname
     encoded_username = urlsafe_base64_encode(
-        b(user.username.encode('utf-8')))
+        b(user.username.encode('utf-8'))).decode('utf-8')
     c = {
         'email': user.email,
         'domain': domain,
         'path': result.path,
         'site_name': site_name,
-        'uid': urlsafe_base64_encode(force_bytes(user.pk)),
+        'uid': urlsafe_base64_encode(force_bytes(user.pk)).decode('utf-8'),
         'username': user.username,
         'encoded_username': encoded_username,
         'token': token_generator.make_token(user),

--- a/onadata/libs/tests/serializers/test_password_reset_serializer.py
+++ b/onadata/libs/tests/serializers/test_password_reset_serializer.py
@@ -2,6 +2,7 @@ from onadata.apps.main.tests.test_base import TestBase
 from onadata.libs.serializers.password_reset_serializer import \
     get_password_reset_email
 from django.utils.http import urlsafe_base64_encode
+from django.utils.encoding import force_bytes
 
 
 class TestPasswordResetSerializer(TestBase):
@@ -15,3 +16,8 @@ class TestPasswordResetSerializer(TestBase):
                 bytes(self.user.username.encode('utf-8'))).decode('utf-8'),
             email,
             "Username is included in reset email.")
+        self.assertIn(
+            'uid={}'.format(urlsafe_base64_encode(
+                force_bytes(self.user.pk)).decode('utf-8')),
+            email,
+            "Uid is included in email.")


### PR DESCRIPTION
In python3, when a binary string is rendered to string, the ascii code representation of `b'` and `'` characters are used.

Here we specifically use the decoded strings to avoid errors caused by the above.
fixes #1610

Signed-off-by: Lincoln Simba <lincolncmba@gmail.com>