### PR TITLE
Change submission endpoint to be case-insensitive when matching usernames

### DIFF
--- a/onadata/apps/api/permissions.py
+++ b/onadata/apps/api/permissions.py
@@ -508,7 +508,7 @@ class IsAuthenticatedSubmission(BasePermission):
                 # raises a permission denied exception, forces authentication
                 return False
             else:
-                user = get_object_or_404(User, username=username.lower())
+                user = get_object_or_404(User, username__iexact=username)
 
                 profile, _ = UserProfile.objects.get_or_create(user=user)
 

--- a/onadata/apps/api/tests/viewsets/test_openid_connect_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_openid_connect_viewset.py
@@ -112,6 +112,17 @@ class TestOpenIDConnectViewSet(TestAbstractViewSet):
                        "Please choose a different one"),
                       response.rendered_content.decode('utf-8'))
 
+        # Should raise error for differently cased versions of the username
+        data = {
+            "id_token": 123456,
+            'username': self.user_profile_data().get('username').upper()}
+        request = self.factory.post('/', data=data)
+        response = self.view(request, openid_connect_provider='msft')
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(("The username provided already exists. "
+                       "Please choose a different one"),
+                      response.rendered_content.decode('utf-8'))
+
     @override_settings(OPENID_CONNECT_PROVIDERS=OPENID_CONNECT_PROVIDERS)
     @patch(('onadata.apps.api.viewsets.openid_connect_viewset.'
             'OpenIDHandler.verify_and_decode_id_token'))

--- a/onadata/apps/api/viewsets/briefcase_viewset.py
+++ b/onadata/apps/api/viewsets/briefcase_viewset.py
@@ -102,7 +102,7 @@ class BriefcaseViewset(mixins.CreateModelMixin,
 
         if username is not None and self.request.user.is_anonymous:
             profile = get_object_or_404(
-                UserProfile, user__username=username.lower())
+                UserProfile, user__username__iexact=username)
 
             if profile.require_auth:
                 # raises a permission denied exception, forces authentication

--- a/onadata/apps/api/viewsets/openid_connect_viewset.py
+++ b/onadata/apps/api/viewsets/openid_connect_viewset.py
@@ -107,7 +107,7 @@ class OpenIDConnectViewSet(viewsets.ViewSet):
                 decoded_token)
 
         if username:
-            if get_user({"username": username}):
+            if get_user({"username__iexact": username}):
                 error_msg = _("The username provided already exists. "
                               "Please choose a different one.")
                 data = {'error_msg': error_msg, 'id_token': id_token}

--- a/onadata/apps/logger/views.py
+++ b/onadata/apps/logger/views.py
@@ -159,7 +159,7 @@ def bulksubmission_form(request, username=None):
     """
     Bulk submission form view
     """
-    username = username if username is None else username.lower()
+    username = username if username is None else username
     if request.user.username == username:
         return render(request, 'bulk_submission_form.html')
 

--- a/onadata/libs/utils/logger_tools.py
+++ b/onadata/libs/utils/logger_tools.py
@@ -147,7 +147,7 @@ def get_xform_from_submission(xml, username, uuid=None):
         return get_object_or_404(
             XForm,
             id_string__iexact=id_string,
-            user__username=username,
+            user__username__iexact=username,
             deleted_at__isnull=True)
     except MultipleObjectsReturned:
         raise NonUniqueFormIdError()
@@ -297,6 +297,7 @@ def create_instance(username,
         if request and request.user.is_authenticated else None
 
     if username:
+        # TODO: Why do we lower the username here ?
         username = username.lower()
 
     xml = xml_file.read()


### PR DESCRIPTION
### Changes / Features implemented

- Query usernames case-insensitively
- Properly validated usernames when creating users through OpenID Connect

### Steps taken to verify this change does what is intended

- Add test to make sure case doesn't matter when making submissions to `/<username/submission`

### Side effects of implementing this change

Closes #1761 
