### PR TITLE
Generate pre-signed URLs with content disposition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,6 @@ before_install:
 install:
   - pip install --upgrade pip setuptools
   - pip install -r requirements/base.pip
-  - pip install -r requirements/s3.pip
   - pip install flake8
 script:
   - python manage.py test $TESTFOLDER --noinput --settings=onadata.settings.travis_test --parallel 4 --verbosity=2

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,7 @@ before_install:
 install:
   - pip install --upgrade pip setuptools
   - pip install -r requirements/base.pip
+  - pip install -r requirements/s3.pip
   - pip install flake8
 script:
   - python manage.py test $TESTFOLDER --noinput --settings=onadata.settings.travis_test --parallel 4 --verbosity=2

--- a/onadata/apps/api/tests/viewsets/test_media_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_media_viewset.py
@@ -33,7 +33,7 @@ class TestMediaViewSet(TestAbstractViewSet):
             'filename': self.attachment.media_file.name}, **self.extra)
         response = self.retrieve_view(request, self.attachment.pk)
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(response['Location'], attachment_url(self.attachment))
+        self.assertEqual(type(response.content), bytes)
 
     @patch('onadata.apps.api.viewsets.media_viewset.image_url')
     def test_handle_image_exception(self, mock_image_url):

--- a/onadata/apps/api/tests/viewsets/test_media_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_media_viewset.py
@@ -2,7 +2,6 @@ import os
 
 from mock import MagicMock, patch
 
-from django.core.files.storage import get_storage_class
 from onadata.apps.api.tests.viewsets.test_abstract_viewset import \
     TestAbstractViewSet
 from onadata.apps.api.viewsets.media_viewset import MediaViewSet
@@ -40,13 +39,14 @@ class TestMediaViewSet(TestAbstractViewSet):
     @patch('onadata.libs.utils.presigned_download_url.boto3.client')
     def test_retrieve_view_from_s3(
             self, mock_presigned_urls, mock_get_storage_class):
+
         mock_presigned_urls().generate_presigned_url = MagicMock(
-            return_value='https://testing.s3.amazonaws.com/johndoe/attachments/'
+            return_value='https://testing.s3.amazonaws.com/doe/attachments/'
             u'4_Media_file/media.png?'
             u'response-content-disposition=attachment%3Bfilename%3media.png&'
             u'response-content-type=application%2Foctet-stream&'
             u'AWSAccessKeyId=AKIAJ3XYHHBIJDL7GY7A'
-            u'&Signature=aGhiK%2BLFVeWm%2Fmg3ShZD5zc05g8%3D&Expires=1615554960')
+            u'&Signature=aGhiK%2BLFVeWm%2Fmg3S5zc05g8%3D&Expires=1615554960')
         request = self.factory.get('/', {
             'filename': self.attachment.media_file.name}, **self.extra)
         response = self.retrieve_view(request, self.attachment.pk)

--- a/onadata/apps/api/tests/viewsets/test_media_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_media_viewset.py
@@ -40,8 +40,6 @@ class TestMediaViewSet(TestAbstractViewSet):
     @patch('onadata.libs.utils.presigned_download_url.boto3.client')
     def test_retrieve_view_from_s3(
             self, mock_presigned_urls, mock_get_storage_class):
