### PR TITLE
Invalidate tokens on password change

### DIFF
--- a/docs/profiles.rst
+++ b/docs/profiles.rst
@@ -233,7 +233,11 @@ Response
 
 ::
 
-    HTTP 200 OK
+    {
+        "username": "demouser",
+        "access_token": "30557df81ac63729d2865e90f334a5d00fe5e57c",
+        "temp_token": "0c6a9f167c7074c781f635fe30cb60efa2473317"
+    }
 
 Get the total number of monthly submissions
 -------------------------------------------

--- a/docs/user.rst
+++ b/docs/user.rst
@@ -97,7 +97,9 @@ Response
 
 ::
 
-       HTTP 204 OK
+       {
+           "username": "demouser"
+       }
 
 Expire temporary token
 ======================
@@ -115,7 +117,7 @@ Example
 
 ::
 
-      curl -X DELETE https://api.ona.io/api/v1/user/expire 
+      curl -X DELETE https://api.ona.io/api/v1/user/expire
 
 Response
 --------

--- a/onadata/apps/api/tests/viewsets/test_connect_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_connect_viewset.py
@@ -299,8 +299,9 @@ class TestConnectViewSet(TestAbstractViewSet):
         # with uid, should be successful
         request = self.factory.post('/', data=data)
         response = self.view(request)
-        self.assertEqual(response.status_code, 204)
+        self.assertEqual(response.status_code, 200)
         user = User.objects.get(email=self.user.email)
+        self.assertEqual(user.username, response.data['username'])
         self.assertTrue(user.check_password(new_password))
 
         request = self.factory.post('/', data=data)

--- a/onadata/apps/api/viewsets/connect_viewset.py
+++ b/onadata/apps/api/viewsets/connect_viewset.py
@@ -20,7 +20,7 @@ from onadata.libs.mixins.cache_control_mixin import CacheControlMixin
 from onadata.libs.mixins.etags_mixin import ETagsMixin
 from onadata.libs.mixins.object_lookup_mixin import ObjectLookupMixin
 from onadata.libs.serializers.password_reset_serializer import (
-    PasswordResetChangeSerializer, PasswordResetSerializer)
+    PasswordResetChangeSerializer, PasswordResetSerializer, get_user_from_uid)
 from onadata.libs.serializers.project_serializer import ProjectSerializer
 from onadata.libs.serializers.user_profile_serializer import \
     UserProfileWithTokenSerializer
@@ -87,13 +87,17 @@ class ConnectViewSet(mixins.CreateModelMixin, AuthenticateHeaderMixin,
         if 'token' in request.data:
             serializer = PasswordResetChangeSerializer(
                 data=data, context=context)
+
+            if serializer.is_valid():
+                serializer.save()
+                user = get_user_from_uid(serializer.data['uid'])
+                return Response(data={'username': user.username},
+                                status=status.HTTP_200_OK)
         else:
             serializer = PasswordResetSerializer(data=data, context=context)
-
-        if serializer.is_valid():
-            serializer.save()
-
-            return Response(status=status.HTTP_204_NO_CONTENT)
+            if serializer.is_valid():
+                serializer.save()
+                return Response(status=status.HTTP_204_NO_CONTENT)
 
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 

--- a/onadata/libs/serializers/password_reset_serializer.py
+++ b/onadata/libs/serializers/password_reset_serializer.py
@@ -11,6 +11,8 @@ from django.utils.http import urlsafe_base64_encode
 from django.utils.translation import ugettext_lazy as _
 from rest_framework import serializers
 
+from onadata.libs.utils.user_auth import invalidate_and_regen_tokens
+
 
 class CustomPasswordResetTokenGenerator(PasswordResetTokenGenerator):
     """Custom Password Token Generator Class."""
@@ -80,6 +82,7 @@ class PasswordResetChange(object):
         if user:
             user.set_password(self.new_password)
             user.save()
+            invalidate_and_regen_tokens(user)
 
 
 class PasswordReset(object):


### PR DESCRIPTION
### Changes / Features 

- Invalidate a users api and temporary token when they're password
  changes.
- Add test to verify that the api and temporary tokens are renewed

### Steps taken to verify this change does what is intended

- Added tests

Pending:
- Add new tests

### Side effects of implementing this change

- API Tokens will now need to be re-retrieved when one changes their password

Closes #1782 
