### PR TITLE
Capture attachment file names whose name exceeds 100 chars

### DIFF
--- a/onadata/apps/logger/xform_instance_parser.py
+++ b/onadata/apps/logger/xform_instance_parser.py
@@ -43,6 +43,10 @@ class InstanceFormatError(Exception):
     pass
 
 
+class AttachmentNameError(Exception):
+    pass
+
+
 class InstanceEncryptionError(Exception):
     pass
 


### PR DESCRIPTION
### Changes / Features implemented
- Include check to confirm attachment file name length before saving submission

### Steps taken to verify this change does what is intended
- Added Tests

Closes #1939
