### PR TITLE
Fix duplicate records after edit

### DIFF
--- a/onadata/apps/api/tests/viewsets/test_xform_submission_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_xform_submission_viewset.py
@@ -564,7 +564,8 @@ class TestXFormSubmissionViewSet(TestAbstractViewSet, TransactionTestCase):
         expected_xml = (
             f"<?xml version='1.0' ?><{self.xform.survey.name} id="
             "'transportation_2011_07_25'><fruit_name>orange"
-            f"</fruit_name></{self.xform.survey.name}>")
+            f"</fruit_name>\n<meta>\n  <instanceID>uuid:{uuid}"
+            f"</instanceID>\n</meta></{self.xform.survey.name}>")
         self.assertEqual(instance.xml, expected_xml)
         self.assertEqual(self.xform.survey.name, 'data')
 

--- a/onadata/libs/serializers/data_serializer.py
+++ b/onadata/libs/serializers/data_serializer.py
@@ -42,12 +42,13 @@ def get_request_and_username(context):
     return (request, username)
 
 
-def create_submission(request, username, data_dict, xform_id):
+def create_submission(
+        request, username, data_dict, xform_id, gen_uuid: bool = False):
     """
     Returns validated data object instances
     """
     xml_string = dict2xform(
-        data_dict, xform_id, username=username)
+        data_dict, xform_id, username=username, gen_uuid=gen_uuid)
     xml_file = BytesIO(xml_string.encode('utf-8'))
 
     error, instance = safe_create_instance(username, xml_file, [], None,
@@ -334,7 +335,8 @@ class RapidProSubmissionSerializer(BaseRapidProSubmissionSerializer):
         request, username = get_request_and_username(self.context)
         rapidpro_dict = query_list_to_dict(request.data.get('values'))
         instance = create_submission(request, username, rapidpro_dict,
-                                     validated_data['id_string'])
+                                     validated_data['id_string'],
+                                     gen_uuid=True)
 
         return instance
 
@@ -352,7 +354,8 @@ class RapidProJSONSubmissionSerializer(BaseRapidProSubmissionSerializer):
         instance_data_dict = {
             k: post_data[k].get('value') for k in post_data.keys()}
         instance = create_submission(
-            request, username, instance_data_dict, validated_data['id_string'])
+            request, username, instance_data_dict,
+            validated_data['id_string'], gen_uuid=True)
         return instance
 
 

--- a/onadata/libs/utils/common_tools.py
+++ b/onadata/libs/utils/common_tools.py
@@ -48,11 +48,11 @@ def get_boolean_value(str_var, default=None):
     return str_var if default else False
 
 
-def get_uuid(hex: bool = True):
+def get_uuid(hex_only: bool = True):
     '''
     Return UUID4 hex value
     '''
-    return uuid.uuid4().hex if hex else str(uuid.uuid4())
+    return uuid.uuid4().hex if hex_only else str(uuid.uuid4())
 
 
 def report_exception(subject, info, exc_info=None):

--- a/onadata/libs/utils/common_tools.py
+++ b/onadata/libs/utils/common_tools.py
@@ -48,11 +48,11 @@ def get_boolean_value(str_var, default=None):
     return str_var if default else False
 
 
-def get_uuid():
+def get_uuid(hex: bool = True):
     '''
     Return UUID4 hex value
     '''
-    return uuid.uuid4().hex
+    return uuid.uuid4().hex if hex else str(uuid.uuid4())
 
 
 def report_exception(subject, info, exc_info=None):

--- a/onadata/libs/utils/logger_tools.py
+++ b/onadata/libs/utils/logger_tools.py
@@ -47,7 +47,7 @@ from onadata.apps.viewer.models.data_dictionary import DataDictionary
 from onadata.apps.viewer.models.parsed_instance import ParsedInstance
 from onadata.apps.viewer.signals import process_submission
 from onadata.libs.utils.common_tags import METADATA_FIELDS
-from onadata.libs.utils.common_tools import report_exception
+from onadata.libs.utils.common_tools import report_exception, get_uuid
 from onadata.libs.utils.model_tools import set_uuid
 from onadata.libs.utils.user_auth import get_user_default_project
 
@@ -112,7 +112,7 @@ def _get_instance(xml, new_uuid, submitted_by, status, xform, checksum):
     return instance
 
 
-def dict2xform(jsform, form_id, root=None, username=None):
+def dict2xform(jsform, form_id, root=None, username=None, gen_uuid=False):
     """
     Converts a dictionary containing submission data into an XML
     Submission for the appropriate form.
@@ -142,6 +142,11 @@ def dict2xform(jsform, form_id, root=None, username=None):
                 root = form.survey.name if form else 'data'
         else:
             root = 'data'
+
+    if gen_uuid:
+        jsform['meta'] = {
+            'instanceID': 'uuid:' + get_uuid(hex_only=False)
+        }
 
     return "<?xml version='1.0' ?><{0} id='{1}'>{2}</{0}>".format(
         root, form_id, dict2xml(jsform))


### PR DESCRIPTION
### Changes / Features implemented

- Set `instanceID` in submission XML when creating

### Steps taken to verify this change does what is intended

- Updated test
- [x] [QA](https://onaio.slack.com/archives/C0E2558SH/p1597064928475100?thread_ts=1597054364.472200&cid=C0E2558SH)

### Side effects of implementing this change

- N/A

### Extra Info

Without the `instanceID` in the XML, Enketo generates a new instanceID which instead of editing the original it creates another one. Setting the `instanceID` ensures that the correct submission is edited.

Closes #1868 
