### PR TITLE
Add the ability to share projects to multiple users

### DIFF
--- a/docs/projects.rst
+++ b/docs/projects.rst
@@ -150,13 +150,13 @@ The following are the available roles in onadata:
 - ``manager`` Role for a user with administrative privileges
 - ``owner`` Role for an owner of a data-set, organization, or project.
 
-Share a project with a specific user
+Share a project with user(s)
 -------------------------------------
 
-You can share a project with a specific user by ``PUT`` a payload with
+You can share a project with a user or multiple users by ``PUT`` a payload with
 
-- ``username`` of the user you want to share the form with and
-- ``role`` you want the user to have on the project.Available roles are ``readonly``, ``dataentry``, ``editor``, ``manager``.
+- ``username`` of the user you want to share the form with or a list of users separated by a comma and
+- ``role`` you want the user(s) to have on the project.Available roles are ``readonly``, ``dataentry``, ``editor``, ``manager``.
 
 .. raw:: html
 
@@ -164,8 +164,8 @@ You can share a project with a specific user by ``PUT`` a payload with
 	<b>PUT</b> /api/v1/projects/<code>{pk}</code>/share
 	</pre>
 
-Example
-^^^^^^^^
+Example 1: Sharing with a specific user
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ::
 
     curl -X PUT -d username=alice -d role=readonly https://api.ona.io/api/v1/projects/1/share
@@ -176,25 +176,11 @@ Response
 
     HTTP 204 NO CONTENT
 
-Share a project with multiple users
--------------------------------------
-
-You can share a project with mutliple users by ``PUT`` a payload with
-
-- ``usernames`` of the users you want to share the form with, separated by a comma and
-- ``role`` you want the users to have on the project.Available roles are ``readonly``, ``dataentry``, ``editor``, ``manager``.
-
-.. raw:: html
-
-	<pre class="prettyprint">
-	<b>PUT</b> /api/v1/projects/<code>{pk}</code>/share
-	</pre>
-
-Example
-^^^^^^^^
+Example 2: Sharing with mutliple users
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ::
 
-    curl -X PUT -d usernames=alice,jake -d role=readonly https://api.ona.io/api/v1/projects/1/share
+    curl -X PUT -d username=alice,jake -d role=readonly https://api.ona.io/api/v1/projects/1/share
 
 Response
 ^^^^^^^^^

--- a/docs/projects.rst
+++ b/docs/projects.rst
@@ -176,6 +176,32 @@ Response
 
     HTTP 204 NO CONTENT
 
+Share a project with multiple users
+-------------------------------------
+
+You can share a project with mutliple users by ``PUT`` a payload with
+
+- ``usernames`` of the users you want to share the form with, separated by a comma and
+- ``role`` you want the users to have on the project.Available roles are ``readonly``, ``dataentry``, ``editor``, ``manager``.
+
+.. raw:: html
+
+	<pre class="prettyprint">
+	<b>PUT</b> /api/v1/projects/<code>{pk}</code>/share
+	</pre>
+
+Example
+^^^^^^^^
+::
+
+    curl -X PUT -d usernames=alice,jake -d role=readonly https://api.ona.io/api/v1/projects/1/share
+
+Response
+^^^^^^^^^
+::
+
+    HTTP 204 NO CONTENT
+
 Send an email to users on project share
 ----------------------------------------
 

--- a/onadata/apps/api/tests/viewsets/test_project_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_project_viewset.py
@@ -2212,3 +2212,44 @@ class TestProjectViewSet(TestAbstractViewSet):
         self.assertEqual(response.status_code, 200)
 
         self.assertFalse(serializer.data in response.data)
