### PR TITLE
1990 validate input fields on put form endpoint requests

### DIFF
--- a/onadata/apps/api/tests/viewsets/test_xform_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_xform_viewset.py
@@ -2694,7 +2694,6 @@ nhMo+jI88L3qfm4/rtWKuQ9/a268phlNj34uQeoDDHuRViQo00L5meE/pFptm
             form_id = self.xform.pk
 
             unsanitized_html_str = "<h1>HTML Injection testing</h1>"
-            version = unsanitized_html_str
             view = XFormViewSet.as_view({
                 'put': 'update',
             })

--- a/onadata/apps/logger/models/xform.py
+++ b/onadata/apps/logger/models/xform.py
@@ -902,7 +902,8 @@ class XForm(XFormMixin, BaseModel):
                         'in settings sheet or reduce the file name if you do'
                         ' not have a settings sheets.' % self.MAX_ID_LENGTH))
 
-        if contains_xml_invalid_char(self.version):
+        is_version_available = self.version is not None
+        if is_version_available and contains_xml_invalid_char(self.version):
             raise XLSFormError(
                 _("Version shouldn't have any invalid "
                   "characters ('>' '&' '<')"))

--- a/onadata/apps/logger/models/xform.py
+++ b/onadata/apps/logger/models/xform.py
@@ -33,6 +33,7 @@ from taggit.managers import TaggableManager
 
 from onadata.apps.logger.xform_instance_parser import (XLSFormError,
                                                        clean_and_parse_xml)
+from django.utils.html import conditional_escape
 from onadata.libs.models.base_model import BaseModel
 from onadata.libs.utils.cache_tools import (
     IS_ORG, PROJ_BASE_FORMS_CACHE, PROJ_FORMS_CACHE,
@@ -900,6 +901,13 @@ class XForm(XFormMixin, BaseModel):
                         ' Please change the "id_string" or "form_id" values'
                         'in settings sheet or reduce the file name if you do'
                         ' not have a settings sheets.' % self.MAX_ID_LENGTH))
+
+        if contains_xml_invalid_char(self.version):
+            raise XLSFormError(
+                _("Version shouldn't have any invalid "
+                  "characters ('>' '&' '<')"))
+
+        self.description = conditional_escape(self.description)
 
         super(XForm, self).save(*args, **kwargs)
 


### PR DESCRIPTION
### Changes / Features implemented
Validate form version and sanitize form description

### Steps taken to verify this change does what is intended
Added checks in a test to validate form versions don't have invalid characters and ensure form description with html tag characters are sanitized

### Side effects of implementing this change

Closes #1990

Fixed has been inspired by https://devstringx-technologies.medium.com/html-injection-f1c9fc713d51