### PR TITLE
Validate auth user username before creating Registration Profile

### DIFF
--- a/onadata/apps/api/tests/models/test_organization_profile.py
+++ b/onadata/apps/api/tests/models/test_organization_profile.py
@@ -35,6 +35,10 @@ class TestOrganizationProfile(TestBase):
         with self.assertRaises(IntegrityError):
             tools.create_organization("ModiLabs", self.user)
 
+        # test disallow org create with same username same cases
+        with self.assertRaises(IntegrityError):
+            tools.create_organization("modiLabs", self.user)
+
     def test_delete_organization(self):
         profile = tools.create_organization_object("modilabs", self.user)
         profile.save()

--- a/onadata/apps/api/tests/viewsets/test_user_profile_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_user_profile_viewset.py
@@ -423,6 +423,16 @@ class TestUserProfileViewSet(TestAbstractViewSet):
         response = self.view(request)
         self.assertEqual(response.status_code, 201)
 
+    def test_disallow_profile_create_w_same_username(self):
+        data = _profile_data()
+        self._create_user_using_profiles_endpoint(data)
+
+        request = self.factory.post(
+            '/api/v1/profiles', data=json.dumps(data),
+            content_type="application/json", **self.extra)
+        response = self.view(request)
+        self.assertEqual(response.status_code, 400)
+
     def test_profile_create_with_malfunctioned_email(self):
         request = self.factory.get('/', **self.extra)
         response = self.view(request)

--- a/onadata/apps/api/tests/viewsets/test_user_profile_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_user_profile_viewset.py
@@ -432,6 +432,8 @@ class TestUserProfileViewSet(TestAbstractViewSet):
             content_type="application/json", **self.extra)
         response = self.view(request)
         self.assertEqual(response.status_code, 400)
+        self.assertTrue(
+            'deno already exists' in response.data['username'][0])
 
     def test_profile_create_with_malfunctioned_email(self):
         request = self.factory.get('/', **self.extra)

--- a/onadata/apps/api/tools.py
+++ b/onadata/apps/api/tools.py
@@ -123,7 +123,13 @@ def create_organization_object(org_name, creator, attrs=None):
         email=email,
         is_active=True)
     new_user.save()
-    registration_profile = RegistrationProfile.objects.create_profile(new_user)
+    try:
+        registration_profile = RegistrationProfile.objects.create_profile(
+            new_user)
+    except IntegrityError:
+        raise ValidationError(_(
+                u"%s already exists" % org_name
+            ))
     if email:
         site = Site.objects.get(pk=settings.SITE_ID)
         registration_profile.send_activation_email(site)

--- a/onadata/libs/serializers/user_profile_serializer.py
+++ b/onadata/libs/serializers/user_profile_serializer.py
@@ -245,7 +245,8 @@ class UserProfileSerializer(serializers.HyperlinkedModelSerializer):
                 send_email=settings.SEND_EMAIL_ACTIVATION_API)
         except IntegrityError:
             raise serializers.ValidationError(_(
-                u"User account already exists"
+                u"User account {} already exists".format(
+                    params.get('username'))
             ))
         new_user.is_active = True
         new_user.first_name = params.get('first_name')

--- a/onadata/libs/serializers/user_profile_serializer.py
+++ b/onadata/libs/serializers/user_profile_serializer.py
@@ -236,12 +236,17 @@ class UserProfileSerializer(serializers.HyperlinkedModelSerializer):
         metadata = {}
 
         site = Site.objects.get(pk=settings.SITE_ID)
-        new_user = RegistrationProfile.objects.create_inactive_user(
-            username=params.get('username'),
-            password=params.get('password1'),
-            email=params.get('email'),
-            site=site,
-            send_email=settings.SEND_EMAIL_ACTIVATION_API)
+        try:
+            new_user = RegistrationProfile.objects.create_inactive_user(
+                username=params.get('username'),
+                password=params.get('password1'),
+                email=params.get('email'),
+                site=site,
+                send_email=settings.SEND_EMAIL_ACTIVATION_API)
+        except IntegrityError:
+            raise serializers.ValidationError(_(
+                u"User account already exists"
+            ))
         new_user.is_active = True
         new_user.first_name = params.get('first_name')
         new_user.last_name = params.get('last_name')


### PR DESCRIPTION
During registration of a new account profile, a new instance of the user model, `Django’s django.contrib.auth.models.User` is created to represent the new account, with the is_active field set to False. 

This occurs in the Registration Profile model.

Onadata validates the username, email and twitter field provided during the creation of a user registration profile against the auth User model.
This PR seeks to catch the IntegrityError exception and return a proper message to the user if the exception is triggered during creation of a user profile. Resolves #936 