### PR TITLE
Enketo endpoint updates

### DIFF
--- a/onadata/apps/api/tests/mocked_data.py
+++ b/onadata/apps/api/tests/mocked_data.py
@@ -6,7 +6,7 @@ urls.
 import json
 
 import requests
-from httmock import urlmatch, all_requests
+from httmock import urlmatch
 
 
 @urlmatch(netloc=r'(.*\.)?ona\.io$', path=r'^/examples/forms/tutorial/form$')
@@ -77,45 +77,32 @@ def enketo_mock(url, request):  # pylint: disable=unused-argument
     return response
 
 
-@all_requests
-def enketo_single_submission_mock(url, request):
-    """Return mocked enketo single submission Response object."""
-    response = requests.Response()
-    response.status_code = 200
-    # pylint: disable=protected-access
-    response._content = \
-        '{\n "single_url": "https:\\/\\/enketo.ona.io\\/single/::XZqoZ94y",\n'\
-        '  "code": "200"\n}'
-    return response
-
-
-@urlmatch(netloc=r'(.*\.)?enketo\.ona\.io$', path=r'^/api_v1/survey/preview$')
-def enketo_preview_url_mock(url, request):  # pylint: disable=unused-argument
+@urlmatch(netloc=r'(.*\.)?enketo\.ona\.io$', path=r'^/api_v2/survey/all$')
+def enketo_urls_mock(url, request):  # pylint: disable=unused-argument
     """
-    Returns mocked Enketo Response object for all queries to enketo.ona.io for
-    a preview link.
-    """
-    response = requests.Response()
-    response.status_code = 201
-    # pylint: disable=protected-access
-    response._content = \
-        '{\n  "preview_url": "https:\\/\\/enketo.ona.io\\/preview/::YY8M",\n'\
-        '  "code": "201"\n}'
-    return response
-
-
-@urlmatch(netloc=r'(.*\.)?enketo\.ona\.io$', path=r'^/api_v1/survey$')
-def enketo_url_mock(url, request):  # pylint: disable=unused-argument
-    """
-    Returns mocked Enketo Response object for all queries to enketo.ona.io to
-    create an Enketo link.
+    Returns mocked Enketo Response object for all enketo.ona.io urls.
     """
     response = requests.Response()
     response.status_code = 201
     # pylint: disable=protected-access
     response._content = \
         '{\n  "url": "https:\\/\\/enketo.ona.io\\/::YY8M",\n'\
-        '  "code": "201"\n}'
+        '   "single_url": "http:\\/\\/enketo.ona.io\\/single\\/::XZqoZ94y",\n'\
+        '   "single_once_url":'\
+        ' "http:\\/\\/enketo.ona.io\\/single'\
+        '\\/::2b27ac0cdcf2842eaac4984f688d9270",\n'\
+        '   "offline_url": "https:\\/\\/enketo.ona.io\\/::YY8M",\n'\
+        '   "preview_url": "https:\\/\\/enketo.ona.io\\/preview\\/::YY8M",\n'\
+        '   "iframe_url": "http:\\/\\/enketo.ona.io\\/i\\/::vtPuefbl",\n'\
+        '   "single_iframe_url":'\
+        ' "http:\\/\\/enketo.ona.io\\/single\\/i\\/::vtPuefbl",\n'\
+        '   "single_once_iframe_url":'\
+        '"http:\\/\\/enketo.ona.io\\/single\\/i\\'\
+        '/::2b27ac0cdcf2842eaac4984f688d9270",\n'\
+        '   "preview_iframe_url":'\
+        '"http:\\/\\/enketo.ona.io\\/preview\\/i\\/::vtPuefbl",\n'\
+        '   "enketo_id": "vtPuefbl",\n'\
+        '   "code": 200\n}'
     return response
 
 

--- a/onadata/apps/api/tests/mocked_data.py
+++ b/onadata/apps/api/tests/mocked_data.py
@@ -151,7 +151,8 @@ def enketo_mock_with_form_defaults(url, request):  # pylint: disable=W0613
     response.status_code = 201
     # pylint: disable=protected-access
     response._content = \
-        '{\n  "url": "https:\\/\\/dmfrm.enketo.org\\/webform?d[%2Fnum]=1",\n'\
+        '{\n  "offline_url":'\
+        '    "https:\\/\\/dmfrm.enketo.org\\/webform?d[%2Fnum]=1",\n'\
         '  "code": "200"\n}'
     return response
 

--- a/onadata/apps/api/tests/views/test_user_permissions.py
+++ b/onadata/apps/api/tests/views/test_user_permissions.py
@@ -8,7 +8,7 @@ from httmock import HTTMock
 from rest_framework.renderers import JSONRenderer
 
 from onadata.apps.api.tests.viewsets.test_abstract_viewset import \
-    TestAbstractViewSet, enketo_preview_url_mock, enketo_url_mock
+    TestAbstractViewSet, enketo_urls_mock
 from onadata.apps.api.viewsets.data_viewset import DataViewSet
 from onadata.apps.api.viewsets.xform_viewset import XFormViewSet
 from onadata.apps.api.viewsets.project_viewset import ProjectViewSet
@@ -56,7 +56,7 @@ class TestUserPermissions(TestAbstractViewSet):
             post_data = {'xls_file': xls_file, 'owner': 'bob'}
             request = self.factory.post('/', data=post_data, **self.extra)
             role.ManagerRole.add(self.user, bob.profile)
-            with HTTMock(enketo_url_mock, enketo_preview_url_mock):
+            with HTTMock(enketo_urls_mock):
                 response = view(request)
                 self.assertEqual(response.status_code, 201)
 

--- a/onadata/apps/api/tests/viewsets/test_abstract_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_abstract_viewset.py
@@ -251,10 +251,6 @@ class TestAbstractViewSet(PyxformMarkdown, TestCase):
                     'url':
                     'http://testserver/api/v1/forms/%s' % (self.xform.pk)
                 })
-                MetaData.enketo_url(self.xform, response.data['enketo_url'])
-                MetaData.enketo_preview_url(self.xform, response.data[
-                    'enketo_preview_url'])
-
                 # Input was a private so change to public if project public
                 if public:
                     data['public_data'] = data['public'] = True

--- a/onadata/apps/api/tests/viewsets/test_abstract_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_abstract_viewset.py
@@ -3,7 +3,6 @@ import os
 import re
 from tempfile import NamedTemporaryFile
 
-import requests
 from builtins import open
 from django.conf import settings
 from django.contrib.auth import authenticate
@@ -11,11 +10,12 @@ from django.contrib.auth.models import Permission, User
 from django.test import TestCase
 from django_digest.test import Client as DigestClient
 from django_digest.test import DigestAuth
-from httmock import HTTMock, urlmatch
+from httmock import HTTMock
 from pyxform.tests_v1.pyxform_test_case import PyxformMarkdown
 from rest_framework.test import APIRequestFactory
 
 from onadata.apps.api.models import OrganizationProfile, Team
+from onadata.apps.api.tests.mocked_data import enketo_urls_mock
 from onadata.apps.api.viewsets.dataview_viewset import DataViewViewSet
 from onadata.apps.api.viewsets.metadata_viewset import MetaDataViewSet
 from onadata.apps.api.viewsets.organization_profile_viewset import \
@@ -33,26 +33,6 @@ from onadata.apps.viewer.models import DataDictionary
 from onadata.libs.serializers.project_serializer import ProjectSerializer
 from onadata.libs.utils.common_tools import merge_dicts
 from onadata.libs.utils.user_auth import get_user_default_project
-
-
-@urlmatch(netloc=r'(.*\.)?enketo\.ona\.io$', path=r'^/api_v1/survey/preview$')
-def enketo_preview_url_mock(url, request):
-    response = requests.Response()
-    response.status_code = 201
-    response._content = \
-        '{\n  "preview_url": "https:\\/\\/enketo.ona.io\\/preview/::YY8M",\n'\
-        '  "code": "201"\n}'
-    return response
-
-
-@urlmatch(netloc=r'(.*\.)?enketo\.ona\.io$', path=r'^/api_v1/survey$')
-def enketo_url_mock(url, request):
-    response = requests.Response()
-    response.status_code = 201
-    response._content = \
-        '{\n  "url": "https:\\/\\/enketo.ona.io\\/::YY8M",\n'\
-        '  "code": "200"\n}'
-    return response
 
 
 class TestAbstractViewSet(PyxformMarkdown, TestCase):
@@ -259,7 +239,7 @@ class TestAbstractViewSet(PyxformMarkdown, TestCase):
             settings.PROJECT_ROOT, "apps", "main", "tests", "fixtures",
             "transportation", "transportation.xls")
 
