### PR TITLE
Use last name as first name if first name isn't sent

### DIFF
--- a/onadata/apps/api/tests/viewsets/test_openid_connect_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_openid_connect_viewset.py
@@ -1,6 +1,7 @@
 """
 Test OpenIDViewset module
 """
+from django.contrib.auth.models import User
 from django.test.utils import override_settings
 
 from mock import patch
@@ -137,9 +138,27 @@ class TestOpenIDConnectViewSet(TestAbstractViewSet):
             'email': 'john@doe.com'
         }
         data = {'id_token': 124, 'username': 'john'}
+        user_count = User.objects.filter(username='john').count()
         request = self.factory.post('/', data=data)
         response = self.view(request, openid_connect_provider='msft')
+        self.assertEqual(
+            user_count + 1, User.objects.filter(username='john').count())
         self.assertEqual(response.status_code, 302)
+
+        # Uses last_name as first_name if missing
+        mock_get_decoded_id_token.return_value = {
+            'family_name': 'davis',
+            'email': 'davis@justdavis.com'
+        }
+        data = {'id_token': 124, 'username': 'davis'}
+        user_count = User.objects.filter(username='davis').count()
+        request = self.factory.post('/', data=data)
+        response = self.view(request, openid_connect_provider='msft')
+        self.assertEqual(
+            user_count + 1, User.objects.filter(username='john').count())
+        self.assertEqual(response.status_code, 302)
+        user = User.objects.get(username='davis')
+        self.assertEqual(user.first_name, 'davis')
 
     @override_settings(OPENID_CONNECT_PROVIDERS=OPENID_CONNECT_PROVIDERS)
     @patch(('onadata.apps.api.viewsets.openid_connect_viewset.'

--- a/onadata/apps/api/tests/viewsets/test_openid_connect_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_openid_connect_viewset.py
@@ -160,6 +160,16 @@ class TestOpenIDConnectViewSet(TestAbstractViewSet):
         user = User.objects.get(username='davis')
         self.assertEqual(user.first_name, 'davis')
 
+        # Returns a 400 response if both family_name and given_name
+        # are missing
+        mock_get_decoded_id_token.return_value = {
+            'email': 'jake@doe.com'
+        }
+        data = {'id_token': 124, 'username': 'jake'}
+        request = self.factory.post('/', data=data)
+        response = self.view(request, openid_connect_provider='msft')
+        self.assertEqual(response.status_code, 400)
+
     @override_settings(OPENID_CONNECT_PROVIDERS=OPENID_CONNECT_PROVIDERS)
     @patch(('onadata.apps.api.viewsets.openid_connect_viewset.'
             'OpenIDHandler.verify_and_decode_id_token'))

--- a/onadata/apps/api/viewsets/openid_connect_viewset.py
+++ b/onadata/apps/api/viewsets/openid_connect_viewset.py
@@ -126,8 +126,10 @@ class OpenIDConnectViewSet(viewsets.ViewSet):
                     return Response(
                         data, template_name='missing_oidc_detail.html')
 
-                first_name = claim_values.get(FIRST_NAME)
                 last_name = claim_values.get(LAST_NAME)
+                first_name = claim_values.get(FIRST_NAME)
+                if not first_name:
+                    first_name = last_name
                 user = create_or_get_user(first_name, last_name, email,
                                           username)
         else:

--- a/onadata/apps/api/viewsets/openid_connect_viewset.py
+++ b/onadata/apps/api/viewsets/openid_connect_viewset.py
@@ -1,4 +1,5 @@
 import secrets
+import json
 
 from django.conf import settings
 from django.contrib.auth.models import User
@@ -128,8 +129,14 @@ class OpenIDConnectViewSet(viewsets.ViewSet):
 
                 last_name = claim_values.get(LAST_NAME)
                 first_name = claim_values.get(FIRST_NAME)
-                if not first_name:
-                    first_name = last_name
+                if not first_name and not last_name:
+                    return HttpResponseBadRequest(
+                        json.dumps(
+                            _('Missing required claims/fields:'
+                              f' {FIRST_NAME}, {LAST_NAME}')))
+                else:
+                    first_name = first_name or last_name
+
                 user = create_or_get_user(first_name, last_name, email,
                                           username)
         else:
@@ -146,7 +153,9 @@ class OpenIDConnectViewSet(viewsets.ViewSet):
         elif data.get('id_token'):
             return Response(data, template_name='oidc_username_entry.html')
         else:
-            return HttpResponseBadRequest()
+            return HttpResponseBadRequest(
+                json.dumps(_(f'Unable to authenticate with {openid_provider}'))
+            )
 
 
 def create_or_get_user(


### PR DESCRIPTION
### Changes / Features implemented

- During the Open ID Connect authentication process use the last name as the first name if not retrieved from token

### Steps taken to verify this change does what is intended

- Updated tests

### Side effects of implementing this change
