### PR TITLE
Clean elements of bind attributes when creating merged datasets

### DIFF
--- a/onadata/libs/serializers/merged_xform_serializer.py
+++ b/onadata/libs/serializers/merged_xform_serializer.py
@@ -74,6 +74,9 @@ def get_merged_xform_survey(xforms):
     for child in merged_xform_dict['children']:
         if child['name'] != 'meta' and is_empty:
             is_empty = False
+        # Remove bind attributes from child elements
+        if 'bind' in child:
+            del child['bind']
 
     if is_empty:
         raise serializers.ValidationError(_("No matching fields in xforms."))


### PR DESCRIPTION
Fixes onaio/zebra#5683

Newly created merged-datasets have bind attributes that contain relevance fields references to fields that were removed when generating the merged datasets. 

This PR seeks to drop/ignore the relevant column coming from the bind attributes of child elements in the newly created merged-datasets.