-        with HTTMock(enketo_preview_url_mock, enketo_url_mock):
+        with HTTMock(enketo_urls_mock):
             with open(path, 'rb') as xls_file:
                 post_data = {'xls_file': xls_file}
                 request = self.factory.post(
@@ -271,6 +251,9 @@ class TestAbstractViewSet(PyxformMarkdown, TestCase):
                     'url':
                     'http://testserver/api/v1/forms/%s' % (self.xform.pk)
                 })
+                MetaData.enketo_url(self.xform, response.data['enketo_url'])
+                MetaData.enketo_preview_url(self.xform, response.data[
+                    'enketo_preview_url'])
 
                 # Input was a private so change to public if project public
                 if public:

--- a/onadata/apps/api/tests/viewsets/test_data_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_data_viewset.py
@@ -46,7 +46,7 @@ from onadata.libs.utils.logger_tools import create_instance
 def enketo_mock(url, request):
     response = requests.Response()
     response.status_code = 201
-    response._content = '{"url": "https:\\/\\/hmh2a.enketo.ona.io"}'
+    response._content = '{"url": "https://hmh2a.enketo.ona.io"}'
     return response
 
 

--- a/onadata/apps/api/tests/viewsets/test_data_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_data_viewset.py
@@ -20,7 +20,7 @@ from mock import patch
 from onadata.apps.api.tests.viewsets.test_abstract_viewset import \
     TestAbstractViewSet
 from onadata.apps.api.tests.viewsets.test_abstract_viewset import \
-    enketo_preview_url_mock
+    enketo_urls_mock
 from onadata.apps.api.viewsets.data_viewset import DataViewSet
 from onadata.apps.api.viewsets.project_viewset import ProjectViewSet
 from onadata.apps.api.viewsets.xform_viewset import XFormViewSet
@@ -46,7 +46,7 @@ from onadata.libs.utils.logger_tools import create_instance
 def enketo_mock(url, request):
     response = requests.Response()
     response.status_code = 201
-    response._content = '{"url": "https://hmh2a.enketo.ona.io"}'
+    response._content = '{"url": "https:\\/\\/hmh2a.enketo.ona.io"}'
     return response
 
 
@@ -1851,7 +1851,7 @@ class TestDataViewSet(TestBase):
         view = DataViewSet.as_view({'get': 'list'})
         request = self.factory.get('/', **self.extra)
         formid = self.xform.pk
-        with HTTMock(enketo_preview_url_mock, enketo_mock):
+        with HTTMock(enketo_urls_mock):
             response = view(request, pk=formid)
             self.assertEquals(response.status_code, 200)
             self.assertEqual(len(response.data), 4)

--- a/onadata/apps/api/tests/viewsets/test_project_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_project_viewset.py
@@ -7,6 +7,7 @@ import os
 from builtins import str
 from future.utils import iteritems
 from operator import itemgetter
+from collections import OrderedDict
 
 from django.conf import settings
 from django.db.models import Q
@@ -450,33 +451,56 @@ class TestProjectViewSet(TestAbstractViewSet):
         self.assertNotEqual(response.get('Cache-Control'), None)
         self.assertEqual(response.status_code, 200)
 
-        resultset = MetaData.objects.filter(Q(object_id=self.xform.pk), Q(
-            data_type='enketo_url') | Q(data_type='enketo_preview_url'))
+        resultset = MetaData.objects.filter(
+                Q(object_id=self.xform.pk), Q(data_type='enketo_url') |
+                Q(data_type='enketo_preview_url') |
+                Q(data_type='enketo_single_submit_url'))
         url = resultset.get(data_type='enketo_url')
         preview_url = resultset.get(data_type='enketo_preview_url')
-        form_metadata = sorted([{
-            'id': preview_url.pk,
-            'xform': self.xform.pk,
-            'data_value': u"https://enketo.ona.io/preview/::YY8M",
-            'data_type': u'enketo_preview_url',
-            'data_file': None,
-            'data_file_type': None,
-            'url': 'http://testserver/api/v1/metadata/%s' % preview_url.pk,
-            'file_hash': None,
-            'media_url': None,
-            'date_created': preview_url.date_created
-        }, {
-            'id': url.pk,
-            'data_value': u"https://enketo.ona.io/::YY8M",
-            'xform': self.xform.pk,
-            'data_file': None,
-            'data_type': 'enketo_url',
-            'url': 'http://testserver/api/v1/metadata/%s' % url.pk,
-            'data_file_type': None,
-            'file_hash': None,
-            'media_url': None,
-            'date_created': url.date_created
-        }], key=itemgetter('id'))
+        single_submit_url = resultset.get(
+            data_type='enketo_single_submit_url')
+        form_metadata = sorted([
+                OrderedDict(
+                    [
+                        ('id', url.pk),
+                        ('xform', self.xform.pk),
+                        ('data_value', 'https://enketo.ona.io/::YY8M'),
+                        ('data_type', 'enketo_url'),
+                        ('data_file', None),
+                        ('data_file_type', None),
+                        ('media_url', None),
+                        ('file_hash', None),
+                        ('url', 'http://testserver/api/v1/metadata/%s'
+                                % url.pk),
+                        ('date_created', url.date_created)]),
+                OrderedDict(
+                    [
+                        ('id', preview_url.pk),
+                        ('xform', self.xform.pk),
+                        ('data_value', 'https://enketo.ona.io/preview/::YY8M'),
+                        ('data_type', 'enketo_preview_url'),
+                        ('data_file', None),
+                        ('data_file_type', None),
+                        ('media_url', None),
+                        ('file_hash', None),
+                        ('url', 'http://testserver/api/v1/metadata/%s' %
+                                preview_url.pk),
+                        ('date_created', preview_url.date_created)]),
+                OrderedDict(
+                    [
+                        ('id', single_submit_url.pk),
+                        ('xform', self.xform.pk),
+                        ('data_value',
+                            'http://enketo.ona.io/single/::XZqoZ94y'),
+                        ('data_type', 'enketo_single_submit_url'),
+                        ('data_file', None),
+                        ('data_file_type', None),
+                        ('media_url', None),
+                        ('file_hash', None),
+                        ('url', 'http://testserver/api/v1/metadata/%s' %
+                                single_submit_url.pk),
+                        ('date_created', single_submit_url.date_created)])],
+                        key=itemgetter('id'))
 
         # test metadata content separately
         response_metadata = sorted(

--- a/onadata/apps/api/tests/viewsets/test_xform_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_xform_viewset.py
@@ -304,34 +304,53 @@ class TestXFormViewSet(TestAbstractViewSet):
             self.assertEqual(response.status_code, 200)
             self.form_data['public'] = True
             # pylint: disable=no-member
-            resultset = MetaData.objects.filter(Q(object_id=self.xform.pk), Q(
-                data_type='enketo_url') | Q(data_type='enketo_preview_url'))
+            resultset = MetaData.objects.filter(
+                Q(object_id=self.xform.pk), Q(data_type='enketo_url') |
+                Q(data_type='enketo_preview_url') |
+                Q(data_type='enketo_single_submit_url'))
             url = resultset.get(data_type='enketo_url')
             preview_url = resultset.get(data_type='enketo_preview_url')
-            self.form_data['metadata'] = [{
-                'id': preview_url.pk,
-                'xform': self.xform.pk,
-                'data_value': "https://enketo.ona.io/preview/::YY8M",
-                'data_type': u'enketo_preview_url',
-                'data_file': None,
-                'data_file_type': None,
-                u'url': u'http://testserver/api/v1/metadata/%s' %
-                preview_url.pk,
-                'file_hash': None,
-                'media_url': None,
-                'date_created': preview_url.date_created
-            }, {
-                'id': url.pk,
-                'data_value': "https://enketo.ona.io/::YY8M",
-                'xform': self.xform.pk,
-                'data_file': None,
-                'data_type': u'enketo_url',
-                u'url': u'http://testserver/api/v1/metadata/%s' % url.pk,
-                'data_file_type': None,
-                'file_hash': None,
-                'media_url': None,
-                'date_created': url.date_created
-            }]
+            single_submit_url = resultset.get(
+                data_type='enketo_single_submit_url')
+            self.form_data['metadata'] = [OrderedDict(
+                [
+                    ('id', url.pk),
+                    ('xform', self.xform.pk),
+                    ('data_value', 'https://enketo.ona.io/::YY8M'),
+                    ('data_type', 'enketo_url'),
+                    ('data_file', None),
+                    ('data_file_type', None),
+                    ('media_url', None),
+                    ('file_hash', None),
+                    ('url', 'http://testserver/api/v1/metadata/%s' % url.pk),
+                    ('date_created', url.date_created)]),
+                OrderedDict(
+                    [
+                        ('id', preview_url.pk),
+                        ('xform', self.xform.pk),
+                        ('data_value', 'https://enketo.ona.io/preview/::YY8M'),
+                        ('data_type', 'enketo_preview_url'),
+                        ('data_file', None),
+                        ('data_file_type', None),
+                        ('media_url', None),
+                        ('file_hash', None),
+                        ('url', 'http://testserver/api/v1/metadata/%s' %
+                                preview_url.pk),
+                        ('date_created', preview_url.date_created)]),
+                OrderedDict(
+                    [
+                        ('id', single_submit_url.pk),
+                        ('xform', self.xform.pk),
+                        ('data_value',
+                            'http://enketo.ona.io/single/::XZqoZ94y'),
+                        ('data_type', 'enketo_single_submit_url'),
+                        ('data_file', None),
+                        ('data_file_type', None),
+                        ('media_url', None),
+                        ('file_hash', None),
+                        ('url', 'http://testserver/api/v1/metadata/%s' %
+                                single_submit_url.pk),
+                        ('date_created', single_submit_url.date_created)])]
             del self.form_data['date_modified']
             del response.data[0]['date_modified']
 
@@ -524,35 +543,55 @@ class TestXFormViewSet(TestAbstractViewSet):
             self.assertEqual(response.status_code, 200)
             # pylint: disable=no-member
             resultset = MetaData.objects.filter(
-                Q(object_id=self.xform.pk),
-                Q(data_type='enketo_url') |
-                Q(data_type='enketo_preview_url'))
+                Q(object_id=self.xform.pk), Q(data_type='enketo_url') |
+                Q(data_type='enketo_preview_url') |
+                Q(data_type='enketo_single_submit_url'))
             url = resultset.get(data_type='enketo_url')
             preview_url = resultset.get(data_type='enketo_preview_url')
