### PR TITLE
Bulk submission review no note

### DIFF
--- a/onadata/apps/api/tests/viewsets/test_submission_review_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_submission_review_viewset.py
@@ -369,5 +369,22 @@ class TestSubmissionReviewViewSet(TestBase):
 
         request = self.factory.post('/', data=submission_data, **self.extra)
         response = view(request=request)
+
+        self.assertEqual(201, response.status_code)
+        self.assertEqual(4, len(response.data))
+
+        submission_data = [
+            {
+                'instance': _.id,
+                'status': SubmissionReview.PENDING,
+                'note': None
+            } for _ in instances
+        ]
+
+        self.extra['format'] = 'json'
+
+        request = self.factory.post('/', data=submission_data, **self.extra)
+        response = view(request=request)
+
         self.assertEqual(201, response.status_code)
         self.assertEqual(4, len(response.data))

--- a/onadata/libs/serializers/submission_review_serializer.py
+++ b/onadata/libs/serializers/submission_review_serializer.py
@@ -15,7 +15,8 @@ class SubmissionReviewSerializer(serializers.ModelSerializer):
     SubmissionReviewSerializer Class
     """
     note = serializers.CharField(
-        source='note.note', required=False, allow_blank=True)
+        source='note.note', required=False, allow_blank=True,
+        allow_null=True)
 
     class Meta:
         """

--- a/onadata/libs/serializers/submission_review_serializer.py
+++ b/onadata/libs/serializers/submission_review_serializer.py
@@ -48,12 +48,13 @@ class SubmissionReviewSerializer(serializers.ModelSerializer):
 
         if 'note' in validated_data:
             note_data = validated_data.pop('note')
-            note_data['instance'] = validated_data.get('instance')
-            note_data['created_by'] = validated_data.get('created_by')
-            note_data['instance_field'] = SUBMISSION_REVIEW_INSTANCE_FIELD
+            if note_data['note']:
+                note_data['instance'] = validated_data.get('instance')
+                note_data['created_by'] = validated_data.get('created_by')
+                note_data['instance_field'] = SUBMISSION_REVIEW_INSTANCE_FIELD
 
-            note = Note.objects.create(**note_data)
-            validated_data['note'] = note
+                note = Note.objects.create(**note_data)
+                validated_data['note'] = note
 
         return SubmissionReview.objects.create(**validated_data)
 


### PR DESCRIPTION
Bulk submission reviews of status approved without a note/comment contain a null value for the note field.

This PR resolves scenerios when this occurs to resultantly create bulk submission reviews of status Approved.