### PR TITLE
Fix caching issues with newly created projects

### DIFF
--- a/onadata/apps/api/tests/viewsets/test_project_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_project_viewset.py
@@ -10,6 +10,7 @@ from operator import itemgetter
 
 from django.conf import settings
 from django.db.models import Q
+from django.core.cache import cache
 from httmock import HTTMock, urlmatch
 from mock import MagicMock, patch
 import requests
@@ -26,6 +27,7 @@ from onadata.apps.logger.models import Project, XForm
 from onadata.apps.main.models import MetaData
 from onadata.libs import permissions as role
 from onadata.libs.models.share_project import ShareProject
+from onadata.libs.utils.cache_tools import PROJ_OWNER_CACHE, safe_key
 from onadata.libs.permissions import (ROLES_ORDERED, DataEntryMinorRole,
                                       DataEntryOnlyRole, DataEntryRole,
                                       EditorMinorRole, EditorRole, ManagerRole,
@@ -1700,6 +1702,8 @@ class TestProjectViewSet(TestAbstractViewSet):
         response = view(request, pk=projectid)
 
         self.assertEqual(response.status_code, 400)
+        self.assertIsNone(
+            cache.get(safe_key(f'{PROJ_OWNER_CACHE}{self.project.pk}')))
         self.assertEqual(
             response.data,
             {'username': [u'The following user(s) is/are not active: alice']})
@@ -1729,6 +1733,8 @@ class TestProjectViewSet(TestAbstractViewSet):
         response = view(request, pk=projectid)
 
         self.assertEqual(response.status_code, 204)
+        self.assertIsNone(
+            cache.get(safe_key(f'{PROJ_OWNER_CACHE}{self.project.pk}')))
 
         self.assertTrue(ReadOnlyRole.user_has_role(alice_profile.user,
                                                    self.project))
@@ -2197,6 +2203,8 @@ class TestProjectViewSet(TestAbstractViewSet):
         response = view(request, pk=projectid)
 
         self.assertEqual(response.status_code, 204)
+        self.assertIsNone(
+            cache.get(safe_key(f'{PROJ_OWNER_CACHE}{self.project.pk}')))
 
         self.assertTrue(ReadOnlyRole.user_has_role(alice_profile.user,
                                                    self.project))

--- a/onadata/apps/api/tests/viewsets/test_project_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_project_viewset.py
@@ -163,6 +163,13 @@ class TestProjectViewSet(TestAbstractViewSet):
 
         self.assertNotEqual(response.get('Cache-Control'), None)
         self.assertEqual(response.status_code, 200)
+
+        # test serialized data
+        serializer = ProjectSerializer(self.project,
+                                       context={'request': request})
+        self.assertEqual(response.data, serializer.data)
+
+        self.assertIsNotNone(self.project_data)
         self.assertEqual(response.data, self.project_data)
         res_user_props = list(response.data['users'][0])
         res_user_props.sort()

--- a/onadata/apps/api/tools.py
+++ b/onadata/apps/api/tools.py
@@ -43,8 +43,8 @@ from onadata.libs.permissions import (
     EditorMinorRole, EditorRole, ManagerRole, OwnerRole, get_role,
     get_role_in_org, is_organization)
 from onadata.libs.utils.api_export_tools import custom_response_handler
-from onadata.libs.utils.cache_tools import (PROJ_BASE_FORMS_CACHE,
-                                            PROJ_FORMS_CACHE, safe_delete)
+from onadata.libs.utils.cache_tools import (
+    PROJ_BASE_FORMS_CACHE, PROJ_FORMS_CACHE, PROJ_OWNER_CACHE, safe_delete)
 from onadata.libs.utils.common_tags import MEMBERS, XFORM_META_PERMS
 from onadata.libs.utils.logger_tools import (publish_form,
                                              response_with_mimetype_and_name)
@@ -406,6 +406,7 @@ def publish_project_xform(request, project):
 
     if 'formid' in request.data:
         xform = get_object_or_404(XForm, pk=request.data.get('formid'))
+        safe_delete('{}{}'.format(PROJ_OWNER_CACHE, xform.project.pk))
         safe_delete('{}{}'.format(PROJ_FORMS_CACHE, xform.project.pk))
         safe_delete('{}{}'.format(PROJ_BASE_FORMS_CACHE, xform.project.pk))
         if not ManagerRole.user_has_role(request.user, xform):

--- a/onadata/apps/api/viewsets/dataview_viewset.py
+++ b/onadata/apps/api/viewsets/dataview_viewset.py
@@ -31,6 +31,7 @@ from onadata.libs.utils.api_export_tools import (custom_response_handler,
                                                  process_async_export,
                                                  response_for_format)
 from onadata.libs.utils.cache_tools import (PROJECT_LINKED_DATAVIEWS,
+                                            PROJ_OWNER_CACHE,
                                             safe_delete)
 from onadata.libs.utils.chart_tools import (get_chart_data_for_field,
                                             get_field_from_field_name)
@@ -249,6 +250,7 @@ class DataViewViewSet(AuthenticateHeaderMixin,
         dataview = self.get_object()
         user = request.user
         dataview.soft_delete(user)
+        safe_delete('{}{}'.format(PROJ_OWNER_CACHE, dataview.project.pk))
 
         return Response(status=status.HTTP_204_NO_CONTENT)
 

--- a/onadata/apps/api/viewsets/project_viewset.py
+++ b/onadata/apps/api/viewsets/project_viewset.py
@@ -29,7 +29,8 @@ from onadata.libs.serializers.share_project_serializer import \
     (RemoveUserFromProjectSerializer, ShareProjectSerializer)
 from onadata.libs.serializers.user_profile_serializer import \
     UserProfileSerializer
-from onadata.libs.utils.cache_tools import PROJ_OWNER_CACHE, safe_delete
+from onadata.libs.utils.cache_tools import (
+    PROJ_OWNER_CACHE, safe_delete)
 from onadata.libs.serializers.xform_serializer import (XFormCreateSerializer,
                                                        XFormSerializer)
 from onadata.libs.utils.common_tools import merge_dicts

--- a/onadata/apps/api/viewsets/project_viewset.py
+++ b/onadata/apps/api/viewsets/project_viewset.py
@@ -109,8 +109,12 @@ class ProjectViewSet(AuthenticateHeaderMixin,
                 published_by_formbuilder = request.data.get(
                     'published_by_formbuilder'
                 )
+
                 if str_to_bool(published_by_formbuilder):
                     MetaData.published_by_formbuilder(survey, 'True')
+
+                # clear project from cache
+                safe_delete(f'{PROJ_OWNER_CACHE}{survey.project.pk}')
 
                 return Response(serializer.data,
                                 status=status.HTTP_201_CREATED)

--- a/onadata/apps/api/viewsets/project_viewset.py
+++ b/onadata/apps/api/viewsets/project_viewset.py
@@ -29,7 +29,7 @@ from onadata.libs.serializers.share_project_serializer import \
     (RemoveUserFromProjectSerializer, ShareProjectSerializer)
 from onadata.libs.serializers.user_profile_serializer import \
     UserProfileSerializer
-from onadata.libs.utils.cache_tools import PROJ_OWNER_CACHE
+from onadata.libs.utils.cache_tools import PROJ_OWNER_CACHE, safe_delete
 from onadata.libs.serializers.xform_serializer import (XFormCreateSerializer,
                                                        XFormSerializer)
 from onadata.libs.utils.common_tools import merge_dicts
@@ -75,6 +75,7 @@ class ProjectViewSet(AuthenticateHeaderMixin,
         return super(ProjectViewSet, self).get_queryset()
 
     def retrieve(self, request, *args, **kwargs):
+        """ Retrieve single project """
         project_id = kwargs.get('pk')
         project = cache.get(f'{PROJ_OWNER_CACHE}{project_id}')
         if project:
@@ -152,6 +153,10 @@ class ProjectViewSet(AuthenticateHeaderMixin,
         else:
             return Response(data=serializer.errors,
                             status=status.HTTP_400_BAD_REQUEST)
+
+        # clear cache
+        safe_delete(f'{PROJ_OWNER_CACHE}{self.object.pk}')
+
         return Response(status=status.HTTP_204_NO_CONTENT)
 
     @action(methods=['DELETE', 'GET', 'POST'], detail=True)

--- a/onadata/apps/api/viewsets/project_viewset.py
+++ b/onadata/apps/api/viewsets/project_viewset.py
@@ -83,6 +83,8 @@ class ProjectViewSet(AuthenticateHeaderMixin,
         self.object = self.get_object()
         serializer = ProjectSerializer(
             self.object, context={'request': request})
+        cache.set(f'{PROJ_OWNER_CACHE}{self.object.pk}', serializer.data)
+
         return Response(serializer.data)
 
     @action(methods=['POST', 'GET'], detail=True)

--- a/onadata/apps/api/viewsets/xform_viewset.py
+++ b/onadata/apps/api/viewsets/xform_viewset.py
@@ -5,7 +5,6 @@ from datetime import datetime
 
 from django.conf import settings
 from django.contrib.auth.models import User
-from django.core.cache import cache
 from django.core.exceptions import ValidationError
 from django.core.files.base import ContentFile
 from django.core.files.storage import default_storage
@@ -51,7 +50,6 @@ from onadata.libs.mixins.cache_control_mixin import CacheControlMixin
 from onadata.libs.mixins.etags_mixin import ETagsMixin
 from onadata.libs.mixins.labels_mixin import LabelsMixin
 from onadata.libs.renderers import renderers
-from onadata.libs.serializers.project_serializer import ProjectSerializer
 from onadata.libs.serializers.clone_xform_serializer import \
     CloneXFormSerializer
 from onadata.libs.serializers.share_xform_serializer import \
@@ -78,7 +76,7 @@ from onadata.libs.utils.viewer_tools import (enketo_url,
                                              get_enketo_single_submit_url)
 from onadata.libs.exceptions import EnketoError
 from onadata.settings.common import XLS_EXTENSIONS, CSV_EXTENSION
-from onadata.libs.utils.cache_tools import PROJ_OWNER_CACHE
+from onadata.libs.utils.cache_tools import PROJ_OWNER_CACHE, safe_delete
 
 ENKETO_AUTH_COOKIE = getattr(settings, 'ENKETO_AUTH_COOKIE',
                              '__enketo')
@@ -722,6 +720,9 @@ class XFormViewSet(AnonymousUserPublicFormsMixin,
                     xform.pk,
                     request.user.id).task_id,
                 u'time_async_triggered': datetime.now()}
+
+            # clear project from cache
+            safe_delete(f'{PROJ_OWNER_CACHE}{xform.project.pk}')
             resp_code = status.HTTP_202_ACCEPTED
 
         elif request.method == 'GET':
@@ -729,9 +730,7 @@ class XFormViewSet(AnonymousUserPublicFormsMixin,
             resp = tasks.get_async_status(job_uuid)
             resp_code = status.HTTP_202_ACCEPTED
             self.etag_data = '{}'.format(timezone.now())
-        serializer = ProjectSerializer(
-            xform.project, context={'request': request})
-        cache.set(f'{PROJ_OWNER_CACHE}{xform.project.pk}', serializer.data)
+
         return Response(data=resp, status=resp_code)
 
     def destroy(self, request, *args, **kwargs):

--- a/onadata/apps/logger/models/data_view.py
+++ b/onadata/apps/logger/models/data_view.py
@@ -20,6 +20,7 @@ from onadata.libs.models.sorting import (json_order_by, json_order_by_params,
 from onadata.libs.utils.cache_tools import (DATAVIEW_COUNT,
                                             DATAVIEW_LAST_SUBMISSION_TIME,
                                             XFORM_LINKED_DATAVIEWS,
+                                            PROJ_OWNER_CACHE,
                                             safe_delete)
 from onadata.libs.utils.common_tags import (ATTACHMENTS, EDITED, GEOLOCATION,
                                             ID, LAST_EDITED, MONGO_STRFTIME,
@@ -376,6 +377,7 @@ def clear_cache(sender, instance, **kwargs):
 def clear_dataview_cache(sender, instance, **kwargs):
     """ Post Save handler for clearing dataview cache on serialized fields.
     """
+    safe_delete('{}{}'.format(PROJ_OWNER_CACHE, instance.project.pk))
     safe_delete('{}{}'.format(DATAVIEW_COUNT, instance.xform.pk))
     safe_delete(
         '{}{}'.format(DATAVIEW_LAST_SUBMISSION_TIME, instance.xform.pk))

--- a/onadata/apps/logger/models/xform.py
+++ b/onadata/apps/logger/models/xform.py
@@ -37,7 +37,7 @@ from onadata.libs.utils.cache_tools import (IS_ORG, PROJ_BASE_FORMS_CACHE,
                                             PROJ_FORMS_CACHE,
                                             PROJ_NUM_DATASET_CACHE,
                                             PROJ_SUB_DATE_CACHE, XFORM_COUNT,
-                                            safe_delete)
+                                            PROJ_OWNER_CACHE, safe_delete)
 from onadata.libs.utils.common_tags import (DURATION, ID, KNOWN_MEDIA_TYPES,
                                             MEDIA_ALL_RECEIVED, MEDIA_COUNT,
                                             NOTES, SUBMISSION_TIME,
@@ -1052,6 +1052,7 @@ pre_save.connect(save_project, sender=XForm, dispatch_uid='save_project_xform')
 
 def xform_post_delete_callback(sender, instance, **kwargs):
     if instance.project_id:
+        safe_delete('{}{}'.format(PROJ_OWNER_CACHE, instance.project_id))
         safe_delete('{}{}'.format(PROJ_FORMS_CACHE, instance.project_id))
         safe_delete('{}{}'.format(PROJ_BASE_FORMS_CACHE, instance.project.pk))
         safe_delete('{}{}'.format(PROJ_SUB_DATE_CACHE, instance.project_id))

--- a/onadata/libs/models/share_project.py
+++ b/onadata/libs/models/share_project.py
@@ -4,7 +4,8 @@ from django.db import transaction
 from onadata.libs.permissions import ROLES
 from onadata.libs.permissions import EditorRole, EditorMinorRole,\
     DataEntryRole, DataEntryMinorRole, DataEntryOnlyRole
-from onadata.libs.utils.cache_tools import PROJ_PERM_CACHE, safe_delete
+from onadata.libs.utils.cache_tools import (
+    PROJ_PERM_CACHE, PROJ_OWNER_CACHE, safe_delete)
 
 
 def remove_xform_permissions(project, user, role):
@@ -63,6 +64,7 @@ class ShareProject(object):
                         role.add(self.user, dataview.xform)
 
         # clear cache
+        safe_delete('{}{}'.format(PROJ_OWNER_CACHE, self.project.pk))
         safe_delete('{}{}'.format(PROJ_PERM_CACHE, self.project.pk))
 
     @transaction.atomic()

--- a/onadata/libs/serializers/project_serializer.py
+++ b/onadata/libs/serializers/project_serializer.py
@@ -25,7 +25,7 @@ from onadata.libs.serializers.tag_list_serializer import TagListSerializer
 from onadata.libs.utils.cache_tools import (
     PROJ_BASE_FORMS_CACHE, PROJ_FORMS_CACHE, PROJ_NUM_DATASET_CACHE,
     PROJ_PERM_CACHE, PROJ_SUB_DATE_CACHE, PROJ_TEAM_USERS_CACHE,
-    PROJECT_LINKED_DATAVIEWS, safe_delete)
+    PROJECT_LINKED_DATAVIEWS, PROJ_OWNER_CACHE, safe_delete)
 from onadata.libs.utils.decorators import check_obj
 
 
@@ -436,7 +436,11 @@ class ProjectSerializer(serializers.HyperlinkedModelSerializer):
         else:
             project.xform_set.exclude(shared=project.shared)\
                 .update(shared=project.shared, shared_data=project.shared)
-
+            request = self.context.get('request')
+            serializer = ProjectSerializer(
+                project, context={'request': request})
+            response = serializer.data
+            cache.set(f'{PROJ_OWNER_CACHE}{project.pk}', response)
             return project
 
     def get_users(self, obj):  # pylint: disable=no-self-use

--- a/onadata/libs/utils/cache_tools.py
+++ b/onadata/libs/utils/cache_tools.py
@@ -9,6 +9,7 @@ PROJ_NUM_DATASET_CACHE = "ps-num_datasets-"
 PROJ_SUB_DATE_CACHE = "ps-last_submission_date-"
 PROJ_FORMS_CACHE = "ps-project_forms-"
 PROJ_BASE_FORMS_CACHE = "ps-project_base_forms-"
+PROJ_OWNER_CACHE = "ps-project_owner-"
 
 # Cache names used in user_profile_serializer
 IS_ORG = "ups-is_org-"


### PR DESCRIPTION
### Changes / Features implemented
- Fixes the issue where making a GET to the projects endpoint immediately after creating a project throws a 404 because the replica db isn't updated with the newly created project on time.

### Steps taken to verify this change does what is intended
- Tests
### Side effects of implementing this change
- This change will also affect caching project forms, dataviews(filtered datasets) and users

Closes https://github.com/onaio/zebra/issues/5911