-        mock_get_storage_class = get_storage_class(
-            'storages.backends.s3boto3.S3Boto3Storage')()
         mock_presigned_urls().generate_presigned_url = MagicMock(
             return_value='https://testing.s3.amazonaws.com/johndoe/attachments/'
             u'4_Media_file/media.png?'

--- a/onadata/apps/api/tests/viewsets/test_media_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_media_viewset.py
@@ -1,5 +1,4 @@
 import os
-from unittest.case import expectedFailure
 
 from mock import MagicMock, patch
 

--- a/onadata/apps/api/tests/viewsets/test_media_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_media_viewset.py
@@ -41,7 +41,8 @@ class TestMediaViewSet(TestAbstractViewSet):
             self, mock_presigned_urls, mock_get_storage_class):
 
         expected_url = (
-            'https://testing.s3.amazonaws.com/doe/attachments/4_Media_file/media.png?'
+            'https://testing.s3.amazonaws.com/doe/attachments/'
+            '4_Media_file/media.png?'
             'response-content-disposition=attachment%3Bfilename%3media.png&'
             'response-content-type=application%2Foctet-stream&'
             'AWSAccessKeyId=AKIAJ3XYHHBIJDL7GY7A'

--- a/onadata/apps/api/tests/viewsets/test_media_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_media_viewset.py
@@ -35,6 +35,14 @@ class TestMediaViewSet(TestAbstractViewSet):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(type(response.content), bytes)
 
+    def test_retrieve_view_with_suffix(self):
+        request = self.factory.get('/', {
+            'filename': self.attachment.media_file.name, 'suffix': 'large'},
+            **self.extra)
+        response = self.retrieve_view(request, self.attachment.pk)
+        self.assertEqual(response.status_code, 302)
+        self.assertTrue(response['Location'], attachment_url(self.attachment))
+
     @patch('onadata.apps.api.viewsets.media_viewset.image_url')
     def test_handle_image_exception(self, mock_image_url):
         mock_image_url.side_effect = Exception()

--- a/onadata/apps/api/tests/viewsets/test_media_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_media_viewset.py
@@ -34,14 +34,6 @@ class TestMediaViewSet(TestAbstractViewSet):
         response = self.retrieve_view(request, self.attachment.pk)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(type(response.content), bytes)
-     
-    @patch('onadata.apps.api.viewsets.media_viewset.generate_media_download_url')
-    def test_retrieve_image_from_aws(self, mock_presigned_url):
-        mock_presigned_url.return_value = "https://testing.s3.amazonaws.com/1/bob/check_fields.hyper?AWSAccessKeyId=key&Signature=sig&Expires=1609838540"
-        request = self.factory.get('/', {
-            'filename': self.attachment.media_file.name}, **self.extra)
-        response = self.retrieve_view(request, self.attachment.pk)
-        print(">>>>response:", response)
 
     def test_retrieve_view_with_suffix(self):
         request = self.factory.get('/', {

--- a/onadata/apps/api/tests/viewsets/test_media_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_media_viewset.py
@@ -34,6 +34,14 @@ class TestMediaViewSet(TestAbstractViewSet):
         response = self.retrieve_view(request, self.attachment.pk)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(type(response.content), bytes)
+     
+    @patch('onadata.apps.api.viewsets.media_viewset.generate_media_download_url')
+    def test_retrieve_image_from_aws(self, mock_presigned_url):
+        mock_presigned_url.return_value = "https://testing.s3.amazonaws.com/1/bob/check_fields.hyper?AWSAccessKeyId=key&Signature=sig&Expires=1609838540"
+        request = self.factory.get('/', {
+            'filename': self.attachment.media_file.name}, **self.extra)
+        response = self.retrieve_view(request, self.attachment.pk)
+        print(">>>>response:", response)
 
     def test_retrieve_view_with_suffix(self):
         request = self.factory.get('/', {

--- a/onadata/apps/api/tests/viewsets/test_media_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_media_viewset.py
@@ -32,7 +32,7 @@ class TestMediaViewSet(TestAbstractViewSet):
         request = self.factory.get('/', {
             'filename': self.attachment.media_file.name}, **self.extra)
         response = self.retrieve_view(request, self.attachment.pk)
-        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.status_code, 200)
         self.assertTrue(response['Location'], attachment_url(self.attachment))
 
     @patch('onadata.apps.api.viewsets.media_viewset.image_url')

--- a/onadata/apps/api/tests/viewsets/test_media_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_media_viewset.py
@@ -1,4 +1,5 @@
 import os
+from unittest.case import expectedFailure
 
 from mock import MagicMock, patch
 
@@ -40,17 +41,20 @@ class TestMediaViewSet(TestAbstractViewSet):
     def test_retrieve_view_from_s3(
             self, mock_presigned_urls, mock_get_storage_class):
 
+        expected_url = (
+            'https://testing.s3.amazonaws.com/doe/attachments/4_Media_file/media.png?'
+            'response-content-disposition=attachment%3Bfilename%3media.png&'
+            'response-content-type=application%2Foctet-stream&'
+            'AWSAccessKeyId=AKIAJ3XYHHBIJDL7GY7A'
+            '&Signature=aGhiK%2BLFVeWm%2Fmg3S5zc05g8%3D&Expires=1615554960')
         mock_presigned_urls().generate_presigned_url = MagicMock(
-            return_value='https://testing.s3.amazonaws.com/doe/attachments/'
-            u'4_Media_file/media.png?'
-            u'response-content-disposition=attachment%3Bfilename%3media.png&'
-            u'response-content-type=application%2Foctet-stream&'
-            u'AWSAccessKeyId=AKIAJ3XYHHBIJDL7GY7A'
-            u'&Signature=aGhiK%2BLFVeWm%2Fmg3S5zc05g8%3D&Expires=1615554960')
+            return_value=expected_url
+        )
         request = self.factory.get('/', {
             'filename': self.attachment.media_file.name}, **self.extra)
         response = self.retrieve_view(request, self.attachment.pk)
         self.assertEqual(response.status_code, 302, response.url)
+        self.assertEqual(response.url, expected_url)
         self.assertTrue(mock_presigned_urls.called)
 
     def test_retrieve_view_with_suffix(self):

--- a/onadata/apps/api/viewsets/media_viewset.py
+++ b/onadata/apps/api/viewsets/media_viewset.py
@@ -8,6 +8,8 @@ from rest_framework import viewsets
 from rest_framework.permissions import AllowAny
 from rest_framework.exceptions import ParseError
 
+from onadata.libs.utils.presigned_download_url import generate_presigned_download_url
+
 from onadata.apps.logger.models import Attachment
 from onadata.libs.mixins.authenticate_header_mixin import \
     AuthenticateHeaderMixin

--- a/onadata/apps/api/viewsets/media_viewset.py
+++ b/onadata/apps/api/viewsets/media_viewset.py
@@ -66,7 +66,7 @@ class MediaViewSet(AuthenticateHeaderMixin,
                         raise Http404()
 
             if not url:
-                response = generate_media_download_url(obj.media_file.name)
+                response = generate_media_download_url(obj)
 
                 return response
 

--- a/onadata/apps/api/viewsets/media_viewset.py
+++ b/onadata/apps/api/viewsets/media_viewset.py
@@ -14,7 +14,7 @@ from onadata.libs.mixins.authenticate_header_mixin import \
 from onadata.libs.mixins.cache_control_mixin import CacheControlMixin
 from onadata.libs.mixins.etags_mixin import ETagsMixin
 from onadata.libs.utils.presigned_download_url import \
-    generate_presigned_download_url
+    generate_media_download_url
 from onadata.libs.utils.image_tools import image_url
 from onadata.apps.api.tools import get_baseviewset_class
 
@@ -66,8 +66,9 @@ class MediaViewSet(AuthenticateHeaderMixin,
                         raise Http404()
 
             if not url:
-                url = generate_presigned_download_url(obj.media_file.name,
-                                                      obj.media_file.url)
+                response = generate_media_download_url(obj.media_file.name)
+
+                return response
 
             return HttpResponseRedirect(url)
 

--- a/onadata/apps/api/viewsets/media_viewset.py
+++ b/onadata/apps/api/viewsets/media_viewset.py
@@ -66,7 +66,8 @@ class MediaViewSet(AuthenticateHeaderMixin,
                         raise Http404()
 
             if not url:
-                url = obj.media_file.url
+                url = generate_presigned_download_url(obj.media_file.name, obj.media_file.url)
+
 
             return HttpResponseRedirect(url)
 

--- a/onadata/apps/api/viewsets/media_viewset.py
+++ b/onadata/apps/api/viewsets/media_viewset.py
@@ -8,13 +8,13 @@ from rest_framework import viewsets
 from rest_framework.permissions import AllowAny
 from rest_framework.exceptions import ParseError
 
-from onadata.libs.utils.presigned_download_url import generate_presigned_download_url
-
 from onadata.apps.logger.models import Attachment
 from onadata.libs.mixins.authenticate_header_mixin import \
     AuthenticateHeaderMixin
 from onadata.libs.mixins.cache_control_mixin import CacheControlMixin
 from onadata.libs.mixins.etags_mixin import ETagsMixin
+from onadata.libs.utils.presigned_download_url import \
+    generate_presigned_download_url
 from onadata.libs.utils.image_tools import image_url
 from onadata.apps.api.tools import get_baseviewset_class
 
@@ -66,8 +66,8 @@ class MediaViewSet(AuthenticateHeaderMixin,
                         raise Http404()
 
             if not url:
-                url = generate_presigned_download_url(obj.media_file.name, obj.media_file.url)
-
+                url = generate_presigned_download_url(obj.media_file.name,
+                                                      obj.media_file.url)
 
             return HttpResponseRedirect(url)
 

--- a/onadata/libs/utils/presigned_download_url.py
+++ b/onadata/libs/utils/presigned_download_url.py
@@ -4,7 +4,7 @@ import logging
 
 from django.conf import settings
 from django.core.files.storage import get_storage_class
-from django.http import HttpResponseRedirect, HttpResponse
+from django.http import HttpResponse, HttpResponseRedirect
 
 from wsgiref.util import FileWrapper
 

--- a/onadata/libs/utils/presigned_download_url.py
+++ b/onadata/libs/utils/presigned_download_url.py
@@ -22,7 +22,7 @@ def generate_media_download_url(obj, expiration: int = 3600):
     if default_storage.__class__ != s3.__class__:
         file_obj = open(settings.MEDIA_ROOT + file_path, 'rb')
         response = HttpResponse(FileWrapper(file_obj),
-                                content_type = obj.mimetype)
+                                content_type=obj.mimetype)
         response['Content-Disposition'] = 'attachment; filename=' + filename
 
         return response

--- a/onadata/libs/utils/presigned_download_url.py
+++ b/onadata/libs/utils/presigned_download_url.py
@@ -1,28 +1,34 @@
-import logging
 import boto3
 from botocore.exceptions import ClientError
+import logging
 
 from django.core.files.storage import get_storage_class
+from django.http import HttpResponse
+from django.http import HttpResponseRedirect
+
+from wsgiref.util import FileWrapper
 
 
-def generate_presigned_download_url(file_path: str, file_url: str, expiration: int = 3600):
- # Generate a presigned URL for the S3 object
+def generate_media_download_url(file_path: str, expiration: int = 3600):
     default_storage = get_storage_class()()
     filename = file_path.split("/")[-1]
     s3 = get_storage_class('storages.backends.s3boto3.S3Boto3Storage')()
-    bucket_name = s3.bucket.name
-    s3_client = boto3.client('s3')
 
-    try:
-        response = s3_client.generate_presigned_url('get_object',
-                                                    Params={'Bucket': bucket_name,
-                                                            'Key': file_path,
-                                                            'ResponseContentDisposition': 'attachment;filename={}'.format(filename),
-                                                            'ResponseContentType': 'application/octet-stream',},
-                                                    ExpiresIn=expiration)
-    except ClientError as e:
-        logging.error(e)
-        return None
+    if default_storage.__class__ != s3.__class__:
+        return file_url
+    else:
+        try:
+            bucket_name = s3.bucket.name
+            s3_client = boto3.client('s3')
+            response = s3_client.generate_presigned_url('get_object',
+                                                        Params={'Bucket': bucket_name,
+                                                                'Key': file_path,
+                                                                'ResponseContentDisposition': 'attachment;filename={}'.format(filename),
+                                                                'ResponseContentType': 'application/octet-stream', },
+                                                        ExpiresIn=expiration)
+        except ClientError as e:
+            logging.error(e)
+            return None
 
-    # The response contains the presigned URL
-    return response
+        # The response contains the presigned URL
+        return response

--- a/onadata/libs/utils/presigned_download_url.py
+++ b/onadata/libs/utils/presigned_download_url.py
@@ -19,7 +19,7 @@ def generate_media_download_url(obj, expiration: int = 3600):
     except ModuleNotFoundError:
         return HttpResponseRedirect(obj.media_file.url)
 
-    if default_storage.__class__ != s3.__class__:
+    if not isinstance(default_storage, type(s3)):
         file_obj = open(settings.MEDIA_ROOT + file_path, 'rb')
         response = HttpResponse(FileWrapper(file_obj),
                                 content_type=obj.mimetype)

--- a/onadata/libs/utils/presigned_download_url.py
+++ b/onadata/libs/utils/presigned_download_url.py
@@ -1,0 +1,16 @@
+
+def generate_presigned_download_url(bucket_name: str, file_path: str, expiration: int = 3600):
+        """
+        Generates a presigned Download URL
+        file_path :string: Path to the file in the S3 Bucket
+        expirationg :integer: The duration in seconds that the URL should be valid for
+        """
+        try:
+            response = s3.generate_presigned_url(
+                "get_object",
+                Params={"Bucket": bucket_name, "Key": file_path},
+                ExpiresIn=expiration,
+            )
+        except ClientError:
+            return None
+        return response

--- a/onadata/libs/utils/presigned_download_url.py
+++ b/onadata/libs/utils/presigned_download_url.py
@@ -1,16 +1,26 @@
+import logging
+import boto3
+from botocore.exceptions import ClientError
 
-def generate_presigned_download_url(bucket_name: str, file_path: str, expiration: int = 3600):
-        """
-        Generates a presigned Download URL
-        file_path :string: Path to the file in the S3 Bucket
-        expirationg :integer: The duration in seconds that the URL should be valid for
-        """
-        try:
-            response = s3.generate_presigned_url(
-                "get_object",
-                Params={"Bucket": bucket_name, "Key": file_path},
-                ExpiresIn=expiration,
-            )
-        except ClientError:
-            return None
-        return response
+from django.core.files.storage import get_storage_class
+
+
+def generate_presigned_download_url(file_path: str, expiration: int = 3600):
+ # Generate a presigned URL for the S3 object
+    s3 = get_storage_class('storages.backends.s3boto3.S3Boto3Storage')()
+    bucket_name = s3.bucket.name
+    s3_client = boto3.client('s3')
+
+    try:
+        response = s3_client.generate_presigned_url('get_object',
+                                                    Params={'Bucket': bucket_name,
+                                                            'Key': file_path,
+                                                            'ResponseContentDisposition': 'attachment;filename={}'.format(filename),
+                                                            'ResponseContentType': 'application/octet-stream',},
+                                                    ExpiresIn=expiration)
+    except ClientError as e:
+        logging.error(e)
+        return None
+
+    # The response contains the presigned URL
+    return response

--- a/onadata/libs/utils/presigned_download_url.py
+++ b/onadata/libs/utils/presigned_download_url.py
@@ -30,9 +30,10 @@ def generate_media_download_url(obj, expiration: int = 3600):
     else:
         try:
             bucket_name = s3.bucket.name
+            s3_client = boto3.client('s3')
 
             # Generate a presigned URL for the S3 object
-            response =  boto3.client('s3').generate_presigned_url(
+            response = s3_client.generate_presigned_url(
                 'get_object',
                 Params={
                     'Bucket': bucket_name,

--- a/onadata/libs/utils/presigned_download_url.py
+++ b/onadata/libs/utils/presigned_download_url.py
@@ -16,8 +16,8 @@ def generate_media_download_url(obj, expiration: int = 3600):
 
     try:
         s3 = get_storage_class('storages.backends.s3boto3.S3Boto3Storage')()
-    except Exception:
-        return obj.media_file.url
+    except ModuleNotFoundError:
+        return HttpResponseRedirect(obj.media_file.url)
 
     if default_storage.__class__ != s3.__class__:
         file_obj = open(settings.MEDIA_ROOT + file_path, 'rb')

--- a/onadata/libs/utils/presigned_download_url.py
+++ b/onadata/libs/utils/presigned_download_url.py
@@ -30,10 +30,9 @@ def generate_media_download_url(obj, expiration: int = 3600):
     else:
         try:
             bucket_name = s3.bucket.name
-            s3_client = boto3.client('s3')
 
             # Generate a presigned URL for the S3 object
-            response = s3_client.generate_presigned_url(
+            response =  boto3.client('s3').generate_presigned_url(
                 'get_object',
                 Params={
                     'Bucket': bucket_name,

--- a/onadata/libs/utils/presigned_download_url.py
+++ b/onadata/libs/utils/presigned_download_url.py
@@ -5,8 +5,10 @@ from botocore.exceptions import ClientError
 from django.core.files.storage import get_storage_class
 
 
-def generate_presigned_download_url(file_path: str, expiration: int = 3600):
+def generate_presigned_download_url(file_path: str, file_url: str, expiration: int = 3600):
  # Generate a presigned URL for the S3 object
+    default_storage = get_storage_class()()
+    filename = file_path.split("/")[-1]
     s3 = get_storage_class('storages.backends.s3boto3.S3Boto3Storage')()
     bucket_name = s3.bucket.name
     s3_client = boto3.client('s3')

--- a/onadata/libs/utils/presigned_download_url.py
+++ b/onadata/libs/utils/presigned_download_url.py
@@ -2,9 +2,9 @@ import boto3
 from botocore.exceptions import ClientError
 import logging
 
+from django.conf import settings
 from django.core.files.storage import get_storage_class
-from django.http import HttpResponse
-from django.http import HttpResponseRedirect
+from django.http import HttpResponseRedirect, HttpResponse
 
 from wsgiref.util import FileWrapper
 
@@ -15,7 +15,7 @@ def generate_media_download_url(file_path: str, expiration: int = 3600):
     s3 = get_storage_class('storages.backends.s3boto3.S3Boto3Storage')()
 
     if default_storage.__class__ != s3.__class__:
-        file_obj = open(file_path, 'rb')
+        file_obj = open(settings.MEDIA_ROOT + file_path, 'rb')
         response = HttpResponse(FileWrapper(file_obj),
                                 content_type='image/jpg')
         response['Content-Disposition'] = 'attachment; filename=' + filename

--- a/onadata/libs/utils/presigned_download_url.py
+++ b/onadata/libs/utils/presigned_download_url.py
@@ -9,15 +9,20 @@ from django.http import HttpResponse, HttpResponseRedirect
 from wsgiref.util import FileWrapper
 
 
-def generate_media_download_url(file_path: str, expiration: int = 3600):
+def generate_media_download_url(obj, expiration: int = 3600):
+    file_path = obj.media_file.name
     default_storage = get_storage_class()()
     filename = file_path.split("/")[-1]
-    s3 = get_storage_class('storages.backends.s3boto3.S3Boto3Storage')()
+
+    try:
+        s3 = get_storage_class('storages.backends.s3boto3.S3Boto3Storage')()
+    except Exception:
+        return obj.media_file.url
 
     if default_storage.__class__ != s3.__class__:
         file_obj = open(settings.MEDIA_ROOT + file_path, 'rb')
         response = HttpResponse(FileWrapper(file_obj),
-                                content_type='image/jpg')
+                                content_type = obj.mimetype)
         response['Content-Disposition'] = 'attachment; filename=' + filename
 
         return response

--- a/onadata/libs/utils/presigned_download_url.py
+++ b/onadata/libs/utils/presigned_download_url.py
@@ -15,7 +15,7 @@ def generate_media_download_url(file_path: str, expiration: int = 3600):
     s3 = get_storage_class('storages.backends.s3boto3.S3Boto3Storage')()
 
     if default_storage.__class__ != s3.__class__:
-        file_obj = open(file_path)
+        file_obj = open(file_path, 'rb')
         response = HttpResponse(FileWrapper(file_obj),
                                 content_type='image/jpg')
         response['Content-Disposition'] = 'attachment; filename=' + filename


### PR DESCRIPTION
### Changes / Features implementation
- Generate image URLs that contain content-disposition whether locally or in s3 bucket
### Steps taken to verify this change does what is intended

### Side effects of implementing this change

Closes #
