### PR TITLE
Limit change password attempts

### DIFF
--- a/onadata/apps/api/viewsets/user_profile_viewset.py
+++ b/onadata/apps/api/viewsets/user_profile_viewset.py
@@ -33,6 +33,9 @@ from onadata.apps.logger.models.instance import Instance
 from onadata.apps.main.models import UserProfile
 from onadata.libs.utils.email import (get_verification_email_data,
                                       get_verification_url)
+from onadata.libs.utils.cache_tools import (cache,
+                                            CHANGE_PASSWORD_ATTEMPTS,
+                                            LOCKOUT_CHANGE_PASSWORD_USER)
 from onadata.libs import filters
 from onadata.libs.mixins.authenticate_header_mixin import \
     AuthenticateHeaderMixin
@@ -45,6 +48,9 @@ from onadata.libs.serializers.user_profile_serializer import \
     UserProfileSerializer
 
 BaseViewset = get_baseviewset_class()  # pylint: disable=invalid-name
+LOCKOUT_TIME = getattr(settings, 'LOCKOUT_TIME', 1800)
+MAX_CHANGE_PASSWORD_ATTEMPTS = getattr(
+    settings, 'MAX_CHANGE_PASSWORD_ATTEMPTS', 10)
 
 
 def replace_key_value(lookup, new_value, expected_dict):
@@ -93,6 +99,47 @@ def serializer_from_settings():
 def set_is_email_verified(profile, is_email_verified):
     profile.metadata.update({"is_email_verified": is_email_verified})
     profile.save()
+
+
+def check_user_lockout(request):
+    username = request.user.username
+    lockout = cache.get('{}{}'.format(LOCKOUT_CHANGE_PASSWORD_USER, username))
+    response_obj = {
+        'error': 'Too many password reset attempts, Try again in {} minutes'}
+    if lockout:
+        time_locked_out = \
+            datetime.datetime.now() - datetime.datetime.strptime(
+                lockout, '%Y-%m-%dT%H:%M:%S')
+        remaining_time = round(
+            (LOCKOUT_TIME -
+             time_locked_out.seconds) / 60)
+        response = response_obj['error'].format(remaining_time)
+        return response
+
+
+def change_password_attempts(request):
+    """Track number of login attempts made by user within a specified amount
+     of time"""
+    username = request.user.username
+    password_attempts = '{}{}'.format(CHANGE_PASSWORD_ATTEMPTS, username)
+    attempts = cache.get(password_attempts)
+
+    if attempts:
+        cache.incr(password_attempts)
+        attempts = cache.get(password_attempts)
+        if attempts >= MAX_CHANGE_PASSWORD_ATTEMPTS:
+            cache.set(
+                '{}{}'.format(LOCKOUT_CHANGE_PASSWORD_USER, username),
+                datetime.datetime.now().strftime('%Y-%m-%dT%H:%M:%S'),
+                LOCKOUT_TIME)
+            if check_user_lockout(request):
+                return check_user_lockout(request)
+
+        return attempts
+
+    cache.set(password_attempts, 1)
+
+    return 1
 
 
 class UserProfileViewSet(
@@ -155,19 +202,32 @@ class UserProfileViewSet(
         user_profile = self.get_object()
         current_password = request.data.get('current_password', None)
         new_password = request.data.get('new_password', None)
+        lock_out = check_user_lockout(request)
+        response_obj = {
+            'error': 'Invalid password. You have {} attempts left.'}
 
         if new_password:
-            if user_profile.user.check_password(current_password):
-                metadata = user_profile.metadata or {}
-                metadata['last_password_edit'] = timezone.now().isoformat()
-                user_profile.user.set_password(new_password)
-                user_profile.metadata = metadata
-                user_profile.user.save()
-                user_profile.save()
+            if not lock_out:
+                if user_profile.user.check_password(current_password):
+                    metadata = user_profile.metadata or {}
+                    metadata['last_password_edit'] = timezone.now().isoformat()
+                    user_profile.user.set_password(new_password)
+                    user_profile.metadata = metadata
+                    user_profile.user.save()
+                    user_profile.save()
 
-                return Response(status=status.HTTP_204_NO_CONTENT)
+                    return Response(status=status.HTTP_204_NO_CONTENT)
 
-        return Response(status=status.HTTP_400_BAD_REQUEST)
+                response = change_password_attempts(request)
+                if isinstance(response, int):
+                    limits_remaining = \
+                        MAX_CHANGE_PASSWORD_ATTEMPTS - response
+                    response = response_obj['error'].format(
+                            limits_remaining)
+                return Response(data=response,
+                                status=status.HTTP_400_BAD_REQUEST)
+
+        return Response(data=lock_out, status=status.HTTP_400_BAD_REQUEST)
 
     def partial_update(self, request, *args, **kwargs):
         profile = self.get_object()

--- a/onadata/libs/utils/cache_tools.py
+++ b/onadata/libs/utils/cache_tools.py
@@ -28,6 +28,8 @@ PROJECT_LINKED_DATAVIEWS = "ps-project-linked_dataviews"
 # cache login attempts
 LOCKOUT_USER = "lockout_user-"
 LOGIN_ATTEMPTS = "login_attempts-"
+LOCKOUT_CHANGE_PASSWORD_USER = 'lockout_change_password_user-'
+CHANGE_PASSWORD_ATTEMPTS = 'change_password_attempts-'
 
 
 def safe_delete(key):


### PR DESCRIPTION
Check if the user is locked out when changing password.
Tracks the number of attempts made to a maximum limit of 10.
Locks out user when maximum limit is reached.
