### PR TITLE
Project Viewset: Caching refactor

### DIFF
--- a/onadata/apps/api/tests/viewsets/test_project_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_project_viewset.py
@@ -70,6 +70,10 @@ class TestProjectViewSet(TestAbstractViewSet):
             'post': 'create'
         })
 
+    def tearDown(self):
+        cache.clear()
+        super(TestProjectViewSet, self).tearDown()
+
     @patch('onadata.apps.main.forms.urlopen')
     def test_publish_xlsform_using_url_upload(self, mock_urlopen):
         with HTTMock(enketo_mock):

--- a/onadata/apps/api/tests/viewsets/test_project_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_project_viewset.py
@@ -535,6 +535,13 @@ class TestProjectViewSet(TestAbstractViewSet):
         self._project_create({'name': project_name})
         self.assertTrue(self.project.name == project_name)
 
+        request = self.factory.get('/', **self.extra)
+        response = view(request, pk=old_project.pk)
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('forms', list(response.data))
+        old_project_form_count = len(response.data['forms'])
+        old_project_num_datasets = response.data['num_datasets']
+
         project_id = self.project.pk
         post_data = {'formid': formid}
         request = self.factory.post('/', data=post_data, **self.extra)
@@ -548,6 +555,17 @@ class TestProjectViewSet(TestAbstractViewSet):
         response = view(request, pk=self.project.pk)
         self.assertIn('forms', list(response.data))
         self.assertEqual(len(response.data['forms']), 1)
