### PR TITLE
Tag release v2.3.5

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,19 @@ Changelog for Onadata
 
 ``* represents releases that introduce new migrations``
 
+v2.3.5(2020-06-18)
+------------------
+
+- Introduced caching for UserProfile objects
+  `PR #1823 <https://github.com/onaio/onadata/pull/1823>`_
+  [@WinnyTroy]
+- Send CRUD notifications for Forms, Submissions and SubmissionReviews
+  `PR #1793 <https://github.com/onaio/onadata/pull/1793>`_
+  [@lincmba]
+- Set enketo cookie `__enketo_meta_username` on login
+  `PR #1834 <https://github.com/onaio/onadata/pull/1834>`_
+  [@FrankApiyo]
+
 v2.3.4(2020-06-15)
 ------------------
 

--- a/onadata/__init__.py
+++ b/onadata/__init__.py
@@ -6,7 +6,7 @@ visualization.
 """
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "2.3.4"
+__version__ = "2.3.5"
 
 
 # This will make sure the app is always imported when


### PR DESCRIPTION
# Changes introduced in this release

- Introduced caching for UserProfile objects. PR #1823
- Send CRUD notifications for Forms, Submissions and SubmissionReviews. PR #1793
- Set enketo cookie `__enketo_meta_username` on login PR #1834

# Features to test

- Basic functionality ( Form Upload, Submissions & Exports )
- User functionality ( Able to create a user, update, login & logout ) #1823
- Presence of `__enketo_meta_username` cookie after login #1834
- Form and Submission notifications #1793