### PR TITLE
Clear cache and refresh user profile on email verification

### DIFF
--- a/onadata/apps/api/tests/viewsets/test_user_profile_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_user_profile_viewset.py
@@ -205,24 +205,6 @@ class TestUserProfileViewSet(TestAbstractViewSet):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data, self.user_profile_data())
 
-    def test_retrieve_user_profile_from_cache(self):
-        """
-        Test that user_profiles are cached on retrieve
-        """
-        view = UserProfileViewSet.as_view({
-            'get': 'retrieve'
-        })
-
-        # clear cache
-        cache.delete(safe_key(f'{USER_PROFILE_PREFIX}bob'))
-
-        self.assertIsNone(cache.get(safe_key(f'{USER_PROFILE_PREFIX}bob')))
-
-        request = self.factory.get('/', **self.extra)
-        view(request, user='bob')
-
-        self.assertIsNotNone(cache.get(f'{USER_PROFILE_PREFIX}bob'))
-
     def test_profiles_get_anon(self):
         view = UserProfileViewSet.as_view({
             'get': 'retrieve'

--- a/onadata/apps/api/tests/viewsets/test_user_profile_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_user_profile_viewset.py
@@ -29,7 +29,6 @@ from onadata.apps.main.models.user_profile import \
 from onadata.libs.authentication import DigestAuthentication
 from onadata.libs.serializers.user_profile_serializer import \
     _get_first_last_names
-from onadata.libs.utils.cache_tools import USER_PROFILE_PREFIX, safe_key
 
 
 def _profile_data():

--- a/onadata/apps/api/viewsets/user_profile_viewset.py
+++ b/onadata/apps/api/viewsets/user_profile_viewset.py
@@ -100,7 +100,8 @@ def serializer_from_settings():
 
 
 def set_is_email_verified(profile, is_email_verified):
-    profile.metadata.update({"is_email_verified": is_email_verified})
+    profile.refresh_from_db()
+    profile.metadata.update({'is_email_verified': is_email_verified})
     profile.save()
 
 
@@ -214,7 +215,6 @@ class UserProfileViewSet(
             return Response(cached_user)
         response = super(UserProfileViewSet, self)\
             .retrieve(request, *args, **kwargs)
-        cache.set(f'{USER_PROFILE_PREFIX}{username}', response.data)
         return response
 
     def create(self, request, *args, **kwargs):

--- a/onadata/apps/api/viewsets/user_profile_viewset.py
+++ b/onadata/apps/api/viewsets/user_profile_viewset.py
@@ -347,9 +347,12 @@ class UserProfileViewSet(
                 rp.save()
 
                 set_is_email_verified(rp.user.profile, True)
+                username = rp.user.username
+                # Clear profiles cache
+                safe_delete(f'{USER_PROFILE_PREFIX}{username}')
 
                 response_data = {
-                    'username': rp.user.username,
+                    'username': username,
                     'is_email_verified': True
                 }
 


### PR DESCRIPTION
### Changes / Features implemented

- Refresh user profile from database before updating metadata
- Clear user-profiles cache on email verification

### Steps taken to verify this change does what is intended

- N/A

### Side effects of implementing this change

- N/A

Possible fix for #1948 