+        self.assertEqual(response.data['num_datasets'], 1)
+
+        # Check if form transferred doesn't appear in the old project
+        # details
+        request = self.factory.get('/', **self.extra)
+        response = view(request, pk=old_project.pk)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            len(response.data['forms']), old_project_form_count - 1)
+        self.assertEqual(
+            response.data['num_datasets'], old_project_num_datasets - 1)
 
     def test_project_manager_can_assign_form_to_project(self):
         view = ProjectViewSet.as_view({

--- a/onadata/apps/api/tools.py
+++ b/onadata/apps/api/tools.py
@@ -46,7 +46,7 @@ from onadata.libs.permissions import (
 from onadata.libs.utils.api_export_tools import custom_response_handler
 from onadata.libs.utils.cache_tools import (
     PROJ_BASE_FORMS_CACHE, PROJ_FORMS_CACHE, PROJ_NUM_DATASET_CACHE,
-    PROJ_OWNER_CACHE, PROJ_SUB_DATE_CACHE, safe_delete)
+    PROJ_OWNER_CACHE, PROJ_SUB_DATE_CACHE, reset_project_cache, safe_delete)
 from onadata.libs.utils.common_tags import MEMBERS, XFORM_META_PERMS
 from onadata.libs.utils.logger_tools import (publish_form,
                                              response_with_mimetype_and_name)
@@ -457,6 +457,7 @@ def publish_project_xform(request, project):
     else:
         xform = publish_form(set_form)
 
+    reset_project_cache(xform.project, request)
     return xform
 
 

--- a/onadata/apps/api/tools.py
+++ b/onadata/apps/api/tools.py
@@ -457,7 +457,8 @@ def publish_project_xform(request, project):
     else:
         xform = publish_form(set_form)
 
-    reset_project_cache(xform.project, request)
+    if isinstance(xform, XForm):
+        reset_project_cache(xform.project, request)
     return xform
 
 

--- a/onadata/apps/api/tools.py
+++ b/onadata/apps/api/tools.py
@@ -45,7 +45,8 @@ from onadata.libs.permissions import (
     get_role_in_org, is_organization)
 from onadata.libs.utils.api_export_tools import custom_response_handler
 from onadata.libs.utils.cache_tools import (
-    PROJ_BASE_FORMS_CACHE, PROJ_FORMS_CACHE, PROJ_OWNER_CACHE, safe_delete)
+    PROJ_BASE_FORMS_CACHE, PROJ_FORMS_CACHE, PROJ_NUM_DATASET_CACHE,
+    PROJ_OWNER_CACHE, PROJ_SUB_DATE_CACHE, safe_delete)
 from onadata.libs.utils.common_tags import MEMBERS, XFORM_META_PERMS
 from onadata.libs.utils.logger_tools import (publish_form,
                                              response_with_mimetype_and_name)
@@ -422,6 +423,8 @@ def publish_project_xform(request, project):
         safe_delete('{}{}'.format(PROJ_OWNER_CACHE, xform.project.pk))
         safe_delete('{}{}'.format(PROJ_FORMS_CACHE, xform.project.pk))
         safe_delete('{}{}'.format(PROJ_BASE_FORMS_CACHE, xform.project.pk))
+        safe_delete('{}{}'.format(PROJ_NUM_DATASET_CACHE, xform.project.pk))
+        safe_delete('{}{}'.format(PROJ_SUB_DATE_CACHE, xform.project.pk))
         if not ManagerRole.user_has_role(request.user, xform):
             raise exceptions.PermissionDenied(
                 _("{} has no manager/owner role to the form {}".format(

--- a/onadata/apps/api/viewsets/project_viewset.py
+++ b/onadata/apps/api/viewsets/project_viewset.py
@@ -90,8 +90,6 @@ class ProjectViewSet(AuthenticateHeaderMixin,
         self.object = self.get_object()
         serializer = ProjectSerializer(
             self.object, context={'request': request})
-        cache.set(f'{PROJ_OWNER_CACHE}{self.object.pk}', serializer.data)
-
         return Response(serializer.data)
 
     @action(methods=['POST', 'GET'], detail=True)
@@ -119,9 +117,6 @@ class ProjectViewSet(AuthenticateHeaderMixin,
 
                 if str_to_bool(published_by_formbuilder):
                     MetaData.published_by_formbuilder(survey, 'True')
-
-                # clear project from cache
-                safe_delete(f'{PROJ_OWNER_CACHE}{survey.project.pk}')
 
                 return Response(serializer.data,
                                 status=status.HTTP_201_CREATED)

--- a/onadata/apps/logger/models/instance.py
+++ b/onadata/apps/logger/models/instance.py
@@ -175,6 +175,9 @@ def update_xform_submission_count(instance_id, created):
             safe_delete('{}{}'.format(XFORM_DATA_VERSIONS, instance.xform_id))
             safe_delete('{}{}'.format(DATAVIEW_COUNT, instance.xform_id))
             safe_delete('{}{}'.format(XFORM_COUNT, instance.xform_id))
+            # Clear project cache
+            from onadata.apps.logger.models.xform import clear_project_cache
+            clear_project_cache(instance.xform.project_id)
 
 
 def update_xform_submission_count_delete(sender, instance, **kwargs):

--- a/onadata/apps/logger/models/xform.py
+++ b/onadata/apps/logger/models/xform.py
@@ -1020,10 +1020,17 @@ post_delete.connect(
     dispatch_uid='update_profile_num_submissions')
 
 
+def clear_project_cache(project_id):
+    safe_delete('{}{}'.format(PROJ_OWNER_CACHE, project_id))
+    safe_delete('{}{}'.format(PROJ_FORMS_CACHE, project_id))
+    safe_delete('{}{}'.format(PROJ_BASE_FORMS_CACHE, project_id))
+    safe_delete('{}{}'.format(PROJ_SUB_DATE_CACHE, project_id))
+    safe_delete('{}{}'.format(PROJ_NUM_DATASET_CACHE, project_id))
+
+
 def set_object_permissions(sender, instance=None, created=False, **kwargs):
     # clear cache
-    safe_delete('{}{}'.format(PROJ_FORMS_CACHE, instance.project.pk))
-    safe_delete('{}{}'.format(PROJ_BASE_FORMS_CACHE, instance.project.pk))
+    clear_project_cache(instance.project.pk)
     safe_delete('{}{}'.format(IS_ORG, instance.pk))
 
     if created:
@@ -1052,11 +1059,7 @@ pre_save.connect(save_project, sender=XForm, dispatch_uid='save_project_xform')
 
 def xform_post_delete_callback(sender, instance, **kwargs):
     if instance.project_id:
-        safe_delete('{}{}'.format(PROJ_OWNER_CACHE, instance.project_id))
-        safe_delete('{}{}'.format(PROJ_FORMS_CACHE, instance.project_id))
-        safe_delete('{}{}'.format(PROJ_BASE_FORMS_CACHE, instance.project.pk))
-        safe_delete('{}{}'.format(PROJ_SUB_DATE_CACHE, instance.project_id))
-        safe_delete('{}{}'.format(PROJ_NUM_DATASET_CACHE, instance.project_id))
+        clear_project_cache(instance.project_id)
 
 
 post_delete.connect(

--- a/onadata/libs/tests/utils/test_cache_tools.py
+++ b/onadata/libs/tests/utils/test_cache_tools.py
@@ -2,9 +2,17 @@
 """
 Test onadata.libs.utils.cache_tools module.
 """
+from django.core.cache import cache
+from django.contrib.auth.models import User
+from django.http.request import HttpRequest
 from unittest import TestCase
 
-from onadata.libs.utils.cache_tools import safe_key
+from onadata.apps.main.models.user_profile import UserProfile
+from onadata.apps.logger.models.project import Project
+from onadata.libs.utils.cache_tools import (
+    PROJ_PERM_CACHE, PROJ_NUM_DATASET_CACHE, PROJ_SUB_DATE_CACHE,
+    PROJ_FORMS_CACHE, PROJ_BASE_FORMS_CACHE, PROJ_OWNER_CACHE,
+    safe_key, reset_project_cache, project_cache_prefixes)
 
 
 class TestCacheTools(TestCase):
@@ -15,3 +23,74 @@ class TestCacheTools(TestCase):
         self.assertEqual(
             safe_key("hello world"),
             "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9")
+
+    def test_reset_project_cache(self):
+        """
+        Test reset_project_cache() function actually resets all project cache
+        entries
+        """
+        bob = User.objects.create(username='bob', first_name='bob')
+        UserProfile.objects.create(user=bob)
+        project = Project.objects.create(
+            name='Some Project', created_by=bob, organization=bob)
+
+        # Set dummy values in cache
+        for prefix in project_cache_prefixes:
+            cache.set(f'{prefix}{project.pk}', 'stale')
+
+        request = HttpRequest()
+        request.user = bob
+        request.META = {
+            'SERVER_NAME': 'testserver',
+            'SERVER_PORT': '80'
+        }
+        reset_project_cache(project, request)
+
+        expected_project_cache = {
+            'url': f'http://testserver/api/v1/projects/{project.pk}',
+            'projectid': project.pk,
+            'owner': 'http://testserver/api/v1/users/bob',
+            'created_by': 'http://testserver/api/v1/users/bob',
+            'metadata': {},
+            'starred': False,
+            'users': [{
+                'is_org': False,
+                'metadata': {},
+                'first_name': 'bob',
+                'last_name': '',
+                'user': 'bob',
+                'role': 'owner'
+            }],
+            'forms': [],
+            'public': False,
+            'tags': [],
+            'num_datasets': 0,
+            'last_submission_date': None,
+            'teams': [],
+            'data_views': [],
+            'name': 'Some Project',
+            'deleted_at': None
+        }
+
+        self.assertEqual(
+            cache.get(f'{PROJ_PERM_CACHE}{project.pk}'),
+            expected_project_cache['users'])
+        self.assertEqual(
+            cache.get(f'{PROJ_NUM_DATASET_CACHE}{project.pk}'),
+            expected_project_cache['num_datasets'])
+        self.assertEqual(
+            cache.get(f'{PROJ_SUB_DATE_CACHE}{project.pk}'),
+            expected_project_cache['last_submission_date'])
+        self.assertEqual(
+            cache.get(f'{PROJ_FORMS_CACHE}{project.pk}'),
+            expected_project_cache['forms'])
+        self.assertEqual(
+            cache.get(f'{PROJ_BASE_FORMS_CACHE}{project.pk}'),
+            None)
+
+        project_cache = cache.get(f'{PROJ_OWNER_CACHE}{project.pk}')
+        project_cache.pop('date_created')
+        project_cache.pop('date_modified')
+        self.assertEqual(
+            project_cache,
+            expected_project_cache)

--- a/onadata/libs/utils/cache_tools.py
+++ b/onadata/libs/utils/cache_tools.py
@@ -54,7 +54,7 @@ def safe_key(key):
 
 def reset_project_cache(project, request):
     """
-    Clears and updates project cache
+    Clears and sets project cache
     """
     from onadata.libs.serializers.project_serializer import ProjectSerializer
 

--- a/onadata/libs/utils/cache_tools.py
+++ b/onadata/libs/utils/cache_tools.py
@@ -10,6 +10,9 @@ PROJ_SUB_DATE_CACHE = "ps-last_submission_date-"
 PROJ_FORMS_CACHE = "ps-project_forms-"
 PROJ_BASE_FORMS_CACHE = "ps-project_base_forms-"
 PROJ_OWNER_CACHE = "ps-project_owner-"
+project_cache_prefixes = [PROJ_PERM_CACHE, PROJ_NUM_DATASET_CACHE,
+                          PROJ_SUB_DATE_CACHE, PROJ_FORMS_CACHE,
+                          PROJ_BASE_FORMS_CACHE, PROJ_OWNER_CACHE]
 
 # Cache names used in user_profile_serializer
 IS_ORG = "ups-is_org-"
@@ -47,3 +50,20 @@ def safe_delete(key):
 def safe_key(key):
     """Return a hashed key."""
     return hashlib.sha256(force_bytes(key)).hexdigest()
+
+
+def reset_project_cache(project, request):
+    """
+    Clears and updates project cache
+    """
+    from onadata.libs.serializers.project_serializer import ProjectSerializer
+
+    # Clear all project cache entries
+    for prefix in project_cache_prefixes:
+        safe_delete(f'{prefix}{project.pk}')
+
+    # Reserialize project and cache value
+    # Note: The ProjectSerializer sets all the other cache entries
+    project_cache_data = ProjectSerializer(
+        project, context={'request': request}).data
+    cache.set(f'{PROJ_OWNER_CACHE}{project.pk}', project_cache_data)


### PR DESCRIPTION
### Changes / Features implemented

- Fix an issue where the `num_datasets` value of a project was not updated when a form that used to belong to that form is transferred
- Add `reset_project_cache` utility function
- Re-sets project cache immediately after a new form is uploaded to a project
- Clears project cache on Instance & XForm creation

### Steps taken to verify this change does what is intended

- Added / Updated tests

### Side effects of implementing this change

- Projects will have their caches re-set immediately after a form is uploaded
- Projects cache will be cleared on XForm save & delete actions as well as on Instance save

Closes #1903