-            self.form_data['metadata'] = [OrderedDict([
-                ('id', preview_url.pk),
-                ('xform', self.xform.pk),
-                ('data_value', "https://enketo.ona.io/preview/::YY8M"),
-                ('data_type', 'enketo_preview_url'),
-                ('data_file', None),
-                ('data_file_type', None),
-                ('media_url', None),
-                ('file_hash', None),
-                ('url', 'http://testserver/api/v1/metadata/%s' %
-                 preview_url.pk),
-                ('date_created', preview_url.date_created)
-            ]), OrderedDict([
-                ('id', url.pk),
-                ('xform', self.xform.pk),
-                ('data_value', "https://enketo.ona.io/::YY8M"),
-                ('data_type', 'enketo_url'),
-                ('data_file', None),
-                ('data_file_type', None),
-                ('media_url', None),
-                ('file_hash', None),
-                ('url', 'http://testserver/api/v1/metadata/%s' % url.pk),
-                ('date_created', url.date_created)
-            ])]
+            single_submit_url = resultset.get(
+                data_type='enketo_single_submit_url')
+
+            self.form_data['metadata'] = [
+                OrderedDict(
+                    [
+                        ('id', url.pk),
+                        ('xform', self.xform.pk),
+                        ('data_value', 'https://enketo.ona.io/::YY8M'),
+                        ('data_type', 'enketo_url'),
+                        ('data_file', None),
+                        ('data_file_type', None),
+                        ('media_url', None),
+                        ('file_hash', None),
+                        ('url', 'http://testserver/api/v1/metadata/%s'
+                                % url.pk),
+                        ('date_created', url.date_created)]),
+                OrderedDict(
+                    [
+                        ('id', preview_url.pk),
+                        ('xform', self.xform.pk),
+                        ('data_value', 'https://enketo.ona.io/preview/::YY8M'),
+                        ('data_type', 'enketo_preview_url'),
+                        ('data_file', None),
+                        ('data_file_type', None),
+                        ('media_url', None),
+                        ('file_hash', None),
+                        ('url', 'http://testserver/api/v1/metadata/%s' %
+                                preview_url.pk),
+                        ('date_created', preview_url.date_created)]),
+                OrderedDict(
+                    [
+                        ('id', single_submit_url.pk),
+                        ('xform', self.xform.pk),
+                        ('data_value',
+                            'http://enketo.ona.io/single/::XZqoZ94y'),
+                        ('data_type', 'enketo_single_submit_url'),
+                        ('data_file', None),
+                        ('data_file_type', None),
+                        ('media_url', None),
+                        ('file_hash', None),
+                        ('url', 'http://testserver/api/v1/metadata/%s' %
+                                single_submit_url.pk),
+                        ('date_created', single_submit_url.date_created)])]
 
             self.form_data['metadata'] = sorted(
                 self.form_data['metadata'], key=lambda x: x['id'])
@@ -683,7 +722,12 @@ class TestXFormViewSet(TestAbstractViewSet):
             response = list_view(request)
             self.assertNotEqual(response.get('Cache-Control'), None)
             self.assertEqual(response.status_code, 200)
-            self.assertEqual(response.data, [self.form_data])
+            response_data = dict(response.data[0])
+            response_data.pop("date_modified")
+            response_data.pop("last_updated_at")
+            self.form_data.pop("date_modified")
+            self.form_data.pop("last_updated_at")
+            self.assertEqual(response_data, self.form_data)
 
             request = self.factory.get(
                 '/', data={"tags": "goodbye"}, **self.extra)
@@ -768,7 +812,7 @@ class TestXFormViewSet(TestAbstractViewSet):
             response = view(request, pk=formid)
             url = "https://enketo.ona.io/::YY8M"
             preview_url = "https://enketo.ona.io/preview/::YY8M"
-            single_url = "http://localhost:8005/single/::vtPuefbl"
+            single_url = "http://enketo.ona.io/single/::XZqoZ94y"
             data = {"enketo_url": url,
                     "enketo_preview_url": preview_url,
                     "single_submit_url": single_url}
@@ -1102,9 +1146,6 @@ class TestXFormViewSet(TestAbstractViewSet):
                     'url':
                     'http://testserver/api/v1/forms/%s' % xform.pk
                 })
-                MetaData.enketo_url(xform, response.data['enketo_url'])
-                MetaData.enketo_preview_url(xform, response.data[
-                    'enketo_preview_url'])
 
                 self.assertDictContainsSubset(data, response.data)
                 self.assertTrue(OwnerRole.user_has_role(self.user, xform))
@@ -1151,10 +1192,6 @@ class TestXFormViewSet(TestAbstractViewSet):
                     'http://testserver/api/v1/forms/%s' % xform.pk,
                     'has_id_string_changed': False,
                 })
-                MetaData.enketo_url(xform, response.data['enketo_url'])
-                MetaData.enketo_preview_url(xform, response.data[
-                    'enketo_preview_url'])
-
                 self.assertDictContainsSubset(data, response.data)
                 self.assertTrue(OwnerRole.user_has_role(self.user, xform))
                 self.assertEquals("owner", response.data['users'][0]['role'])
@@ -1186,9 +1223,6 @@ class TestXFormViewSet(TestAbstractViewSet):
                     'sms_id_string': u'Transportation_2011_07_25',
                     'has_id_string_changed': True,
                 })
-                MetaData.enketo_url(xform, response.data['enketo_url'])
-                MetaData.enketo_preview_url(xform, response.data[
-                    'enketo_preview_url'])
 
                 self.assertDictContainsSubset(data, response.data)
                 self.assertTrue(OwnerRole.user_has_role(self.user, xform))
@@ -1334,7 +1368,7 @@ class TestXFormViewSet(TestAbstractViewSet):
             self.assertEqual(XForm.objects.count(), pre_count + 1)
 
     def test_publish_select_external_xlsform(self):
-        with HTTMock(enketo_mock):
+        with HTTMock(enketo_urls_mock):
             view = XFormViewSet.as_view({
                 'post': 'create'
             })
@@ -1348,11 +1382,8 @@ class TestXFormViewSet(TestAbstractViewSet):
                 request = self.factory.post('/', data=post_data, **self.extra)
                 response = view(request)
                 xform = self.user.xforms.all()[0]
-                MetaData.enketo_url(xform, response.data['enketo_url'])
-                MetaData.enketo_preview_url(xform, response.data[
-                    'enketo_preview_url'])
                 self.assertEqual(response.status_code, 201)
-                self.assertEqual(meta_count + 3, MetaData.objects.count())
+                self.assertEqual(meta_count + 4, MetaData.objects.count())
                 metadata = MetaData.objects.get(
                     object_id=xform.id, data_value='itemsets.csv')
                 self.assertIsNotNone(metadata)
@@ -4577,11 +4608,8 @@ nhMo+jI88L3qfm4/rtWKuQ9/a268phlNj34uQeoDDHuRViQo00L5meE/pFptm
                 request = self.factory.post('/', data=post_data, **self.extra)
                 response = view(request)
                 xform = self.user.xforms.all()[0]
-                MetaData.enketo_url(xform, response.data['enketo_url'])
-                MetaData.enketo_preview_url(xform, response.data[
-                    'enketo_preview_url'])
                 self.assertEqual(response.status_code, 201)
