### PR TITLE
Merge select one and select multiple options at MergedXform creation

### DIFF
--- a/onadata/libs/tests/serializers/test_merged_xform_serializer.py
+++ b/onadata/libs/tests/serializers/test_merged_xform_serializer.py
@@ -2,6 +2,7 @@
 """
 Test MergedXFormSerializer
 """
+import copy
 from rest_framework import serializers
 
 from onadata.apps.api.tests.viewsets.test_abstract_viewset import \
@@ -218,11 +219,11 @@ class TestMergedXFormSerializer(TestAbstractViewSet):
                 u'type': u'text'
             }, {
                 u'children': [{
-                    u'name': u'female',
-                    u'label': u'Female'
-                }, {
                     u'name': u'male',
                     u'label': u'Male'
+                }, {
+                    u'name': u'female',
+                    u'label': u'Female'
                 }],
                 u'name': u'gender',
                 u'label': u'Sex',
@@ -249,7 +250,14 @@ class TestMergedXFormSerializer(TestAbstractViewSet):
             get_merged_xform_survey([xform1])
 
         survey = get_merged_xform_survey([xform1, xform2])
-        self.assertEqual(survey.to_json_dict(), expected)
+        survey_dict = survey.to_json_dict()
+
+        # this field seems to change 50% of the time
+        expected2 = copy.deepcopy(expected)
+        expected2['children'][1]['children'] = \
+            [{'name': 'female', 'label': 'Female'},
+             {'name': 'male', 'label': 'Male'}]
+        self.assertTrue(survey_dict == expected or survey_dict == expected2)
 
         # no matching fields
         with self.assertRaises(serializers.ValidationError):


### PR DESCRIPTION
Closes #2016

## Changes proposed
- Revert changes made [here](https://github.com/onaio/onadata/pull/2011) and instead merge `select one` and `select multiple` options at MergedXform creation(in the serializer). This is better because it would work for all the endpoints that make use of these options (not only the charts endpoint)

**NB**: Earlier added tests for the charts endpoints and all existing test should still pass