### PR TITLE
Bulk creation of submission reviews

### DIFF
--- a/docs/submission_review.rst
+++ b/docs/submission_review.rst
@@ -1,0 +1,214 @@
+SubmissionReview
+****************
+
+This endpoint supports List, Retrieve, Update, Create Submission Reviews
+
+Where:
+
+- ``id`` - the id of the submission review (required when doing an update)
+- ``instance`` - the id of the Instance object being reviewed
+- ``note`` - the submission review comment
+- ``status`` - the submission review status. Should be one of:
+
+    - ``'1'`` - approved
+    - ``'2'`` - rejected
+    - ``'3'`` - pending
+
+Note must be provided incase the status in '2' (rejected)
+
+Make a Submission Review
+------------------------
+.. raw:: html
+
+    <pre class="prettyprint">
+    <b>POST</b> /api/v1/submissionreview.json</pre>
+
+Example
+^^^^^^^
+::
+
+    curl -X POST -H "Content-type:application/json" -d '{"status":"1","instance":1337,"note":"This was approved because it is awesome!"}' https://example.com/api/v1/submissionreview.json
+
+Response
+^^^^^^^^^
+::
+
+    {
+        "id": 4,
+        "instance": 1337,
+        "created_by": 2,
+        "status": "1",
+        "date_created": "2019-07-18T08:25:54.536762-04:00",
+        "note": "This was approved because it is awesome!",
+        "date_modified": "2019-07-18T08:25:54.536785-04:00"
+    }
+
+
+Update a Submission Review
+--------------------------
+.. raw:: html
+
+    <pre class="prettyprint">
+    <b>PUT</b> /api/v1/submissionreview/<code>{id}</code>.json</pre>
+
+Example
+^^^^^^^
+::
+
+    curl -X PUT -H "Content-type:application/json" -d '{"id": 4,"instance": 1337,"created_by": 2,"status": "3","date_created": "2019-07-18T08:25:54.536762-04:00","note": "Returned to pending!","date_modified": "2019-07-18T08:25:54.536785-04:00"}' https://example.com/api/v1/submissionreview/4.json
+
+Response
+^^^^^^^^^
+::
+
+    {
+        "id": 4,
+        "instance": 1337,
+        "created_by": 2,
+        "status": "3",
+        "date_created": "2019-07-18T08:25:54.536762-04:00",
+        "note": "Returned to pending!",
+        "date_modified": "2019-07-18T08:25:54.536785-04:00"
+    }
+
+
+Delete a Submission Review
+--------------------------
+.. raw:: html
+
+    <pre class="prettyprint">
+    <b>DELETE</b> /api/v1/submissionreview/<code>{id}</code>.json</pre>
+
+Example
+^^^^^^^
+::
+
+    curl -X DELETE https://example.com/api/v1/submissionreview/4.json
+
+Response
+^^^^^^^^^
+::
+
+    HTTP 204 NO CONTENT
+
+
+Retrieve a Submission Review
+----------------------------
+.. raw:: html
+
+    <pre class="prettyprint">
+    <b>GET</b> /api/v1/submissionreview/<code>{id}</code>.json</pre>
+
+Example
+^^^^^^^
+::
+
+    curl -X GET https://example.com/api/v1/submissionreview/4.json
+
+Response
+^^^^^^^^^
+::
+
+    {
+        "id": 4,
+        "instance": 1337,
+        "created_by": 2,
+        "status": "3",
+        "date_created": "2019-07-18T08:25:54.536762-04:00",
+        "note": "Returned to pending!",
+        "date_modified": "2019-07-18T08:25:54.536785-04:00"
+    }
+
+Get a List of Submission Reviews
+--------------------------------
+.. raw:: html
+
+    <pre class="prettyprint">
+    <b>GET</b> /api/v1/submissionreview/.json</pre>
+
+Example
+^^^^^^^
+::
+
+    curl -X GET https://example.com/api/v1/submissionreview/.json
+
+Response
+^^^^^^^^^
+::
+
+    [
+        {
+            "id": 1,
+            "instance": 10,
+            "created_by": 2,
+            "status": "1",
+            "date_created": "2019-06-13T03:02:52.485116-04:00",
+            "note": "null",
+            "date_modified": "2019-06-13T03:02:52.485140-04:00"
+        },
+        {
+            "id": 2,
+            "instance": 11,
+            "created_by": 2,
+            "status": "1",
+            "date_created": "2019-06-13T03:19:46.127652-04:00",
+            "date_modified": "2019-06-13T03:19:46.127686-04:00"
+        } ...
+    ]
+
+Bulk Create Submission Review
+-----------------------------
+.. raw:: html
+
+    <pre class="prettyprint">
+    <b>POST</b> /api/v1/submissionreview.json</pre>
+
+Example
+^^^^^^^
+::
+
+    curl -X POST -H "Content-type:application/json" -d '[{"status":"1","instance":1337,"note":"This was approved because it is awesome!"},{"status":"1","instance":1338}]' https://example.com/api/v1/submissionreview.json
+
+Response
+^^^^^^^^^
+::
+
+    [
+        {
+            "id": 5,
+            "instance": 1337,
+            "created_by": 2,
+            "status": "1",
+            "date_created": "2019-07-18T09:25:33.795161-04:00",
+            "note": "This was approved because it is awesome!",
+            "date_modified": "2019-07-18T09:25:33.795182-04:00"
+        },
+        {
+            "id": 6,
+            "instance": 1338,
+            "created_by": 2,
+            "status": "1",
+            "date_created": "2019-07-18T09:25:33.917456-04:00",
+            "date_modified": "2019-07-18T09:25:33.917484-04:00"
+        }
+    ]
+
+Filtering by Instance
+---------------------
+
+Example
+^^^^^^^
+::
+
+    curl -X GET -H "Content-Type:application/json" https://example.com/api/v1/submissionreview/?instance=66
+
+
+Filtering by Status
+---------------------
+
+Example
+^^^^^^^
+::
+
+    curl -X GET -H "Content-Type:application/json" https://example.com/api/v1/submissionreview/?status=2
+