+
+    def test_project_share_multiple_users(self):
+        """
+        Test that the project can be shared to multiple users
+        """
+        self._publish_xls_form_to_project()
+        alice_data = {'username': 'alice', 'email': 'alice@localhost.com'}
+        alice_profile = self._create_user_profile(alice_data)
+
+        tom_data = {'username': 'tom', 'email': 'tom@localhost.com'}
+        tom_data = self._create_user_profile(tom_data)
+        projectid = self.project.pk
+
+        self.assertFalse(
+            ReadOnlyRole.user_has_role(alice_profile.user, self.project))
+
+        data = {'usernames': 'alice,tom', 'role': ReadOnlyRole.name}
+        request = self.factory.post('/', data=data, **self.extra)
+
+        view = ProjectViewSet.as_view({
+            'post': 'share',
+            'get': 'retrieve'
+        })
+        response = view(request, pk=projectid)
+
+        self.assertEqual(response.status_code, 204)
+
+        request = self.factory.get('/', **self.extra)
+
+        response = view(request, pk=self.project.pk)
+
+        # get the users
+        users = response.data.get('users')
+
+        self.assertEqual(len(users), 3)
+
+        for user in users:
+            if user.get('user') == 'bob':
+                self.assertEquals(user.get('role'), 'owner')
+            else:
+                self.assertEquals(user.get('role'), 'readonly')

--- a/onadata/apps/api/tests/viewsets/test_project_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_project_viewset.py
@@ -1562,7 +1562,7 @@ class TestProjectViewSet(TestAbstractViewSet):
 
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.data['username'], [u"Cannot share project"
-                                                     u" with the owner"])
+                                                     u" with the owner (bob)"])
         self.assertTrue(OwnerRole.user_has_role(self.user, self.project))
 
     def test_project_share_readonly(self):

--- a/onadata/apps/api/tests/viewsets/test_project_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_project_viewset.py
@@ -1649,7 +1649,9 @@ class TestProjectViewSet(TestAbstractViewSet):
         response = view(request, pk=projectid)
 
         self.assertEqual(response.status_code, 400)
-        self.assertEqual(response.data, {'username': [u'User is not active']})
+        self.assertEqual(
+            response.data,
+            {'username': [u'The following user(s) is/are not active: alice']})
 
         self.assertFalse(ReadOnlyRole.user_has_role(alice_profile.user,
                                                     self.project))

