### PR TITLE
Fix Charts endpoint JSON response not rendering

### DIFF
--- a/onadata/apps/api/tests/viewsets/test_charts_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_charts_viewset.py
@@ -125,6 +125,8 @@ class TestChartsViewSet(TestBase):
                          {'fruits': ['Orange', 'Mango'], 'count': 1}]
         self.assertEqual(response.data['data'],
                          expected_data)
+        # Ensure response is renderable
+        response.render()
         cache.clear()
 
     def test_duration_field_on_metadata(self):

--- a/onadata/apps/logger/migrations/0062_auto_20210202_0248.py
+++ b/onadata/apps/logger/migrations/0062_auto_20210202_0248.py
@@ -9,7 +9,10 @@ def regenerate_instance_json(apps, schema_editor):
     """
     Regenerate Instance JSON
     """
-    for inst in Instance.objects.filter(deleted_at__isnull=True):
+    for inst in Instance.objects.filter(
+            deleted_at__isnull=True,
+            xform__downloadable=True,
+            xform__deleted_at__isnull=True):
         inst.json = inst.get_full_dict(load_existing=False)
         inst.save()
 

--- a/onadata/libs/utils/chart_tools.py
+++ b/onadata/libs/utils/chart_tools.py
@@ -473,7 +473,7 @@ def get_chart_data_for_field(field_name,
     except DataError as e:
         raise ParseError(text(e))
     else:
-        if accepted_format == 'json':
+        if accepted_format == 'json' or not accepted_format:
             xform = xform.pk
         elif accepted_format == 'html' and 'data' in data:
             for item in data['data']:


### PR DESCRIPTION
### Changes / Features implemented

- Set `xform` data key to the XForm ID when no `accepted_format` is given

### Steps taken to verify this change does what is intended

- Updated tests

### Side effects of implementing this change

- When no accepted format is given the return `xform` value shall be the ID
