### PR TITLE
Limit login attempts

### DIFF
--- a/onadata/apps/api/tasks.py
+++ b/onadata/apps/api/tasks.py
@@ -2,15 +2,15 @@ import os
 import sys
 from builtins import str
 from io import BytesIO
-from past.builtins import basestring
 
 from celery import task
 from celery.result import AsyncResult
+from django.conf import settings
 from django.core.files.uploadedfile import (InMemoryUploadedFile,
                                             TemporaryUploadedFile)
-from django.utils.datastructures import MultiValueDict
-from django.conf import settings
 from django.core.mail import EmailMultiAlternatives
+from django.utils.datastructures import MultiValueDict
+from past.builtins import basestring
 
 from onadata.apps.api import tools
 from onadata.apps.logger.models.xform import XForm
@@ -79,11 +79,7 @@ def get_async_status(job_uuid):
     return result
 
 
-@task()
-def send_verification_email(email, message_txt, subject):
-    """
-    Sends a verification email
-    """
+def send_generic_email(email, message_txt, subject):
     if any(a in [None, ''] for a in [email, message_txt, subject]):
         raise ValueError(
             "email, message_txt amd subject arguments are ALL required."
@@ -98,3 +94,16 @@ def send_verification_email(email, message_txt, subject):
     )
 
     email_message.send()
+
+
+@task()
+def send_verification_email(email, message_txt, subject):
+    """
+    Sends a verification email
+    """
+    send_generic_email(email, subject, message_txt)
+
+
+@task()
+def send_account_lockout_email(email, subject, message_txt):
+    send_generic_email(email, subject, message_txt)

--- a/onadata/apps/api/tests/viewsets/test_connect_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_connect_viewset.py
@@ -206,7 +206,9 @@ class TestConnectViewSet(TestAbstractViewSet):
         response = view(request)
         self.assertEqual(response.status_code, 401)
         self.assertEqual(response.data['detail'],
-                         u"Invalid username/password")
+                         u"Invalid username/password. For security reasons, "
+                         u"after 4 more failed login attempts you'll "
+                         u"have to wait 30 minutes before trying again.")
         auth = DigestAuth('bob', 'bobbob')
         request.META.update(auth(request.META, response))
         request.session = self.client.session
@@ -315,7 +317,9 @@ class TestConnectViewSet(TestAbstractViewSet):
         response = view(request)
         self.assertEqual(response.status_code, 401)
         self.assertEqual(response.data['detail'],
-                         u"Invalid username/password")
+                         u"Invalid username/password. For security reasons, "
+                         u"after 4 more failed login attempts you'll have to "
+                         u"wait 30 minutes before trying again.")
 
     def test_user_updates_email(self):
         view = ConnectViewSet.as_view(
@@ -376,14 +380,18 @@ class TestConnectViewSet(TestAbstractViewSet):
         response = view(request)
         self.assertEqual(response.status_code, 401)
         self.assertEqual(response.data['detail'],
-                         u"Invalid username/password")
+                         u"Invalid username/password. For security reasons, "
+                         u"after 4 more failed login attempts you'll have to "
+                         u"wait 30 minutes before trying again.")
         self.assertEqual(cache.get('login_attempts-bob'), 1)
 
         # cache value increments with subsequent attempts
         response = view(request)
         self.assertEqual(response.status_code, 401)
         self.assertEqual(response.data['detail'],
-                         u"Invalid username/password")
+                         u"Invalid username/password. For security reasons, "
+                         u"after 3 more failed login attempts you'll have to "
+                         u"wait 30 minutes before trying again.")
         self.assertEqual(cache.get('login_attempts-bob'), 2)
 
         # login_attempts doesn't increase with correct login
@@ -402,7 +410,8 @@ class TestConnectViewSet(TestAbstractViewSet):
         response = view(request)
         self.assertEqual(response.status_code, 401)
         self.assertEqual(response.data['detail'],
-                         u"Invalid username/password")
+                         u"Locked out. Too many wrong username/password "
+                         u"attempts. Try again in 30 minutes.")
         self.assertEqual(cache.get('login_attempts-bob'), 5)
         self.assertIsNotNone(cache.get('lockout_user-bob'))
         lockout = datetime.strptime(
@@ -424,8 +433,8 @@ class TestConnectViewSet(TestAbstractViewSet):
         response = view(request)
         self.assertEqual(response.status_code, 401)
         self.assertEqual(response.data['detail'],
-                         u"Locked out. Too many password attempts. "
-                         u"Try again in 30 minutes")
+                         u"Locked out. Too many wrong username/password "
+                         u"attempts. Try again in 30 minutes.")
         # clear cache
         cache.delete('login_attempts-bob')
         cache.delete('lockout_user-bob')