--- a/onadata/apps/api/viewsets/project_viewset.py
+++ b/onadata/apps/api/viewsets/project_viewset.py
@@ -125,11 +125,17 @@ class ProjectViewSet(AuthenticateHeaderMixin,
             email_msg = data.get('email_msg')
             if email_msg:
                 # send out email message.
-                user = serializer.instance.user
-                send_mail(SHARE_PROJECT_SUBJECT.format(self.object.name),
-                          email_msg,
-                          DEFAULT_FROM_EMAIL,
-                          (user.email, ))
+                try:
+                    user = serializer.instance.user
+                except AttributeError:
+                    for instance in serializer.instance:
+                        user = instance.user
+                        send_mail(
+                            SHARE_PROJECT_SUBJECT.format(self.object.name),
+                            email_msg, DEFAULT_FROM_EMAIL, (user.email, ))
+                else:
+                    send_mail(SHARE_PROJECT_SUBJECT.format(self.object.name),
+                              email_msg, DEFAULT_FROM_EMAIL, (user.email,))
         else:
             return Response(data=serializer.errors,
                             status=status.HTTP_400_BAD_REQUEST)

--- a/onadata/libs/serializers/share_project_serializer.py
+++ b/onadata/libs/serializers/share_project_serializer.py
@@ -24,7 +24,7 @@ class ShareProjectSerializer(serializers.Serializer):
     role = serializers.CharField(max_length=50)
 
     def create(self, validated_data):
-        usernames = validated_data.pop('username')
+        usernames = validated_data.pop('username').split(',')
         created_instances = []
 
         for username in usernames:
@@ -42,7 +42,7 @@ class ShareProjectSerializer(serializers.Serializer):
         return instance
 
     def validate(self, attrs):
-        usernames = attrs.get('username')
+        usernames = attrs.get('username').split(',')
 
         for username in usernames:
             user = User.objects.get(username=username)
@@ -79,7 +79,7 @@ class ShareProjectSerializer(serializers.Serializer):
             raise serializers.ValidationError(
                 _(f'The following users do not exist: {non_existant_users}'))
 
-        return usernames
+        return value
 
     def validate_role(self, value):
         """check that the role exists"""

--- a/onadata/libs/serializers/share_project_serializer.py
+++ b/onadata/libs/serializers/share_project_serializer.py
@@ -98,19 +98,23 @@ class ShareProjectSerializer(serializers.Serializer):
     def validate_usernames(self, value):
         """Check that all usernames in the list exist"""
         usernames = value.split(',')
+        non_existing_usernames = []
 
         for username in usernames:
             try:
                 user = User.objects.get(username=username)
             except User.DoesNotExist:
-                raise serializers.ValidationError(
-                    _(u"User '%(username)s' does not exist." %
-                      {"username": username}))
+                non_existing_usernames.append(username)
             else:
                 if not user.is_active:
                     raise serializers.ValidationError(
                         _(u"User '%(username)s' is not active") %
                         {"username": username})
+
+        if non_existing_usernames:
+            raise serializers.ValidationError(
+                    _(u"The following users do not exist: '%(usernames)s'" %
+                      {"usernames": ', '.join(non_existing_usernames)}))
 
         return usernames
 

--- a/onadata/libs/serializers/share_project_serializer.py
+++ b/onadata/libs/serializers/share_project_serializer.py
@@ -63,21 +63,30 @@ class ShareProjectSerializer(serializers.Serializer):
         """Check that the username exists"""
         usernames = value.split(',')
         user = None
-        non_existant_users = []
+        non_existent_users = []
+        inactive_users = []
 
         for username in usernames:
             try:
                 user = User.objects.get(username=username)
             except User.DoesNotExist:
-                non_existant_users.append(username)
+                non_existent_users.append(username)
             else:
                 if not user.is_active:
-                    raise serializers.ValidationError(_(u"User is not active"))
+                    inactive_users.append(username)
 
-        if non_existant_users:
-            non_existant_users = ", ".join(non_existant_users)
+        if non_existent_users:
+            non_existent_users = ', '.join(non_existent_users)
             raise serializers.ValidationError(
-                _(f'The following users do not exist: {non_existant_users}'))
+                _('The following user(s) does/do not exist:'
+                    f' {non_existent_users}'
+                  ))
+
+        if inactive_users:
+            inactive_users = ', '.join(inactive_users)
+            raise serializers.ValidationError(
+                _(f'The following user(s) is/are not active: {inactive_users}')
+            )
 
         return value
 

