### PR TITLE
Tag release v2.3.6

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,19 @@ Changelog for Onadata
 
 ``* represents releases that introduce new migrations``
 
+v2.3.6(2020-07-29)
+------------------
+
+- Return FLOIP data for Merged Datasets*
+  `PR #1773 <https://github.com/onaio/onadata/pull/1773>`_
+  [@DavisRayM]
+- Add deletion suffix to a Users email upon soft deletion
+  `PR #1844 <https://github.com/onaio/onadata/pull/1844>`_
+  [@WinnyTroy]
+- Add more flexible MQTT Topics
+  `PR #1850 <https://github.com/onaio/onadata/pull/1850>`_
+  [@lincmba]
+
 v2.3.5(2020-06-18)
 ------------------
 

--- a/onadata/__init__.py
+++ b/onadata/__init__.py
@@ -6,7 +6,7 @@ visualization.
 """
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "2.3.5"
+__version__ = "2.3.6"
 
 
 # This will make sure the app is always imported when


### PR DESCRIPTION
# Changes introduced in this release

- Return FLOIP data for Merged Datasets #1773,  _Introduces a new [migration](https://github.com/onaio/onadata/blob/master/onadata/apps/logger/migrations/0061_auto_20200713_0814.py) on the `logger` app_
- Add deletion suffix to a Users email upon soft deletion #1844 
- Add more flexible MQTT Topics #1850 

## Functionality to QA

- [x] `flow-results` endpoint
        - Able to retrieve FLOIP responses & packages for XForms and MergedDatasets(_as well as anything else that should be returned from the endpoint_)
- [x] Notification functionality
- [x] Basic onadata functionality
        - Able to upload, update, delete and retrieve forms & projects
        - Able to submit data to forms via Enketo and ODK Collect
        - Able to create a user profile