### PR TITLE
Get rid of _async keyword on Parsed Instance save() method.

### DIFF
--- a/onadata/apps/viewer/models/parsed_instance.py
+++ b/onadata/apps/viewer/models/parsed_instance.py
@@ -1,28 +1,29 @@
 import datetime
 import json
-import six
 import types
 from builtins import str as text
-from dateutil import parser
 
+import six
+from dateutil import parser
 from django.conf import settings
 from django.db import connection
 from django.db import models
-from django.utils.translation import ugettext as _
 from django.db.models.query import EmptyQuerySet
+from django.utils.translation import ugettext as _
 
-from onadata.apps.logger.models.note import Note
-from onadata.apps.logger.models.instance import _get_attachments_from_instance
 from onadata.apps.logger.models.instance import Instance
+from onadata.apps.logger.models.instance import _get_attachments_from_instance
+from onadata.apps.logger.models.note import Note
 from onadata.apps.logger.models.xform import _encode_for_mongo
 from onadata.apps.viewer.parsed_instance_tools import (get_where_clause,
                                                        NONE_JSON_FIELDS)
 from onadata.libs.models.sorting import (
     json_order_by, json_order_by_params, sort_from_mongo_sort_str)
-from onadata.libs.utils.common_tags import ID, UUID, ATTACHMENTS, GEOLOCATION,\
-    SUBMISSION_TIME, MONGO_STRFTIME, BAMBOO_DATASET_ID, DELETEDAT, TAGS,\
-    NOTES, SUBMITTED_BY, VERSION, DURATION, EDITED, MEDIA_COUNT, TOTAL_MEDIA,\
-    MEDIA_ALL_RECEIVED, XFORM_ID, REVIEW_STATUS, REVIEW_COMMENT
+from onadata.libs.utils.common_tags import ID, UUID, ATTACHMENTS, \
+    GEOLOCATION, SUBMISSION_TIME, MONGO_STRFTIME, BAMBOO_DATASET_ID, \
+    DELETEDAT, TAGS, NOTES, SUBMITTED_BY, VERSION, DURATION, EDITED, \
+    MEDIA_COUNT, TOTAL_MEDIA, MEDIA_ALL_RECEIVED, XFORM_ID, REVIEW_STATUS, \
+    REVIEW_COMMENT
 from onadata.libs.utils.model_tools import queryset_iterator
 from onadata.libs.utils.mongo import _is_invalid_for_mongo
 
@@ -338,7 +339,7 @@ class ParsedInstance(models.Model):
             self.lat = self.instance.point.y
             self.lng = self.instance.point.x
 
-    def save(self, _async=False, *args, **kwargs):  # noqa
+    def save(self, *args, **kwargs):  # noqa
         # start/end_time obsolete: originally used to approximate for
         # instanceID, before instanceIDs were implemented
         self.start_time = None

--- a/onadata/libs/utils/logger_tools.py
+++ b/onadata/libs/utils/logger_tools.py
@@ -4,6 +4,7 @@ import sys
 import tempfile
 from builtins import str as text
 from datetime import datetime
+from hashlib import sha256
 from wsgiref.util import FileWrapper
 from xml.dom import Node
 from xml.parsers.expat import ExpatError
@@ -23,9 +24,10 @@ from django.shortcuts import get_object_or_404
 from django.utils import timezone
 from django.utils.encoding import DjangoUnicodeDecodeError
 from django.utils.translation import ugettext as _
-from hashlib import sha256
 from modilabs.utils.subprocess_timeout import ProcessTimedOut
 from multidb.pinning import use_master
+from pyxform.errors import PyXFormError
+from pyxform.xform2json import create_survey_element_from_xml
 
 from onadata.apps.logger.models import Attachment, Instance, XForm
 from onadata.apps.logger.models.instance import (
@@ -43,8 +45,6 @@ from onadata.apps.viewer.signals import process_submission
 from onadata.libs.utils.common_tools import report_exception
 from onadata.libs.utils.model_tools import set_uuid
 from onadata.libs.utils.user_auth import get_user_default_project
-from pyxform.errors import PyXFormError
-from pyxform.xform2json import create_survey_element_from_xml
 
 OPEN_ROSA_VERSION_HEADER = 'X-OpenRosa-Version'
 HTTP_OPEN_ROSA_VERSION_HEADER = 'HTTP_X_OPENROSA_VERSION'
@@ -265,7 +265,7 @@ def save_submission(xform, xml, media_files, new_uuid, submitted_by, status,
         instance.save()
         pi, created = ParsedInstance.objects.get_or_create(instance=instance)
         if not created:
-            pi.save(_async=False)  # noqa
+            pi.save()  # noqa
 
     return instance
 


### PR DESCRIPTION
I can't find the use of this argument in this save function.
It throws errors aswell when included.
fixes #1615

Signed-off-by: Lincoln Simba <lincolncmba@gmail.com>