### PR TITLE
Change queryset in project viewset in order to return only projects associated to active organizations.

### DIFF
--- a/onadata/apps/api/tests/viewsets/test_project_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_project_viewset.py
@@ -142,7 +142,12 @@ class TestProjectViewSet(TestAbstractViewSet):
         request.user = self.user
         response = self.view(request)
         self.assertEqual(len(response.data), 2)
-        self.assertEqual(response.data[1].get('projectid'), shared_project.id)
+
+        shared_project_in_response = False
+        for project in response.data:
+            if project.get('projectid') == shared_project.id:
+                shared_project_in_response = True
+        self.assertTrue(shared_project_in_response)
 
     def test_projects_get(self):
         self._project_create()

--- a/onadata/apps/api/tests/viewsets/test_project_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_project_viewset.py
@@ -125,7 +125,7 @@ class TestProjectViewSet(TestAbstractViewSet):
             shared_project, self.user.username, 'manager')
         shareProject.save()
 
-        # ensure when alice_user is active we can NOT
+        # ensure when alice_user isn't active we can NOT
         # see the project she shared
         alice_user.is_active = False
         alice_user.save()

--- a/onadata/apps/api/tests/viewsets/test_project_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_project_viewset.py
@@ -120,30 +120,34 @@ class TestProjectViewSet(TestAbstractViewSet):
         alice_profile.save()
         alice_user.save()
         shared_project.save()
-        
+
         # share project with self.user
-        shareProject = ShareProject(shared_project, self.user.username, 'manager')
+        shareProject = ShareProject(
+            shared_project, self.user.username, 'manager')
         shareProject.save()
 
-        # ensure when alice_user is active we can NOT see the project she shared 
+        # ensure when alice_user is active we can NOT
+        # see the project she shared
         alice_user.is_active = False
         alice_user.save()
         request = self.factory.get('/', **self.extra)
         request.user = self.user
         response = self.view(request)
-        project_serializer = BaseProjectSerializer(self.project,
-                                           context={'request': request})
-        shared_project_serializer = BaseProjectSerializer(shared_project,
-                                           context={'request': request})
+        project_serializer = BaseProjectSerializer(
+            self.project, context={'request': request})
+        shared_project_serializer = BaseProjectSerializer(
+            shared_project, context={'request': request})
         self.assertEqual(response.data, [project_serializer.data])
 
-        # ensure when alice_user is active we can see the project she shared 
+        # ensure when alice_user is active we cansee the project she shared
         alice_user.is_active = True
         alice_user.save()
         request = self.factory.get('/', **self.extra)
         request.user = self.user
         response = self.view(request)
-        self.assertEqual(response.data, [project_serializer.data, shared_project_serializer.data])        
+        self.assertEqual(
+            response.data,
+            [project_serializer.data, shared_project_serializer.data])
 
     def test_projects_get(self):
         self._project_create()
@@ -1035,7 +1039,7 @@ class TestProjectViewSet(TestAbstractViewSet):
         alice_project_data = BaseProjectSerializer(
             self.project, context={'request': request}).data
         result = [{'owner': p.get('owner'),
-                  'projectid': p.get('projectid')} for p in response.data]
+                   'projectid': p.get('projectid')} for p in response.data]
         bob_data = {'owner': 'http://testserver/api/v1/users/bob',
                     'projectid': bobs_project_data.get('projectid')}
         alice_data = {'owner': 'http://testserver/api/v1/users/alice',

--- a/onadata/apps/api/tests/viewsets/test_project_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_project_viewset.py
@@ -133,7 +133,8 @@ class TestProjectViewSet(TestAbstractViewSet):
         request.user = self.user
         response = self.view(request)
         self.assertEqual(len(response.data), 1)
-        self.assertNotEqual(response.data[0].get('projectid'), shared_project.id)
+        self.assertNotEqual(response.data[0].get(
+            'projectid'), shared_project.id)
 
         # ensure when alice_user is active we can
         # see the project she shared

--- a/onadata/apps/api/tests/viewsets/test_project_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_project_viewset.py
@@ -146,7 +146,7 @@ class TestProjectViewSet(TestAbstractViewSet):
         request.user = self.user
         response = self.view(request)
         self.assertEqual(
-            response.data,
+            [dict(i) for i in response.data],
             [project_serializer.data, shared_project_serializer.data])
 
     def test_projects_get(self):

--- a/onadata/apps/api/tests/viewsets/test_project_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_project_viewset.py
@@ -116,8 +116,6 @@ class TestProjectViewSet(TestAbstractViewSet):
                                  metadata=json.dumps({'description': ''}),
                                  created_by=alice_user,
                                  organization=alice_user)
-        alice_profile.save()
-        alice_user.save()
         shared_project.save()
 
         # share project with self.user

--- a/onadata/apps/api/tests/viewsets/test_project_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_project_viewset.py
@@ -116,7 +116,6 @@ class TestProjectViewSet(TestAbstractViewSet):
                                  metadata=json.dumps({'description': ''}),
                                  created_by=alice_user,
                                  organization=alice_user)
