### PR TITLE
Add documentation for the messaging endpoint

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -81,6 +81,14 @@ Onadata-Tableau Intergration
 
   onadata-tableau
 
+Event tracking and messaging (Beta)
+-----------------------------------
+
+.. toctree::
+    :maxdepth: 2
+
+  messaging
+
 Ona Tagging API
 ~~~~~~~~~~~~~~~
 

--- a/docs/messaging.rst
+++ b/docs/messaging.rst
@@ -1,0 +1,101 @@
+Messaging
+*********
+
+This endpoint provides access to event messages sent for a specific target. Where:
+
+- ``target_type`` - The type of the target object. The supported target types are ``xform``, ``project`` & ``user``.
+- ``target_id`` - The unique identifier of the target object.
+- ``verb`` - A specific action that has occured on the object i.e ``form_updated``
+
+
+GET All event messages that have been sent for a form
+------------------------------------------------------
+
+Lists the events messages that have been sent for a specific form.
+
+.. raw:: html
+
+  <pre class="prettyprint">
+  <b>GET</b> /api/v1/messaging?target_type=<code>{type}</code>&target_id=<code>{form_id}</code>
+
+Example
+^^^^^^^^
+
+::
+
+    curl -X GET https://api.ona.io/api/v1/messaging?target_type=xform&target_id=1
+
+
+Response
+^^^^^^^^^
+::
+
+    [
+        {
+            "id": 16485370,
+            "verb": "message",
+            "message": "Hey there",
+            "user": "bob",
+            "timestamp": "2021-02-26T03:32:57.799647-05:00"
+        },
+        {
+            "id": 16484965,
+            "verb": "submission_deleted",
+            "message": "{\"id\": [\"71470149\"]}",
+            "user": "bob",
+            "timestamp": "2021-02-26T03:28:19.512875-05:00"
+        },
+        {
+            "id": 12778522,
+            "verb": "submission_edited",
+            "message": "{\"id\": [71472574]}",
+            "user": "bob",
+            "timestamp": "2020-12-14T02:57:23.454169-05:00"
+        },
+        {
+            "id": 12778520,
+            "verb": "submission_created",
+            "message": "{\"id\": [71472574]}",
+            "user": "bob",
+            "timestamp": "2020-12-14T02:57:23.264655-05:00"
+        }
+    ]
+
+GET List of events that have occured on a form for a specific verb
+------------------------------------------------------------------
+
+Lists out all messages sent for a specific ``verb``. The supported verbs are **message**, **submission_created**, **submission_edited**, **submission_deleted**, **submission_reviewed**, **form_updated**.
+
+.. raw:: html
+
+  <pre class="prettyprint">
+  <b>GET</b> /api/v1/messaging?target_type=<code>{type}</code>&target_id=<code>{form_id}</code>&verb=<code>{message}</code>
+  </pre>
+
+Example
+^^^^^^^^
+::
+
+    curl -X GET https://api.ona.io/api/v1/messaging?target_type=xform&target_id=1&verb=message
+
+
+Response
+^^^^^^^^^
+::
+
+    [
+        {
+            "id": 16485370,
+            "verb": "message",
+            "message": "Hey there",
+            "user": "bob",
+            "timestamp": "2021-02-26T03:32:57.799647-05:00"
+        },
+        {
+            "id": 16485370,
+            "verb": "message",
+            "message": "lorem ipsum",
+            "user": "bob",
+            "timestamp": "2021-02-26T03:49:57.799647-05:00"
+        }
+    ]


### PR DESCRIPTION
### Changes / Features implemented

- Add documentation for the messaging viewset

### Steps taken to verify this change does what is intended

N/A

### Side effects of implementing this change

N/A

### Note for reviewers

I've tagged the documentation as WIP since the `project` and `user` target types are currently not utilized on the application; There is currently no message sent for those target types

Closes #2063 