--- a/onadata/libs/tests/serializers/test_share_project_serializer.py
+++ b/onadata/libs/tests/serializers/test_share_project_serializer.py
@@ -50,7 +50,7 @@ class TestShareProjectSerializer(TestAbstractViewSet, TestBase):
 
         data = {
             'project': project.id,
-            'usernames': 'joe,%(user)s,jake' % {
+            'username': 'joe,%(user)s,jake' % {
                 "user": self.user.username,
             },
             'role': ReadOnlyRole.name
@@ -94,7 +94,7 @@ class TestShareProjectSerializer(TestAbstractViewSet, TestBase):
 
         data = {
             'project': project.id,
-            'usernames': 'dave,jake',
+            'username': 'dave,jake',
             'role': ReadOnlyRole.name
         }
 
@@ -103,26 +103,6 @@ class TestShareProjectSerializer(TestAbstractViewSet, TestBase):
         serializer.save()
         self.assertTrue(ReadOnlyRole.user_has_role(user_dave, project))
         self.assertTrue(ReadOnlyRole.user_has_role(user_jake, project))
-
-    def test_error_on_username_and_usernames_missing(self):
-        """
-        Test that an error is raised when both "username" and "usernames"
-        field are missing
-        """
-        self._publish_xls_form_to_project()
-
-        project = Project.objects.last()
-
-        data = {'project': project.id, 'role': ReadOnlyRole.name}
-
-        serializer = ShareProjectSerializer(data=data)
-        self.assertFalse(serializer.is_valid())
-        self.assertEqual(
-            str(serializer.errors['username'][0]),
-            "Either username or usernames field should be present")
-        self.assertEqual(
-            str(serializer.errors['usernames'][0]),
-            "Either username or usernames field should be present")
 
     def test_error_on_non_existing_user(self):
         """
@@ -143,15 +123,15 @@ class TestShareProjectSerializer(TestAbstractViewSet, TestBase):
         serializer = ShareProjectSerializer(data=data)
         self.assertFalse(serializer.is_valid())
         self.assertEqual(str(serializer.errors['username'][0]),
-                         "User 'doe' does not exist.")
+                         "The following users do not exist: doe")
 
         data = {
             'project': project.id,
-            'usernames': 'doe,john',
+            'username': 'doe,john',
             'role': ReadOnlyRole.name
         }
 
         serializer = ShareProjectSerializer(data=data)
         self.assertFalse(serializer.is_valid())
-        self.assertEqual(str(serializer.errors['usernames'][0]),
-                         "The following users do not exist: 'doe, john'")
+        self.assertEqual(str(serializer.errors['username'][0]),
+                         "The following users do not exist: doe, john")

--- a/onadata/libs/tests/serializers/test_share_project_serializer.py
+++ b/onadata/libs/tests/serializers/test_share_project_serializer.py
@@ -9,6 +9,7 @@ from onadata.apps.logger.models import Project
 from onadata.apps.main.tests.test_base import TestBase
 from onadata.libs.serializers.share_project_serializer import (
     ShareProjectSerializer)
+from onadata.libs.permissions import ReadOnlyRole
 
 
 class TestShareProjectSerializer(TestAbstractViewSet, TestBase):
@@ -33,7 +34,7 @@ class TestShareProjectSerializer(TestAbstractViewSet, TestBase):
         data = {
             'project': project.id,
             'username': self.user.username,
-            'role': 'readonly'
+            'role': ReadOnlyRole.name
         }
 
         serializer = ShareProjectSerializer(data=data)
@@ -44,17 +45,15 @@ class TestShareProjectSerializer(TestAbstractViewSet, TestBase):
             {"value": self.user.username})
 
         # Test that this fails even when multiple users are passed
-        user_joe = self._create_user('joe', 'joe')
-        user_jake = self._create_user('jake', 'jake')
+        self._create_user('joe', 'joe')
+        self._create_user('jake', 'jake')
 
         data = {
             'project': project.id,
-            'usernames': '%(user_a)s,%(user_b)s,%(user_c)s' % {
-                "user_a": user_joe.username,
-                "user_b": self.user.username,
-                "user_c": user_jake.username,
+            'usernames': 'joe,%(user)s,jake' % {
+                "user": self.user.username,
             },
-            'role': 'readonly'
+            'role': ReadOnlyRole.name
         }
 
         serializer = ShareProjectSerializer(data=data)
@@ -73,37 +72,34 @@ class TestShareProjectSerializer(TestAbstractViewSet, TestBase):
 
         user_joe = self._create_user('joe', 'joe')
 
-        self.assertFalse(user_joe.has_perm('view_project', obj=project))
+        self.assertFalse(ReadOnlyRole.user_has_role(user_joe, project))
 
         data = {
             'project': project.id,
-            'username': user_joe.username,
-            'role': 'readonly'
+            'username': 'joe',
+            'role': ReadOnlyRole.name
         }
 
         serializer = ShareProjectSerializer(data=data)
         self.assertTrue(serializer.is_valid())
         serializer.save()
-        self.assertTrue(user_joe.has_perm('view_project', obj=project))
+        self.assertTrue(ReadOnlyRole.user_has_role(user_joe, project))
 
         # Test that it can share to multiple users
         user_dave = self._create_user('dave', 'dave')
         user_jake = self._create_user('jake', 'jake')
 
-        self.assertFalse(user_dave.has_perm('view_project', obj=project))
-        self.assertFalse(user_jake.has_perm('view_project', obj=project))
+        self.assertFalse(ReadOnlyRole.user_has_role(user_dave, project))
+        self.assertFalse(ReadOnlyRole.user_has_role(user_jake, project))
 
         data = {
             'project': project.id,
-            'usernames': '%(user_a)s,%(user_b)s' % {
-                "user_a": user_dave.username,
-                "user_b": user_jake.username
-            },
-            'role': 'readonly'
+            'usernames': 'dave,jake',
+            'role': ReadOnlyRole.name
         }
 
         serializer = ShareProjectSerializer(data=data)
         self.assertTrue(serializer.is_valid())
         serializer.save()
-        self.assertTrue(user_dave.has_perm('view_project', obj=project))
-        self.assertTrue(user_jake.has_perm('view_project', obj=project))
+        self.assertTrue(ReadOnlyRole.user_has_role(user_dave, project))
+        self.assertTrue(ReadOnlyRole.user_has_role(user_jake, project))

--- a/onadata/libs/tests/serializers/test_share_project_serializer.py
+++ b/onadata/libs/tests/serializers/test_share_project_serializer.py
@@ -103,3 +103,26 @@ class TestShareProjectSerializer(TestAbstractViewSet, TestBase):
         serializer.save()
         self.assertTrue(ReadOnlyRole.user_has_role(user_dave, project))
         self.assertTrue(ReadOnlyRole.user_has_role(user_jake, project))
+
+    def test_error_on_username_and_usernames_missing(self):
+        """
+        Test that an error is raised when both "username" and "usernames"
+        field are missing
+        """
+        self._publish_xls_form_to_project()
+
+        project = Project.objects.last()
+
+        data = {
+            'project': project.id,
+            'role': ReadOnlyRole.name
+        }
+
+        serializer = ShareProjectSerializer(data=data)
+        self.assertFalse(serializer.is_valid())
+        self.assertEqual(
+            str(serializer.errors['username'][0]),
+            "Either username or usernames field should be present")
+        self.assertEqual(
+            str(serializer.errors['usernames'][0]),
+            "Either username or usernames field should be present")

--- a/onadata/libs/tests/serializers/test_share_project_serializer.py
+++ b/onadata/libs/tests/serializers/test_share_project_serializer.py
@@ -1,0 +1,109 @@
+"""
+Test ShareProjectSerializer module
+"""
+from rest_framework.test import APIRequestFactory
+
+from onadata.apps.api.tests.viewsets.test_abstract_viewset import (
+    TestAbstractViewSet)
+from onadata.apps.logger.models import Project
+from onadata.apps.main.tests.test_base import TestBase
+from onadata.libs.serializers.share_project_serializer import (
+    ShareProjectSerializer)
+
+
+class TestShareProjectSerializer(TestAbstractViewSet, TestBase):
+    """
+    TestShareProjectSerializer class
+    """
+
+    def setUp(self):
+        self.factory = APIRequestFactory()
+        self._login_user_and_profile()
+
+    def test_error_on_share_to_owner(self):
+        """
+        Test that a validation error is raised when
+        trying to share a project to the owner
+        """
+
+        self._publish_xls_form_to_project()
+
+        project = Project.objects.last()
+
+        data = {
+            'project': project.id,
+            'username': self.user.username,
+            'role': 'readonly'
+        }
+
+        serializer = ShareProjectSerializer(data=data)
+        self.assertFalse(serializer.is_valid())
+        self.assertEqual(
+            str(serializer.errors['username'][0]),
+            "Cannot share project with the owner (%(value)s)" %
+            {"value": self.user.username})
+
+        # Test that this fails even when multiple users are passed
+        user_joe = self._create_user('joe', 'joe')
+        user_jake = self._create_user('jake', 'jake')
+
+        data = {
+            'project': project.id,
+            'usernames': '%(user_a)s,%(user_b)s,%(user_c)s' % {
+                "user_a": user_joe.username,
+                "user_b": self.user.username,
+                "user_c": user_jake.username,
+            },
+            'role': 'readonly'
+        }
+
+        serializer = ShareProjectSerializer(data=data)
+        self.assertFalse(serializer.is_valid())
+        self.assertEqual(
+            str(serializer.errors['username'][0]),
+            "Cannot share project with the owner (%(value)s)" %
+            {"value": self.user.username})
+
+    def test_shares_project(self):
+        """
+        Test that the ShareProjectSerializer shares the projects to users
+        """
+        self._publish_xls_form_to_project()
+        project = Project.objects.last()
+
+        user_joe = self._create_user('joe', 'joe')
+
+        self.assertFalse(user_joe.has_perm('view_project', obj=project))
+
+        data = {
+            'project': project.id,
+            'username': user_joe.username,
+            'role': 'readonly'
+        }
+
+        serializer = ShareProjectSerializer(data=data)
+        self.assertTrue(serializer.is_valid())
+        serializer.save()
+        self.assertTrue(user_joe.has_perm('view_project', obj=project))
+
+        # Test that it can share to multiple users
+        user_dave = self._create_user('dave', 'dave')
+        user_jake = self._create_user('jake', 'jake')
+
+        self.assertFalse(user_dave.has_perm('view_project', obj=project))
+        self.assertFalse(user_jake.has_perm('view_project', obj=project))
+
+        data = {
+            'project': project.id,
+            'usernames': '%(user_a)s,%(user_b)s' % {
+                "user_a": user_dave.username,
+                "user_b": user_jake.username
+            },
+            'role': 'readonly'
+        }
+
+        serializer = ShareProjectSerializer(data=data)
+        self.assertTrue(serializer.is_valid())
+        serializer.save()
+        self.assertTrue(user_dave.has_perm('view_project', obj=project))
+        self.assertTrue(user_jake.has_perm('view_project', obj=project))

--- a/onadata/libs/tests/serializers/test_share_project_serializer.py
+++ b/onadata/libs/tests/serializers/test_share_project_serializer.py
@@ -113,10 +113,7 @@ class TestShareProjectSerializer(TestAbstractViewSet, TestBase):
 
         project = Project.objects.last()
 
-        data = {
-            'project': project.id,
-            'role': ReadOnlyRole.name
-        }
+        data = {'project': project.id, 'role': ReadOnlyRole.name}
 
         serializer = ShareProjectSerializer(data=data)
         self.assertFalse(serializer.is_valid())
@@ -126,3 +123,35 @@ class TestShareProjectSerializer(TestAbstractViewSet, TestBase):
         self.assertEqual(
             str(serializer.errors['usernames'][0]),
             "Either username or usernames field should be present")
+
+    def test_error_on_non_existing_user(self):
+        """
+        Test that an error is raised when user(s) passed does not
+        exist
+        """
+
+        self._publish_xls_form_to_project()
+
+        project = Project.objects.last()
+
+        data = {
+            'project': project.id,
+            'username': 'doe',
+            'role': ReadOnlyRole.name
+        }
+
+        serializer = ShareProjectSerializer(data=data)
+        self.assertFalse(serializer.is_valid())
+        self.assertEqual(str(serializer.errors['username'][0]),
+                         "User 'doe' does not exist.")
+
+        data = {
+            'project': project.id,
+            'usernames': 'doe,john',
+            'role': ReadOnlyRole.name
+        }
+
+        serializer = ShareProjectSerializer(data=data)
+        self.assertFalse(serializer.is_valid())
+        self.assertEqual(str(serializer.errors['usernames'][0]),
+                         "The following users do not exist: 'doe, john'")


### PR DESCRIPTION
Enable permissions to be added to multiple users when sharing a project by passing in a list of comma separated usernames

## Implemented Change

- Allow the `/api/v1/project/{pk}/share` endpoint to accept CSV values on the `username` param. 


Changed payload sample:

```
{
    username: "some_user,another_user",
    role: "change_form",
}
```
Closes #1700 