--- a/onadata/apps/api/tests/viewsets/test_submission_review_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_submission_review_viewset.py
@@ -351,3 +351,23 @@ class TestSubmissionReviewViewSet(TestBase):
         self.assertEqual(200, response.status_code)
         self.assertEqual(1, len(response.data))
         self.assertEqual(review_two_data['id'], response.data[0]['id'])
+
+    def test_bulk_create_approved_review_missiong_note(self):
+        """
+        Test that we can bulk create approved submission reviews without a note
+        """
+        instances = self.xform.instances.all()
+        submission_data = [
+            {
+                'instance': _.id,
+                'status': SubmissionReview.APPROVED
+            } for _ in instances
+        ]
+        view = SubmissionReviewViewSet.as_view({'post': 'create'})
+
+        self.extra['format'] = 'json'
+
+        request = self.factory.post('/', data=submission_data, **self.extra)
+        response = view(request=request)
+        self.assertEqual(201, response.status_code)
+        self.assertEqual(4, len(response.data))

--- a/onadata/libs/tests/serializers/test_submission_review_serializer.py
+++ b/onadata/libs/tests/serializers/test_submission_review_serializer.py
@@ -108,16 +108,15 @@ class TestSubmissionReviewSerializer(TestBase):
         self.assertNotEqual(old_note_text, new_review.note_text)
 
     def test_approved_and_pending_status_allows_blank_in_note(self):
-        self._publish_transportation_form_and_submit_instance()
+        self._publish_transportation_form()
+        self._make_submissions()
 
         instance = Instance.objects.first()
 
         data = {
             "instance": instance.id,
-            "note": "",
             "status": SubmissionReview.APPROVED
         }
-
         serializer_instance = SubmissionReviewSerializer(data=data)
         self.assertTrue(serializer_instance.is_valid())
         data = {
@@ -139,3 +138,17 @@ class TestSubmissionReviewSerializer(TestBase):
 
             no_comment_error_detail = no_comment.exception.detail['note']
             self.assertEqual(COMMENT_REQUIRED, no_comment_error_detail)
+
+        # bulk creation of approved submissions without comments
+        list_data = [{
+            "instance": instance.id,
+            "status": SubmissionReview.APPROVED
+        },
+            {
+                "instance": instance.id + 1,
+                "status": SubmissionReview.APPROVED
+            }
+        ]
+        serializer_instance = SubmissionReviewSerializer(
+            data=list_data, many=True)
+        self.assertTrue(serializer_instance.is_valid())


### PR DESCRIPTION
 Bulk creation of reviews was only implemented and tested at the serializer but not at the Viewset.
 This PR addresses this with a custom create function to handle bulk creation of submission reviews.
 fixes #1623

Signed-off-by: lincmba <lincolncmba@gmail.com>