### PR TITLE
CSV Import: Handle re-importing of select_multiple questions

### DIFF
--- a/onadata/apps/api/tests/viewsets/test_xform_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_xform_viewset.py
@@ -2086,9 +2086,7 @@ nhMo+jI88L3qfm4/rtWKuQ9/a268phlNj34uQeoDDHuRViQo00L5meE/pFptm
         self.assertEqual(response.data.get('additions'), 1)
         instance_data = xform.instances.first().json
 
-        self.assertEqual(instance_data.get('mood/meh'), '0')
-        self.assertEqual(instance_data.get('mood/sad'), '0')
-        self.assertEqual(instance_data.get('mood/happy'), '1')
+        self.assertEqual(instance_data.get('mood'), 'happy')
 
     @override_settings(CSV_FILESIZE_IMPORT_ASYNC_THRESHOLD=4*100000)
     def test_large_csv_import(self):

--- a/onadata/apps/api/tests/viewsets/test_xform_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_xform_viewset.py
@@ -2047,6 +2047,33 @@ nhMo+jI88L3qfm4/rtWKuQ9/a268phlNj34uQeoDDHuRViQo00L5meE/pFptm
             self.assertEqual(response.data.get('additions'), 9)
             self.assertEqual(response.data.get('updates'), 0)
 
+    def test_extra_data_passed_in_select_multiple(self):
+        """
+        Test that extra details present in CSV Import is
+        safely removed
+        """
+        form_md = """
+        | survey |
+        |        | type                  | name | label                       |
+        |        | select_multiple moods | mood | How are you feeling today ? |
+        |        | dateTime              | now  | Current time                |
+        | choices |
+        |         | list_name | name  | label |
+        |         | moods     | happy | Happy |
+        |         | moods     | sad   | Sad   |
+        |         | moods     | meh   | Meh   |
+        """
+
+        xform = self._publish_markdown(form_md, self.user)
+        view = XFormViewSet.as_view({'post': 'csv_import'})
+        csv_import = fixtures_path('extra_details.csv')
+        post_data = {'csv_file': csv_import}
+        request = self.factory.post('/', data=post_data, **self.extra)
+        response = view(request, pk=xform.id)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data.get('additions'), 3)
+
     @override_settings(CSV_FILESIZE_IMPORT_ASYNC_THRESHOLD=4*100000)
     def test_large_csv_import(self):
         with HTTMock(enketo_mock):

--- a/onadata/apps/api/tests/viewsets/test_xform_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_xform_viewset.py
@@ -2073,6 +2073,22 @@ nhMo+jI88L3qfm4/rtWKuQ9/a268phlNj34uQeoDDHuRViQo00L5meE/pFptm
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data.get('additions'), 3)
+        # Delete instances
+        xform.instances.all().delete()
+
+        # Ensure data is correctly imported
+        csv_import = fixtures_path('single_submission_extra_details.csv')
+        post_data = {'csv_file': csv_import}
+        request = self.factory.post('/', data=post_data, **self.extra)
+        response = view(request, pk=xform.id)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data.get('additions'), 1)
+        instance_data = xform.instances.first().json
+
+        self.assertEqual(instance_data.get('mood/meh'), '0')
+        self.assertEqual(instance_data.get('mood/sad'), '0')
+        self.assertEqual(instance_data.get('mood/happy'), '1')
 
     @override_settings(CSV_FILESIZE_IMPORT_ASYNC_THRESHOLD=4*100000)
     def test_large_csv_import(self):

