### PR TITLE
Downgrade celery requirement

### DIFF
--- a/onadata/settings/common.py
+++ b/onadata/settings/common.py
@@ -430,7 +430,6 @@ THUMB_ORDER = ['large', 'medium', 'small']
 DEFAULT_IMG_FILE_TYPE = 'jpg'
 
 # celery
-CELERY_RESULT_BACKEND = 'django-db'
 CELERY_TASK_ALWAYS_EAGER = False
 CELERY_TASK_IGNORE_RESULT = False
 CELERY_TASK_TRACK_STARTED = True

--- a/requirements/base.pip
+++ b/requirements/base.pip
@@ -11,7 +11,7 @@
 -e git+https://github.com/onaio/python-digest.git@3af1bd0ef6114e24bf23d0e8fd9d7ebf389845d1#egg=python-digest  # via -r requirements/base.in
 -e git+https://github.com/onaio/python-json2xlsclient.git@62b4645f7b4f2684421a13ce98da0331a9dd66a0#egg=python-json2xlsclient  # via -r requirements/base.in
 alabaster==0.7.12         # via sphinx
-amqp==5.0.1               # via kombu
+amqp==2.6.1               # via kombu
 analytics-python==1.2.9   # via onadata
 appoptics-metrics==5.1.0  # via onadata
 argparse==1.4.0           # via unittest2
@@ -21,13 +21,11 @@ billiard==3.6.3.0         # via celery
 boto3==1.15.17            # via tabulator
 botocore==1.18.17         # via boto3, s3transfer
 cached-property==1.5.2    # via tableschema
-celery==5.0.1             # via onadata
+celery==4.4.7             # via onadata
 certifi==2020.6.20        # via requests
 cffi==1.14.3              # via cryptography
 chardet==3.0.4            # via datapackage, requests, tabulator
-click-didyoumean==0.0.3   # via celery
-click-repl==0.1.6         # via celery
-click==7.1.2              # via celery, click-didyoumean, click-repl, datapackage, tableschema, tabulator
+click==7.1.2              # via datapackage, tableschema, tabulator
 cryptography==3.1.1       # via onadata
 datapackage==1.15.1       # via pyfloip
 defusedxml==0.6.0         # via djangorestframework-xml
@@ -68,7 +66,7 @@ httplib2==0.18.1          # via oauth2client, onadata
 idna==2.10                # via requests
 ijson==3.1.2              # via tabulator
 imagesize==1.2.0          # via sphinx
-importlib-metadata==2.0.0  # via flake8, jsonpickle, jsonschema, kombu, markdown
+importlib-metadata==2.0.0  # via jsonpickle
 inflection==0.5.1         # via djangorestframework-jsonapi
 isodate==0.6.0            # via tableschema
 jdcal==1.4.1              # via openpyxl
@@ -79,7 +77,7 @@ jsonlines==1.2.0          # via tabulator
 jsonpickle==1.4.1         # via onadata
 jsonpointer==2.0          # via datapackage
 jsonschema==3.2.0         # via datapackage, tableschema
-kombu==5.0.2              # via celery
+kombu==4.6.11             # via celery
 linear-tsv==1.1.0         # via tabulator
 linecache2==1.0.0         # via traceback2
 lxml==4.5.2               # via onadata
@@ -95,7 +93,6 @@ openpyxl==3.0.5           # via onadata, tabulator
 packaging==20.4           # via sphinx
 paho-mqtt==1.5.1          # via onadata
 pillow==8.0.0             # via elaphe3, onadata
-prompt-toolkit==3.0.8     # via click-repl
 psycopg2==2.8.6           # via onadata
 pyasn1-modules==0.2.8     # via oauth2client
 pyasn1==0.4.8             # via oauth2client, pyasn1-modules, rsa
@@ -121,7 +118,7 @@ rsa==4.6                  # via oauth2client
 s3transfer==0.3.3         # via boto3
 savreaderwriter==3.4.2    # via onadata
 simplejson==3.17.2        # via onadata
-six==1.15.0               # via analytics-python, appoptics-metrics, click-repl, cryptography, datapackage, django-query-builder, django-templated-email, djangorestframework-csv, formencode, isodate, jsonlines, jsonschema, linear-tsv, oauth2client, packaging, python-dateutil, python-memcached, requests-mock, tableschema, tabulator, unittest2
+six==1.15.0               # via analytics-python, appoptics-metrics, cryptography, datapackage, django-query-builder, django-templated-email, djangorestframework-csv, formencode, isodate, jsonlines, jsonschema, linear-tsv, oauth2client, packaging, python-dateutil, python-memcached, requests-mock, tableschema, tabulator, unittest2
 snowballstemmer==2.0.0    # via sphinx
 sphinx==3.2.1             # via onadata
 sphinxcontrib-applehelp==1.0.2  # via sphinx
@@ -139,8 +136,7 @@ unicodecsv==0.14.1        # via datapackage, djangorestframework-csv, onadata, p
 unittest2==1.1.0          # via pyxform
 urllib3==1.25.10          # via botocore, requests
 uwsgi==2.0.19.1           # via onadata
-vine==5.0.0               # via amqp, celery
-wcwidth==0.2.5            # via prompt-toolkit
+vine==1.3.0               # via amqp, celery
 xlrd==1.2.0               # via onadata, pyxform, tabulator
 xlwt==1.3.0               # via onadata
 zipp==3.3.1               # via importlib-metadata

