### PR TITLE
Fix generation of enketo edit urls

### DIFF
--- a/onadata/apps/api/tests/viewsets/test_data_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_data_viewset.py
@@ -1169,8 +1169,8 @@ class TestDataViewSet(TestBase):
             self.assertEqual(
                 response.data['url'],
                 "https://hmh2a.enketo.ona.io/edit/XA0bG8Df?instance_id="
-                "672927e3-9ad4-42bb-9538-388ea1fb6699&returnUrl=http://test.io/"
-                "test_url")
+                "672927e3-9ad4-42bb-9538-388ea1fb6699&returnUrl=http://test"
+                ".io/test_url")
 
         with HTTMock(enketo_mock_http_413):
             response = view(request, pk=formid, dataid=dataid)

--- a/onadata/apps/api/tests/viewsets/test_data_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_data_viewset.py
@@ -43,10 +43,13 @@ from onadata.libs.utils.logger_tools import create_instance
 
 
 @urlmatch(netloc=r'(.*\.)?enketo\.ona\.io$')
-def enketo_mock(url, request):
+def enketo_edit_mock(url, request):
     response = requests.Response()
     response.status_code = 201
-    response._content = '{"url": "https://hmh2a.enketo.ona.io"}'
+    response._content = (
+        '{"edit_url": "https://hmh2a.enketo.ona.io/edit/XA0bG8D'
+        'f?instance_id=672927e3-9ad4-42bb-9538-388ea1fb6699&retu'
+        'rnUrl=http://test.io/test_url", "code": 201}')
     return response
 
 
@@ -1161,11 +1164,13 @@ class TestDataViewSet(TestBase):
             '/',
             data={'return_url': "http://test.io/test_url"}, **self.extra)
 
-        with HTTMock(enketo_mock):
+        with HTTMock(enketo_edit_mock):
             response = view(request, pk=formid, dataid=dataid)
             self.assertEqual(
                 response.data['url'],
-                "https://hmh2a.enketo.ona.io")
+                "https://hmh2a.enketo.ona.io/edit/XA0bG8Df?instance_id="
+                "672927e3-9ad4-42bb-9538-388ea1fb6699&returnUrl=http://test.io/"
+                "test_url")
 
         with HTTMock(enketo_mock_http_413):
             response = view(request, pk=formid, dataid=dataid)

--- a/onadata/apps/api/viewsets/data_viewset.py
+++ b/onadata/apps/api/viewsets/data_viewset.py
@@ -272,8 +272,11 @@ class DataViewSet(AnonymousUserPublicFormsMixin,
                     data = get_enketo_urls(
                         form_url,
                         self.object.xform.id_string,
-                        return_url)
-
+                        instance_id=self.object.uuid,
+                        instance_xml=self.object.xml,
+                        return_url=return_url)
+                    if "edit_url" in data:
+                        data["url"] = data.pop("edit_url")
                 except EnketoError as e:
                     raise ParseError(text(e))
             else:


### PR DESCRIPTION
### Changes / Features implemented

- Use `instance_id` and `instance_xml` when generating edit url

### Steps taken to verify this change does what is intended

- Update tests
- QA

### Side effects of implementing this change

- N/A