### PR TITLE
Set profile avatar url to cache

### DIFF
--- a/onadata/apps/api/models/organization_profile.py
+++ b/onadata/apps/api/models/organization_profile.py
@@ -117,7 +117,9 @@ class OrganizationProfile(UserProfile):
         # set avatar url to cache
         # key should be <username>-org-avatar format
         if 'avatar-url' in self.metadata:
-            cache.set(f'{self.user.username}{ORG_AVATAR_CACHE}', self.metadata['avatar-url'])
+            cache.set(
+                f'{self.user.username}{ORG_AVATAR_CACHE}',
+                self.metadata['avatar-url'])
         super(OrganizationProfile, self).save(*args, **kwargs)
 
     def remove_user_from_organization(self, user):

--- a/onadata/apps/api/models/organization_profile.py
+++ b/onadata/apps/api/models/organization_profile.py
@@ -31,6 +31,9 @@ def org_profile_post_delete_callback(sender, instance, **kwargs):
 
 
 def clear_proj_users_cache(sender, instance, created, **kwargs):
+    """
+    Signal handler to clear project users from cache.
+    """
     if not created:
         projects = Project.objects.filter(organization=instance.id)
         for project in queryset_iterator(projects):

--- a/onadata/apps/api/models/organization_profile.py
+++ b/onadata/apps/api/models/organization_profile.py
@@ -117,8 +117,7 @@ class OrganizationProfile(UserProfile):
         # set avatar url to cache
         # key should be <username>-org-avatar format
         if 'avatar-url' in self.metadata:
-            cache.set('{}{}'.format(
-                self.user, ORG_AVATAR_CACHE), self.metadata['avatar-url'])
+            cache.set(f'{self.user.username}{ORG_AVATAR_CACHE}', self.metadata['avatar-url'])
         super(OrganizationProfile, self).save(*args, **kwargs)
 
     def remove_user_from_organization(self, user):

--- a/onadata/apps/api/tests/models/test_organization_profile.py
+++ b/onadata/apps/api/tests/models/test_organization_profile.py
@@ -5,7 +5,8 @@ from onadata.apps.api.models.team import Team
 from django.db import IntegrityError
 from django.test import override_settings
 from django.core.cache import cache
-from onadata.libs.utils.cache_tools import IS_ORG, safe_delete
+from onadata.libs.utils.cache_tools import (
+    IS_ORG, ORG_AVATAR_CACHE, safe_delete)
 from onadata.libs.permissions import OwnerRole
 
 
@@ -68,3 +69,22 @@ class TestOrganizationProfile(TestBase):
         profile.save()
 
         self.assertFalse(profile.user.is_active)
+    
+    def test_cached_org_avatar(self):
+        """
+        Test that avatar url is set to cache
+        after being updated
+        """
+        profile = tools.create_organization_object("modilabs", self.user)
+
+        # clear cache
+        cache.delete('{}{}'.format(profile.user, ORG_AVATAR_CACHE))
+
+        self.assertIsNone(cache.get('{}{}'.format(profile.user, ORG_AVATAR_CACHE)))
+
+        avatar_url = 'http://test.images.io/image/ffdc3526ba647278c7d4f3/test.png'
+        profile.metadata['avatar-url'] = avatar_url
+        profile.save()
+        # check avatar url is saved in cache
+        self.assertEqual(cache.get('{}{}'.format(profile.user, ORG_AVATAR_CACHE)), avatar_url)
+

--- a/onadata/apps/api/tests/models/test_organization_profile.py
+++ b/onadata/apps/api/tests/models/test_organization_profile.py
@@ -82,8 +82,10 @@ class TestOrganizationProfile(TestBase):
 
         self.assertIsNone(cache.get(f'{profile.user}{ORG_AVATAR_CACHE}'))
 
-        avatar_url = 'http://test.images.io/image/ffdc3526ba647278c7d4f3/test.png'
+        avatar_url =\
+            'http://test.images.io/image/ffdc3526ba647278c7d4f3/test.png'
         profile.metadata['avatar-url'] = avatar_url
         profile.save()
         # check avatar url is saved in cache
-        self.assertEqual(cache.get(f'{profile.user}{ORG_AVATAR_CACHE}'), avatar_url)
+        self.assertEqual(cache.get(
+            f'{profile.user}{ORG_AVATAR_CACHE}'), avatar_url)

--- a/onadata/apps/api/tests/models/test_organization_profile.py
+++ b/onadata/apps/api/tests/models/test_organization_profile.py
@@ -69,7 +69,7 @@ class TestOrganizationProfile(TestBase):
         profile.save()
 
         self.assertFalse(profile.user.is_active)