--- a/onadata/apps/api/tests/viewsets/test_xform_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_xform_viewset.py
@@ -2049,7 +2049,7 @@ nhMo+jI88L3qfm4/rtWKuQ9/a268phlNj34uQeoDDHuRViQo00L5meE/pFptm
 
     def test_extra_data_passed_in_select_multiple(self):
         """
-        Test that extra details present in CSV Import is
+        Test that extra details present in CSV Import are
         safely removed
         """
         form_md = """

--- a/onadata/libs/renderers/renderers.py
+++ b/onadata/libs/renderers/renderers.py
@@ -371,7 +371,9 @@ class DebugToolbarRenderer(TemplateHTMLRenderer):  # pylint: disable=R0903
     def render(self, data, accepted_media_type=None, renderer_context=None):
         data = {
             'debug_data':
-            JSONRenderer().render(data, renderer_context=renderer_context)
+            str(
+                JSONRenderer().render(data, renderer_context=renderer_context),
+                self.charset)
         }
 
         return super(DebugToolbarRenderer, self).render(

--- a/onadata/libs/tests/utils/fixtures/extra_details.csv
+++ b/onadata/libs/tests/utils/fixtures/extra_details.csv
@@ -1,0 +1,4 @@
+mood,mood/happy,mood/sad,mood/meh,now,meta/instanceID,_id,_uuid,_submission_time,_tags,_notes,_version,_duration,_submitted_by,_total_media,_media_count,_media_all_received,_xform_id
+Feeling pretty happy today,1,0,0,2020-07-30T17:00:00.000+03:00,uuid:dc110d37-1d16-4492-8896-8314a3ce5567,52169,dc110d37-1d16-4492-8896-8314a3ce5567,2020-07-30T13:47:54,,,202007301346,,,0,0,True,1826
+Feeling pretty sad because I'm sad,0,0,1,2020-07-30T17:00:00.000+03:00,uuid:d24f54ab-34bf-4269-8372-d120efcad612,52170,d24f54ab-34bf-4269-8372-d120efcad612,2020-07-30T13:47:55,,,202007301346,,,0,0,True,1826
+Meh,0,1,0,2020-07-30T17:00:00.000+03:00,uuid:14bb6e59-ecb2-4f6d-ae10-e684cf3b7502,52171,14bb6e59-ecb2-4f6d-ae10-e684cf3b7502,2020-07-30T13:48:03,,,202007301346,,,0,0,True,1826

--- a/onadata/libs/tests/utils/fixtures/single_submission_extra_details.csv
+++ b/onadata/libs/tests/utils/fixtures/single_submission_extra_details.csv
@@ -1,0 +1,2 @@
+mood,mood/happy,mood/sad,mood/meh,now,meta/instanceID,_id,_uuid,_submission_time,_tags,_notes,_version,_duration,_submitted_by,_total_media,_media_count,_media_all_received,_xform_id
+Feeling pretty happy today,1,0,0,2020-07-30T17:00:00.000+03:00,uuid:dc110d37-1d16-4492-8896-8314a3ce5567,52169,dc110d37-1d16-4492-8896-8314a3ce5567,2020-07-30T13:47:54,,,202007301346,,,0,0,True,1826

--- a/onadata/libs/utils/dict_tools.py
+++ b/onadata/libs/utils/dict_tools.py
@@ -127,7 +127,9 @@ def csv_dict_to_nested_dict(csv_dict):
         if len(split_keys) == 1:
             result[key] = value
         else:
-            select_question_keys.append(split_keys[0])
+            if split_keys[0] not in select_question_keys and \
+                split_keys[0] != 'meta':
+                select_question_keys.append(split_keys[0])
             result = list_to_dict(split_keys, value)
 
         results.append(result)

--- a/onadata/libs/utils/dict_tools.py
+++ b/onadata/libs/utils/dict_tools.py
@@ -65,7 +65,7 @@ def merge_list_of_dicts(list_of_dicts, override_keys: list = None):
                     if isinstance(v, dict):
                         try:
                             result[k] = merge_list_of_dicts([result[k], v])
-                        except AttributeError:
+                        except AttributeError as e:
                             # If the key is within the override_keys
                             # (Is a select_multiple question) We make
                             # the assumption that the dict values are
@@ -76,6 +76,8 @@ def merge_list_of_dicts(list_of_dicts, override_keys: list = None):
                                  k in override_keys:
                                 result[k] = {}
                                 result[k] = merge_list_of_dicts([result[k], v])
+                            else:
+                                raise e
                     else:
                         result = [result, row]
                 else:

--- a/onadata/libs/utils/dict_tools.py
+++ b/onadata/libs/utils/dict_tools.py
@@ -49,7 +49,7 @@ def list_to_dict(items, value):
     return result
 
 
-def merge_list_of_dicts(list_of_dicts):
+def merge_list_of_dicts(list_of_dicts, override_keys: list = None):
     """
     Merges a list of dicts to return one dict.
     """
@@ -63,7 +63,20 @@ def merge_list_of_dicts(list_of_dicts):
             else:
                 if k in result:
                     if isinstance(v, dict):
-                        result[k] = merge_list_of_dicts([result[k], v])
+                        try:
+                            result[k] = merge_list_of_dicts([result[k], v])
+                        except AttributeError:
+                            # If the key is within the override_keys
+                            # (Is a select_multiple question) We make
+                            # the assumption that the dict values are
+                            # more accurate as they usually mean that
+                            # the select_multiple has been split into
+                            # separate columns for each choice
+                            if isinstance(result[k], str) and \
+                                 k in override_keys:
+                                result[k] = {}
+                                result[k] = merge_list_of_dicts([result[k], v])
+                            return result
                     else:
                         result = [result, row]
                 else:
@@ -104,6 +117,7 @@ def csv_dict_to_nested_dict(csv_dict):
     Converts a CSV dict to nested dicts.
     """
     results = []
