### PR TITLE
Fix Multi ODK Token return on regeneration

### DIFF
--- a/onadata/apps/api/storage.py
+++ b/onadata/apps/api/storage.py
@@ -67,6 +67,7 @@ class ODKTokenAccountStorage(AccountStorage):
 
         if timezone.now() > token.expires:
             token.status = ODKToken.INACTIVE
+            token.save()
             return None
 
         return partial_digest

--- a/onadata/apps/api/tests/viewsets/test_connect_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_connect_viewset.py
@@ -513,7 +513,6 @@ class TestConnectViewSet(TestAbstractViewSet):
         response = view(request)
         self.assertEqual(response.status_code, 201)
         self.assertNotEqual(response.data['odk_token'], old_token)
-        old_token = response.data['odk_token']
 
         # Test that the previous token was set to inactive
         inactive_token = ODKToken.objects.get(

--- a/onadata/apps/api/tests/viewsets/test_connect_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_connect_viewset.py
@@ -520,13 +520,6 @@ class TestConnectViewSet(TestAbstractViewSet):
             user=self.user, status=ODKToken.INACTIVE)
         self.assertEqual(inactive_token.raw_key, old_token)
 
-        # Test no errors occur when more than two tokens exist
-        request = self.factory.post('/', **self.extra)
-        request.session = self.client.session
-        response = view(request)
-        self.assertEqual(response.status_code, 201)
-        self.assertNotEqual(response.data['odk_token'], old_token)
-
     def test_retrieve_odk_token(self):
         """
         Test that ODK Tokens can be retrieved
@@ -548,3 +541,55 @@ class TestConnectViewSet(TestAbstractViewSet):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data['odk_token'], odk_token)
         self.assertEqual(response.data['expires'], expires)
+
+    def test_deactivates_multiple_active_odk_token(self):
+        """
+        Test that the viewset deactivates tokens when two or more are
+        active at the same time and returns a new token
+        """
+        view = ConnectViewSet.as_view({
+            'post': 'odk_token',
+            'get': 'odk_token'
+        })
+
+        # Create two active tokens
+        token_1 = ODKToken.objects.create(user=self.user)
+        token_2 = ODKToken.objects.create(user=self.user)
+
+        self.assertEqual(token_1.status, ODKToken.ACTIVE)
+        self.assertEqual(token_2.status, ODKToken.ACTIVE)
+
+        # Test that the GET request deactivates the two active tokens
+        # and returns a new active token
+        request = self.factory.get('/', **self.extra)
+        request.session = self.client.session
+        response = view(request)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            len(ODKToken.objects.filter(status=ODKToken.ACTIVE)), 1)
+        self.assertNotEqual(response.data['odk_token'], token_1.raw_key)
+        self.assertNotEqual(response.data['odk_token'], token_2.raw_key)
+
+        token_1 = ODKToken.objects.get(pk=token_1.pk)
+        token_2 = ODKToken.objects.get(pk=token_2.pk)
+        token_3_key = response.data['odk_token']
+
+        self.assertEqual(token_1.status, ODKToken.INACTIVE)
+        self.assertEqual(token_2.status, ODKToken.INACTIVE)
+
+        # Test that the POST request deactivates two active tokens and returns
+        # a new active token
+
+        token_1.status = ODKToken.ACTIVE
+        token_1.save()
+
+        self.assertEqual(
+            len(ODKToken.objects.filter(status=ODKToken.ACTIVE)), 2)
+        request = self.factory.post('/', **self.extra)
+        request.session = self.client.session
+        response = view(request)
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(
+            len(ODKToken.objects.filter(status=ODKToken.ACTIVE)), 1)
+        self.assertNotEqual(response.data['odk_token'], token_1.raw_key)
+        self.assertNotEqual(response.data['odk_token'], token_3_key)

--- a/onadata/apps/api/tests/viewsets/test_connect_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_connect_viewset.py
@@ -513,11 +513,19 @@ class TestConnectViewSet(TestAbstractViewSet):
         response = view(request)
         self.assertEqual(response.status_code, 201)
         self.assertNotEqual(response.data['odk_token'], old_token)
+        old_token = response.data['odk_token']
 
         # Test that the previous token was set to inactive
         inactive_token = ODKToken.objects.get(
             user=self.user, status=ODKToken.INACTIVE)
         self.assertEqual(inactive_token.raw_key, old_token)
+
+        # Test no errors occur when more than two tokens exist
+        request = self.factory.post('/', **self.extra)
+        request.session = self.client.session
+        response = view(request)
+        self.assertEqual(response.status_code, 201)
+        self.assertNotEqual(response.data['odk_token'], old_token)
 
     def test_retrieve_odk_token(self):
         """

--- a/onadata/apps/api/viewsets/connect_viewset.py
+++ b/onadata/apps/api/viewsets/connect_viewset.py
@@ -1,3 +1,4 @@
+from django.core.exceptions import MultipleObjectsReturned
 from django.utils import timezone
 from django.utils.decorators import classonlymethod
 from django.utils.translation import ugettext as _
@@ -121,12 +122,18 @@ class ConnectViewSet(mixins.CreateModelMixin, AuthenticateHeaderMixin,
         user = request.user
 
         if request.method == 'GET':
-            token, created = ODKToken.objects.get_or_create(
-                user=user, status=ODKToken.ACTIVE)
+            try:
+                token, created = ODKToken.objects.get_or_create(
+                    user=user, status=ODKToken.ACTIVE)
 
-            if not created and timezone.now() > token.expires:
-                token.status = ODKToken.INACTIVE
-                token.save()
+                if not created and timezone.now() > token.expires:
+                    token.status = ODKToken.INACTIVE
+                    token.save()
+                    token = ODKToken.objects.create(user=user)
+            except MultipleObjectsReturned:
+                ODKToken.objects.filter(
+                    user=user, status=ODKToken.ACTIVE).update(
+                        status=ODKToken.INACTIVE)
                 token = ODKToken.objects.create(user=user)
 
             return Response(data={
@@ -134,13 +141,9 @@ class ConnectViewSet(mixins.CreateModelMixin, AuthenticateHeaderMixin,
                 'expires': token.expires}, status=status.HTTP_200_OK)
         elif request.method == 'POST':
             # Regenerates the ODK Token if one is already existant
-            try:
-                old_token = ODKToken.objects.get(
-                    user=user, status=ODKToken.ACTIVE)
-                old_token.status = ODKToken.INACTIVE
-                old_token.save()
-            except ODKToken.DoesNotExist:
-                pass
+            ODKToken.objects.filter(
+                user=user, status=ODKToken.ACTIVE).update(
+                    status=ODKToken.INACTIVE)
 
             token = ODKToken.objects.create(user=user)
 

--- a/onadata/apps/api/viewsets/connect_viewset.py
+++ b/onadata/apps/api/viewsets/connect_viewset.py
@@ -135,7 +135,8 @@ class ConnectViewSet(mixins.CreateModelMixin, AuthenticateHeaderMixin,
         elif request.method == 'POST':
             # Regenerates the ODK Token if one is already existant
             try:
-                old_token = ODKToken.objects.get(user=user)
+                old_token = ODKToken.objects.get(
+                    user=user, status=ODKToken.ACTIVE)
                 old_token.status = ODKToken.INACTIVE
                 old_token.save()
             except ODKToken.DoesNotExist:


### PR DESCRIPTION
Fix an issue where multiple ODKTokens would be returned when more that one token existed at the time of regeneration.