### PR TITLE
Update travis.yml file to include required global package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ before_install:
   - sudo -E apt-get -y update
   - sudo -E apt-get -yq --no-install-suggests --no-install-recommends --force-yes install postgresql-9.6-postgis-2.3
   - sudo -E apt-get -yq --no-install-suggests --no-install-recommends --force-yes install openjdk-8-jre-headless
+  - sudo -E apt-get -yq --no-install-suggests --no-install-recommends --force-yes install libffi-dev
   - ./script/database/install_postgis onadata_test postgres 127.0.0.1
 
 install:


### PR DESCRIPTION
At the moment travis tests are failing in google-export when trying to set up the cryptography package with the following message:
```
Running setup.py bdist_wheel for cryptography: started
  Running setup.py bdist_wheel for cryptography: finished with status 'error'
  Complete output from command /.venv/bin/python3.6 -u -c "import setuptools, tokenize;__file__='/tmp/pip-build-6q6sblcj/cryptography/setup.py';exec(compile(getattr(tokenize, 'open', open)(__file__).read().replace('\r\n', '\n'), __file__, 'exec'))" bdist_wheel -d /tmp/tmpdp4glecdpip-wheel- --python-tag cp36:
  Package libffi was not found in the pkg-config search path.
  Perhaps you should add the directory containing `libffi.pc'
  to the PKG_CONFIG_PATH environment variable
```

This PR includes command to install `libffi` package that is required by the cryptography package introduced here: onaio/onadata#1705