### PR TITLE
Ignore accepted renderer & media type for the export async endpoint

### DIFF
--- a/onadata/apps/api/tests/viewsets/test_xform_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_xform_viewset.py
@@ -4898,3 +4898,20 @@ nhMo+jI88L3qfm4/rtWKuQ9/a268phlNj34uQeoDDHuRViQo00L5meE/pFptm
         self.assertEqual(
             response.data.get('text'),
             error_msg)
+
+    def test_export_csvzip_form_data_async(self):
+        with HTTMock(enketo_mock):
+            self._publish_xls_form_to_project()
+            view = XFormViewSet.as_view({
+                'get': 'export_async',
+            })
+            formid = self.xform.pk
+
+            request = self.factory.get(
+                '/', data={"format": "csvzip"}, **self.extra)
+            response = view(request, pk=formid)
+            self.assertIsNotNone(response.data)
+            self.assertEqual(response.status_code, 202)
+            print(response.data)
+            # Ensure response is renderable
+            response.render()

--- a/onadata/apps/api/tests/viewsets/test_xform_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_xform_viewset.py
@@ -4901,7 +4901,9 @@ nhMo+jI88L3qfm4/rtWKuQ9/a268phlNj34uQeoDDHuRViQo00L5meE/pFptm
 
     def test_export_csvzip_form_data_async(self):
         with HTTMock(enketo_mock):
-            self._publish_xls_form_to_project()
+            xls_path = os.path.join(settings.PROJECT_ROOT, "apps", "main",
+                                    "tests", "fixtures", "tutorial.xls")
+            self._publish_xls_form_to_project(xlsform_path=xls_path)
             view = XFormViewSet.as_view({
                 'get': 'export_async',
             })

--- a/onadata/apps/api/viewsets/xform_viewset.py
+++ b/onadata/apps/api/viewsets/xform_viewset.py
@@ -793,8 +793,8 @@ class XFormViewSet(AnonymousUserPublicFormsMixin,
         if request.query_params.get('format') in ['csvzip', 'savzip']:
             # Overide renderer and mediatype because all response are
             # suppose to be in json
-            # TODO: Avoid overiding the format query param which DRF uses
-            #       to select the renderer
+            # TODO: Avoid overiding the format query param for export type
+            #  DRF uses format to select the renderer
             self.request.accepted_renderer = renderers.JSONRenderer()
             self.request.accepted_mediatype = 'application/json'
 

--- a/onadata/apps/api/viewsets/xform_viewset.py
+++ b/onadata/apps/api/viewsets/xform_viewset.py
@@ -790,6 +790,14 @@ class XFormViewSet(AnonymousUserPublicFormsMixin,
         if query:
             options.update({'query': query})
 
+        if request.query_params.get('format') in ['csvzip', 'savzip']:
+            # Overide renderer and mediatype because all response are
+            # suppose to be in json
+            # TODO: Avoid overiding the format query param which DRF uses
+            #       to select the renderer
+            self.request.accepted_renderer = renderers.JSONRenderer()
+            self.request.accepted_mediatype = 'application/json'
+
         if job_uuid:
             try:
                 resp = get_async_response(job_uuid, request, xform)


### PR DESCRIPTION
### Changes / Features implemented

### Steps taken to verify this change does what is intended

### Side effects of implementing this change

Closes #1964 
