### PR TITLE
Allow logged in users(non anonymous users) to view forms in accounts that have require_authentication set to False

### DIFF
--- a/onadata/apps/api/tests/viewsets/test_xform_list_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_xform_list_viewset.py
@@ -100,6 +100,58 @@ class TestXFormListViewSet(TestAbstractViewSet, TransactionTestCase):
             content = response.render().content.decode('utf-8')
             self.assertEqual(content, form_list_xml % data)
 
+    def test_form_id_filter_for_non_require_auth_account(self):
+        """
+        Test formList formID filter for account that requires authentication
+        """
+        # Bob submit forms
+        xls_path = os.path.join(settings.PROJECT_ROOT, "apps", "main", "tests",
+                                "fixtures", "tutorial.xls")
+        self._publish_xls_form_to_project(xlsform_path=xls_path)
+
+        xls_file_path = os.path.join(settings.PROJECT_ROOT, "apps", "logger",
+                                     "fixtures",
+                                     "external_choice_form_v1.xlsx")
+        self._publish_xls_form_to_project(xlsform_path=xls_file_path)
+
+        # Set require auth to true for this user
+        self.user.profile.require_auth = True
+        self.user.profile.save()
+
+        # Ensure that anonymous users do not have access to private forms
+        request = self.factory.get(
+            f'/{self.user.username}/{self.xform.pk}/formList', {'formID': self.xform.id_string})
+        response = self.view(request,  username=self.user.username, xform_pk=self.xform.pk)
+        self.assertEqual(response.status_code, 401)
+
+        self.user.profile.require_auth = False
+        self.user.profile.save()
+
+        # make form public
+        self.xform.shared = True
+        self.xform.save()
+
+        alice_data = {
+            'username': 'alice',
+            'email': 'alice@localhost.com',
+            'password1': 'alice',
+            'password2': 'alice'
+        }
+        alice_profile = self._create_user_profile(alice_data)
+
+        auth = DigestAuth('alice', 'alice')
+        request = self.factory.get(f'/{self.user.username}/{self.xform.pk}/formList', {'formID': self.xform.id_string})
+        request.META.update(auth(request.META, response))
+        response = self.view(request, username=self.user.username, xform_pk=self.xform.pk)
+        self.assertEqual(response.status_code, 200)
+
+        # ensure anonymous users still have access to the xform with id self.xform.pk
+        request = self.factory.get(
+           f'/{self.user.username}/{self.xform.pk}/formList', {'formID': self.xform.id_string})
+        response = self.view(request,  username=self.user.username, xform_pk=self.xform.pk)
+        self.assertEqual(response.status_code, 200)
+
+
     def test_form_id_filter_for_require_auth_account(self):
         """
         Test formList formID filter for account that requires authentication

--- a/onadata/apps/api/tests/viewsets/test_xform_list_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_xform_list_viewset.py
@@ -120,8 +120,10 @@ class TestXFormListViewSet(TestAbstractViewSet, TransactionTestCase):
 
         # Ensure that anonymous users do not have access to private forms
         request = self.factory.get(
-            f'/{self.user.username}/{self.xform.pk}/formList', {'formID': self.xform.id_string})
-        response = self.view(request,  username=self.user.username, xform_pk=self.xform.pk)
+            f'/{self.user.username}/{self.xform.pk}/formList',
+            {'formID': self.xform.id_string})
+        response = self.view(
+            request,  username=self.user.username, xform_pk=self.xform.pk)
         self.assertEqual(response.status_code, 401)
 
         self.user.profile.require_auth = False
@@ -137,20 +139,25 @@ class TestXFormListViewSet(TestAbstractViewSet, TransactionTestCase):
             'password1': 'alice',
             'password2': 'alice'
         }
-        alice_profile = self._create_user_profile(alice_data)
+        self._create_user_profile(alice_data)
 
         auth = DigestAuth('alice', 'alice')
-        request = self.factory.get(f'/{self.user.username}/{self.xform.pk}/formList', {'formID': self.xform.id_string})
-        request.META.update(auth(request.META, response))
-        response = self.view(request, username=self.user.username, xform_pk=self.xform.pk)
-        self.assertEqual(response.status_code, 200)
-
-        # ensure anonymous users still have access to the xform with id self.xform.pk
         request = self.factory.get(
-           f'/{self.user.username}/{self.xform.pk}/formList', {'formID': self.xform.id_string})
-        response = self.view(request,  username=self.user.username, xform_pk=self.xform.pk)
+            f'/{self.user.username}/{self.xform.pk}/formList',
+            {'formID': self.xform.id_string})
+        request.META.update(auth(request.META, response))
+        response = self.view(
+            request, username=self.user.username, xform_pk=self.xform.pk)
         self.assertEqual(response.status_code, 200)
 
+        # ensure anonymous users still have access
+        # to the xform with id self.xform.pk
+        request = self.factory.get(
+            f'/{self.user.username}/{self.xform.pk}/formList',
+            {'formID': self.xform.id_string})
+        response = self.view(
+            request,  username=self.user.username, xform_pk=self.xform.pk)
+        self.assertEqual(response.status_code, 200)
 
     def test_form_id_filter_for_require_auth_account(self):
         """

