### PR TITLE
Organization profile caching fixes

### DIFF
--- a/onadata/apps/api/tests/viewsets/test_user_profile_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_user_profile_viewset.py
@@ -251,7 +251,7 @@ class TestUserProfileViewSet(TestAbstractViewSet):
         request = self.factory.get('/')
         response = view(request, user=self.company_data['org'])
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.data['first_name'],
+        self.assertEqual(response.data['name'],
                          self.company_data['name'])
         self.assertIn('is_org', response.data)
         self.assertEqual(response.data['is_org'], True)

--- a/onadata/apps/api/viewsets/user_profile_viewset.py
+++ b/onadata/apps/api/viewsets/user_profile_viewset.py
@@ -37,7 +37,8 @@ from onadata.libs.utils.email import (get_verification_email_data,
 from onadata.libs.utils.cache_tools import (safe_delete,
                                             CHANGE_PASSWORD_ATTEMPTS,
                                             LOCKOUT_CHANGE_PASSWORD_USER,
-                                            USER_PROFILE_PREFIX)
+                                            USER_PROFILE_PREFIX,
+                                            ORG_PROFILE_CACHE)
 from onadata.libs import filters
 from onadata.libs.utils.user_auth import invalidate_and_regen_tokens
 from onadata.libs.mixins.authenticate_header_mixin import \
@@ -210,6 +211,8 @@ class UserProfileViewSet(
         """ Get user profile from cache or db """
         username = kwargs.get('user')
         cached_user = cache.get(f'{USER_PROFILE_PREFIX}{username}')
+        if not cached_user:
+            cached_user = cache.get(f'{ORG_PROFILE_CACHE}{username}')
         if cached_user:
             return Response(cached_user)
         response = super(UserProfileViewSet, self)\

--- a/onadata/libs/serializers/organization_serializer.py
+++ b/onadata/libs/serializers/organization_serializer.py
@@ -32,6 +32,7 @@ class OrganizationSerializer(serializers.HyperlinkedModelSerializer):
     creator = serializers.HyperlinkedRelatedField(
         view_name='user-detail', lookup_field='username', read_only=True)
     users = serializers.SerializerMethodField()
+    is_org = serializers.SerializerMethodField()
     metadata = JsonField(required=False)
     name = serializers.CharField(max_length=30)
 
@@ -134,3 +135,6 @@ class OrganizationSerializer(serializers.HyperlinkedModelSerializer):
         owners_list = create_user_list(owners)
 
         return owners_list + members_list
+
+    def get_is_org(self, obj):
+        return obj.is_organization


### PR DESCRIPTION
### Changes / Features implemented
- Add `is_org` SerializerMethodField to OrganizationSerializer
- Checked for cached organization profile in `retrieve` method of `UserProfileViewSet`
### Steps taken to verify this change does what is intended
- Tested locally
Closes https://github.com/onaio/onadata/issues/1898
