### PR TITLE
XForm and Data ViewSet updates

### DIFF
--- a/docs/data.rst
+++ b/docs/data.rst
@@ -242,6 +242,9 @@ Paginate data of a specific form
 -------------------------------------------
 Returns a list of json submitted data for a specific form using page number and the number of items per page. Use the ``page`` parameter to specify page number and ``page_size`` parameter is used to set the custom page size.
 
+- ``page`` - Integer representing the page.
+- ``page_size`` - Integer representing the number of records that should be returned in a single page. *Has a maximum value of 10,000 records*
+
 Example
 ^^^^^^^^
 ::

--- a/onadata/apps/api/tests/viewsets/test_data_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_data_viewset.py
@@ -1740,7 +1740,9 @@ class TestDataViewSet(TestBase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data, data)
 
-    @patch('onadata.apps.api.viewsets.data_viewset.DataViewSet.paginate_queryset')
+    @patch(
+        'onadata.apps.api.viewsets.data_viewset'
+        '.DataViewSet.paginate_queryset')
     def test_retry_on_operational_error(self, mock_paginate_queryset):
         self._make_submissions()
         view = DataViewSet.as_view({'get': 'list'})
@@ -2345,7 +2347,8 @@ class TestDataViewSet(TestBase):
         self.assertEqual(
             form.submission_count_for_today, current_count)
 
-        # Confirm submission count isn't deleted if the date_created is different
+        # Confirm submission count isn't deleted if the
+        # date_created is different
         future_date = c_date - timedelta(days=1)
         inst_two.date_created = future_date
         inst_two.save()
@@ -2353,7 +2356,6 @@ class TestDataViewSet(TestBase):
         self.assertEqual(
             form.submission_count_for_today, current_count
         )
-
 
     def test_data_query_ornull(self):
         """

--- a/onadata/apps/api/tests/viewsets/test_data_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_data_viewset.py
@@ -2347,7 +2347,7 @@ class TestDataViewSet(TestBase):
         self.assertEqual(
             form.submission_count_for_today, current_count)
 
-        # Confirm submission count isn't deleted if the
+        # Confirm submission count isn't decreased if the
         # date_created is different
         future_date = c_date - timedelta(days=1)
         inst_two.date_created = future_date

--- a/onadata/apps/api/viewsets/data_viewset.py
+++ b/onadata/apps/api/viewsets/data_viewset.py
@@ -6,7 +6,7 @@ from django.conf import settings
 from django.core.exceptions import PermissionDenied
 from django.db.models import Q
 from django.db.models.query import QuerySet
-from django.db.utils import DataError
+from django.db.utils import DataError, OperationalError
 from django.http import Http404
 from django.http import StreamingHttpResponse
 from django.utils import six
@@ -554,7 +554,10 @@ class DataViewSet(AnonymousUserPublicFormsMixin,
         should_paginate = any([k in query_param_keys for k in pagination_keys])
         if not isinstance(self.object_list, types.GeneratorType) and \
                 should_paginate:
-            self.object_list = self.paginate_queryset(self.object_list)
+            try:
+                self.object_list = self.paginate_queryset(self.object_list)
+            except OperationalError:
+                self.object_list = self.paginate_queryset(self.object_list)
 
         STREAM_DATA = getattr(settings, 'STREAM_DATA', False)
         if STREAM_DATA:

--- a/onadata/libs/pagination.py
+++ b/onadata/libs/pagination.py
@@ -1,4 +1,5 @@
 from django.core.paginator import Paginator
+from django.conf import settings
 from rest_framework.pagination import (
     PageNumberPagination, InvalidPage, NotFound)
 
@@ -6,7 +7,8 @@ from rest_framework.pagination import (
 class StandardPageNumberPagination(PageNumberPagination):
     page_size = 1000
     page_size_query_param = 'page_size'
-    max_page_size = 10000
+    max_page_size = getattr(
+        settings, "STANDARD_PAGINATION_MAX_PAGE_SIZE", 10000)
 
 
 class CountOverridablePaginator(Paginator):

--- a/onadata/libs/serializers/xform_serializer.py
+++ b/onadata/libs/serializers/xform_serializer.py
@@ -36,6 +36,11 @@ from onadata.libs.utils.viewer_tools import (
     get_enketo_urls, get_form_url)
 
 
+SUBMISSION_RETRIEVAL_THRESHOLD = getattr(settings,
+                                         "SUBMISSION_RETRIEVAL_THRESHOLD",
+                                         10000)
+
+
 def _create_enketo_urls(request, xform):
     """
     Generate enketo urls for a form
@@ -388,6 +393,8 @@ class XFormSerializer(XFormMixin, serializers.HyperlinkedModelSerializer):
 
             if versions:
                 return versions
+            elif obj.num_of_submissions > SUBMISSION_RETRIEVAL_THRESHOLD:
+                return []
 
             versions = list(
                 Instance.objects.filter(xform=obj, deleted_at__isnull=True)

--- a/onadata/libs/serializers/xform_serializer.py
+++ b/onadata/libs/serializers/xform_serializer.py
@@ -28,7 +28,7 @@ from onadata.libs.serializers.tag_list_serializer import TagListSerializer
 from onadata.libs.utils.cache_tools import (
     ENKETO_PREVIEW_URL_CACHE, ENKETO_URL_CACHE, ENKETO_SINGLE_SUBMIT_URL_CACHE,
     XFORM_LINKED_DATAVIEWS, XFORM_METADATA_CACHE, XFORM_PERMISSIONS_CACHE,
-    XFORM_COUNT, XFORM_DATA_VERSIONS)
+    XFORM_DATA_VERSIONS, XFORM_COUNT)
 from onadata.libs.utils.common_tags import (GROUP_DELIMETER_TAG,
                                             REPEAT_INDEX_TAGS)
 from onadata.libs.utils.decorators import check_obj

--- a/onadata/libs/utils/cache_tools.py
+++ b/onadata/libs/utils/cache_tools.py
@@ -41,6 +41,10 @@ LOGIN_ATTEMPTS = "login_attempts-"
 LOCKOUT_CHANGE_PASSWORD_USER = 'lockout_change_password_user-'
 CHANGE_PASSWORD_ATTEMPTS = 'change_password_attempts-'
 
+# Cache names used in XForm Model
+XFORM_SUBMISSION_COUNT_FOR_DAY = "xfm-get_submission_count-"
+XFORM_SUBMISSION_COUNT_FOR_DAY_DATE = "xfm-get_submission_count_date-"
+
 
 def safe_delete(key):
     """Safely deletes a given key from the cache."""


### PR DESCRIPTION
### Changes / Features implemented

- Utilize stored `num_of_submissions` value instead of recalculating the value when User requests `XForm`
- Add ability to configure `max_page_size`
- Retry pagination when an `OperationalError` is raised
- Update documentation on the `page` and `page_size` query parameters
- Modify how `submission_count_for_today` is tracked/calculated

### Steps taken to verify this change does what is intended

- Added Tests

### Side effects of implementing this change


Closes #