-                self.assertEqual(meta_count + 3, MetaData.objects.count())
+                self.assertEqual(meta_count + 4, MetaData.objects.count())
                 metadata = MetaData.objects.get(
                     object_id=xform.id, data_value='itemsets.csv')
                 self.assertIsNotNone(metadata)

--- a/onadata/apps/api/viewsets/data_viewset.py
+++ b/onadata/apps/api/viewsets/data_viewset.py
@@ -59,7 +59,7 @@ from onadata.libs.serializers.geojson_serializer import GeoJsonSerializer
 from onadata.libs.utils.api_export_tools import custom_response_handler
 from onadata.libs.utils.common_tools import json_stream
 from onadata.libs.utils.model_tools import queryset_iterator
-from onadata.libs.utils.viewer_tools import get_enketo_edit_url
+from onadata.libs.utils.viewer_tools import get_form_url, enketo_url
 
 SAFE_METHODS = ['GET', 'HEAD', 'OPTIONS']
 BaseViewset = get_baseviewset_class()
@@ -261,12 +261,16 @@ class DataViewSet(AnonymousUserPublicFormsMixin,
         elif(isinstance(self.object, Instance)):
             if request.user.has_perm("change_xform", self.object.xform):
                 return_url = request.query_params.get('return_url')
+                form_url = get_form_url(
+                    request,
+                    self.object.xform.user.username,
+                    xform_pk=self.object.xform.id)
                 if not return_url:
                     raise ParseError(_(u"return_url not provided."))
 
                 try:
-                    data["url"] = get_enketo_edit_url(
-                        request, self.object, return_url)
+                    data = enketo_url(form_url, self.object.xform.id_string)
+
                 except EnketoError as e:
                     raise ParseError(text(e))
             else:

--- a/onadata/apps/api/viewsets/data_viewset.py
+++ b/onadata/apps/api/viewsets/data_viewset.py
@@ -59,7 +59,7 @@ from onadata.libs.serializers.geojson_serializer import GeoJsonSerializer
 from onadata.libs.utils.api_export_tools import custom_response_handler
 from onadata.libs.utils.common_tools import json_stream
 from onadata.libs.utils.model_tools import queryset_iterator
-from onadata.libs.utils.viewer_tools import get_form_url, enketo_url
+from onadata.libs.utils.viewer_tools import get_form_url, get_enketo_urls
 
 SAFE_METHODS = ['GET', 'HEAD', 'OPTIONS']
 BaseViewset = get_baseviewset_class()
@@ -269,7 +269,10 @@ class DataViewSet(AnonymousUserPublicFormsMixin,
                     raise ParseError(_(u"return_url not provided."))
 
                 try:
-                    data = enketo_url(form_url, self.object.xform.id_string)
+                    data = get_enketo_urls(
+                        form_url,
+                        self.object.xform.id_string,
+                        return_url)
 
                 except EnketoError as e:
                     raise ParseError(text(e))

--- a/onadata/apps/api/viewsets/xform_viewset.py
+++ b/onadata/apps/api/viewsets/xform_viewset.py
@@ -429,18 +429,19 @@ class XFormViewSet(AnonymousUserPublicFormsMixin,
                                                  self.object.user.username,
                                                  self.object.id_string,
                                                  xform_pk=self.object.pk)
+            single_submit_url = get_enketo_single_submit_url(
+                request, self.object.user.username, self.object.id_string,
+                xform_pk=self.object.pk)
         except EnketoError as e:
             data = {'message': _(u"Enketo error: %s" % e)}
         else:
             if survey_type == 'single':
-                single_submit_url = get_enketo_single_submit_url(
-                    request, self.object.user.username, self.object.id_string,
-                    xform_pk=self.object.pk)
                 data = {"single_submit_url": single_submit_url}
-            elif url and preview_url:
+            else:
                 http_status = status.HTTP_200_OK
                 data = {"enketo_url": url,
-                        "enketo_preview_url": preview_url}
+                        "enketo_preview_url": preview_url,
+                        "single_submit_url": single_submit_url}
 
         return Response(data, http_status)
 

--- a/onadata/apps/api/viewsets/xform_viewset.py
+++ b/onadata/apps/api/viewsets/xform_viewset.py
@@ -71,7 +71,7 @@ from onadata.libs.utils.export_tools import parse_request_export_options
 from onadata.libs.utils.logger_tools import publish_form
 from onadata.libs.utils.model_tools import queryset_iterator
 from onadata.libs.utils.string import str2bool
-from onadata.libs.utils.viewer_tools import (enketo_url,
+from onadata.libs.utils.viewer_tools import (get_enketo_urls,
                                              generate_enketo_form_defaults,
                                              get_form_url)
 from onadata.libs.exceptions import EnketoError
@@ -421,7 +421,7 @@ class XFormViewSet(AnonymousUserPublicFormsMixin,
             request_vars = request.GET
             defaults = generate_enketo_form_defaults(
                 self.object, **request_vars)
-            enketo_urls = enketo_url(
+            enketo_urls = get_enketo_urls(
                 form_url, self.object.id_string, **defaults)
             offline_url = enketo_urls.get('offline_url')
             preview_url = enketo_urls.get('preview_url')

--- a/onadata/apps/api/viewsets/xform_viewset.py
+++ b/onadata/apps/api/viewsets/xform_viewset.py
@@ -73,9 +73,7 @@ from onadata.libs.utils.model_tools import queryset_iterator
 from onadata.libs.utils.string import str2bool
 from onadata.libs.utils.viewer_tools import (enketo_url,
                                              generate_enketo_form_defaults,
-                                             get_enketo_preview_url,
-                                             get_form_url,
-                                             get_enketo_single_submit_url)
+                                             get_form_url)
 from onadata.libs.exceptions import EnketoError
 from onadata.settings.common import XLS_EXTENSIONS, CSV_EXTENSION
 from onadata.libs.utils.cache_tools import PROJ_OWNER_CACHE, safe_delete
@@ -423,15 +421,12 @@ class XFormViewSet(AnonymousUserPublicFormsMixin,
             request_vars = request.GET
             defaults = generate_enketo_form_defaults(
                 self.object, **request_vars)
-            url = enketo_url(
+            data = enketo_url(
                 form_url, self.object.id_string, **defaults)
-            preview_url = get_enketo_preview_url(request,
-                                                 self.object.user.username,
-                                                 self.object.id_string,
-                                                 xform_pk=self.object.pk)
-            single_submit_url = get_enketo_single_submit_url(
-                request, self.object.user.username, self.object.id_string,
-                xform_pk=self.object.pk)
+            offline_url = (data.get('edit_url') or data.get('offline_url') or
+                           data.get('url'))
+            preview_url = (data.get('preview_url'))
+            single_submit_url = (data.get('single_url'))
         except EnketoError as e:
             data = {'message': _(u"Enketo error: %s" % e)}
         else:
@@ -439,7 +434,7 @@ class XFormViewSet(AnonymousUserPublicFormsMixin,
                 data = {"single_submit_url": single_submit_url}
             else:
                 http_status = status.HTTP_200_OK
-                data = {"enketo_url": url,
+                data = {"enketo_url": offline_url,
                         "enketo_preview_url": preview_url,
                         "single_submit_url": single_submit_url}
 

--- a/onadata/apps/api/viewsets/xform_viewset.py
+++ b/onadata/apps/api/viewsets/xform_viewset.py
@@ -421,16 +421,16 @@ class XFormViewSet(AnonymousUserPublicFormsMixin,
             request_vars = request.GET
             defaults = generate_enketo_form_defaults(
                 self.object, **request_vars)
-            data = enketo_url(
+            enketo_urls = enketo_url(
                 form_url, self.object.id_string, **defaults)
-            offline_url = (data.get('edit_url') or data.get('offline_url') or
-                           data.get('url'))
-            preview_url = (data.get('preview_url'))
-            single_submit_url = (data.get('single_url'))
+            offline_url = enketo_urls.get('offline_url')
+            preview_url = enketo_urls.get('preview_url')
+            single_submit_url = enketo_urls.get('single_url')
         except EnketoError as e:
             data = {'message': _(u"Enketo error: %s" % e)}
         else:
             if survey_type == 'single':
+                http_status = status.HTTP_200_OK
                 data = {"single_submit_url": single_submit_url}
             else:
                 http_status = status.HTTP_200_OK

--- a/onadata/apps/logger/views.py
+++ b/onadata/apps/logger/views.py
@@ -45,7 +45,8 @@ from onadata.libs.utils.logger_tools import (
 from onadata.libs.utils.user_auth import (
     HttpResponseNotAuthorized, add_cors_headers, has_edit_permission,
     has_permission, helper_auth_helper)
-from onadata.libs.utils.viewer_tools import enketo_url, get_form, get_form_url
+from onadata.libs.utils.viewer_tools import (
+    get_enketo_urls, get_form, get_form_url)
 
 IO_ERROR_STRINGS = [
     'request data read error', 'error during read(65536) on wsgi.input'
@@ -504,7 +505,7 @@ def enter_data(request, username, id_string):
     form_url = get_form_url(request, username, settings.ENKETO_PROTOCOL)
 
     try:
-        enketo_urls = enketo_url(form_url, xform.id_string)
+        enketo_urls = get_enketo_urls(form_url, xform.id_string)
         url = enketo_urls.get('url')
         if not url:
             return HttpResponseRedirect(
@@ -570,7 +571,7 @@ def edit_data(request, username, id_string, data_id):
     form_url = get_form_url(request, username, settings.ENKETO_PROTOCOL)
 
     try:
-        url = enketo_url(
+        url = get_enketo_urls(
             form_url,
             xform.id_string,
             instance_xml=injected_xml,

--- a/onadata/apps/logger/views.py
+++ b/onadata/apps/logger/views.py
@@ -504,7 +504,8 @@ def enter_data(request, username, id_string):
     form_url = get_form_url(request, username, settings.ENKETO_PROTOCOL)
 
     try:
-        url = enketo_url(form_url, xform.id_string)
+        enketo_urls = enketo_url(form_url, xform.id_string)
+        url = enketo_urls.get('url')
         if not url:
             return HttpResponseRedirect(
                 reverse(
@@ -587,6 +588,7 @@ def edit_data(request, username, id_string, data_id):
             fail_silently=True)
     else:
         if url:
+            url = url['edit_url']
             context.enketo = url
             return HttpResponseRedirect(url)
     return HttpResponseRedirect(

--- a/onadata/apps/main/management/commands/create_enketo_express_urls.py
+++ b/onadata/apps/main/management/commands/create_enketo_express_urls.py
@@ -5,7 +5,7 @@ from django.utils.translation import ugettext_lazy
 from onadata.apps.logger.models import XForm
 from onadata.libs.utils.model_tools import queryset_iterator
 from onadata.libs.utils.viewer_tools import (
-    enketo_url, get_form_url)
+    get_enketo_urls, get_form_url)
 
 
 class Command(BaseCommand):
@@ -60,7 +60,7 @@ class Command(BaseCommand):
                         xform_pk=xform.pk,
                         generate_consistent_urls=generate_consistent_urls)
                 id_string = xform.id_string
-                enketo_urls = enketo_url(form_url, id_string)
+                enketo_urls = get_enketo_urls(form_url, id_string)
                 _url = (enketo_urls.get('offline_url') or
                         enketo_urls.get('url'))
                 _preview_url = enketo_urls.get('preview_url')
@@ -83,7 +83,7 @@ class Command(BaseCommand):
                             xform_pk=xform.pk,
                             generate_consistent_urls=generate_consistent_urls)
                     id_string = xform.id_string
-                    enketo_urls = enketo_url(form_url, id_string)
+                    enketo_urls = get_enketo_urls(form_url, id_string)
                     _url = (enketo_urls.get('offline_url') or
                             enketo_urls.get('url'))
                     _preview_url = enketo_urls.get('preview_url')
@@ -106,7 +106,7 @@ class Command(BaseCommand):
                         protocol=protocol,
                         xform_pk=xform.pk,
                         generate_consistent_urls=generate_consistent_urls)
-                enketo_urls = enketo_url(form_url, id_string)
+                enketo_urls = get_enketo_urls(form_url, id_string)
                 _url = (enketo_urls.get('offline_url') or
                         enketo_urls.get('url'))
                 _preview_url = enketo_urls.get('preview_url')

--- a/onadata/apps/main/management/commands/create_enketo_express_urls.py
+++ b/onadata/apps/main/management/commands/create_enketo_express_urls.py
@@ -38,9 +38,6 @@ class Command(BaseCommand):
             raise CommandError(
                 'please provide a server_name, a server_port and a protocol')
 
-        if server_name not in ['api.ona.io', 'stage-api.ona.io', 'localhost']:
-            raise CommandError('server name provided is not valid')
-
         if protocol not in ['http', 'https']:
             raise CommandError('protocol provided is not valid')
 
@@ -63,10 +60,10 @@ class Command(BaseCommand):
                         xform_pk=xform.pk,
                         generate_consistent_urls=generate_consistent_urls)
                 id_string = xform.id_string
-                data = enketo_url(form_url, id_string)
-                _url = (data.get('edit_url') or data.get('offline_url') or
-                        data.get('url'))
-                _preview_url = (data.get('preview_url'))
+                enketo_urls = enketo_url(form_url, id_string)
+                _url = (enketo_urls.get('offline_url') or
+                        enketo_urls.get('url'))
+                _preview_url = enketo_urls.get('preview_url')
 
                 self.stdout.write('enketo url: %s | preview url: %s' %
                                   (_url, _preview_url))
@@ -86,10 +83,10 @@ class Command(BaseCommand):
                             xform_pk=xform.pk,
                             generate_consistent_urls=generate_consistent_urls)
                     id_string = xform.id_string
-                    data = enketo_url(form_url, id_string)
-                    _url = (data.get('edit_url') or data.get('offline_url') or
-                            data.get('url'))
-                    _preview_url = (data.get('preview_url'))
+                    enketo_urls = enketo_url(form_url, id_string)
+                    _url = (enketo_urls.get('offline_url') or
+                            enketo_urls.get('url'))
+                    _preview_url = enketo_urls.get('preview_url')
                     num_of_xforms -= 1
                     self.stdout.write(
                         'enketo url: %s | preview url: %s | remaining: %s' %
@@ -109,10 +106,10 @@ class Command(BaseCommand):
                         protocol=protocol,
                         xform_pk=xform.pk,
                         generate_consistent_urls=generate_consistent_urls)
-                data = enketo_url(form_url, id_string)
-                _url = (data.get('edit_url') or data.get('offline_url') or
-                        data.get('url'))
-                _preview_url = (data.get('preview_url'))
+                enketo_urls = enketo_url(form_url, id_string)
+                _url = (enketo_urls.get('offline_url') or
+                        enketo_urls.get('url'))
+                _preview_url = enketo_urls.get('preview_url')
                 num_of_xforms -= 1
                 self.stdout.write(
                     'enketo url: %s | preview url: %s | remaining: %s' %

--- a/onadata/apps/main/management/commands/create_enketo_express_urls.py
+++ b/onadata/apps/main/management/commands/create_enketo_express_urls.py
@@ -5,7 +5,7 @@ from django.utils.translation import ugettext_lazy
 from onadata.apps.logger.models import XForm
 from onadata.libs.utils.model_tools import queryset_iterator
 from onadata.libs.utils.viewer_tools import (
-    enketo_url, get_enketo_preview_url, get_form_url)
+    enketo_url, get_form_url)
 
 
 class Command(BaseCommand):
@@ -63,13 +63,11 @@ class Command(BaseCommand):
                         xform_pk=xform.pk,
                         generate_consistent_urls=generate_consistent_urls)
                 id_string = xform.id_string
-                _url = enketo_url(form_url, id_string)
-                _preview_url = get_enketo_preview_url(
-                        request,
-                        username,
-                        id_string,
-                        xform_pk=xform.pk,
-                        generate_consistent_urls=generate_consistent_urls)
+                data = enketo_url(form_url, id_string)
+                _url = (data.get('edit_url') or data.get('offline_url') or
+                        data.get('url'))
+                _preview_url = (data.get('preview_url'))
+
                 self.stdout.write('enketo url: %s | preview url: %s' %
                                   (_url, _preview_url))
                 self.stdout.write("enketo urls generation completed!!")
@@ -88,10 +86,10 @@ class Command(BaseCommand):
                             xform_pk=xform.pk,
                             generate_consistent_urls=generate_consistent_urls)
                     id_string = xform.id_string
-                    _url = enketo_url(form_url, id_string)
-                    _preview_url = get_enketo_preview_url(
-                        request, username, id_string, xform_pk=xform.pk,
-                        generate_consistent_urls=generate_consistent_urls)
+                    data = enketo_url(form_url, id_string)
+                    _url = (data.get('edit_url') or data.get('offline_url') or
+                            data.get('url'))
+                    _preview_url = (data.get('preview_url'))
                     num_of_xforms -= 1
                     self.stdout.write(
                         'enketo url: %s | preview url: %s | remaining: %s' %
@@ -111,10 +109,10 @@ class Command(BaseCommand):
                         protocol=protocol,
                         xform_pk=xform.pk,
                         generate_consistent_urls=generate_consistent_urls)
-                _url = enketo_url(form_url, id_string)
-                _preview_url = get_enketo_preview_url(
-                    request, id_string=id_string, xform_pk=xform.pk,
-                    generate_consistent_urls=generate_consistent_urls)
+                data = enketo_url(form_url, id_string)
+                _url = (data.get('edit_url') or data.get('offline_url') or
+                        data.get('url'))
+                _preview_url = (data.get('preview_url'))
                 num_of_xforms -= 1
                 self.stdout.write(
                     'enketo url: %s | preview url: %s | remaining: %s' %

--- a/onadata/apps/main/management/commands/update_enketo_urls.py
+++ b/onadata/apps/main/management/commands/update_enketo_urls.py
@@ -5,7 +5,7 @@ from django.utils.translation import ugettext_lazy
 
 from onadata.apps.main.models.meta_data import MetaData
 from onadata.libs.utils.viewer_tools import (
-    enketo_url, get_enketo_preview_url, get_form_url)
+    enketo_url, get_form_url)
 
 
 class Command(BaseCommand):
@@ -60,18 +60,18 @@ class Command(BaseCommand):
             xform_pk = xform.pk
 
             with open('/tmp/enketo_url', 'a') as f:
+                form_url = get_form_url(
+                    request, username=username, id_string=id_string,
+                    xform_pk=xform_pk,
+                    generate_consistent_urls=generate_consistent_urls)
+                data = enketo_url(form_url, id_string)
                 if data_type == 'enketo_url':
-                    form_url = get_form_url(
-                        request, username=username, id_string=id_string,
-                        xform_pk=xform_pk,
-                        generate_consistent_urls=generate_consistent_urls)
-                    _enketo_url = enketo_url(form_url, id_string)
+                    _enketo_url = (data.get('edit_url') or
+                                   data.get('offline_url') or
+                                   data.get('url'))
                     MetaData.enketo_url(xform, _enketo_url)
                 elif data_type == 'enketo_preview_url':
-                    _enketo_preview_url = get_enketo_preview_url(
-                        request, id_string, username=username,
-                        xform_pk=xform_pk,
-                        generate_consistent_urls=generate_consistent_urls)
+                    _enketo_preview_url = (data.get('preview_url'))
                     MetaData.enketo_preview_url(xform, _enketo_preview_url)
 
                 f.write('%s : %s \n' % (id_string, data_value))

--- a/onadata/apps/main/management/commands/update_enketo_urls.py
+++ b/onadata/apps/main/management/commands/update_enketo_urls.py
@@ -5,7 +5,7 @@ from django.utils.translation import ugettext_lazy
 
 from onadata.apps.main.models.meta_data import MetaData
 from onadata.libs.utils.viewer_tools import (
-    enketo_url, get_form_url)
+    get_enketo_urls, get_form_url)
 
 
 class Command(BaseCommand):
@@ -64,7 +64,7 @@ class Command(BaseCommand):
                     request, username=username, id_string=id_string,
                     xform_pk=xform_pk,
                     generate_consistent_urls=generate_consistent_urls)
-                enketo_urls = enketo_url(form_url, id_string)
+                enketo_urls = get_enketo_urls(form_url, id_string)
                 if data_type == 'enketo_url':
                     _enketo_url = (enketo_urls.get('offline_url') or
                                    enketo_urls.get('url'))

--- a/onadata/apps/main/management/commands/update_enketo_urls.py
+++ b/onadata/apps/main/management/commands/update_enketo_urls.py
@@ -64,14 +64,13 @@ class Command(BaseCommand):
                     request, username=username, id_string=id_string,
                     xform_pk=xform_pk,
                     generate_consistent_urls=generate_consistent_urls)
-                data = enketo_url(form_url, id_string)
+                enketo_urls = enketo_url(form_url, id_string)
                 if data_type == 'enketo_url':
-                    _enketo_url = (data.get('edit_url') or
-                                   data.get('offline_url') or
-                                   data.get('url'))
+                    _enketo_url = (enketo_urls.get('offline_url') or
+                                   enketo_urls.get('url'))
                     MetaData.enketo_url(xform, _enketo_url)
                 elif data_type == 'enketo_preview_url':
-                    _enketo_preview_url = (data.get('preview_url'))
+                    _enketo_preview_url = (enketo_urls.get('preview_url'))
                     MetaData.enketo_preview_url(xform, _enketo_preview_url)
 
                 f.write('%s : %s \n' % (id_string, data_value))

--- a/onadata/apps/main/models/meta_data.py
+++ b/onadata/apps/main/models/meta_data.py
@@ -265,6 +265,11 @@ class MetaData(models.Model):
         return unique_type_for_form(content_object, data_type, data_value)
 
     @staticmethod
+    def enketo_single_submit_url(content_object, data_value=None):
+        data_type = 'enketo_single_submit_url'
+        return unique_type_for_form(content_object, data_type, data_value)
+
+    @staticmethod
     def form_license(content_object, data_value=None):
         data_type = 'form_license'
         obj = unique_type_for_form(content_object, data_type, data_value)

--- a/onadata/apps/main/tests/test_form_enter_data.py
+++ b/onadata/apps/main/tests/test_form_enter_data.py
@@ -16,7 +16,7 @@ from onadata.apps.logger.views import enter_data
 from onadata.apps.main.models import MetaData
 from onadata.apps.main.tests.test_base import TestBase
 from onadata.apps.main.views import qrcode, set_perm, show
-from onadata.libs.utils.viewer_tools import enketo_url
+from onadata.libs.utils.viewer_tools import get_enketo_urls
 
 
 @urlmatch(netloc=r"(.*\.)?enketo\.ona\.io$")
@@ -79,7 +79,7 @@ class TestFormEnterData(TestBase):
         with HTTMock(enketo_mock):
             server_url = "https://testserver.com/bob"
             form_id = "test_%s" % re.sub(re.compile("\."), "_", str(time()))  # noqa
-            url = enketo_url(server_url, form_id)
+            url = get_enketo_urls(server_url, form_id)
             self.assertIsInstance(url['url'], basestring)
             self.assertIsNone(URLValidator()(url['url']))
 
@@ -89,7 +89,7 @@ class TestFormEnterData(TestBase):
         with HTTMock(enketo_mock_http):
             server_url = "http://testserver.com/bob"
             form_id = "test_%s" % re.sub(re.compile("\."), "_", str(time()))  # noqa
-            url = enketo_url(server_url, form_id)
+            url = get_enketo_urls(server_url, form_id)
             self.assertIn("http:", url['url'])
             self.assertIsInstance(url['url'], basestring)
             self.assertIsNone(URLValidator()(url['url']))

--- a/onadata/apps/main/tests/test_form_enter_data.py
+++ b/onadata/apps/main/tests/test_form_enter_data.py
@@ -80,8 +80,8 @@ class TestFormEnterData(TestBase):
             server_url = "https://testserver.com/bob"
             form_id = "test_%s" % re.sub(re.compile("\."), "_", str(time()))  # noqa
             url = enketo_url(server_url, form_id)
-            self.assertIsInstance(url, basestring)
-            self.assertIsNone(URLValidator()(url))
+            self.assertIsInstance(url['url'], basestring)
+            self.assertIsNone(URLValidator()(url['url']))
 
     def test_enketo_url_with_http_protocol_on_formlist(self):
         if not self._running_enketo():
@@ -90,9 +90,9 @@ class TestFormEnterData(TestBase):
             server_url = "http://testserver.com/bob"
             form_id = "test_%s" % re.sub(re.compile("\."), "_", str(time()))  # noqa
             url = enketo_url(server_url, form_id)
-            self.assertIn("http:", url)
-            self.assertIsInstance(url, basestring)
-            self.assertIsNone(URLValidator()(url))
+            self.assertIn("http:", url['url'])
+            self.assertIsInstance(url['url'], basestring)
+            self.assertIsNone(URLValidator()(url['url']))
 
     def _get_grcode_view_response(self):
         factory = RequestFactory()

--- a/onadata/apps/main/tests/test_form_show.py
+++ b/onadata/apps/main/tests/test_form_show.py
@@ -7,9 +7,9 @@ from django.core.exceptions import MultipleObjectsReturned
 from django.core.files.base import ContentFile
 from django.urls import reverse
 from httmock import HTTMock
+from django.test.utils import override_settings
 
-from onadata.apps.api.tests.viewsets.test_xform_viewset import \
-    enketo_preview_url_mock
+from onadata.apps.api.tests.mocked_data import enketo_urls_mock
 from onadata.apps.logger.models import XForm
 from onadata.apps.logger.views import download_xlsform, download_jsonform, \
     download_xform, delete_xform
@@ -466,8 +466,9 @@ class TestFormShow(TestBase):
             user=bob, id_string=id_string).count() == 0
         self.assertFalse(form_deleted)
 
+    @override_settings(TESTING_MODE=False)
     def test_enketo_preview(self):
-        with HTTMock(enketo_preview_url_mock):
+        with HTTMock(enketo_urls_mock):
             url = reverse(
                 enketo_preview, kwargs={'username': self.user.username,
                                         'id_string': self.xform.id_string})
@@ -475,7 +476,7 @@ class TestFormShow(TestBase):
             self.assertEqual(response.status_code, 302)
 
     def test_enketo_preview_works_on_shared_forms(self):
-        with HTTMock(enketo_preview_url_mock):
+        with HTTMock(enketo_urls_mock):
             self.xform.shared = True
             self.xform.save()
             url = reverse(

--- a/onadata/apps/main/views.py
+++ b/onadata/apps/main/views.py
@@ -62,7 +62,7 @@ from onadata.libs.utils.user_auth import (add_cors_headers, check_and_set_user,
                                           get_xform_users_with_perms,
                                           has_permission,
                                           helper_auth_helper, set_profile_data)
-from onadata.libs.utils.viewer_tools import (enketo_url, get_form)
+from onadata.libs.utils.viewer_tools import (get_enketo_urls, get_form)
 
 
 def home(request):
@@ -1383,7 +1383,7 @@ def qrcode(request, username, id_string):
     results = _(u"Unexpected Error occured: No QRCODE generated")
     status = 200
     try:
-        enketo_urls = enketo_url(formhub_url, id_string)
+        enketo_urls = get_enketo_urls(formhub_url, id_string)
     except Exception as e:
         error_msg = _(u"Error Generating QRCODE: %s" % e)
         results = """<div class="alert alert-error">%s</div>""" % error_msg
@@ -1412,7 +1412,7 @@ def enketo_preview(request, username, id_string):
         return HttpResponseForbidden(_(u'Not shared.'))
 
     try:
-        enketo_urls = enketo_url(
+        enketo_urls = get_enketo_urls(
                 xform.url, xform.id_string)
 
         enketo_preview_url = enketo_urls.get('preview_url')

--- a/onadata/apps/main/views.py
+++ b/onadata/apps/main/views.py
@@ -62,8 +62,7 @@ from onadata.libs.utils.user_auth import (add_cors_headers, check_and_set_user,
                                           get_xform_users_with_perms,
                                           has_permission,
                                           helper_auth_helper, set_profile_data)
-from onadata.libs.utils.viewer_tools import (enketo_url,
-                                             get_enketo_preview_url, get_form)
+from onadata.libs.utils.viewer_tools import (enketo_url, get_form)
 
 
 def home(request):
@@ -1384,13 +1383,14 @@ def qrcode(request, username, id_string):
     results = _(u"Unexpected Error occured: No QRCODE generated")
     status = 200
     try:
-        url = enketo_url(formhub_url, id_string)
+        data = enketo_url(formhub_url, id_string)
     except Exception as e:
         error_msg = _(u"Error Generating QRCODE: %s" % e)
         results = """<div class="alert alert-error">%s</div>""" % error_msg
         status = 400
     else:
-        if url:
+        if data:
+            url = data.get("single_url")
             image = generate_qrcode(url)
             results = """<img class="qrcode" src="%s" alt="%s" />
                     </br><a href="%s" target="_blank">%s</a>""" \
@@ -1412,10 +1412,10 @@ def enketo_preview(request, username, id_string):
         return HttpResponseForbidden(_(u'Not shared.'))
 
     try:
-        enketo_preview_url = get_enketo_preview_url(request,
-                                                    owner.username,
-                                                    xform.id_string,
-                                                    xform_pk=xform.pk)
+        data = enketo_url(
+                xform.url, xform.id_string)
+
+        enketo_preview_url = (data.get('preview_url'))
     except EnketoError as e:
         return HttpResponse(e)
 

--- a/onadata/apps/main/views.py
+++ b/onadata/apps/main/views.py
@@ -1383,14 +1383,14 @@ def qrcode(request, username, id_string):
     results = _(u"Unexpected Error occured: No QRCODE generated")
     status = 200
     try:
-        data = enketo_url(formhub_url, id_string)
+        enketo_urls = enketo_url(formhub_url, id_string)
     except Exception as e:
         error_msg = _(u"Error Generating QRCODE: %s" % e)
         results = """<div class="alert alert-error">%s</div>""" % error_msg
         status = 400
     else:
-        if data:
-            url = data.get("single_url")
+        if enketo_urls:
+            url = enketo_urls.get("url")
             image = generate_qrcode(url)
             results = """<img class="qrcode" src="%s" alt="%s" />
                     </br><a href="%s" target="_blank">%s</a>""" \
@@ -1412,10 +1412,10 @@ def enketo_preview(request, username, id_string):
         return HttpResponseForbidden(_(u'Not shared.'))
 
     try:
-        data = enketo_url(
+        enketo_urls = enketo_url(
                 xform.url, xform.id_string)
 
-        enketo_preview_url = (data.get('preview_url'))
+        enketo_preview_url = enketo_urls.get('preview_url')
     except EnketoError as e:
         return HttpResponse(e)
 

--- a/onadata/libs/serializers/xform_serializer.py
+++ b/onadata/libs/serializers/xform_serializer.py
@@ -33,7 +33,7 @@ from onadata.libs.utils.common_tags import (GROUP_DELIMETER_TAG,
                                             REPEAT_INDEX_TAGS)
 from onadata.libs.utils.decorators import check_obj
 from onadata.libs.utils.viewer_tools import (
-    enketo_url, get_form_url)
+    get_enketo_urls, get_form_url)
 
 
 def _create_enketo_urls(request, xform):
@@ -49,7 +49,7 @@ def _create_enketo_urls(request, xform):
                             generate_consistent_urls=True)
     data = {}
     try:
-        enketo_urls = enketo_url(form_url, xform.id_string)
+        enketo_urls = get_enketo_urls(form_url, xform.id_string)
         offline_url = enketo_urls.get("offline_url")
         MetaData.enketo_url(xform, offline_url)
         data['offline_url'] = offline_url
@@ -194,8 +194,6 @@ class XFormMixin(object):
                     url = enketo_urls.get('preview_url')
                 except Exception:
                     return url
-                else:
-                    MetaData.enketo_preview_url(obj, url)
 
             return _set_cache(ENKETO_PREVIEW_URL_CACHE, url, obj)
 

--- a/onadata/libs/serializers/xform_serializer.py
+++ b/onadata/libs/serializers/xform_serializer.py
@@ -33,7 +33,7 @@ from onadata.libs.utils.common_tags import (GROUP_DELIMETER_TAG,
                                             REPEAT_INDEX_TAGS)
 from onadata.libs.utils.decorators import check_obj
 from onadata.libs.utils.viewer_tools import (
-    enketo_url, get_enketo_preview_url, get_form_url)
+    enketo_url, get_form_url)
 
 
 def _create_enketo_url(request, xform):
@@ -50,7 +50,9 @@ def _create_enketo_url(request, xform):
     url = ""
 
     try:
-        url = enketo_url(form_url, xform.id_string)
+        data = enketo_url(form_url, xform.id_string)
+        if data:
+            url = data.get("single_url")
         MetaData.enketo_url(xform, url)
     except ConnectionError as e:
         logging.exception("Connection Error: %s" % e)
@@ -158,9 +160,9 @@ class XFormMixin(object):
             url = self._get_metadata(obj, 'enketo_preview_url')
             if url is None:
                 try:
-                    url = get_enketo_preview_url(
-                        self.context.get('request'), obj.user.username,
-                        obj.id_string, xform_pk=obj.pk)
+                    data = enketo_url(obj.url, obj.id_string)
+                    if data:
+                        url = data.get("enketo_preview_url")
                 except Exception:
                     return url
                 else:

--- a/onadata/libs/utils/cache_tools.py
+++ b/onadata/libs/utils/cache_tools.py
@@ -18,6 +18,7 @@ USER_PROFILE_PREFIX = "user_profile-"
 # Cache names user in xform_serializer
 XFORM_PERMISSIONS_CACHE = "xfs-get_xform_permissions"
 ENKETO_URL_CACHE = "xfs-get_enketo_url"
+ENKETO_SINGLE_SUBMIT_URL_CACHE = "xfs-get_enketosingle_submit__url"
 ENKETO_PREVIEW_URL_CACHE = "xfs-get_enketo_preview_url"
 XFORM_METADATA_CACHE = "xfs-get_xform_metadata"
 XFORM_DATA_VERSIONS = "xfs-get_xform_data_versions"

--- a/onadata/libs/utils/viewer_tools.py
+++ b/onadata/libs/utils/viewer_tools.py
@@ -170,12 +170,13 @@ def enketo_url(form_url,
                **kwargs):
     """Return Enketo webform URL."""
     if (not hasattr(settings, 'ENKETO_URL') or
-            not hasattr(settings, 'ENKETO_API_SURVEY_PATH') or
+            not hasattr(settings, 'ENKETO_API_ALL_SURVEY_LINKS_PATH') or
             not hasattr(settings, 'ENKETO_API_TOKEN') or
             settings.ENKETO_API_TOKEN == ''):
         return False
 
-    url = urljoin(settings.ENKETO_URL, settings.ENKETO_API_SURVEY_PATH)
+    url = urljoin(
+        settings.ENKETO_URL, settings.ENKETO_API_ALL_SURVEY_LINKS_PATH)
 
     values = {'form_id': id_string, 'server_url': form_url}
     if instance_id is not None and instance_xml is not None:

--- a/onadata/libs/utils/viewer_tools.py
+++ b/onadata/libs/utils/viewer_tools.py
@@ -381,12 +381,13 @@ def get_enketo_preview_url(
 
 def get_enketo_single_submit_url(request, username, id_string, xform_pk=None):
     """Return single submit url of the submission instance."""
-    import ipdb; ipdb.set_trace()
     enketo_url = urljoin(settings.ENKETO_URL, getattr(
-        settings, 'ENKETO_SINGLE_SUBMIT_PATH', "/api/v2/survey/single/once"))
+        settings, 'ENKETO_SINGLE_SUBMIT_PATH', "/api/v2/survey/all"))
     form_id = id_string
     server_url = get_form_url(
-        request, username, settings.ENKETO_PROTOCOL, True, xform_pk=xform_pk)
+        request,
+        username,
+        settings.ENKETO_PROTOCOL)
 
     url = '{}?server_url={}&form_id={}'.format(
         enketo_url, server_url, form_id)
@@ -398,6 +399,6 @@ def get_enketo_single_submit_url(request, username, id_string, xform_pk=None):
             data = json.loads(response.content)
         except ValueError:
             pass
-        return data['single_once_url']
+        return data['single_url']
 
     handle_enketo_error(response)

--- a/onadata/libs/utils/viewer_tools.py
+++ b/onadata/libs/utils/viewer_tools.py
@@ -9,6 +9,7 @@ from builtins import open
 from future.utils import iteritems
 from json.decoder import JSONDecodeError
 from tempfile import NamedTemporaryFile
+from typing import Dict
 from xml.dom import minidom
 
 from future.moves.urllib.parse import urljoin
@@ -162,13 +163,13 @@ def get_client_ip(request):
     return request.META.get('REMOTE_ADDR')
 
 
-def enketo_url(form_url,
-               id_string,
-               instance_xml=None,
-               instance_id=None,
-               return_url=None,
-               **kwargs):
-    """Return Enketo webform URL."""
+def get_enketo_urls(form_url,
+                    id_string,
+                    instance_xml=None,
+                    instance_id=None,
+                    return_url=None,
+                    **kwargs) -> Dict[str, str]:
+    """Return Enketo URLs."""
     if (not hasattr(settings, 'ENKETO_URL') or
             not hasattr(settings, 'ENKETO_API_ALL_SURVEY_LINKS_PATH') or
             not hasattr(settings, 'ENKETO_API_TOKEN') or
@@ -321,21 +322,4 @@ def get_form_url(request,
         url += "/{}/{}".format(username, xform_pk) if xform_pk \
              else "/{}".format(username)
 
-    return url
-
-
-def get_enketo_edit_url(request, instance, return_url):
-    """Given a submssion instance,
-    returns an Enketo link to edit the specified submission."""
-    form_url = get_form_url(
-        request,
-        instance.xform.user.username,
-        settings.ENKETO_PROTOCOL,
-        xform_pk=instance.xform_id)
-    url = enketo_url(
-        form_url,
-        instance.xform.id_string,
-        instance_xml=instance.xml,
-        instance_id=instance.uuid,
-        return_url=return_url)
     return url

--- a/onadata/libs/utils/viewer_tools.py
+++ b/onadata/libs/utils/viewer_tools.py
@@ -381,6 +381,7 @@ def get_enketo_preview_url(
 
 def get_enketo_single_submit_url(request, username, id_string, xform_pk=None):
     """Return single submit url of the submission instance."""
+    import ipdb; ipdb.set_trace()
     enketo_url = urljoin(settings.ENKETO_URL, getattr(
         settings, 'ENKETO_SINGLE_SUBMIT_PATH', "/api/v2/survey/single/once"))
     form_id = id_string
@@ -397,6 +398,6 @@ def get_enketo_single_submit_url(request, username, id_string, xform_pk=None):
             data = json.loads(response.content)
         except ValueError:
             pass
-        return data['single_url']
+        return data['single_once_url']
 
     handle_enketo_error(response)

--- a/onadata/settings/common.py
+++ b/onadata/settings/common.py
@@ -19,7 +19,6 @@ from imp import reload
 from celery.signals import after_setup_logger
 from django.core.exceptions import SuspiciousOperation
 from django.utils.log import AdminEmailHandler
-from future.moves.urllib.parse import urljoin
 from past.builtins import basestring
 
 # setting default encoding to utf-8
@@ -98,9 +97,8 @@ STATIC_URL = '/static/'
 # Enketo URL
 ENKETO_PROTOCOL = 'https'
 ENKETO_URL = 'https://enketo.ona.io/'
-ENKETO_API_SURVEY_PATH = '/api_v2/survey/all'
+ENKETO_API_ALL_SURVEY_LINKS_PATH = '/api_v2/survey/all'
 ENKETO_API_INSTANCE_PATH = '/api_v2/instance'
-ENKETO_PREVIEW_URL = urljoin(ENKETO_URL, ENKETO_API_SURVEY_PATH + '/preview')
 ENKETO_API_TOKEN = ''
 ENKETO_API_INSTANCE_IFRAME_URL = ENKETO_URL + "api_v2/instance/iframe"
 ENKETO_API_SALT = 'secretsalt'

--- a/onadata/settings/common.py
+++ b/onadata/settings/common.py
@@ -98,7 +98,7 @@ STATIC_URL = '/static/'
 # Enketo URL
 ENKETO_PROTOCOL = 'https'
 ENKETO_URL = 'https://enketo.ona.io/'
-ENKETO_API_SURVEY_PATH = '/api_v2/survey'
+ENKETO_API_SURVEY_PATH = '/api_v2/survey/all'
 ENKETO_API_INSTANCE_PATH = '/api_v2/instance'
 ENKETO_PREVIEW_URL = urljoin(ENKETO_URL, ENKETO_API_SURVEY_PATH + '/preview')
 ENKETO_API_TOKEN = ''

--- a/onadata/settings/docker.py
+++ b/onadata/settings/docker.py
@@ -15,8 +15,6 @@ import os
 import subprocess
 import sys
 
-from future.moves.urllib.parse import urljoin
-
 from onadata.settings.common import *  # noqa
 
 # # # now override the settings which came from staging # # # #
@@ -72,10 +70,8 @@ if TESTING_MODE:
     ENKETO_API_TOKEN = 'abc'
     ENKETO_PROTOCOL = 'https'
     ENKETO_URL = 'https://enketo.ona.io/'
-    ENKETO_API_SURVEY_PATH = '/api_v1/survey'
+    ENKETO_API_ALL_SURVEY_LINKS_PATH = '/api_v2/survey'
     ENKETO_API_INSTANCE_PATH = '/api_v1/instance'
-    ENKETO_PREVIEW_URL = urljoin(ENKETO_URL, ENKETO_API_SURVEY_PATH +
-                                 '/preview')
     ENKETO_SINGLE_SUBMIT_PATH = '/api/v2/survey/single/once'
     ENKETO_API_INSTANCE_IFRAME_URL = ENKETO_URL + "api_v1/instance/iframe"
 else:

--- a/onadata/settings/travis_test.py
+++ b/onadata/settings/travis_test.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import
 
 from .common import *  # nopep8
 
+# database settings
 DATABASES = {
     'default': {
         'ENGINE': 'django.contrib.gis.db.backends.postgis',
@@ -39,10 +40,8 @@ if TESTING_MODE:
     ENKETO_API_TOKEN = 'abc'
     ENKETO_PROTOCOL = 'https'
     ENKETO_URL = 'https://enketo.ona.io/'
-    ENKETO_API_SURVEY_PATH = '/api_v1/survey'
+    ENKETO_API_ALL_SURVEY_LINKS_PATH = '/api_v2/survey/all'
     ENKETO_API_INSTANCE_PATH = '/api_v1/instance'
-    ENKETO_PREVIEW_URL = urljoin(ENKETO_URL, ENKETO_API_SURVEY_PATH +
-                                 '/preview')
     ENKETO_SINGLE_SUBMIT_PATH = '/api/v2/survey/single/once'
     ENKETO_API_INSTANCE_IFRAME_URL = ENKETO_URL + "api_v1/instance/iframe"
 else:


### PR DESCRIPTION
### Changes Introduced
I. The single_submission_url should be present in the response returned by /api/v1/forms/<form_id>/enketo
II. Should be able to retrieve the single_submission_url using /api/v1/forms/<form_id>/enketo?survey_type=single
III. Allow submissions collection from this single Enketo URL

### Steps taken to verify this change does what is intended
- [ ] Include tests
- [ ] QA

### Side effects of implementing this change
None

Closes #1855 
