### PR TITLE
Depracate load_class in favour of Django's import_string

### DIFF
--- a/onadata/apps/api/tools.py
+++ b/onadata/apps/api/tools.py
@@ -2,7 +2,6 @@
 """
 API util functions.
 """
-import importlib
 import os
 import tempfile
 from datetime import datetime

--- a/onadata/apps/api/tools.py
+++ b/onadata/apps/api/tools.py
@@ -21,6 +21,7 @@ from django.db.utils import IntegrityError
 from django.http import HttpResponseNotFound, HttpResponseRedirect
 from django.shortcuts import get_object_or_404
 from django.utils.translation import ugettext as _
+from django.utils.module_loading import import_string
 from future.utils import listitems
 from guardian.shortcuts import assign_perm, get_perms_for_model, remove_perm
 from guardian.shortcuts import get_perms
@@ -603,27 +604,13 @@ def _set_xform_permission(role, user, xform):
         role_class.add(user, xform)
 
 
-def load_class(full_class_string):
-    """
-    dynamically load a class from a string
-    """
-
-    class_data = full_class_string.split(".")
-    module_path = ".".join(class_data[:-1])
-    class_str = class_data[-1]
-
-    module = importlib.import_module(module_path)
-    # Finally, we retrieve the Class
-    return getattr(module, class_str)
-
-
 def get_baseviewset_class():
     """
     Checks the setting if the default viewset is implementded otherwise loads
     the default in onadata
     :return: the default baseviewset
     """
-    return load_class(settings.BASE_VIEWSET) \
+    return import_string(settings.BASE_VIEWSET) \
         if settings.BASE_VIEWSET else DefaultBaseViewset
 
 

--- a/onadata/apps/api/viewsets/organization_profile_viewset.py
+++ b/onadata/apps/api/viewsets/organization_profile_viewset.py
@@ -1,5 +1,6 @@
 import json
 from django.conf import settings
+from django.utils.module_loading import import_string
 
 from rest_framework import status
 from rest_framework.viewsets import ModelViewSet
@@ -9,7 +10,7 @@ from rest_framework.response import Response
 from onadata.apps.api.models.organization_profile import OrganizationProfile
 
 from onadata.apps.api import permissions
-from onadata.apps.api.tools import get_baseviewset_class, load_class
+from onadata.apps.api.tools import get_baseviewset_class
 from onadata.libs.utils.common_tools import merge_dicts
 from onadata.libs.filters import (OrganizationPermissionFilter,
                                   OrganizationsSharedWithUserFilter)
@@ -29,7 +30,7 @@ BaseViewset = get_baseviewset_class()
 
 def serializer_from_settings():
     if settings.ORG_PROFILE_SERIALIZER:
-        return load_class(settings.ORG_PROFILE_SERIALIZER)
+        return import_string(settings.ORG_PROFILE_SERIALIZER)
 
     return OrganizationSerializer
 

--- a/onadata/apps/api/viewsets/user_profile_viewset.py
+++ b/onadata/apps/api/viewsets/user_profile_viewset.py
@@ -15,6 +15,7 @@ from django.db.models import Count
 from django.http import HttpResponseRedirect, HttpResponseBadRequest
 from django.utils.translation import ugettext as _
 from django.utils import timezone
+from django.utils.module_loading import import_string
 
 from registration.models import RegistrationProfile
 from rest_framework import serializers, status
@@ -27,7 +28,7 @@ from rest_framework.viewsets import ModelViewSet
 
 from onadata.apps.api.tasks import send_verification_email
 from onadata.apps.api.permissions import UserProfilePermissions
-from onadata.apps.api.tools import get_baseviewset_class, load_class
+from onadata.apps.api.tools import get_baseviewset_class
 from onadata.apps.logger.models.instance import Instance
 from onadata.apps.main.models import UserProfile
 from onadata.libs.utils.email import (get_verification_email_data,
@@ -84,7 +85,7 @@ def serializer_from_settings():
     default to UserProfileSerializer.
     """
     if settings.PROFILE_SERIALIZER:
-        return load_class(settings.PROFILE_SERIALIZER)
+        return import_string(settings.PROFILE_SERIALIZER)
 
     return UserProfileSerializer
 

--- a/onadata/apps/messaging/backends/base.py
+++ b/onadata/apps/messaging/backends/base.py
@@ -4,8 +4,6 @@ Messaging notification base module.
 """
 from __future__ import unicode_literals
 
-from importlib import import_module
-
 from django.utils.module_loading import import_string
 
 from actstream.models import Action

--- a/onadata/apps/messaging/backends/base.py
+++ b/onadata/apps/messaging/backends/base.py
@@ -6,6 +6,8 @@ from __future__ import unicode_literals
 
 from importlib import import_module
 
+from django.utils.module_loading import import_string
+
 from actstream.models import Action
 
 
@@ -18,10 +20,7 @@ def call_backend(backend, instance_id, backend_options=None):
     except Action.DoesNotExist:
         pass
     else:
-        backend_module = '.'.join(backend.split('.')[:-1])
-        backend_class = backend.split('.')[-1:].pop()
-        backend_module = import_module(backend_module)
-        backend_class = getattr(backend_module, backend_class)
+        backend_class = import_string(backend)
         backend_class(options=backend_options).send(instance)
 
 

--- a/onadata/apps/restservice/viewsets/restservices_viewset.py
+++ b/onadata/apps/restservice/viewsets/restservices_viewset.py
@@ -1,5 +1,6 @@
 import importlib
 from django.conf import settings
+from django.utils.module_loading import import_string
 from rest_framework.viewsets import ModelViewSet
 from rest_framework.response import Response
 
@@ -20,26 +21,13 @@ from onadata.apps.api.tools import get_baseviewset_class
 BaseViewset = get_baseviewset_class()
 
 
-def load_class(full_class_string):
-    """
-    Dynamically load a class from a string
-    """
-
-    class_data = full_class_string.split(".")
-    module_path = ".".join(class_data[:-1])
-    class_str = class_data[-1]
-    module = importlib.import_module(module_path)
-
-    return getattr(module, class_str)
-
-
 def get_serializer_class(name):
     services_to_serializers = getattr(settings,
                                       'REST_SERVICES_TO_SERIALIZERS', {})
     serializer_class = services_to_serializers.get(name)
 
     if serializer_class:
-        return load_class(serializer_class)
+        return import_string(serializer_class)
 
     if name == TEXTIT:
         return TextItSerializer

--- a/onadata/apps/restservice/viewsets/restservices_viewset.py
+++ b/onadata/apps/restservice/viewsets/restservices_viewset.py
@@ -1,4 +1,3 @@
-import importlib
 from django.conf import settings
 from django.utils.module_loading import import_string
 from rest_framework.viewsets import ModelViewSet


### PR DESCRIPTION
Replaces custom load_class function with a Django utility function import_string that has the same functionality with a more comprehensive error handling and reporting scheme

closes: #1636 