### PR TITLE
Handle spaces passed within the CSV usernames while sharing projects

### DIFF
--- a/onadata/libs/serializers/share_project_serializer.py
+++ b/onadata/libs/serializers/share_project_serializer.py
@@ -24,10 +24,9 @@ class ShareProjectSerializer(serializers.Serializer):
     role = serializers.CharField(max_length=50)
 
     def create(self, validated_data):
-        usernames = validated_data.pop('username').split(',')
         created_instances = []
 
-        for username in usernames:
+        for username in validated_data.pop('username').split(','):
             validated_data['username'] = username
             instance = ShareProject(**validated_data)
             instance.save()
@@ -42,9 +41,7 @@ class ShareProjectSerializer(serializers.Serializer):
         return instance
 
     def validate(self, attrs):
-        usernames = attrs.get('username').split(',')
-
-        for username in usernames:
+        for username in attrs.get('username').split(','):
             user = User.objects.get(username=username)
             project = attrs.get('project')
 
@@ -61,7 +58,7 @@ class ShareProjectSerializer(serializers.Serializer):
 
     def validate_username(self, value):
         """Check that the username exists"""
-        usernames = value.split(',')
+        usernames = [u.strip() for u in value.split(',')]
         user = None
         non_existent_users = []
         inactive_users = []
@@ -88,7 +85,7 @@ class ShareProjectSerializer(serializers.Serializer):
                 _(f'The following user(s) is/are not active: {inactive_users}')
             )
 
-        return value
+        return (',').join(usernames)
 
     def validate_role(self, value):
         """check that the role exists"""

--- a/onadata/libs/tests/serializers/test_share_project_serializer.py
+++ b/onadata/libs/tests/serializers/test_share_project_serializer.py
@@ -104,6 +104,25 @@ class TestShareProjectSerializer(TestAbstractViewSet, TestBase):
         self.assertTrue(ReadOnlyRole.user_has_role(user_dave, project))
         self.assertTrue(ReadOnlyRole.user_has_role(user_jake, project))
 
+        # Test strips spaces between commas
+        user_sam = self._create_user('sam', 'sam')
+        user_joy = self._create_user('joy', 'joy')
+
+        self.assertFalse(ReadOnlyRole.user_has_role(user_sam, project))
+        self.assertFalse(ReadOnlyRole.user_has_role(user_joy, project))
+
+        data = {
+            'project': project.id,
+            'username': 'sam, joy',
+            'role': ReadOnlyRole.name
+        }
+
+        serializer = ShareProjectSerializer(data=data)
+        self.assertTrue(serializer.is_valid())
+        serializer.save()
+        self.assertTrue(ReadOnlyRole.user_has_role(user_sam, project))
+        self.assertTrue(ReadOnlyRole.user_has_role(user_joy, project))
+
     def test_error_on_non_existing_user(self):
         """
         Test that an error is raised when user(s) passed does not


### PR DESCRIPTION
When a user tries to share a project with multiple users by passing in CSV data with space inbetween the usernames an error is returned The following user(s) does not exist: someuser even though the user does.

This error is caused by spacing in between the data (userone, someuser). This PR fixes the error by stripping the spaces from the username before sharing a project.

Closes #1722 