### PR TITLE
Allow blank notes in reviewing Approved/Pending submissions

### DIFF
--- a/onadata/libs/serializers/submission_review_serializer.py
+++ b/onadata/libs/serializers/submission_review_serializer.py
@@ -14,7 +14,8 @@ class SubmissionReviewSerializer(serializers.ModelSerializer):
     """
     SubmissionReviewSerializer Class
     """
-    note = serializers.CharField(source='note.note', required=False)
+    note = serializers.CharField(
+        source='note.note', required=False, allow_blank=True)
 
     class Meta:
         """
@@ -59,6 +60,7 @@ class SubmissionReviewSerializer(serializers.ModelSerializer):
         """
         Custom update method for SubmissionReviewSerializer
         """
+        __import__('ipdb').set_trace()
         note = instance.note
         note_data = validated_data.pop('note')
 

--- a/onadata/libs/serializers/submission_review_serializer.py
+++ b/onadata/libs/serializers/submission_review_serializer.py
@@ -60,7 +60,6 @@ class SubmissionReviewSerializer(serializers.ModelSerializer):
         """
         Custom update method for SubmissionReviewSerializer
         """
-        __import__('ipdb').set_trace()
         note = instance.note
         note_data = validated_data.pop('note')
 

--- a/onadata/libs/tests/serializers/test_submission_review_serializer.py
+++ b/onadata/libs/tests/serializers/test_submission_review_serializer.py
@@ -106,3 +106,36 @@ class TestSubmissionReviewSerializer(TestBase):
         # Doesnt create a new note
         self.assertEqual(len(Note.objects.all()), 1)
         self.assertNotEqual(old_note_text, new_review.note_text)
+
+    def test_approved_and_pending_status_allows_blank_in_note(self):
+        self._publish_transportation_form_and_submit_instance()
+
+        instance = Instance.objects.first()
+
+        data = {
+            "instance": instance.id,
+            "note": "",
+            "status": SubmissionReview.APPROVED
+        }
+
+        serializer_instance = SubmissionReviewSerializer(data=data)
+        self.assertTrue(serializer_instance.is_valid())
+        data = {
+            "instance": instance.id,
+            "note": "",
+            "status": SubmissionReview.PENDING
+        }
+        serializer_instance = SubmissionReviewSerializer(data=data)
+        self.assertTrue(serializer_instance.is_valid())
+        data = {
+            "instance": instance.id,
+            "note": "",
+            "status": SubmissionReview.REJECTED
+        }
+        serializer_instance = SubmissionReviewSerializer(data=data)
+        self.assertTrue(serializer_instance.is_valid())
+        with self.assertRaises(ValidationError) as no_comment:
+            serializer_instance.validate(data)
+
+            no_comment_error_detail = no_comment.exception.detail['note']
+            self.assertEqual(COMMENT_REQUIRED, no_comment_error_detail)


### PR DESCRIPTION
In the previous implementation, the post request either had to include a note string or have the the note completely not included in the payload and therefore, having a blank note i.e `"note":""` failed.
Here, empty notes are permitted for APPROVED and PENDING statuses.
More details [here](https://www.django-rest-framework.org/community/3.0-announcement/#the-required-allow_null-allow_blank-and-default-arguments)
fixes #1623 
Signed-off-by: Lincoln Simba <lincolncmba@gmail.com>