### PR TITLE
Add X-Frame-Options Middleware class.

### DIFF
--- a/onadata/settings/common.py
+++ b/onadata/settings/common.py
@@ -169,7 +169,10 @@ MIDDLEWARE = (
     'django.contrib.messages.middleware.MessageMiddleware',
     'onadata.libs.utils.middleware.HTTPResponseNotAllowedMiddleware',
     'onadata.libs.utils.middleware.OperationalErrorMiddleware',
+    'django.middleware.clickjacking.XFrameOptionsMiddleware',
 )
+
+X_FRAME_OPTIONS = 'SAMEORIGIN'
 
 LOCALE_PATHS = (os.path.join(PROJECT_ROOT, 'onadata.apps.main', 'locale'), )
 

--- a/onadata/settings/common.py
+++ b/onadata/settings/common.py
@@ -172,7 +172,7 @@ MIDDLEWARE = (
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 )
 
-X_FRAME_OPTIONS = 'SAMEORIGIN'
+X_FRAME_OPTIONS = 'DENY'
 
 LOCALE_PATHS = (os.path.join(PROJECT_ROOT, 'onadata.apps.main', 'locale'), )
 


### PR DESCRIPTION
Set the x-frame-options header. Guide from django's documentation [here](https://docs.djangoproject.com/en/3.0/ref/clickjacking/#setting-x-frame-options-for-all-responses)
Fixes #1767