### PR TITLE
 Manually strip newlines from email headers when sending user verification emails

### DIFF
--- a/onadata/apps/api/tasks.py
+++ b/onadata/apps/api/tasks.py
@@ -101,9 +101,9 @@ def send_verification_email(email, message_txt, subject):
     """
     Sends a verification email
     """
-    send_generic_email(email, subject, message_txt)
+    send_generic_email(email, message_txt, subject)
 
 
 @task()
-def send_account_lockout_email(email, subject, message_txt):
-    send_generic_email(email, subject, message_txt)
+def send_account_lockout_email(email, message_txt, subject):
+    send_generic_email(email, message_txt, subject)

--- a/onadata/libs/authentication.py
+++ b/onadata/libs/authentication.py
@@ -292,16 +292,16 @@ def send_lockout_email(username):
         send_account_lockout_email.apply_async(
             args=[
                 user.email,
-                email_data.get("subject"),
                 email_data.get("message_txt"),
+                email_data.get("subject"),
             ]
         )
         # send end of lockout email 1 minute after lockout time
         send_account_lockout_email.apply_async(
             args=[
                 user.email,
-                end_email_data.get("subject"),
                 end_email_data.get("message_txt"),
+                end_email_data.get("subject"),
             ],
             countdown=getattr(settings, "LOCKOUT_TIME", 1800) + 60,
         )

--- a/onadata/libs/tests/utils/test_email.py
+++ b/onadata/libs/tests/utils/test_email.py
@@ -105,3 +105,7 @@ class TestEmail(TestBase):
         self.assertIn(
             encoded_url.replace('&', '&amp;'), email_data.get('message_txt')
         )
+
+    def test_email_data_does_not_contain_newline_chars(self):
+        email_data = self._get_email_data(include_redirect_url=True)
+        self.assertNotIn('\n', email_data.get('subject'))

--- a/onadata/libs/utils/email.py
+++ b/onadata/libs/utils/email.py
@@ -33,13 +33,10 @@ def get_verification_email_data(email, username, verification_url, request):
         'message_txt': 'registration/verification_email.txt'
     }
     for key, template_path in key_template_path_dict.items():
-        email_data.update({
-            key: render_to_string(
-                template_path,
-                ctx_dict,
-                request=request
-            )
-        })
+        # Email subject *must not* contain newlines
+        subject = render_to_string(template_path, ctx_dict, request=request)
+        subject = ''.join(subject.splitlines())
+        email_data.update({key: subject})
 
     return email_data
 

--- a/onadata/libs/utils/email.py
+++ b/onadata/libs/utils/email.py
@@ -33,10 +33,13 @@ def get_verification_email_data(email, username, verification_url, request):
         'message_txt': 'registration/verification_email.txt'
     }
     for key, template_path in key_template_path_dict.items():
-        # Email subject *must not* contain newlines
-        subject = render_to_string(template_path, ctx_dict, request=request)
-        subject = ''.join(subject.splitlines())
-        email_data.update({key: subject})
+        email_data.update({
+            key: render_to_string(
+                template_path,
+                ctx_dict,
+                request=request
+            )
+        })
 
     return email_data
 


### PR DESCRIPTION
Fixes #1667 