### PR TITLE
Tag release v2.4.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,25 @@ Changelog for Onadata
 
 ``* represents releases that introduce new migrations``
 
+v2.4.0(2020-09-01)
+------------------
+
+- Initial support for tracking submissions with Segment
+  `PR #1872 <https://github.com/onaio/onadata/pull/1872>`_
+  [@DavisRayM]
+- Add caching to the organization profile viewset
+  `PR #1876 <https://github.com/onaio/onadata/pull/1876>`_
+  [@FrankApiyo]
+- Include support for repeat groups in the Tableau-Onadata integration
+  `PR #1845 <https://github.com/onaio/onadata/pull/1845>`_
+  [@WinnyTroy]
+- Enketo intergration updates
+  `PR #1857 <https://github.com/onaio/onadata/pull/1845>`_
+  [@WinnyTroy]
+- Unpack GPS data into separate columns for altitude, precision, latitude and longitude
+  `PR #1880 <https://github.com/onaio/onadata/pull/1880>`_
+  [@WinnyTroy]
+
 v2.3.8(2020-08-25)
 ------------------
 

--- a/onadata/__init__.py
+++ b/onadata/__init__.py
@@ -6,7 +6,7 @@ visualization.
 """
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "2.3.8"
+__version__ = "2.4.0"
 
 
 # This will make sure the app is always imported when

--- a/onadata/apps/api/viewsets/open_data_viewset.py
+++ b/onadata/apps/api/viewsets/open_data_viewset.py
@@ -32,6 +32,7 @@ from onadata.libs.utils.common_tags import (
     NOTES,
     GEOLOCATION,
     MULTIPLE_SELECT_TYPE,
+    REPEAT_SELECT_TYPE,
     NA_REP)
 
 BaseViewset = get_baseviewset_class()
@@ -73,6 +74,15 @@ def process_tableau_data(data, xform):
             for choice in choices:
                 xpaths = f'{key}/{choice}'
                 data_dict[xpaths] = choice
+        elif isinstance(value, list):
+            try:
+                for item in value:
+                    for (nested_key, nested_val) in item.items():
+                        xpath = get_xpath(key, nested_key)
+                        data_dict[xpath] = nested_val
+            except AttributeError:
+                data_dict[key] = value
+
         return data_dict
 
     def get_ordered_repeat_value(key, item, index):
@@ -96,6 +106,9 @@ def process_tableau_data(data, xform):
                     qstn_type = xform.get_element(nested_key).type
                     xpaths = get_xpath(key, nested_key)
                     if qstn_type == MULTIPLE_SELECT_TYPE:
+                        data = get_updated_data_dict(
+                            xpaths, nested_val, data)
+                    elif qstn_type == REPEAT_SELECT_TYPE:
                         data = get_updated_data_dict(
                             xpaths, nested_val, data)
                     else:

--- a/onadata/libs/tests/utils/test_analytics.py
+++ b/onadata/libs/tests/utils/test_analytics.py
@@ -14,7 +14,7 @@ from onadata.apps.api.tests.viewsets.test_abstract_viewset import \
     TestAbstractViewSet
 from onadata.apps.api.viewsets.xform_submission_viewset import \
     XFormSubmissionViewSet
-from onadata.libs.utils.analytics import get_user_id
+from onadata.libs.utils.analytics import get_user_id, sanitize_metric_values
 
 
 class TestAnalytics(TestAbstractViewSet):
@@ -47,6 +47,34 @@ class TestAnalytics(TestAbstractViewSet):
             'testing track function',
             {'value': 1},
             {'source': 'test-server'})
+
+    def test_sanitize_metric_values(self):
+        """Test sanitize_metric_values()"""
+        expected_output = {
+            'action_from': 'XML_Submissions',
+            'event_by': 'bob',
+            'ip': '18.203.134.101',
+            'path': '/enketo/1814/submission',
+            'source': 'onadata-ona-stage',
+            'url': 'https://stage-api.ona.io/enketo/1814/submission',
+            'userId': 1,
+            'xform_id': 1}
+        context = {
+            'action_from': 'XML Submissions',
+            'event_by': 'bob',
+            'ip': '18.203.134.101',
+            'library': {
+                'name': 'analytics-python',
+                'version': '1.2.9'
+                },
+            'organization': '',
+            'path': '/enketo/1814/submission',
+            'source': 'onadata-ona-stage',
+            'url': 'https://stage-api.ona.io/enketo/1814/submission',
+            'userId': 1,
+            'xform_id': 1}
+
+        self.assertEqual(sanitize_metric_values(context), expected_output)
 
     @override_settings(
             SEGMENT_WRITE_KEY='123', HOSTNAME='test-server',
@@ -112,7 +140,6 @@ class TestAnalytics(TestAbstractViewSet):
                 'event_by': 'anonymous',
                 'action_from': 'XML Submissions',
                 'xform_id': self.xform.pk,
-                'userAgent': '',
                 'path': f'/{username}/submission',
                 'url': f'http://testserver/{username}/submission',
                 'ip': '127.0.0.1',
@@ -128,7 +155,6 @@ class TestAnalytics(TestAbstractViewSet):
                 'organization': 'Bob_Inc.',
                 'action_from': 'XML_Submissions',
                 'xform_id': self.xform.pk,
-                'userAgent': '',
                 'path': f'/{username}/submission',
                 'url': f'http://testserver/{username}/submission',
                 'ip': '127.0.0.1',

--- a/onadata/libs/utils/common_tags.py
+++ b/onadata/libs/utils/common_tags.py
@@ -85,6 +85,7 @@ TEXTIT = 'textit'
 OSM = 'osm'
 SELECT_BIND_TYPE = 'string'
 MULTIPLE_SELECT_TYPE = 'select all that apply'
+REPEAT_SELECT_TYPE = 'repeat'
 GROUPNAME_REMOVED_FLAG = 'group-name-removed'
 DATAVIEW_EXPORT = U'dataview'
 OWNER_TEAM_NAME = "Owners"


### PR DESCRIPTION
### Changes / Features implemented

- Initial support for tracking submissions with Segment. PR #1872
- Add caching to the organization profile viewset. PR #1876
- Include support for repeat groups in the Tableau-Onadata integration. PR #1845
- Enketo integration updates. PR #1857 
- Unpack GPS data into separate columns for altitude, precision, latitude, and longitude. PR #1880

### Steps taken to verify this change does what is intended

- [x] QA
