### PR TITLE
Return owner team members on the Organization endpoint

### DIFF
--- a/onadata/apps/api/tests/models/test_organization_profile.py
+++ b/onadata/apps/api/tests/models/test_organization_profile.py
@@ -6,6 +6,7 @@ from django.db import IntegrityError
 from django.test import override_settings
 from django.core.cache import cache
 from onadata.libs.utils.cache_tools import IS_ORG, safe_delete
+from onadata.libs.permissions import OwnerRole
 
 
 class TestOrganizationProfile(TestBase):
@@ -30,6 +31,10 @@ class TestOrganizationProfile(TestBase):
         self.assertIsInstance(team, Team)
         self.assertIn(team.group_ptr, self.user.groups.all())
         self.assertTrue(self.user.has_perm('api.is_org_owner'))
+
+        # Assert that the user has the OwnerRole for the Organization
+        self.assertTrue(
+            OwnerRole.user_has_role(self.user, organization_profile))
 
     def test_disallow_same_username_with_different_cases(self):
         tools.create_organization("modilabs", self.user)

--- a/onadata/apps/api/tests/viewsets/test_organization_profile_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_organization_profile_viewset.py
@@ -14,6 +14,7 @@ from onadata.libs.permissions import OwnerRole
 from onadata.apps.api.tools import (get_organization_owners_team,
                                     add_user_to_organization)
 from onadata.apps.api.models.organization_profile import OrganizationProfile
+from onadata.apps.main.models import UserProfile
 from rest_framework import status
 
 
@@ -85,6 +86,11 @@ class TestOrganizationProfileViewSet(TestAbstractViewSet):
         authenticated_user = self.user
         user_in_shared_organization, _ = User.objects.get_or_create(
             username='the_stalked')
+
+        UserProfile.objects.get_or_create(
+            user=user_in_shared_organization,
+            name=user_in_shared_organization.username
+        )
 
         unshared_organization, _ = User.objects.get_or_create(
             username='NotShared')
@@ -374,7 +380,8 @@ class TestOrganizationProfileViewSet(TestAbstractViewSet):
         for user in response.data['users']:
             username = user['user']
             role = user['role']
-            expected_role = 'owner' if username == 'denoinc' else user_role
+            expected_role = 'owner' if username == 'denoinc' or \
+                username == self.user.username else user_role
             self.assertEqual(role, expected_role)
 
     def test_add_members_to_org_with_anonymous_user(self):
@@ -584,7 +591,8 @@ class TestOrganizationProfileViewSet(TestAbstractViewSet):
         for user in response.data['users']:
             username = user['user']
             role = user['role']
-            expected_role = 'owner' if username == 'denoinc' else user_role
+            expected_role = 'owner' if username == 'denoinc' or \
+                username == self.user.username else user_role
             self.assertEqual(role, expected_role)
 
     def test_put_require_role(self):
@@ -719,8 +727,8 @@ class TestOrganizationProfileViewSet(TestAbstractViewSet):
         request = self.factory.get('/', **self.extra)
         response = view(request, user='denoinc')
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.data['users'][1]['user'], 'aboy')
-        self.assertEqual(response.data['users'][1]['role'], 'editor')
+        self.assertEqual(response.data['users'][2]['user'], 'aboy')
+        self.assertEqual(response.data['users'][2]['role'], 'editor')
 
     def test_add_members_to_owner_role(self):
         self._org_create()
@@ -1000,3 +1008,23 @@ class TestOrganizationProfileViewSet(TestAbstractViewSet):
         response = view(request, user='denoinc')
         expected_results = [u'denoinc']
         self.assertEqual(expected_results, response.data)
+
+    def test_creator_in_users(self):
+        """
+        Test that the creator of the organization is returned
+        in the value of the 'users' key within the response from /orgs
+        """
+        self._org_create()
+        request = self.factory.get('/', **self.extra)
+        response = self.view(request)
+        self.assertNotEqual(response.get('Cache-Control'), None)
+        self.assertEqual(response.status_code, 200)
+
+        expected_user = {
+            'user': self.user.username,
+            'role': 'owner',
+            'first_name': 'Bob',
+            'last_name': 'erama',
+            'gravatar': self.user.profile.gravatar
+        }
+        self.assertIn(expected_user, response.data[0]['users'])

--- a/onadata/apps/api/tools.py
+++ b/onadata/apps/api/tools.py
@@ -261,6 +261,12 @@ def get_organization_members(organization):
     return team.user_set.all()
 
 
+def get_organization_owners(organization):
+    """Get owners team user queryset"""
+    team = get_organization_owners_team(organization)
+    return team.user_set.all()
+
+
 def _get_owners(organization):
     # Get users with owners perms and not the org itself
 

--- a/onadata/libs/serializers/organization_serializer.py
+++ b/onadata/libs/serializers/organization_serializer.py
@@ -13,7 +13,8 @@ from rest_framework import serializers
 from onadata.apps.api import tools
 from onadata.apps.api.models import OrganizationProfile
 from onadata.apps.api.tools import (_get_first_last_names,
-                                    get_organization_members)
+                                    get_organization_members,
+                                    get_organization_owners)
 from onadata.apps.main.forms import RegistrationFormUserProfile
 from onadata.libs.permissions import get_role_in_org
 from onadata.libs.serializers.fields.json_field import JsonField
@@ -113,12 +114,23 @@ class OrganizationSerializer(serializers.HyperlinkedModelSerializer):
         """
         Return organization members.
         """
-        members = get_organization_members(obj) if obj else []
+        def create_user_list(user_list):
+            return [{
+                'user': u.username,
+                'role': get_role_in_org(u, obj),
+                'first_name': u.first_name,
+                'last_name': u.last_name,
+                'gravatar': u.profile.gravatar
+            } for u in user_list]
 
-        return [{
-            'user': u.username,
-            'role': get_role_in_org(u, obj),
-            'first_name': u.first_name,
-            'last_name': u.last_name,
-            'gravatar': u.profile.gravatar,
-        } for u in members]
+        members = get_organization_members(obj) if obj else []
+        owners = get_organization_owners(obj) if obj else []
+
+        if owners and members:
+            members.exclude(
+                username__in=[user.username for user in owners])
+
+        members_list = create_user_list(members)
+        owners_list = create_user_list(owners)
+
+        return owners_list + members_list


### PR DESCRIPTION
## Changes

- Return members of the 'Owners' team on the `/orgs` endpoint under the `users` key.