### PR TITLE
Add support for login with email/password on the classic login pages

### DIFF
--- a/onadata/apps/main/backends.py
+++ b/onadata/apps/main/backends.py
@@ -1,13 +1,17 @@
 from django.contrib.auth.models import User
 from django.contrib.auth.backends import ModelBackend as DjangoModelBackend
+from django.db.models import Q
 
 
 class ModelBackend(DjangoModelBackend):
     def authenticate(self, request=None, username=None, password=None):
-        """Username is case insensitive."""
-        try:
-            user = User.objects.get(username__iexact=username)
-            if user.check_password(password):
-                return user
-        except User.DoesNotExist:
-            return None
+        """
+        Username is case insensitive. Supports using email in place of username
+        """
+        user = User.objects.filter(
+            Q(username__iexact=username) | Q(email__iexact=username)).first()
+
+        if user and user.check_password(password):
+            return user
+
+        return None

--- a/onadata/apps/main/tests/test_http_auth.py
+++ b/onadata/apps/main/tests/test_http_auth.py
@@ -28,6 +28,14 @@ class TestBasicHttpAuthentication(TestBase):
                                    **self._set_auth_headers('bob', 'bob'))
         self.assertEqual(response.status_code, 200)
 
+        # Set user email
+        self.user.email = "bob@testing_pros.com"
+        self.user.save()
+        # headers with valid email/pass
+        response = self.client.get(
+            self.api_url, **self._set_auth_headers(self.user.email, 'bob'))
+        self.assertEqual(response.status_code, 200)
+
     def test_http_auth_shared_data(self):
         self.xform.shared_data = True
         self.xform.save()


### PR DESCRIPTION
### Changes / Features implemented

- Add support for using email in place of username when authenticating through the Non-API views

### Steps taken to verify this change does what is intended

- Added tests

### Side effects of implementing this change

Closes #1789 
