### PR TITLE
Add enketo_meta_usename cookie

### DIFF
--- a/onadata/apps/api/tests/viewsets/test_xform_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_xform_viewset.py
@@ -1055,6 +1055,13 @@ class TestXFormViewSet(TestAbstractViewSet):
             query_data = {'return': url}
             request = self.factory.get('/', data=query_data)
             response = view(request, pk=formid)
+            cookies = response.cookies
+            uid_cookie = cookies.get(settings.ENKETO_META_UID_COOKIE)._value
+            username_cookie = cookies.get(settings.ENKETO_META_USERNAME_COOKIE)
+            username_cookie = username_cookie._value
+            # exmple cookie: bob:1jlVih:i2KvHoAtsQOlYB71CJeNuVUlEY0
+            self.assertEqual(username_cookie.split(':')[0], 'bob')
+            self.assertEqual(username_cookie.split(':')[0], 'bob')
             self.assertEqual(response.status_code, 302)
             self.assertEqual(response.get('Location'), return_url)
 

--- a/onadata/apps/api/tests/viewsets/test_xform_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_xform_viewset.py
@@ -1055,15 +1055,15 @@ class TestXFormViewSet(TestAbstractViewSet):
             query_data = {'return': url}
             request = self.factory.get('/', data=query_data)
             response = view(request, pk=formid)
-            cookies = response.cookies
-            uid_cookie = cookies.get(settings.ENKETO_META_UID_COOKIE)._value
-            username_cookie = cookies.get(settings.ENKETO_META_USERNAME_COOKIE)
-            username_cookie = username_cookie._value
-            # exmple cookie: bob:1jlVih:i2KvHoAtsQOlYB71CJeNuVUlEY0
-            self.assertEqual(username_cookie.split(':')[0], 'bob')
-            self.assertEqual(username_cookie.split(':')[0], 'bob')
             self.assertEqual(response.status_code, 302)
             self.assertEqual(response.get('Location'), return_url)
+            cookies = response.cookies
+            uid_cookie = cookies.get(settings.ENKETO_META_UID_COOKIE)._value
+            username_cookie = cookies.get(
+                settings.ENKETO_META_USERNAME_COOKIE)._value
+            # example cookie: bob:1jlVih:i2KvHoAtsQOlYB71CJeNuVUlEY0
+            self.assertEqual(username_cookie.split(':')[0], 'bob')
+            self.assertEqual(uid_cookie.split(':')[0], 'bob')
 
     def test_publish_xlsform(self):
         with HTTMock(enketo_mock):

--- a/onadata/apps/api/viewsets/xform_viewset.py
+++ b/onadata/apps/api/viewsets/xform_viewset.py
@@ -82,6 +82,9 @@ ENKETO_AUTH_COOKIE = getattr(settings, 'ENKETO_AUTH_COOKIE',
                              '__enketo')
 ENKETO_META_UID_COOKIE = getattr(settings, 'ENKETO_META_UID_COOKIE',
                                  '__enketo_meta_uid')
+ENKETO_META_USERNAME_COOKIE = getattr(settings,
+                                      'ENKETO_META_USERNAME_COOKIE',
+                                      '__enketo_meta_username')
 
 BaseViewset = get_baseviewset_class()
 
@@ -172,6 +175,8 @@ def set_enketo_signed_cookies(resp, username=None, json_web_token=None):
         enketo['domain'] = settings.ENKETO_AUTH_COOKIE_DOMAIN
 
     resp.set_signed_cookie(ENKETO_META_UID_COOKIE, username, **enketo_meta_uid)
+    resp.set_signed_cookie(ENKETO_META_USERNAME_COOKIE, username,
+                           **enketo_meta_uid)
     resp.set_signed_cookie(ENKETO_AUTH_COOKIE, json_web_token, **enketo)
 
     return resp

--- a/onadata/settings/common.py
+++ b/onadata/settings/common.py
@@ -107,6 +107,7 @@ ENKETO_API_SALT = 'secretsalt'
 VERIFY_SSL = True
 ENKETO_AUTH_COOKIE = '__enketo'
 ENKETO_META_UID_COOKIE = '__enketo_meta_uid'
+ENKETO_META_USERNAME_COOKIE = '__enketo_meta_username'
 
 # Login URLs
 LOGIN_URL = '/accounts/login/'


### PR DESCRIPTION
### Changes / Features implemented
Add `__enketo_meta_username` cookie with the same value as the `enketo_meta_uid` cookie

Closes #1832 
