### PR TITLE
Project forms caching

### DIFF
--- a/onadata/apps/api/tests/viewsets/test_project_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_project_viewset.py
@@ -531,6 +531,13 @@ class TestProjectViewSet(TestAbstractViewSet):
         self._project_create({'name': project_name})
         self.assertTrue(self.project.name == project_name)
 
+        # Check previous form data
+        request = self.factory.get('/', **self.extra)
+        response = view(request, pk=old_project.pk)
+        self.assertEqual(response.status_code, 200)
+        old_project_form_count = len(response.data.get('forms'))
+        old_project_num_datasets = response.data.get('num_datasets')
+
         project_id = self.project.pk
         post_data = {'formid': formid}
         request = self.factory.post('/', data=post_data, **self.extra)
@@ -542,8 +549,19 @@ class TestProjectViewSet(TestAbstractViewSet):
         # check if form added appears in the project details
         request = self.factory.get('/', **self.extra)
         response = view(request, pk=self.project.pk)
+        self.assertEqual(response.status_code, 200)
         self.assertIn('forms', list(response.data))
         self.assertEqual(len(response.data['forms']), 1)
+
+        # Ensure forms list & num_datasets value of previous project was
+        # updated
+        request = self.factory.get('/', **self.extra)
+        response = view(request, pk=old_project.pk)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            len(response.data.get('forms')), old_project_form_count - 1)
+        self.assertEqual(
+            response.data.get('num_datasets'), old_project_num_datasets - 1)
 
     def test_project_manager_can_assign_form_to_project(self):
         view = ProjectViewSet.as_view({

--- a/onadata/apps/api/viewsets/project_viewset.py
+++ b/onadata/apps/api/viewsets/project_viewset.py
@@ -58,6 +58,15 @@ class ProjectViewSet(AuthenticateHeaderMixin,
                        ProjectOwnerFilter,
                        TagFilter)
 
+    def _clear_project_cache(self, object_id: int = None) -> None:
+        """
+        Clear all project related cache entries
+        """
+        project_id = object_id or self.get_object().pk
+        safe_delete('{}{}'.format(PROJ_FORMS_CACHE, project_id))
+        safe_delete('{}{}'.format(PROJ_BASE_FORMS_CACHE, project_id))
+        safe_delete('{}{}'.format(PROJ_OWNER_CACHE, project_id))
+
     def get_serializer_class(self):
         action = self.action
 
@@ -185,7 +194,7 @@ class ProjectViewSet(AuthenticateHeaderMixin,
                             status=status.HTTP_400_BAD_REQUEST)
 
         # clear cache
-        safe_delete(f'{PROJ_OWNER_CACHE}{self.object.pk}')
+        self._clear_project_cache()
 
         return Response(status=status.HTTP_204_NO_CONTENT)
 

--- a/onadata/apps/logger/models/xform.py
+++ b/onadata/apps/logger/models/xform.py
@@ -1024,6 +1024,7 @@ def set_object_permissions(sender, instance=None, created=False, **kwargs):
     # clear cache
     safe_delete('{}{}'.format(PROJ_FORMS_CACHE, instance.project.pk))
     safe_delete('{}{}'.format(PROJ_BASE_FORMS_CACHE, instance.project.pk))
+    safe_delete('{}{}'.format(PROJ_OWNER_CACHE, instance.project.pk))
     safe_delete('{}{}'.format(IS_ORG, instance.pk))
 
     if created:


### PR DESCRIPTION
### Changes / Features implemented

- Set cache immediately after form upload; Ensures that the cached value is always up to date with what is on master, avoiding the creation of an outdated cached version of the forms information on subsequent GET requests(Mostly happens when GET requests are made instantly after the creation of a form in master-read replica deployments).

### Steps taken to verify this change does what is intended

### Side effects of implementing this change

Closes #
