### PR TITLE
Retrieve user profile using case insensitive username filter

### DIFF
--- a/onadata/apps/api/tests/viewsets/test_xform_list_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_xform_list_viewset.py
@@ -980,6 +980,30 @@ class TestXFormListViewSet(TestAbstractViewSet, TransactionTestCase):
             '/%s</manifestUrl>') % (self.user.username, self.xform.id)
         self.assertTrue(manifest_url in content)
 
+    def test_form_list_case_insensitivity(self):
+        """
+        Test that the <username>/formList endpoint utilizes the username in a
+        case insensitive manner
+        """
+        request = self.factory.get(
+            f'/{self.user.username}/formList', **self.extra)
+        response = self.view(request, username=self.user.username)
+        self.assertEqual(response.status_code, 200)
+
+        request = self.factory.get(
+            f'/{self.user.username.capitalize()}', **self.extra)
+        response_2 = self.view(
+            request, username=self.user.username.capitalize())
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data, response_2.data)
+
+        request = self.factory.get(
+            f'/{self.user.username.swapcase()}', **self.extra)
+        response_3 = self.view(
+            request, username=self.user.username.capitalize())
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data, response_3.data)
+
     def test_retrieve_form_using_pk(self):
         """
         Test formList endpoint utilizing primary key is able to retrieve

--- a/onadata/apps/api/viewsets/xform_list_viewset.py
+++ b/onadata/apps/api/viewsets/xform_list_viewset.py
@@ -82,7 +82,7 @@ class XFormListViewSet(ETagsMixin, BaseViewset,
         profile = None
         if username:
             profile = get_object_or_404(
-                UserProfile, user__username=username)
+                UserProfile, user__username__iexact=username)
         elif form_pk:
             queryset = queryset.filter(pk=form_pk)
             if queryset.first():


### PR DESCRIPTION
### Changes / Features implemented

- Retrieve user profile using case insensitive username filter

### Steps taken to verify this change does what is intended

- Added test

### Side effects of implementing this change

All requests made to `<username>/formList` will now search for the `user` via a case-insensitive search using the username.

Closes #1982 