### PR TITLE
Only convert to string sav_writer values in `encode_if_str`

### DIFF
--- a/onadata/libs/tests/utils/test_export_tools.py
+++ b/onadata/libs/tests/utils/test_export_tools.py
@@ -6,9 +6,9 @@ import os
 import shutil
 import tempfile
 import zipfile
+from builtins import open
 from datetime import date, datetime, timedelta
 
-from builtins import open
 from django.conf import settings
 from django.contrib.sites.models import Site
 from django.core.files.storage import default_storage
@@ -65,6 +65,15 @@ class TestExportTools(TestBase):
         row = {"datetime": datetime(2001, 9, 9)}
         date_str = encode_if_str(row, "datetime", True)
         self.assertEqual(date_str, '2001-09-09T00:00:00')
+
+        row = {"integer_value": 1}
+        integer_value = encode_if_str(
+            row, "integer_value", sav_writer=True)
+        self.assertEqual(integer_value, '1')
+
+        integer_value = encode_if_str(
+            row, "integer_value")
+        self.assertEqual(integer_value, 1)
 
     def test_generate_osm_export(self):
         filenames = [

--- a/onadata/libs/utils/export_builder.py
+++ b/onadata/libs/utils/export_builder.py
@@ -10,14 +10,13 @@ import sys
 import uuid
 from builtins import str as text
 from datetime import datetime, date
-from future.utils import iteritems
 from zipfile import ZipFile, ZIP_DEFLATED
 
+from celery import current_task
 from django.conf import settings
 from django.core.files.temp import NamedTemporaryFile
 from django.utils.translation import ugettext as _
-
-from celery import current_task
+from future.utils import iteritems
 from openpyxl.utils.datetime import to_excel
 from openpyxl.workbook import Workbook
 from pyxform.question import Question
@@ -167,8 +166,10 @@ def encode_if_str(row, key, encode_dates=False, sav_writer=None):
         elif encode_dates:
             return val.isoformat()
 
-    val = '' if val is None else val
-    return text(val) if IS_PY_3K and not isinstance(val, bool) else val
+    if sav_writer:
+        val = '' if val is None else val
+        return text(val) if IS_PY_3K and not isinstance(val, bool) else val
+    return val
 
 
 def dict_to_joined_export(data, index, indices, name, survey, row,


### PR DESCRIPTION
 This function `encode_if_str` is used in Google Export aswell. Converting all items to string is a functionality only applicable to sav. In google export, this function leads to problems when data supposed to be sent as raw is sent as a string.
Will fix [this](https://github.com/onaio/google-export/issues/89) google-export issue
Signed-off-by: Lincoln Simba <lincolncmba@gmail.com>