### PR TITLE
[WIP] Allow users to resubmit soft-deleted instances

### DIFF
--- a/onadata/apps/logger/tests/test_form_submission.py
+++ b/onadata/apps/logger/tests/test_form_submission.py
@@ -215,6 +215,14 @@ class TestFormSubmission(TestBase):
         self._make_submission(xml_submission_file_path)
         self.assertEqual(self.response.status_code, 202)
 
+        # Ensure one can resubmit the data if submissions is soft-deleted
+        instance = Instance.objects.last()
+        instance.set_deleted()
+        instance.save()
+
+        self._make_submission(xml_submission_file_path)
+        self.assertEqual(self.response.status_code, 201)
+
     def test_unicode_submission(self):
         """Test xml submissions that contain unicode characters
         """

--- a/onadata/libs/utils/logger_tools.py
+++ b/onadata/libs/utils/logger_tools.py
@@ -315,7 +315,8 @@ def create_instance(username,
 
     new_uuid = get_uuid_from_xml(xml)
     filtered_instances = get_filtered_instances(
-        Q(checksum=checksum) | Q(uuid=new_uuid), xform_id=xform.pk)
+        Q(checksum=checksum) | Q(uuid=new_uuid), xform_id=xform.pk,
+        deleted_at__isnull=True)
     existing_instance = get_first_record(filtered_instances.only('id'))
     if existing_instance and \
             (new_uuid or existing_instance.xform.has_start_time):


### PR DESCRIPTION
### Changes / Features implemented

- Allow users to submit submissions that have been `soft-deleted`

### Steps taken to verify this change does what is intended

- Updated tests

### Side effects of implementing this change

- Users will be able to submit new submissions with the same uuid as a submission in the system as long as the other submissions have been deleted.

Closes #1801 
