### PR TITLE
Add ability to disable creation of public projects and xforms

### DIFF
--- a/onadata/libs/serializers/project_serializer.py
+++ b/onadata/libs/serializers/project_serializer.py
@@ -369,6 +369,15 @@ class ProjectSerializer(serializers.HyperlinkedModelSerializer):
             })
         return attrs
 
+    def validate_public(self, value):  # pylint: disable=no-self-use
+        """
+        Validate the public field
+        """
+        if not settings.ALLOW_PUBLIC_DATASETS and value:
+            raise serializers.ValidationError(
+                _('Public projects are currently disabled.'))
+        return value
+
     def validate_metadata(self, value):  # pylint: disable=no-self-use
         """
         Validate metadaata is a valid JSON value.

--- a/onadata/libs/serializers/xform_serializer.py
+++ b/onadata/libs/serializers/xform_serializer.py
@@ -328,6 +328,28 @@ class XFormSerializer(XFormMixin, serializers.HyperlinkedModelSerializer):
                 _('The public key is not a valid base64 RSA key'))
         return clean_public_key(value)
 
+    def _check_if_allowed_public(self, value):  # pylint: disable=no-self-use
+        """
+        Verify that users are allowed to create public
+        forms
+        """
+        if not settings.ALLOW_PUBLIC_DATASETS and value:
+            raise serializers.ValidationError(
+                _('Public forms are currently disabled.'))
+        return value
+
+    def validate_public_data(self, value):
+        """
+        Validate the public_data field
+        """
+        return self._check_if_allowed_public(value)
+
+    def validate_public(self, value):
+        """
+        Validate the public field
+        """
+        return self._check_if_allowed_public(value)
+
     def get_form_versions(self, obj):
         versions = []
         if obj:

--- a/onadata/settings/common.py
+++ b/onadata/settings/common.py
@@ -571,3 +571,6 @@ SECRET_KEY = 'mlfs33^s1l4xf6a36$0#j%dd*sisfoi&)&4s-v=91#^l01v)*j'
 LOCKOUT_TIME = 30 * 60
 MAX_LOGIN_ATTEMPTS = 10
 SUPPORT_EMAIL = "support@example.com"
+
+# Project & XForm Visibility Settings
+ALLOW_PUBLIC_DATASETS = True


### PR DESCRIPTION
### Changes / Features implemented

- Added new `ALLOW_PUBLIC_DATASETS` settings
- Added ability to disable creation of public projects and forms

### Steps taken to verify this change does what is intended

### Side effects of implementing this change

