### PR TITLE
use_master when fetching external export metadata information

### DIFF
--- a/onadata/apps/viewer/tests/test_exports.py
+++ b/onadata/apps/viewer/tests/test_exports.py
@@ -1285,12 +1285,6 @@ class TestExports(TestBase):
         self.assertEqual(response.status_code, 302)
         self.assertEqual(Export.objects.count(), num_exports + 1)
 
-    def test_external_export_metadata_retrieved_from_master_db(self):
-        self._publish_transportation_form()
-        self._submit_transport_instance()
-        meta = MetaData.external_export(self.xform)
-        self.assertEqual(meta.db, "default")
-
     @patch('onadata.apps.viewer.tasks.get_object_or_404')
     def test_create_external_export_url_with_non_existing_export_id(
             self, mock_404):

--- a/onadata/apps/viewer/tests/test_exports.py
+++ b/onadata/apps/viewer/tests/test_exports.py
@@ -1285,6 +1285,12 @@ class TestExports(TestBase):
         self.assertEqual(response.status_code, 302)
         self.assertEqual(Export.objects.count(), num_exports + 1)
 
+    def test_external_export_metadata_retrieved_from_master_db(self):
+        self._publish_transportation_form()
+        self._submit_transport_instance()
+        meta = MetaData.external_export(self.xform)
+        self.assertEqual(meta.db, "default")
+
     @patch('onadata.apps.viewer.tasks.get_object_or_404')
     def test_create_external_export_url_with_non_existing_export_id(
             self, mock_404):

--- a/onadata/libs/utils/export_tools.py
+++ b/onadata/libs/utils/export_tools.py
@@ -692,7 +692,10 @@ def clean_keys_of_slashes(record):
 
 
 def _get_server_from_metadata(xform, meta, token):
-    report_templates = MetaData.external_export(xform)
+    from multidb.pinning import use_master
+    # Fetch metadata details from master directly
+    with use_master:
+        report_templates = MetaData.external_export(xform)
 
     if meta:
         try:

--- a/onadata/libs/utils/export_tools.py
+++ b/onadata/libs/utils/export_tools.py
@@ -694,8 +694,11 @@ def clean_keys_of_slashes(record):
 def _get_server_from_metadata(xform, meta, token):
     from multidb.pinning import use_master
     # Fetch metadata details from master directly
-    with use_master:
+    try:
         report_templates = MetaData.external_export(xform)
+    except MetaData.DoesNotExist:
+        with use_master:
+            report_templates = MetaData.external_export(xform)
 
     if meta:
         try:

--- a/onadata/libs/utils/export_tools.py
+++ b/onadata/libs/utils/export_tools.py
@@ -692,11 +692,11 @@ def clean_keys_of_slashes(record):
 
 
 def _get_server_from_metadata(xform, meta, token):
-    from multidb.pinning import use_master
     # Fetch metadata details from master directly
     try:
         report_templates = MetaData.external_export(xform)
     except MetaData.DoesNotExist:
+        from multidb.pinning import use_master
         with use_master:
             report_templates = MetaData.external_export(xform)
 


### PR DESCRIPTION
Metadata details for extenal exports are being fetched from the replica database. This may fail if the record may still not be available in read replica.

Fixes #1758 
