### PR TITLE
Data viewset retrieval optimisations

### DIFF
--- a/onadata/apps/api/viewsets/data_viewset.py
+++ b/onadata/apps/api/viewsets/data_viewset.py
@@ -529,7 +529,8 @@ class DataViewSet(AnonymousUserPublicFormsMixin,
                         xform, query=query, sort=sort, start_index=start,
                         limit=limit, fields=fields
                     )
-                    self.etag_hash = get_etag_hash_from_query(records, sql, params)
+                    self.etag_hash = get_etag_hash_from_query(
+                        records, sql, params)
         except ValueError as e:
             raise ParseError(text(e))
         except DataError as e:

--- a/onadata/libs/pagination.py
+++ b/onadata/libs/pagination.py
@@ -1,7 +1,56 @@
-from rest_framework.pagination import PageNumberPagination
+from django.core.paginator import Paginator
+from rest_framework.pagination import PageNumberPagination, InvalidPage, NotFound
 
 
 class StandardPageNumberPagination(PageNumberPagination):
     page_size = 1000
     page_size_query_param = 'page_size'
     max_page_size = 10000
+
+
+class CountOverridablePaginator(Paginator):
+    def __init__(
+            self, object_list, per_page,
+            orphans: int = 0, allow_empty_first_page: bool = True,
+            count_override: int = None) -> None:
+        self.count_override = count_override
+        super().__init__(
+            object_list, per_page,
+            orphans=orphans, allow_empty_first_page=allow_empty_first_page)
+
+    @property
+    def count(self):
+        if self.count_override:
+            return self.count_override
+        return super().count
+
+
+class CountOverridablePageNumberPagination(StandardPageNumberPagination):
+    django_paginator_class = CountOverridablePaginator
+
+    def paginate_queryset(self, queryset, request, view, count=None):
+        page_size = self.get_page_size(request)
+        if not page_size:
+            return None
+
+        paginator = self.django_paginator_class(
+            queryset,
+            page_size,
+            count_override=count
+        )
+        page_number = request.query_params.get(self.page_query_param, 1)
+        if page_number in self.last_page_strings:
+            page_number = paginator.num_pages
+
+        try:
+            self.page = paginator.page(page_number)
+        except InvalidPage as exc:
+            msg = self.invalid_page_message.format(page_number=page_number,
+                                                   message=str(exc))
+            raise NotFound(msg)
+
+        if paginator.num_pages > 1 and self.template is not None:
+            self.display_page_controls = True
+
+        self.request = request
+        return list(self.page)

--- a/onadata/libs/pagination.py
+++ b/onadata/libs/pagination.py
@@ -1,5 +1,6 @@
 from django.core.paginator import Paginator
-from rest_framework.pagination import PageNumberPagination, InvalidPage, NotFound
+from rest_framework.pagination import (
+    PageNumberPagination, InvalidPage, NotFound)
 
 
 class StandardPageNumberPagination(PageNumberPagination):


### PR DESCRIPTION
### Changes / Features implemented

- Introduced new `SUBMISSION_RETRIEVAL_THRESHOLD` setting
- Disable Queryset ordering after an XForms' submission count surpasses the `SUBMISSION_RETRIEVAL_THRESHOLD` setting
- Disable ETag functionality after an XForms' submission count surpasses the `SUBMISSION_RETRIEVAL_THRESHOLD` setting
- Add `CountOverridablePaginator` and `CountOverridablePageNumberPagination`
- Switch the default pagination class for the Data viewset to `CountOverridablePageNumberPagination`

### TODO

- Set a limit on the number of records that can be returned at one time when pagination is not used; _Separate PR... Will most likely break 3rd Party applications that rely on this functionality_

### Steps taken to verify this change does what is intended

- N/A

### Side effects of implementing this change

- After a certain threshold data retrieval (even via pagination) is not ordered and the ETag functionality is disabled