--- a/onadata/apps/api/tests/viewsets/test_connect_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_connect_viewset.py
@@ -207,7 +207,7 @@ class TestConnectViewSet(TestAbstractViewSet):
         self.assertEqual(response.status_code, 401)
         self.assertEqual(response.data['detail'],
                          u"Invalid username/password. For security reasons, "
-                         u"after 4 more failed login attempts you'll "
+                         u"after 9 more failed login attempts you'll "
                          u"have to wait 30 minutes before trying again.")
         auth = DigestAuth('bob', 'bobbob')
         request.META.update(auth(request.META, response))
@@ -318,7 +318,7 @@ class TestConnectViewSet(TestAbstractViewSet):
         self.assertEqual(response.status_code, 401)
         self.assertEqual(response.data['detail'],
                          u"Invalid username/password. For security reasons, "
-                         u"after 4 more failed login attempts you'll have to "
+                         u"after 9 more failed login attempts you'll have to "
                          u"wait 30 minutes before trying again.")
 
     def test_user_updates_email(self):
@@ -381,7 +381,7 @@ class TestConnectViewSet(TestAbstractViewSet):
         self.assertEqual(response.status_code, 401)
         self.assertEqual(response.data['detail'],
                          u"Invalid username/password. For security reasons, "
-                         u"after 4 more failed login attempts you'll have to "
+                         u"after 9 more failed login attempts you'll have to "
                          u"wait 30 minutes before trying again.")
         self.assertEqual(cache.get('login_attempts-bob'), 1)
 
@@ -390,7 +390,7 @@ class TestConnectViewSet(TestAbstractViewSet):
         self.assertEqual(response.status_code, 401)
         self.assertEqual(response.data['detail'],
                          u"Invalid username/password. For security reasons, "
-                         u"after 3 more failed login attempts you'll have to "
+                         u"after 8 more failed login attempts you'll have to "
                          u"wait 30 minutes before trying again.")
         self.assertEqual(cache.get('login_attempts-bob'), 2)
 
@@ -405,14 +405,14 @@ class TestConnectViewSet(TestAbstractViewSet):
         auth = DigestAuth('bob', 'bob')
         request = self._get_request_session_with_auth(view, auth)
         self.assertFalse(send_account_lockout_email.called)
-        cache.set('login_attempts-bob', 4)
+        cache.set('login_attempts-bob', 9)
         self.assertIsNone(cache.get('lockout_user-bob'))
         response = view(request)
         self.assertEqual(response.status_code, 401)
         self.assertEqual(response.data['detail'],
                          u"Locked out. Too many wrong username/password "
                          u"attempts. Try again in 30 minutes.")
-        self.assertEqual(cache.get('login_attempts-bob'), 5)
+        self.assertEqual(cache.get('login_attempts-bob'), 10)
         self.assertIsNotNone(cache.get('lockout_user-bob'))
         lockout = datetime.strptime(
             cache.get('lockout_user-bob'), '%Y-%m-%dT%H:%M:%S')

--- a/onadata/libs/authentication.py
+++ b/onadata/libs/authentication.py
@@ -88,7 +88,7 @@ class DigestAuthentication(BaseAuthentication):
             else:
                 attempts = login_attempts(request)
                 remaining_attempts = \