-    
+
     def test_cached_org_avatar(self):
         """
         Test that avatar url is set to cache
@@ -78,13 +78,12 @@ class TestOrganizationProfile(TestBase):
         profile = tools.create_organization_object("modilabs", self.user)
 
         # clear cache
-        cache.delete('{}{}'.format(profile.user, ORG_AVATAR_CACHE))
+        cache.delete(f'{profile.user}{ORG_AVATAR_CACHE}')
 
-        self.assertIsNone(cache.get('{}{}'.format(profile.user, ORG_AVATAR_CACHE)))
+        self.assertIsNone(cache.get(f'{profile.user}{ORG_AVATAR_CACHE}'))
 
         avatar_url = 'http://test.images.io/image/ffdc3526ba647278c7d4f3/test.png'
         profile.metadata['avatar-url'] = avatar_url
         profile.save()
         # check avatar url is saved in cache
-        self.assertEqual(cache.get('{}{}'.format(profile.user, ORG_AVATAR_CACHE)), avatar_url)
-
+        self.assertEqual(cache.get(f'{profile.user}{ORG_AVATAR_CACHE}'), avatar_url)

--- a/onadata/libs/serializers/project_serializer.py
+++ b/onadata/libs/serializers/project_serializer.py
@@ -25,7 +25,7 @@ from onadata.libs.serializers.tag_list_serializer import TagListSerializer
 from onadata.libs.utils.cache_tools import (
     PROJ_BASE_FORMS_CACHE, PROJ_FORMS_CACHE, PROJ_NUM_DATASET_CACHE,
     PROJ_PERM_CACHE, PROJ_SUB_DATE_CACHE, PROJ_TEAM_USERS_CACHE,
-    PROJECT_LINKED_DATAVIEWS, PROJ_OWNER_CACHE, safe_delete)
+    PROJECT_LINKED_DATAVIEWS, PROJ_OWNER_CACHE, ORG_AVATAR_CACHE, safe_delete)
 from onadata.libs.utils.decorators import check_obj
 
 
@@ -139,6 +139,11 @@ def get_users(project, context, all_perms=True):
             if all_perms or user in [
                     context['request'].user, project.organization
             ]:
+                get_avatar_url = cache.get('{}{}'.format(
+                    user.username, ORG_AVATAR_CACHE))
+                if get_avatar_url:
+                    user.profile.metadata['avatar-url'] = get_avatar_url
+    
                 data[perm.user_id] = {
                     'permissions': [],
                     'is_org': is_organization(user.profile),

--- a/onadata/libs/serializers/project_serializer.py
+++ b/onadata/libs/serializers/project_serializer.py
@@ -139,11 +139,11 @@ def get_users(project, context, all_perms=True):
             if all_perms or user in [
                     context['request'].user, project.organization
             ]:
-                get_avatar_url = cache.get('{}{}'.format(
-                    user.username, ORG_AVATAR_CACHE))
+                get_avatar_url = cache.get(
+                    f'{user.username}{ORG_AVATAR_CACHE}')
                 if get_avatar_url:
                     user.profile.metadata['avatar-url'] = get_avatar_url
-    
+
                 data[perm.user_id] = {
                     'permissions': [],
                     'is_org': is_organization(user.profile),

--- a/onadata/libs/utils/cache_tools.py
+++ b/onadata/libs/utils/cache_tools.py
@@ -37,6 +37,8 @@ CHANGE_PASSWORD_ATTEMPTS = 'change_password_attempts-'
 # cache avatar link
 ORG_AVATAR_CACHE = "-org-avatar"
 
+OWNER_PROJECT_IDS = "project-ids"
+
 
 def safe_delete(key):
     """Safely deletes a given key from the cache."""

--- a/onadata/libs/utils/cache_tools.py
+++ b/onadata/libs/utils/cache_tools.py
@@ -37,6 +37,7 @@ CHANGE_PASSWORD_ATTEMPTS = 'change_password_attempts-'
 # cache avatar link
 ORG_AVATAR_CACHE = "-org-avatar"
 
+
 def safe_delete(key):
     """Safely deletes a given key from the cache."""
     _ = cache.get(key) and cache.delete(key)

--- a/onadata/libs/utils/cache_tools.py
+++ b/onadata/libs/utils/cache_tools.py
@@ -34,6 +34,8 @@ LOGIN_ATTEMPTS = "login_attempts-"
 LOCKOUT_CHANGE_PASSWORD_USER = 'lockout_change_password_user-'
 CHANGE_PASSWORD_ATTEMPTS = 'change_password_attempts-'
 
+# cache avatar link
+ORG_AVATAR_CACHE = "-org-avatar"
 
 def safe_delete(key):
     """Safely deletes a given key from the cache."""


### PR DESCRIPTION
### Changes / Features implemented
- Set and fetch avatar url from cache because sometimes when uploading/updating a profile avatar the replica db takes time to sync with master db.

- Once the key expires from cache after  5 mins (default django timeout value), the replica db will hopefully have synced with master

### Steps taken to verify this change does what is intended
- Tests
### Side effects of implementing this change

Addresses https://github.com/onaio/zebra/issues/5831
