### PR TITLE
Fix an issue caused when a user tries to submit to a copy of a shared form

### DIFF
--- a/onadata/apps/api/tests/viewsets/test_xform_submission_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_xform_submission_viewset.py
@@ -181,7 +181,7 @@ class TestXFormSubmissionViewSet(TestAbstractViewSet, TransactionTestCase):
                 auth = DigestAuth('alice', 'bobbob')
                 request.META.update(auth(request.META, response))
                 response = self.view(request)
-                self.assertEqual(response.status_code, 403)
+                self.assertEqual(response.status_code, 404)
 
     def test_post_submission_authenticated_json(self):
         """

--- a/onadata/apps/api/tests/viewsets/test_xform_submission_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_xform_submission_viewset.py
@@ -21,6 +21,7 @@ from onadata.apps.api.viewsets.xform_submission_viewset import \
     XFormSubmissionViewSet
 from onadata.apps.logger.models import Attachment, Instance, XForm
 from onadata.libs.permissions import DataEntryRole
+from onadata.libs.utils.common_tools import get_uuid
 
 
 # pylint: disable=W0201,R0904,C0103
@@ -182,6 +183,59 @@ class TestXFormSubmissionViewSet(TestAbstractViewSet, TransactionTestCase):
                 request.META.update(auth(request.META, response))
                 response = self.view(request)
                 self.assertEqual(response.status_code, 404)
+
+    def test_post_submission_uuid_duplicate_no_username_provided(self):
+        """
+        Test submission to a duplicate of a form with a different uuid
+        from the original is properly routed to the request users version of
+        the form
+        """
+        alice_profile = self._create_user_profile({
+            'username': 'alice',
+            'email': 'alice@localhost.com'
+            })
+        s = self.surveys[0]
+        media_file = "1335783522563.jpg"
+        path = os.path.join(self.main_directory, 'fixtures',
+                            'transportation', 'instances', s, media_file)
+        with open(path, 'rb') as f:
+            f = InMemoryUploadedFile(f, 'media_file', media_file, 'image/jpg',
+                                     os.path.getsize(path), None)
+            path = os.path.join(
+                self.main_directory, 'fixtures',
+                'transportation', 'instances', s, s + '.xml')
+            path = self._add_uuid_to_submission_xml(path, self.xform)
+
+            with open(path, 'rb') as sf:
+                # Submits to the correct form
+                count = XForm.objects.count()
+                original_form_pk = self.xform.pk
+                duplicate_form = self.xform
+                duplicate_form.pk = None
+                duplicate_form.uuid = get_uuid()
+                duplicate_form.user = alice_profile.user
+                duplicate_form.save()
+                duplicate_form.refresh_from_db()
+
+                self.assertNotEqual(original_form_pk, duplicate_form.pk)
+                self.assertEqual(XForm.objects.count(), count + 1)
+
+                request = self.factory.post(
+                    '/submission',
+                    {'xml_submission_file': sf, 'media_file': f})
+                response = self.view(request)
+                self.assertEqual(response.status_code, 401)
+                auth = DigestAuth('alice', 'bobbob')
+                request.META.update(auth(request.META, response))
+                response = self.view(request)
+                self.assertEqual(response.status_code, 201)
+                duplicate_form.refresh_from_db()
+                self.assertEqual(
+                    duplicate_form.instances.all().count(),
+                    1)
+                self.assertEqual(
+                    XForm.objects.get(
+                        pk=original_form_pk).instances.all().count(), 0)
 
     def test_post_submission_authenticated_json(self):
         """

--- a/onadata/apps/logger/tests/test_digest_authentication.py
+++ b/onadata/apps/logger/tests/test_digest_authentication.py
@@ -3,6 +3,7 @@ from datetime import timedelta
 
 from django.conf import settings
 from django.test.utils import override_settings
+from django.http import Http404
 from django.utils import timezone
 
 from cryptography.fernet import Fernet
@@ -60,10 +61,9 @@ class TestDigestAuthentication(TestBase):
         # Authentication required
         self.assertEqual(self.response.status_code, 401)
         auth = DigestAuth('dennis', 'dennis')
-        self._make_submission(xml_submission_file_path, add_uuid=True,
-                              auth=auth)
-        # Not allowed
-        self.assertEqual(self.response.status_code, 403)
+        with self.assertRaises(Http404):
+            self._make_submission(xml_submission_file_path, add_uuid=True,
+                                  auth=auth)
 
     @override_settings(
         DIGEST_ACCOUNT_BACKEND=ODK_TOKEN_STORAGE


### PR DESCRIPTION
### Changes / Features implemented

- Modify the get_xform_from_submission function

### Steps taken to verify this change does what is intended

- [x] Add/Update tests

### Pending changes

- [x] Support the old submission processing flow. _We should not be completely switching towards this new form of submission processing_

### Side effects of implementing this change

Closes #1801 