-                    getattr(settings, 'MAX_LOGIN_ATTEMPTS', 5) - attempts
+                    getattr(settings, 'MAX_LOGIN_ATTEMPTS', 10) - attempts
                 raise AuthenticationFailed(
                     _("Invalid username/password. "
                       "For security reasons, after {} more failed "
@@ -237,7 +237,7 @@ def login_attempts(request):
     if attempts:
         cache.incr('{}{}'.format(LOGIN_ATTEMPTS, username))
         attempts = cache.get('{}{}'.format(LOGIN_ATTEMPTS, username))
-        if attempts >= getattr(settings, 'MAX_LOGIN_ATTEMPTS', 5):
+        if attempts >= getattr(settings, 'MAX_LOGIN_ATTEMPTS', 10):
             send_lockout_email(username)
             cache.set(
                 '{}{}'.format(LOCKOUT_USER, username),

--- a/onadata/libs/templates/account_lockout/lockout_email_subject.txt
+++ b/onadata/libs/templates/account_lockout/lockout_email_subject.txt
@@ -1,0 +1,1 @@
+{% load i18n %}{% blocktrans %}Ona Account Lockout{% endblocktrans %}

--- a/onadata/libs/templates/account_lockout/lockout_end.txt
+++ b/onadata/libs/templates/account_lockout/lockout_end.txt
@@ -6,7 +6,7 @@ You are no longer locked out of Ona, you can now log in to your account.
 
 Thank you for choosing Ona!
 
-Please contact us with any questions, we're always happy to help.
+Please contact us at support@ona.io with any questions, we're always happy to help.
 
 The Team at Ona
 {% endblocktrans %}

--- a/onadata/libs/templates/account_lockout/lockout_end.txt
+++ b/onadata/libs/templates/account_lockout/lockout_end.txt
@@ -3,9 +3,10 @@
 Hi {{ username }},
 
 You are no longer locked out of Ona, you can now log in to your account.
+
 Thank you for choosing Ona!
+
 Please contact us with any questions, we're always happy to help.
 
-Thanks,
 The Team at Ona
 {% endblocktrans %}

--- a/onadata/libs/templates/account_lockout/lockout_end.txt
+++ b/onadata/libs/templates/account_lockout/lockout_end.txt
@@ -6,7 +6,7 @@ You are no longer locked out of Ona, you can now log in to your account.
 
 Thank you for choosing Ona!
 
-Please contact us at support@ona.io with any questions, we're always happy to help.
+Please contact us at {{ support_email }} with any questions, we're always happy to help.
 
 The Team at Ona
 {% endblocktrans %}

--- a/onadata/libs/templates/account_lockout/lockout_end.txt
+++ b/onadata/libs/templates/account_lockout/lockout_end.txt
@@ -1,0 +1,11 @@
+{% load i18n %}
+{% blocktrans with username=username %}
+Hi {{ username }},
+
+You are no longer locked out of Ona, you can now log in to your account.
+Thank you for choosing Ona!
+Please contact us with any questions, we're always happy to help.
+
+Thanks,
+The Team at Ona
+{% endblocktrans %}

--- a/onadata/libs/templates/account_lockout/lockout_start.txt
+++ b/onadata/libs/templates/account_lockout/lockout_start.txt
@@ -2,11 +2,13 @@
 {% blocktrans with lockout_time=lockout_time username=username %}
 Hi {{ username }},
 
-You have been locked out from your Ona account because of too many wrong passwords.
+You have been locked out from your Ona account because you have entered too many wrong passwords.
+
 Please wait for {{ lockout_time }} minutes before trying to access your account again.
-If this was not you please reach out to our support team for help.
+
+If this was not you, you can reach out to our support team for help, support@ona.io.
+
 Thank you for choosing Ona!
 
-Thanks,
 The Team at Ona
 {% endblocktrans %}

--- a/onadata/libs/templates/account_lockout/lockout_start.txt
+++ b/onadata/libs/templates/account_lockout/lockout_start.txt
@@ -1,0 +1,12 @@
+{% load i18n %}
+{% blocktrans with lockout_time=lockout_time username=username %}
+Hi {{ username }},
+
+You have been locked out from your Ona account because of too many wrong passwords.
+Please wait for {{ lockout_time }} minutes before trying to access your account again.
+If this was not you please reach out to our support team for help.
+Thank you for choosing Ona!
+
+Thanks,
+The Team at Ona
+{% endblocktrans %}

--- a/onadata/libs/templates/account_lockout/lockout_start.txt
+++ b/onadata/libs/templates/account_lockout/lockout_start.txt
@@ -6,7 +6,7 @@ You have been locked out from your Ona account because you have entered too many
 
 Please wait for {{ lockout_time }} minutes before trying to access your account again.
 
-If this was not you, you can reach out to our support team for help, support@ona.io.
+If this was not you, you can reach out to our support team for help, {{ support_email }}.
 
 Thank you for choosing Ona!
 

--- a/onadata/libs/utils/cache_tools.py
+++ b/onadata/libs/utils/cache_tools.py
@@ -27,3 +27,7 @@ DATAVIEW_LAST_SUBMISSION_TIME = 'dvs-last_submission_time'
 PROJ_TEAM_USERS_CACHE = 'ps-project-team-users'
 XFORM_LINKED_DATAVIEWS = 'xfs-linked_dataviews'
 PROJECT_LINKED_DATAVIEWS = 'ps-project-linked_dataviews'
+
+# cache login attempts
+LOCKOUT_USER = 'lockout_user-'
+LOGIN_ATTEMPTS = 'login_attempts-'

--- a/onadata/libs/utils/email.py
+++ b/onadata/libs/utils/email.py
@@ -52,7 +52,8 @@ def get_account_lockout_email_data(username, end=False):
         message_path = 'account_lockout/lockout_end.txt'
     ctx_dict = {
         'username': username,
-        'lockout_time': getattr(settings, 'LOCKOUT_TIME', 1800) / 60
+        'lockout_time': getattr(settings, 'LOCKOUT_TIME', 1800) / 60,
+        'support_email': getattr(settings, 'SUPPORT_EMAIL', 'support@ona.io')
     }
 
     email_data = {

--- a/onadata/libs/utils/email.py
+++ b/onadata/libs/utils/email.py
@@ -52,7 +52,7 @@ def get_account_lockout_email_data(username, end=False):
         message_path = 'account_lockout/lockout_end.txt'
     ctx_dict = {
         'username': username,
-        'lockout_time': settings.LOCKOUT_TIME / 60
+        'lockout_time': getattr(settings, 'LOCKOUT_TIME', 1800) / 60
     }
 
     email_data = {

--- a/onadata/libs/utils/email.py
+++ b/onadata/libs/utils/email.py
@@ -1,7 +1,6 @@
-from future.moves.urllib.parse import urlencode
-
 from django.conf import settings
 from django.template.loader import render_to_string
+from future.moves.urllib.parse import urlencode
 from rest_framework.reverse import reverse
 
 
@@ -41,5 +40,24 @@ def get_verification_email_data(email, username, verification_url, request):
                 request=request
             )
         })
+
+    return email_data
+
+
+def get_account_lockout_email_data(username, end=False):
+    """Generates both the email upon start and end of account lockout"""
+    message_path = 'account_lockout/lockout_start.txt'
+    subject_path = 'account_lockout/lockout_email_subject.txt'
+    if end:
+        message_path = 'account_lockout/lockout_end.txt'
+    ctx_dict = {
+        'username': username,
+        'lockout_time': settings.LOCKOUT_TIME / 60
+    }
+
+    email_data = {
+        'subject': render_to_string(subject_path),
+        'message_txt': render_to_string(message_path, ctx_dict)
+    }
 
     return email_data

--- a/onadata/libs/utils/email.py
+++ b/onadata/libs/utils/email.py
@@ -53,7 +53,8 @@ def get_account_lockout_email_data(username, end=False):
     ctx_dict = {
         'username': username,
         'lockout_time': getattr(settings, 'LOCKOUT_TIME', 1800) / 60,
-        'support_email': getattr(settings, 'SUPPORT_EMAIL', 'support@ona.io')
+        'support_email': getattr(
+            settings, 'SUPPORT_EMAIL', 'support@example.com')
     }
 
     email_data = {

--- a/onadata/settings/common.py
+++ b/onadata/settings/common.py
@@ -562,3 +562,8 @@ PROJECT_QUERY_CHUNK_SIZE = 5000
 # Prevents "The number of GET/POST parameters exceeded" exception
 DATA_UPLOAD_MAX_NUMBER_FIELDS = 10000000
 SECRET_KEY = 'mlfs33^s1l4xf6a36$0#j%dd*sisfoi&)&4s-v=91#^l01v)*j'
+
+# Time in minutes to lock out user from account
+LOCKOUT_TIME = 30 * 60
+MAX_LOGIN_ATTEMPTS = 10
+SUPPORT_EMAIL = "support@example.com"

--- a/onadata/settings/travis_test.py
+++ b/onadata/settings/travis_test.py
@@ -65,8 +65,3 @@ MIDDLEWARE_CLASSES = (
 )
 
 VERIFIED_KEY_TEXT = 'ALREADY_ACTIVATED'
-
-# Time in minutes to lock out user from account
-LOCKOUT_TIME = 30 * 60
-MAX_LOGIN_ATTEMPTS = 10
-SUPPORT_EMAIL = "support@ona.io"

--- a/onadata/settings/travis_test.py
+++ b/onadata/settings/travis_test.py
@@ -2,8 +2,6 @@
 # this preset is used for automated testing of formhub
 from __future__ import absolute_import
 
-from future.moves.urllib.parse import urljoin
-
 from .common import *  # nopep8
 
 DATABASES = {
@@ -67,3 +65,7 @@ MIDDLEWARE_CLASSES = (
 )
 
 VERIFIED_KEY_TEXT = 'ALREADY_ACTIVATED'
+
+# Time in minutes to lock out user from account
+LOCKOUT_TIME = 30 * 60
+MAX_LOGIN_ATTEMPTS = 5

--- a/onadata/settings/travis_test.py
+++ b/onadata/settings/travis_test.py
@@ -68,4 +68,5 @@ VERIFIED_KEY_TEXT = 'ALREADY_ACTIVATED'
 
 # Time in minutes to lock out user from account
 LOCKOUT_TIME = 30 * 60
-MAX_LOGIN_ATTEMPTS = 5
+MAX_LOGIN_ATTEMPTS = 10
+SUPPORT_EMAIL = "support@ona.io"


### PR DESCRIPTION
Track the login attempts using MemCache.
Lockout user if the limit is reached.
Send email upon lockout and end of the lockout.
Addresses [this](https://github.com/onaio/playbooks/issues/1298).