### PR TITLE
Assign Owner permission to creator for organization account UserProfile

### DIFF
--- a/onadata/apps/api/management/commands/set_api_permissions.py
+++ b/onadata/apps/api/management/commands/set_api_permissions.py
@@ -29,12 +29,18 @@ class Command(BaseCommand):
         # OrganizationProfile
         for profile in queryset_iterator(OrganizationProfile.objects.all()):
             OwnerRole.add(profile.user, profile)
+            OwnerRole.add(
+                profile.user, profile.userprofile_ptr)
 
             if profile.created_by is not None:
                 OwnerRole.add(profile.created_by, profile)
+                OwnerRole.add(
+                    profile.created_by, profile.userprofile_ptr)
 
             if profile.creator is not None:
                 OwnerRole.add(profile.creator, profile)
+                OwnerRole.add(
+                    profile.creator, profile.userprofile_ptr)
 
         # Project
         for project in queryset_iterator(Project.objects.all()):

--- a/onadata/apps/api/models/organization_profile.py
+++ b/onadata/apps/api/models/organization_profile.py
@@ -52,6 +52,25 @@ def create_owner_team_and_permissions(sender, instance, created, **kwargs):
             if instance.created_by and instance.created_by != instance.creator:
                 assign_perm(perm.codename, instance.created_by, instance)
 
+        if instance.userprofile_ptr:
+            for perm in get_perms_for_model(
+                    instance.userprofile_ptr.__class__):
+                assign_perm(
+                    perm.codename, instance.user, instance.userprofile_ptr)
+
+                if instance.creator:
+                    assign_perm(
+                        perm.codename,
+                        instance.creator,
+                        instance.userprofile_ptr)
+
+                if instance.created_by and\
+                        instance.created_by != instance.creator:
+                    assign_perm(
+                        perm.codename,
+                        instance.created_by,
+                        instance.userprofile_ptr)
+
 
 @python_2_unicode_compatible
 class OrganizationProfile(UserProfile):

--- a/onadata/apps/api/tools.py
+++ b/onadata/apps/api/tools.py
@@ -201,6 +201,13 @@ def remove_user_from_organization(organization, user):
     remove_user_from_team(owners_team, user)
 
     role = get_role_in_org(user, organization)
+    role_cls = ROLES.get(role)
+
+    if role_cls:
+        # Remove object permissions
+        role_cls.remove_obj_permissions(user, organization)
+        role_cls.remove_obj_permissions(user, organization.userprofile_ptr)
+
     # Remove user from all org projects
     for project in organization.user.project_org.all():
         ShareProject(project, user.username, role, remove=True).save()

--- a/onadata/libs/serializers/organization_member_serializer.py
+++ b/onadata/libs/serializers/organization_member_serializer.py
@@ -41,6 +41,7 @@ def _set_organization_role_to_user(organization, user, role):
 
     # add the owner to owners team
     if role == OwnerRole.name:
+        role_cls.add(user, organization.userprofile_ptr)
         add_user_to_team(owners_team, user)
         # add user to org projects
         for project in organization.user.project_org.all():


### PR DESCRIPTION
### Changes / Features implemented

- Add `OwnerRole` permissions to creator for `OrganizationalProfile.userprofile_ptr`
- Remove `Role` permissions from a user when they are removed from an organization

### Pending work on PR

- [x] Make sure users added into the organization have the correct permissions
- [x] Make sure users permissions are removed when the user is removed from the organization

### Steps taken to verify this change does what is intended

- Added a test to verify that the change works

### Side effects of implementing this change

- In order for these changes to take effect for all existing organizations the `set_api_permissions` management command needs to be run

### Additional Information

Issue #1754 is being caused because the `User` object returned through `User.objects.get` and `get_object_or_404` links to a `UserProfile` and not a `OrganizationProfile` when `user.profile` is called. The user / creator in this case normally doesn't have the OwnerRole / `can_add_xform` attached to the `UserProfile` / `org.userprofile_ptr`.

The `UserProfile` is present due to how django handles model inheritances(more info on that [here](https://docs.djangoproject.com/en/2.2/topics/db/models/#multi-table-inheritance)), as such it seems for some reason the `User` object defaults to linking to `org_profile.userprofile_ptr`

Closes #1754 