--- a/onadata/apps/api/tests/viewsets/test_xform_list_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_xform_list_viewset.py
@@ -119,6 +119,8 @@ class TestXFormListViewSet(TestAbstractViewSet, TransactionTestCase):
         self.user.profile.save()
 
         # Ensure that anonymous users do not have access to private forms
+        self.xform.shared = False
+        self.xform.save()
         request = self.factory.get(
             f'/{self.user.username}/{self.xform.pk}/formList',
             {'formID': self.xform.id_string})

--- a/onadata/libs/filters.py
+++ b/onadata/libs/filters.py
@@ -20,7 +20,7 @@ class AnonDjangoObjectPermissionFilter(filters.DjangoObjectPermissionsFilter):
         """
         Anonymous user has no object permissions, return queryset as it is.
         """
-        form_id = view.kwargs.get(view.lookup_field)
+        form_id = view.kwargs.get(view.lookup_field, view.kwargs.get('xform_pk'))
         queryset = queryset.filter(deleted_at=None)
         if request.user.is_anonymous:
             return queryset

--- a/onadata/libs/filters.py
+++ b/onadata/libs/filters.py
@@ -20,7 +20,8 @@ class AnonDjangoObjectPermissionFilter(filters.DjangoObjectPermissionsFilter):
         """
         Anonymous user has no object permissions, return queryset as it is.
         """
-        form_id = view.kwargs.get(view.lookup_field, view.kwargs.get('xform_pk'))
+        form_id = view.kwargs.get(
+            view.lookup_field, view.kwargs.get('xform_pk'))
         queryset = queryset.filter(deleted_at=None)
         if request.user.is_anonymous:
             return queryset
@@ -527,13 +528,14 @@ class ExportFilter(XFormPermissionFilterMixin,
     ExportFilter class uses permissions on the related xform to filter Export
     queryesets. Also filters submitted_by a specific user.
     """
+
     def filter_queryset(self, request, queryset, view):
         has_submitted_by_key = (Q(options__has_key='query') &
                                 Q(options__query__has_key='_submitted_by'),)
         if request.user.is_anonymous:
             return self._xform_filter_queryset(
                 request, queryset, view, 'xform_id')\
-                    .exclude(*has_submitted_by_key)
+                .exclude(*has_submitted_by_key)
 
         old_perm_format = self.perm_format
 


### PR DESCRIPTION
### Changes / Features implemented
This PR currently allows logged in users to be able to get forms belonging to user accounts that have require authentication set to false from the XForm list viewset.

Fixes: #1753 