+    select_question_keys = []
 
     for key in list(csv_dict):
         result = {}
@@ -113,11 +127,12 @@ def csv_dict_to_nested_dict(csv_dict):
         if len(split_keys) == 1:
             result[key] = value
         else:
+            select_question_keys.append(split_keys[0])
             result = list_to_dict(split_keys, value)
 
         results.append(result)
 
-    merged_dict = merge_list_of_dicts(results)
+    merged_dict = merge_list_of_dicts(results, select_question_keys)
 
     return remove_indices_from_dict(merged_dict)
 

--- a/onadata/libs/utils/dict_tools.py
+++ b/onadata/libs/utils/dict_tools.py
@@ -76,7 +76,6 @@ def merge_list_of_dicts(list_of_dicts, override_keys: list = None):
                                  k in override_keys:
                                 result[k] = {}
                                 result[k] = merge_list_of_dicts([result[k], v])
-                            return result
                     else:
                         result = [result, row]
                 else:
@@ -128,7 +127,7 @@ def csv_dict_to_nested_dict(csv_dict):
             result[key] = value
         else:
             if split_keys[0] not in select_question_keys and \
-                split_keys[0] != 'meta':
+                    split_keys[0] != 'meta':
                 select_question_keys.append(split_keys[0])
             result = list_to_dict(split_keys, value)
 


### PR DESCRIPTION
### Changes / Features implemented

- Handle cases where extra details are added on an extra column.
- Flatten split select_multiple questions into one column

### Steps taken to verify this change does what is intended

- [x] Added test that replicates the issue and confirmed the test passes with the fix
- [x] QA

### Side effects of implementing this change

- Possible loss of data? _Chance that the `string` value passed in the `select_multiple` field is actually useful? Should we store the data in the metadata ?_

### Extra Info

Seems the issue documented in #1655 occurs when a user adds in a column(matching a `select_multiple` question) for extra information. i.e When using a form such as [this](https://docs.google.com/spreadsheets/d/1vu8rN8BCfgK0Dm1NvAp_8Gd66Ux_HbPhXs5K16qN7FU/edit?usp=sharing) and trying to import this kind of [data](https://docs.google.com/spreadsheets/d/1U1wZriv5pJBxCiB_rnCT6ZP5sD27X2fVS2yrjqkiBvU/edit?usp=sharing)

Closes #1655 