--- a/requirements/dev.pip
+++ b/requirements/dev.pip
@@ -11,7 +11,7 @@
 -e git+https://github.com/onaio/python-digest.git@3af1bd0ef6114e24bf23d0e8fd9d7ebf389845d1#egg=python-digest  # via -r requirements/base.in
 -e git+https://github.com/onaio/python-json2xlsclient.git@62b4645f7b4f2684421a13ce98da0331a9dd66a0#egg=python-json2xlsclient  # via -r requirements/base.in
 alabaster==0.7.12         # via sphinx
-amqp==5.0.1               # via kombu
+amqp==2.6.1               # via kombu
 analytics-python==1.2.9   # via onadata
 appnope==0.1.0            # via ipython
 appoptics-metrics==5.1.0  # via onadata
@@ -24,13 +24,11 @@ billiard==3.6.3.0         # via celery
 boto3==1.15.17            # via tabulator
 botocore==1.18.17         # via boto3, s3transfer
 cached-property==1.5.2    # via tableschema
-celery==5.0.1             # via onadata
+celery==4.4.7             # via onadata
 certifi==2020.6.20        # via requests
 cffi==1.14.3              # via cryptography
 chardet==3.0.4            # via datapackage, requests, tabulator
-click-didyoumean==0.0.3   # via celery
-click-repl==0.1.6         # via celery
-click==7.1.2              # via celery, click-didyoumean, click-repl, datapackage, tableschema, tabulator
+click==7.1.2              # via datapackage, tableschema, tabulator
 cryptography==3.1.1       # via onadata
 datapackage==1.15.1       # via pyfloip
 decorator==4.4.2          # via ipython
@@ -73,7 +71,7 @@ httplib2==0.18.1          # via oauth2client, onadata
 idna==2.10                # via requests
 ijson==3.1.2              # via tabulator
 imagesize==1.2.0          # via sphinx
-importlib-metadata==2.0.0  # via flake8, jsonpickle, jsonschema, kombu, markdown
+importlib-metadata==2.0.0  # via jsonpickle
 inflection==0.5.1         # via djangorestframework-jsonapi
 ipdb==0.13.4              # via -r requirements/dev.in
 ipython-genutils==0.2.0   # via traitlets
@@ -89,7 +87,7 @@ jsonlines==1.2.0          # via tabulator
 jsonpickle==1.4.1         # via onadata
 jsonpointer==2.0          # via datapackage
 jsonschema==3.2.0         # via datapackage, tableschema
-kombu==5.0.2              # via celery
+kombu==4.6.11             # via celery
 lazy-object-proxy==1.5.1  # via astroid
 linear-tsv==1.1.0         # via tabulator
 linecache2==1.0.0         # via traceback2
@@ -109,7 +107,7 @@ parso==0.7.1              # via jedi
 pexpect==4.8.0            # via ipython
 pickleshare==0.7.5        # via ipython
 pillow==8.0.0             # via elaphe3, onadata
-prompt-toolkit==3.0.8     # via click-repl, ipython
+prompt-toolkit==3.0.8     # via ipython
 psycopg2==2.8.6           # via onadata
 ptyprocess==0.6.0         # via pexpect
 pyasn1-modules==0.2.8     # via oauth2client
@@ -139,7 +137,7 @@ rsa==4.6                  # via oauth2client
 s3transfer==0.3.3         # via boto3
 savreaderwriter==3.4.2    # via onadata
 simplejson==3.17.2        # via onadata
-six==1.15.0               # via analytics-python, appoptics-metrics, astroid, click-repl, cryptography, datapackage, django-query-builder, django-templated-email, djangorestframework-csv, formencode, isodate, jsonlines, jsonschema, linear-tsv, oauth2client, packaging, pylint, python-dateutil, python-memcached, requests-mock, tableschema, tabulator, unittest2
+six==1.15.0               # via analytics-python, appoptics-metrics, astroid, cryptography, datapackage, django-query-builder, django-templated-email, djangorestframework-csv, formencode, isodate, jsonlines, jsonschema, linear-tsv, oauth2client, packaging, pylint, python-dateutil, python-memcached, requests-mock, tableschema, tabulator, unittest2
 snowballstemmer==2.0.0    # via sphinx
 sphinx==3.2.1             # via onadata
 sphinxcontrib-applehelp==1.0.2  # via sphinx
@@ -158,10 +156,11 @@ unicodecsv==0.14.1        # via datapackage, djangorestframework-csv, onadata, p
 unittest2==1.1.0          # via pyxform
 urllib3==1.25.10          # via botocore, requests
 uwsgi==2.0.19.1           # via onadata
-vine==5.0.0               # via amqp, celery
+vine==1.3.0               # via amqp, celery
 wcwidth==0.2.5            # via prompt-toolkit
 wrapt==1.12.1             # via astroid
 xlrd==1.2.0               # via onadata, pyxform, tabulator
 xlwt==1.3.0               # via onadata
 yapf==0.30.0              # via -r requirements/dev.in
 zipp==3.3.1               # via importlib-metadata
+

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
         "django-ordered-model",
         # generic relation
         "django-query-builder",
-        "celery",
+        "celery<5",
         # cors
         "django-cors-headers",
         "django-debug-toolbar",


### PR DESCRIPTION
#Changes / Features implemented

- Downgrade celery requirement. _Celery 5 is still not stable enough for us to move to it_

Partially reverts #1905 
