### PR TITLE
Python oauth2client library swap

### DIFF
--- a/onadata/apps/viewer/views.py
+++ b/onadata/apps/viewer/views.py
@@ -434,8 +434,7 @@ def _get_google_credential(request):
     elif request.session.get('access_token'):
         credential = google_client.OAuth2Credentials.from_json(token)
 
-    return credential or HttpResponseRedirect(
-        google_flow.step1_get_authorize_url())
+    return credential or google_flow.run_local_server()
 
 
 def export_list(request, username, id_string, export_type):
@@ -733,7 +732,7 @@ def google_xls_export(request, username, id_string):
             google_xls_export,
             kwargs={'username': username,
                     'id_string': id_string})
-        return HttpResponseRedirect(google_flow.step1_get_authorize_url())
+        return google_flow.run_local_server()
 
     owner = get_object_or_404(User, username__iexact=username)
     xform = get_form({'user': owner, 'id_string__iexact': id_string})

--- a/onadata/libs/utils/api_export_tools.py
+++ b/onadata/libs/utils/api_export_tools.py
@@ -585,5 +585,9 @@ def _get_google_credential(request):
 
     if not credential or credential.invalid:
         google_flow = generate_google_web_flow(request)
-        return google_flow.run_local_server()
+        # Run the OAuth 2.0 flow to obtain credentials from the user.
+        google_flow.run_local_server()
+
+        credential = google_flow.credentials
+        return credential
     return credential

--- a/onadata/libs/utils/google.py
+++ b/onadata/libs/utils/google.py
@@ -1,11 +1,12 @@
-from oauth2client.client import OAuth2WebServerFlow
+import os
 from django.conf import settings
+from google_auth_oauthlib.flow import InstalledAppFlow
 
-google_flow = OAuth2WebServerFlow(
-    client_id=settings.GOOGLE_OAUTH2_CLIENT_ID,
-    client_secret=settings.GOOGLE_OAUTH2_CLIENT_SECRET,
-    scope=' '.join(
-        ['https://docs.google.com/feeds/',
-         'https://spreadsheets.google.com/feeds/',
-         'https://www.googleapis.com/auth/drive.file']),
-    redirect_uri=settings.GOOGLE_STEP2_URI,  prompt="consent")
+client_secrets_file = os.path.join(
+    settings.PROJECT_ROOT, "settings", "client_secrets.json")
+
+google_flow = InstalledAppFlow.from_client_secrets_file(
+    client_secrets_file, scopes=[
+        'https://www.googleapis.com/auth/docs',
+        'https://www.googleapis.com/auth/spreadsheets',
+        'https://www.googleapis.com/auth/drive.file'])

--- a/onadata/settings/client_secrets.json
+++ b/onadata/settings/client_secrets.json
@@ -1,0 +1,10 @@
+{
+    "web": 
+    {
+      "client_id": "CLIENT ID",
+      "client_secret":"CLIENT SECRET",
+      "redirect_uris": ["http://127.0.0.1:3000/signup/google/callback/", "http://127.0.0.1:3001/google-auth/code"],
+      "auth_uri": "https://accounts.google.com/o/oauth2/authuriendpoint",
+      "token_uri": "https://accounts.google.com/o/oauth2/tokenuriendpoint"
+    }
+}

--- a/requirements/base.pip
+++ b/requirements/base.pip
@@ -61,6 +61,9 @@ fleming==0.5.0            # via django-query-builder
 formencode==2.0.0         # via pyxform
 future==0.18.2            # via python-json2xlsclient
 geojson==2.5.0            # via onadata
+google-auth
+google-auth-oauthlib
+google-api-python-client
 httmock==1.3.0            # via onadata
 httplib2==0.18.1          # via oauth2client, onadata
 idna==2.10                # via requests
@@ -140,4 +143,3 @@ vine==1.3.0               # via amqp, celery
 xlrd==1.2.0               # via onadata, pyxform, tabulator
 xlwt==1.3.0               # via onadata
 zipp==3.3.1               # via importlib-metadata
-

--- a/requirements/dev.pip
+++ b/requirements/dev.pip
@@ -66,6 +66,9 @@ fleming==0.5.0            # via django-query-builder
 formencode==2.0.0         # via pyxform
 future==0.18.2            # via python-json2xlsclient
 geojson==2.5.0            # via onadata
+google-auth
+google-auth-oauthlib
+google-api-python-client
 httmock==1.3.0            # via onadata
 httplib2==0.18.1          # via oauth2client, onadata
 idna==2.10                # via requests

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,9 @@ setup(
         "django-oauth-toolkit",
         # "oauth2client",
         "jsonpickle",
+        "google-auth",
+        "google-auth-oauthlib",
+        "google-api-python-client",
         # jwt
         "PyJWT",
         # captcha


### PR DESCRIPTION
### Changes / Features implemented

- [x] Remove oauth2client OAuth2WebServerFlow usage in google-auth's InstalledAppFlows stead
- [ ] Implement ability to convert existing oauth2client credentials to google-auth credentials


#### Exisiting onadata functionalities that rely on oauth2client packages

- Initialize oauth2 flow
- Fetch stored oauth2credentials
- Validate stored oauth2 credentials
- Save oauth2 credentials

#### Changes implemented

- [x] Initialize oauth2 flow
        - Newly created google-auth credentials are able to initialize the oauth2 flow
- [ ] Fetch stored oauth2credentials
        - We store newly created google-auth credentials in the TojenStorageModel
        - Challenges
              - newly created google-auth credentials do not have all necessary fields
              - Its still unclear to how validate stored google-auth credentials when fetching
              - 

### Steps taken to verify this change does what is intended

- [ ] Updated Tests
- [ ] QA

Closes #1992 
