### PR TITLE
Modify '$or' operator

### DIFF
--- a/docs/data.rst
+++ b/docs/data.rst
@@ -431,18 +431,26 @@ Query submissions with case insensitive and partial search
 
     curl -X GET https://api.ona.io/api/v1/data/22845?query={"name":{"$i":"hosee"}}
 
+Example V
+^^^^^^^
+Query submissions where age is 21 or name is hosee
+
+::
+
+    curl -X GET https://api.ona.io/api/v1/data/22845?query={"$or": [{"age": "21", "name": "hosee"}]}
 
 All Filters Options
 
-========  ===================================
-Filter    Description
-========  ===================================
-**$gt**   Greater than
-**$gte**  Greater than or Equal to
-**$lt**   Less than
-**$lte**  Less or Equal to
-**$i**    Case insensitive or partial search
-========  ===================================
+=======  ===================================
+Filter   Description
+=======  ===================================
+**$gt**  Greater than
+**$gte** Greater than or Equal to
+**$lt**  Less than
+**$lte** Less or Equal to
+**$i**   Case insensitive or partial search
+**$or**  Or
+=======  ===================================
 
 Query submitted data of a specific form using date_created
 ----------------------------------------------------------

--- a/onadata/apps/viewer/parsed_instance_tools.py
+++ b/onadata/apps/viewer/parsed_instance_tools.py
@@ -103,10 +103,15 @@ def get_where_clause(query, form_integer_fields=None,
 
             if isinstance(query, dict) and '$or' in list(query):
                 or_dict = query.pop('$or')
+
                 for l in or_dict:
-                    or_where.extend([u"json->>%s = %s" for i in iteritems(l)])
-                    for i in iteritems(l):
-                        or_params.extend(i)
+                    for k, v in l.items():
+                        if v is None:
+                            or_where.extend([u"json->>'{}' IS NULL".format(k)])
+                        else:
+                            or_where.extend(
+                                [u"json->>%s = %s"])
+                            or_params.extend([k, v])
 
                 or_where = [u"".join([u"(", u" OR ".join(or_where), u")"])]
 


### PR DESCRIPTION
### Changes / Features implemented

- Modify '$or' operator. Enable the operator to accept null values

```
/api/v1/data/<form_id>?start=0&limit=100&query={"$or": [{"_review_status":"1", "_review_status": null}]}
```

### Steps taken to verify this change does what is intended

- Added tests to verify the filter option works

### Side effects of implementing this change

_None so far_

Closes #1743 