### PR TITLE
Override django inbuilt password reset token generation

### DIFF
--- a/onadata/apps/api/tests/viewsets/test_connect_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_connect_viewset.py
@@ -3,7 +3,6 @@ from datetime import timedelta
 
 from django.conf import settings
 from django.contrib.auth.models import User
-from django.contrib.auth.tokens import default_token_generator
 from django.core.cache import cache
 from django.template.loader import render_to_string
 from django.utils.encoding import force_bytes
@@ -20,7 +19,7 @@ from onadata.apps.api.tests.viewsets.test_abstract_viewset import \
     TestAbstractViewSet
 from onadata.apps.api.viewsets.connect_viewset import ConnectViewSet
 from onadata.libs.serializers.password_reset_serializer import \
-    CustomPasswordResetTokenGenerator
+    custom_default_token_generator
 from onadata.apps.api.viewsets.project_viewset import ProjectViewSet
 from onadata.libs.authentication import DigestAuthentication
 from onadata.libs.serializers.project_serializer import ProjectSerializer
@@ -277,7 +276,7 @@ class TestConnectViewSet(TestAbstractViewSet):
         # https://code.djangoproject.com/ticket/10265
         self.user.last_login = now()
         self.user.save()
-        token = default_token_generator.make_token(self.user)
+        token = custom_default_token_generator.make_token(self.user)
         new_password = "bobbob1"
         data = {'token': token, 'new_password': new_password}
         # missing uid, should fail
@@ -306,7 +305,7 @@ class TestConnectViewSet(TestAbstractViewSet):
         new_password = "bobbob1"
         uid = urlsafe_base64_encode(
             force_bytes(self.user.pk)).decode('utf-8')
-        mhv = CustomPasswordResetTokenGenerator()
+        mhv = custom_default_token_generator
         token = mhv.make_token(self.user)
         data = {'token': token, 'new_password': new_password,
                 'uid': uid}

--- a/onadata/apps/api/tests/viewsets/test_connect_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_connect_viewset.py
@@ -19,7 +19,7 @@ from onadata.apps.api.tests.viewsets.test_abstract_viewset import \
     TestAbstractViewSet
 from onadata.apps.api.viewsets.connect_viewset import ConnectViewSet
 from onadata.libs.serializers.password_reset_serializer import \
-    custom_default_token_generator
+    default_token_generator
 from onadata.apps.api.viewsets.project_viewset import ProjectViewSet
 from onadata.libs.authentication import DigestAuthentication
 from onadata.libs.serializers.project_serializer import ProjectSerializer
@@ -276,7 +276,7 @@ class TestConnectViewSet(TestAbstractViewSet):
         # https://code.djangoproject.com/ticket/10265
         self.user.last_login = now()
         self.user.save()
-        token = custom_default_token_generator.make_token(self.user)
+        token = default_token_generator.make_token(self.user)
         new_password = "bobbob1"
         data = {'token': token, 'new_password': new_password}
         # missing uid, should fail
@@ -305,7 +305,7 @@ class TestConnectViewSet(TestAbstractViewSet):
         new_password = "bobbob1"
         uid = urlsafe_base64_encode(
             force_bytes(self.user.pk)).decode('utf-8')
-        mhv = custom_default_token_generator
+        mhv = default_token_generator
         token = mhv.make_token(self.user)
         data = {'token': token, 'new_password': new_password,
                 'uid': uid}

--- a/onadata/libs/serializers/password_reset_serializer.py
+++ b/onadata/libs/serializers/password_reset_serializer.py
@@ -55,14 +55,17 @@ def get_user_from_uid(uid):
 
     return user
 
+
 class CustomPasswordResetTokenGenerator(PasswordResetTokenGenerator):
     """Custom Password Token Generator Class."""
     def _make_hash_value(self, user, timestamp):
         # Include user email alongside user password to the generated token
         # as the user state object that might change after a password reset
         # to produce a token that invalidated.
-        login_timestamp = '' if user.last_login is None else user.last_login.replace(microsecond=0, tzinfo=None)
-        return str(user.pk) + user.password + user.email + str(login_timestamp) + str(timestamp)
+        login_timestamp = '' if user.last_login is None\
+            else user.last_login.replace(microsecond=0, tzinfo=None)
+        return str(user.pk) + user.password + user.email +\
+            str(login_timestamp) + str(timestamp)
 
 
 class PasswordResetChange(object):

--- a/onadata/libs/serializers/password_reset_serializer.py
+++ b/onadata/libs/serializers/password_reset_serializer.py
@@ -24,13 +24,13 @@ class CustomPasswordResetTokenGenerator(PasswordResetTokenGenerator):
             str(login_timestamp) + str(timestamp)
 
 
-custom_default_token_generator = CustomPasswordResetTokenGenerator()
+default_token_generator = CustomPasswordResetTokenGenerator()
 
 
 def get_password_reset_email(user, reset_url,
                              subject_template_name='registration/password_reset_subject.txt',  # noqa
                              email_template_name='api_password_reset_email.html',  # noqa
-                             token_generator=custom_default_token_generator,
+                             token_generator=default_token_generator,
                              email_subject=None):
     """Creates the subject and email body for password reset email."""
     result = urlparse(reset_url)
@@ -92,7 +92,7 @@ class PasswordReset(object):
     def save(self,
              subject_template_name='registration/password_reset_subject.txt',
              email_template_name='api_password_reset_email.html',
-             token_generator=custom_default_token_generator,
+             token_generator=default_token_generator,
              from_email=None):
         """
         Generates a one-use only link for resetting password and sends to the
@@ -158,7 +158,7 @@ class PasswordResetChangeSerializer(serializers.Serializer):
         user = get_user_from_uid(attrs.get('uid'))
         token = attrs.get('token')
 
-        if not custom_default_token_generator.check_token(user, token):
+        if not default_token_generator.check_token(user, token):
             raise serializers.ValidationError(_("Invalid token: %s") % token)
 
         return attrs


### PR DESCRIPTION
Fixes playbooks#1410

Introduces the user email during token generation.
This would invalidate the token when the user updates their email.