### PR TITLE
Remove duplicate function that generates uuid

### DIFF
--- a/onadata/apps/logger/models/widget.py
+++ b/onadata/apps/logger/models/widget.py
@@ -20,7 +20,7 @@ from onadata.libs.utils.chart_tools import (DATA_TYPE_MAP,
                                             get_field_label)
 from onadata.libs.utils.common_tags import (NUMERIC_LIST, SELECT_ONE,
                                             SUBMISSION_TIME)
-from onadata.libs.utils.model_tools import generate_uuid_for_form
+from onadata.libs.utils.common_tools import get_uuid
 
 
 class Widget(OrderedModel):
@@ -60,7 +60,7 @@ class Widget(OrderedModel):
     def save(self, *args, **kwargs):
 
         if not self.key:
-            self.key = generate_uuid_for_form()
+            self.key = get_uuid()
 
         super(Widget, self).save(*args, **kwargs)
 

--- a/onadata/apps/viewer/views.py
+++ b/onadata/apps/viewer/views.py
@@ -4,7 +4,6 @@ data views.
 """
 import json
 import os
-import uuid
 from datetime import datetime
 from tempfile import NamedTemporaryFile
 from time import strftime, strptime
@@ -52,6 +51,7 @@ from onadata.libs.utils.user_auth import (get_xform_and_perms, has_permission,
                                           helper_auth_helper)
 from onadata.libs.utils.viewer_tools import (
     create_attachments_zipfile, export_def_from_filename, get_form)
+from onadata.libs.utils.common_tools import get_uuid
 
 
 def _get_start_end_submission_time(request):
@@ -244,7 +244,7 @@ def add_submission_with(request, username, id_string):
         'form_id': id_string,
         'server_url': openrosa_url,
         'instance': instance_xml,
-        'instance_id': uuid.uuid4().hex
+        'instance_id': get_uuid()
     }
 
     response = requests.post(

--- a/onadata/libs/utils/model_tools.py
+++ b/onadata/libs/utils/model_tools.py
@@ -2,14 +2,7 @@
 """
 Model utility functions.
 """
-import uuid
-
-
-def generate_uuid_for_form():
-    """
-    Returns the UUID4 hex value.
-    """
-    return uuid.uuid4().hex
+from onadata.libs.utils.common_tools import get_uuid
 
 
 def set_uuid(obj):
@@ -17,7 +10,7 @@ def set_uuid(obj):
     Only give an object a new UUID if it does not have one.
     """
     if not obj.uuid:
-        obj.uuid = generate_uuid_for_form()
+        obj.uuid = get_uuid()
 
 
 def queryset_iterator(queryset, chunksize=100):


### PR DESCRIPTION
Removes ```generate_uuid_for_form``` since its simiilar in functionality and syntax to  ```get_uuid```.  

closes #1638 