### PR TITLE
Handle TypeError raised when `current_count` value is None

### DIFF
--- a/onadata/apps/api/tests/viewsets/test_data_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_data_viewset.py
@@ -2339,8 +2339,9 @@ class TestDataViewSet(TestBase):
 
         # Confirm that the submission count is decreased
         # accordingly
-        inst_one = instances.first()
-        inst_two = instances.last()
+        inst_one = instances[0]
+        inst_two = instances[1]
+        inst_three = instances[2]
 
         inst_one.set_deleted()
         current_count -= 1
@@ -2356,6 +2357,11 @@ class TestDataViewSet(TestBase):
         self.assertEqual(
             form.submission_count_for_today, current_count
         )
+
+        # Check that deletes made with no current count cached
+        # are successful
+        cache.clear()
+        inst_three.set_deleted()
 
     def test_data_query_ornull(self):
         """

--- a/onadata/apps/logger/models/instance.py
+++ b/onadata/apps/logger/models/instance.py
@@ -169,7 +169,7 @@ def _update_submission_count_for_today(
         cache.set(count_cache_key, 1, 86400)
     elif incr:
         cache.incr(count_cache_key)
-    elif current_count > 0 and date_created == current_date:
+    elif current_count and current_count > 0 and date_created == current_date:
         cache.decr(count_cache_key)
 
 


### PR DESCRIPTION
### Changes / Features implemented

- Handle TypeError raised when `current_count` value is None

### Steps taken to verify this change does what is intended

- Updated Tests

### Side effects of implementing this change

- N/A

Solves: 

<img width="554" alt="Screenshot 2021-01-07 at 15 22 44" src="https://user-images.githubusercontent.com/25849009/103892187-32d91400-50fc-11eb-9392-e5c2b754d182.png">

https://sentry.onalabs.org/ona/onadata/issues/86687/?query=is%3Aunresolved

