### PR TITLE
Add support for sort and handle streaming of empty datasets on XML Responses

### DIFF
--- a/onadata/apps/api/tests/viewsets/test_data_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_data_viewset.py
@@ -2609,7 +2609,9 @@ class TestDataViewSet(TestBase):
         request = self.factory.get('/', **self.extra)
 
         formid = self.xform.pk
-        expected_order = [4, 3, 2, 1]
+        expected_order = list(Instance.objects.filter(
+            xform=self.xform).order_by(
+                '-date_modified').values_list('id', flat=True))
         request = self.factory.get(
             '/?sort=-date_modified', **self.extra)
         response = view(request, pk=formid, format='xml')

--- a/onadata/apps/api/tests/viewsets/test_data_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_data_viewset.py
@@ -2599,6 +2599,25 @@ class TestDataViewSet(TestBase):
 
         self.assertEqual(expected_xml, returned_xml)
 
+    def test_data_list_xml_format_sort(self):
+        """
+        Test that "sort" query param works as expected on XML formatted
+        responses
+        """
+        self._make_submissions()
+        view = DataViewSet.as_view({'get': 'list'})
+        request = self.factory.get('/', **self.extra)
+
+        formid = self.xform.pk
+        expected_order = [4, 3, 2, 1]
+        request = self.factory.get(
+            '/?sort=-date_modified', **self.extra)
+        response = view(request, pk=formid, format='xml')
+        self.assertEqual(response.status_code, 200)
+        items_in_order = [
+            int(data.get('@objectID')) for data in response.data]
+        self.assertEqual(expected_order, items_in_order)
+
     @override_settings(SUBMISSION_RETRIEVAL_THRESHOLD=1)
     def test_data_paginated_past_threshold(self):
         """

--- a/onadata/apps/api/tests/viewsets/test_data_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_data_viewset.py
@@ -879,7 +879,7 @@ class TestDataViewSet(TestBase):
         self.assertEqual(len(response.data), 4)
 
         instance = self.xform.instances.all().order_by('-date_created')[0]
-        date_modified = instance.date_modified.strftime(MONGO_STRFTIME)
+        date_modified = instance.date_modified.isoformat()
 
         query_str = ('{"_date_modified": {"$gte": "%s"},'
                      ' "_submitted_by": "%s"}' % (date_modified, 'bob'))
@@ -890,7 +890,7 @@ class TestDataViewSet(TestBase):
         response = view(request, pk=formid)
         self.assertEqual(response.status_code, 200)
         expected_count = self.xform.instances.filter(
-            json___date_modified__gte=date_modified).count()
+            date_modified__gte=date_modified).count()
         self.assertEqual(len(response.data), expected_count)
 
     def test_filter_by_submission_time_and_submitted_by_with_data_arg(self):

--- a/onadata/apps/api/tests/viewsets/test_data_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_data_viewset.py
@@ -2558,7 +2558,7 @@ class TestDataViewSet(TestBase):
         server_time = ET.fromstring(returned_xml).attrib.get('serverTime')
         expected_xml = (
             f'<?xml version="1.0" encoding="utf-8"?>\n<submission-batch serverTime="{server_time}">'  # noqa
-            f'<submission-item created="{instance.date_created.isoformat()}" formVersion="{instance.version}" lastModified="{instance.date_modified.isoformat()}" objectID="{instance.id}">'  # noqa
+            f'<submission-item dateCreated="{instance.date_created.isoformat()}" formVersion="{instance.version}" lastModified="{instance.date_modified.isoformat()}" objectID="{instance.id}">'  # noqa
             '<tutorial id="tutorial"><name>Larry\n        Again</name><age>23</age><picture>1333604907194.jpg</picture>'  # noqa
             '<has_children>0</has_children><gps>-1.2836198 36.8795437 0.0 1044.0</gps><web_browsers>firefox chrome safari'  # noqa
             '</web_browsers><meta><instanceID>uuid:729f173c688e482486a48661700455ff</instanceID></meta></tutorial>'  # noqa

--- a/onadata/apps/api/viewsets/data_viewset.py
+++ b/onadata/apps/api/viewsets/data_viewset.py
@@ -582,9 +582,10 @@ class DataViewSet(AnonymousUserPublicFormsMixin,
                         filter_queryset_xform_meta_perms_sql(self.get_object(),
                                                              self.request.user,
                                                              query)
-                    self.object_list = query_data(xform, query=query,
-                                                  sort=sort, start_index=start,
-                                                  limit=limit, fields=fields)
+                    self.object_list = query_data(
+                        xform, query=query, sort=sort, start_index=start,
+                        limit=limit, fields=fields,
+                        json_only=not self.kwargs.get('format') == 'xml')
                 except NoRecordsPermission:
                     self.object_list = []
 

--- a/onadata/apps/viewer/models/parsed_instance.py
+++ b/onadata/apps/viewer/models/parsed_instance.py
@@ -213,8 +213,12 @@ def get_sql_with_params(xform, query=None, fields=None, sort=None, start=None,
             if not fields:
                 # we have to do a sql query for json field order
                 sql, params = records.query.sql_with_params()
-            params = list(params) + json_order_by_params(sort)
-            sql = u"%s %s" % (sql, json_order_by(sort))
+            params = list(params) + json_order_by_params(
+                sort, none_json_fields=NONE_JSON_FIELDS)
+            sql = u"%s %s" % (sql, json_order_by(
+                sort,
+                none_json_fields=NONE_JSON_FIELDS,
+                model_name="logger_instance"))
         elif not fields:
             records = records.order_by(*sort)
 

--- a/onadata/apps/viewer/models/parsed_instance.py
+++ b/onadata/apps/viewer/models/parsed_instance.py
@@ -71,7 +71,12 @@ def get_name_from_survey_element(element):
 
 def _parse_sort_fields(fields):
     for field in fields:
-        yield NONE_JSON_FIELDS.get(field, field)
+        key = field.lstrip('-')
+        if field.startswith('-') and key in NONE_JSON_FIELDS.keys():
+            field = NONE_JSON_FIELDS.get(key)
+            yield f'-{field}'
+        else:
+            yield NONE_JSON_FIELDS.get(field, field)
 
 
 def _query_iterator(sql, fields=None, params=[], count=False):

--- a/onadata/apps/viewer/models/parsed_instance.py
+++ b/onadata/apps/viewer/models/parsed_instance.py
@@ -170,7 +170,8 @@ def _get_sort_fields(sort):
 
 
 def get_sql_with_params(xform, query=None, fields=None, sort=None, start=None,
-                        end=None, start_index=None, limit=None, count=None):
+                        end=None, start_index=None, limit=None, count=None,
+                        json_only: bool = True):
     records = _get_instances(xform, start, end)
     params = []
     sort = _get_sort_fields(sort)
@@ -196,8 +197,9 @@ def get_sql_with_params(xform, query=None, fields=None, sort=None, start=None,
             + u" AND deleted_at IS NULL"
         params = [xform.pk] + where_params
     else:
+        if json_only:
+            records = records.values_list('json', flat=True)
 
-        records = records.values_list('json', flat=True)
         if query and isinstance(query, list):
             for qry in query:
                 w, wp = get_where_clause(qry, known_integers)
@@ -230,10 +232,12 @@ def get_sql_with_params(xform, query=None, fields=None, sort=None, start=None,
 
 
 def query_data(xform, query=None, fields=None, sort=None, start=None,
-               end=None, start_index=None, limit=None, count=None):
+               end=None, start_index=None, limit=None, count=None,
+               json_only: bool = True):
 
     sql, params, records = get_sql_with_params(
-        xform, query, fields, sort, start, end, start_index, limit, count
+        xform, query, fields, sort, start, end, start_index, limit, count,
+        json_only=json_only
     )
     if fields and isinstance(fields, six.string_types):
         fields = json.loads(fields)

--- a/onadata/apps/viewer/parsed_instance_tools.py
+++ b/onadata/apps/viewer/parsed_instance_tools.py
@@ -10,6 +10,7 @@ from onadata.libs.utils.common_tags import MONGO_STRFTIME, DATE_FORMAT
 KNOWN_DATES = ['_submission_time']
 NONE_JSON_FIELDS = {
     '_submission_time': 'date_created',
+    '_date_modified': 'date_modified',
     '_id': 'id',
     '_version': 'version'
 }

--- a/onadata/apps/viewer/parsed_instance_tools.py
+++ b/onadata/apps/viewer/parsed_instance_tools.py
@@ -12,7 +12,8 @@ NONE_JSON_FIELDS = {
     '_submission_time': 'date_created',
     '_date_modified': 'date_modified',
     '_id': 'id',
-    '_version': 'version'
+    '_version': 'version',
+    '_last_edited': 'last_edited'
 }
 
 

--- a/onadata/apps/viewer/tests/test_parsed_instance.py
+++ b/onadata/apps/viewer/tests/test_parsed_instance.py
@@ -4,7 +4,7 @@ from onadata.apps.logger.models.instance import Instance
 from onadata.apps.main.models.user_profile import UserProfile
 from onadata.apps.main.tests.test_base import TestBase
 from onadata.apps.viewer.models.parsed_instance import (
-    get_where_clause, get_sql_with_params
+    get_where_clause, get_sql_with_params, _parse_sort_fields
 )
 
 
@@ -130,3 +130,12 @@ class TestParsedInstance(TestBase):
             xform=self.xform, query=[{'_submitted_by': 'bob'}, 'ambulance']
         )
         self.assertEqual(2, records.count())
+
+    def test_parse_sort_fields_function(self):
+        """
+        Test that the _parse_sort_fields function works as intended
+        """
+        fields = ['name', '_submission_time', '-_date_modified']
+        expected_return = ['name', 'date_created', '-date_modified']
+        self.assertEqual(
+            [i for i in _parse_sort_fields(fields)], expected_return)

--- a/onadata/libs/models/sorting.py
+++ b/onadata/libs/models/sorting.py
@@ -1,5 +1,6 @@
 import json
 import six
+from typing import Dict
 
 
 def sort_from_mongo_sort_str(sort_str):
@@ -21,11 +22,16 @@ def sort_from_mongo_sort_str(sort_str):
     return sort_values
 
 
-def json_order_by(sort_list):
+def json_order_by(
+        sort_list, none_json_fields: Dict = {}, model_name: str = ""):
     _list = []
 
     for field in sort_list:
-        _str = u" json->>%s"
+        field_key = field.lstrip('-')
+        _str = u" json->>%s"\
+            if field_key not in none_json_fields.keys() else\
+            f'"{model_name}"."{none_json_fields.get(field_key)}"'
+
         if field.startswith('-'):
             _str += u" DESC"
         else:
@@ -38,10 +44,12 @@ def json_order_by(sort_list):
     return u""
 
 
-def json_order_by_params(sort_list):
+def json_order_by_params(sort_list, none_json_fields: Dict = {}):
     params = []
 
     for field in sort_list:
-        params.append(field.lstrip('-'))
+        field = field.lstrip('-')
+        if field not in none_json_fields.keys():
+            params.append(field.lstrip('-'))
 
     return params

--- a/onadata/libs/renderers/renderers.py
+++ b/onadata/libs/renderers/renderers.py
@@ -335,7 +335,11 @@ class InstanceXMLRenderer(XMLRenderer):
         yield self._get_current_buffer_data()
 
         data = data.__iter__()
-        out = next(data)
+
+        try:
+            out = next(data)
+        except StopIteration:
+            out = None
 
         while out:
             try:

--- a/onadata/libs/serializers/data_serializer.py
+++ b/onadata/libs/serializers/data_serializer.py
@@ -120,7 +120,7 @@ class DataInstanceXMLSerializer(serializers.ModelSerializer):
         instance_attributes = {
             '@formVersion': instance.version,
             '@lastModified': instance.date_modified.isoformat(),
-            '@created': instance.date_created.isoformat(),
+            '@dateCreated': instance.date_created.isoformat(),
             '@objectID': str(instance.id)
         }
         ret.update(instance_attributes)

--- a/onadata/libs/serializers/data_serializer.py
+++ b/onadata/libs/serializers/data_serializer.py
@@ -111,9 +111,6 @@ class DataInstanceXMLSerializer(serializers.ModelSerializer):
         fields = ('xml', )
 
     def to_representation(self, instance):
-        if isinstance(instance, dict):
-            instance = Instance.objects.get(id=instance.get('_id'))
-
         ret = super(
             DataInstanceXMLSerializer, self).to_representation(instance)
         if 'xml' in ret:

--- a/onadata/libs/serializers/data_serializer.py
+++ b/onadata/libs/serializers/data_serializer.py
@@ -111,6 +111,9 @@ class DataInstanceXMLSerializer(serializers.ModelSerializer):
         fields = ('xml', )
 
     def to_representation(self, instance):
+        if isinstance(instance, dict):
+            instance = Instance.objects.get(id=instance.get('_id'))
+
         ret = super(
             DataInstanceXMLSerializer, self).to_representation(instance)
         if 'xml' in ret:

--- a/onadata/libs/tests/utils/test_sorting.py
+++ b/onadata/libs/tests/utils/test_sorting.py
@@ -1,0 +1,51 @@
+from unittest import TestCase
+from onadata.libs.models.sorting import json_order_by, json_order_by_params
+
+
+class TestSorting(TestCase):
+    def test_json_order_by(self):
+        """
+        Test that the json_order_by function works as intended
+        1. Generates correct SQL ORDER BY query for JSON Fields
+        2. Generates correct SQL ORDER BY query for none JSON fields;
+           Includes the model field in the generated SQL
+        """
+        sort_list = ['name', '-qstn1', 'date_created']
+        expected_return = (
+            "ORDER BY  json->>%s ASC, json->>%s"
+            " DESC, json->>%s ASC")
+        self.assertEqual(json_order_by(sort_list), expected_return)
+
+        sort_list = ['name', '-qstn1', '-date_created', 'date_modified']
+        none_json_fields = {
+            'date_created': 'created',
+            'date_modified': 'last_modified'
+        }
+        model_name = "logger_instance"
+        expected_return = (
+            'ORDER BY  json->>%s ASC, json->>%s DESC,'
+            '"logger_instance"."created" DESC,'
+            '"logger_instance"."last_modified" ASC')
+        self.assertEqual(
+            json_order_by(sort_list, none_json_fields, model_name),
+            expected_return)
+
+    def test_json_order_by_params(self):
+        """
+        Test that the json_order_by_params works as intended
+        1. Returns the correct JSON fields; without the - symbol
+        2. Excludes none JSON fields in the return; The json_order_by function
+           returns an SQL Statement with the fields in built
+        """
+        sort_list = ['name', 'qstn1', 'date_created']
+        expected_return = ['name', 'qstn1', 'date_created']
+        self.assertEqual(json_order_by_params(sort_list), expected_return)
+
+        sort_list = ['name', '-qstn1', '-date_created', 'date_modified']
+        none_json_fields = {
+            'date_created': 'created',
+            'date_modified': 'last_modified'
+        }
+        expected_return = ['name', 'qstn1']
+        self.assertEqual(
+            json_order_by_params(sort_list, none_json_fields), expected_return)


### PR DESCRIPTION
### Changes / Features implemented

- Handle streaming empty datasets using XML Renderer
- Add `_date_modified` to the NONE_JSON_FIELD list
- Sort none & filter none JSON fields using the model field

### Steps taken to verify this change does what is intended

- Added tests

### Side effects of implementing this change

- N/A

Closes #2000 