-
         alice_profile.save()
         alice_user.save()
         shared_project.save()
@@ -133,21 +132,19 @@ class TestProjectViewSet(TestAbstractViewSet):
         request = self.factory.get('/', **self.extra)
         request.user = self.user
         response = self.view(request)
-        project_serializer = BaseProjectSerializer(
-            self.project, context={'request': request})
-        shared_project_serializer = BaseProjectSerializer(
-            shared_project, context={'request': request})
-        self.assertEqual(response.data, [project_serializer.data])
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0].get('projectid'), 1)
 
-        # ensure when alice_user is active we cansee the project she shared
+        # ensure when alice_user is active we can
+        # see the project she shared
         alice_user.is_active = True
         alice_user.save()
         request = self.factory.get('/', **self.extra)
         request.user = self.user
         response = self.view(request)
-        self.assertEqual(
-            [dict(i) for i in response.data],
-            [project_serializer.data, shared_project_serializer.data])
+        self.assertEqual(len(response.data), 2)
+        self.assertEqual(response.data[0].get('projectid'), 1)
+        self.assertEqual(response.data[1].get('projectid'), 2)
 
     def test_projects_get(self):
         self._project_create()

--- a/onadata/apps/api/tests/viewsets/test_project_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_project_viewset.py
@@ -147,6 +147,7 @@ class TestProjectViewSet(TestAbstractViewSet):
         for project in response.data:
             if project.get('projectid') == shared_project.id:
                 shared_project_in_response = True
+                break
         self.assertTrue(shared_project_in_response)
 
     def test_projects_get(self):

--- a/onadata/apps/api/tests/viewsets/test_project_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_project_viewset.py
@@ -133,6 +133,7 @@ class TestProjectViewSet(TestAbstractViewSet):
         request.user = self.user
         response = self.view(request)
         self.assertEqual(len(response.data), 1)
+        self.assertNotEqual(response.data[0].get('projectid'), shared_project.id)
 
         # ensure when alice_user is active we can
         # see the project she shared

--- a/onadata/apps/api/tests/viewsets/test_project_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_project_viewset.py
@@ -133,7 +133,6 @@ class TestProjectViewSet(TestAbstractViewSet):
         request.user = self.user
         response = self.view(request)
         self.assertEqual(len(response.data), 1)
-        self.assertEqual(response.data[0].get('projectid'), 1)
 
         # ensure when alice_user is active we can
         # see the project she shared
@@ -143,8 +142,7 @@ class TestProjectViewSet(TestAbstractViewSet):
         request.user = self.user
         response = self.view(request)
         self.assertEqual(len(response.data), 2)
-        self.assertEqual(response.data[0].get('projectid'), 1)
-        self.assertEqual(response.data[1].get('projectid'), 2)
+        self.assertEqual(response.data[1].get('projectid'), shared_project.id)
 
     def test_projects_get(self):
         self._project_create()

--- a/onadata/apps/api/viewsets/project_viewset.py
+++ b/onadata/apps/api/viewsets/project_viewset.py
@@ -68,7 +68,7 @@ class ProjectViewSet(AuthenticateHeaderMixin,
     def get_queryset(self):
         if self.request.method.upper() in ['GET', 'OPTIONS']:
             self.queryset = Project.prefetched.filter(
-                deleted_at__isnull=True).filter(organization__is_active=True)
+                deleted_at__isnull=True, organization__is_active=True)
 
         return super(ProjectViewSet, self).get_queryset()
 

--- a/onadata/apps/api/viewsets/project_viewset.py
+++ b/onadata/apps/api/viewsets/project_viewset.py
@@ -67,7 +67,8 @@ class ProjectViewSet(AuthenticateHeaderMixin,
 
     def get_queryset(self):
         if self.request.method.upper() in ['GET', 'OPTIONS']:
-            self.queryset = Project.prefetched.filter(deleted_at__isnull=True).filter(organization__is_active=True)
+            self.queryset = Project.prefetched.filter(
+                deleted_at__isnull=True).filter(organization__is_active=True)
 
         return super(ProjectViewSet, self).get_queryset()
 

--- a/onadata/apps/api/viewsets/project_viewset.py
+++ b/onadata/apps/api/viewsets/project_viewset.py
@@ -67,7 +67,7 @@ class ProjectViewSet(AuthenticateHeaderMixin,
 
     def get_queryset(self):
         if self.request.method.upper() in ['GET', 'OPTIONS']:
-            self.queryset = Project.prefetched.filter(deleted_at__isnull=True)
+            self.queryset = Project.prefetched.filter(deleted_at__isnull=True).filter(organization__is_active=True)
 
         return super(ProjectViewSet, self).get_queryset()
 


### PR DESCRIPTION
### Changes / Features implemented

Added a filter to the queryset in ProjectViewset to ensure that we do not return projects associated with inactive organizations

### Steps taken to verify this change does what is intended

Ran onadata locally and ensured that only projects associated with active organizations are gotten from the projects endpoint

Fixes: #1732