### PR TITLE
Ensure that the CSV Import status is updated on failed import

### DIFF
--- a/onadata/libs/utils/csv_import.py
+++ b/onadata/libs/utils/csv_import.py
@@ -160,6 +160,7 @@ def failed_import(rollback_uuids, xform, exception, status_message):
     :return: The async_status result
     """
     Instance.objects.filter(uuid__in=rollback_uuids, xform=xform).delete()
+    xform.submission_count(True)
     report_exception(
         'CSV Import Failed : %d - %s - %s' % (xform.pk, xform.id_string,
                                               xform.title), exception,
@@ -455,6 +456,7 @@ def submit_csv(username, xform, csv_file, overwrite=False):
         # validation
         Instance.objects.filter(
             uuid__in=rollback_uuids, xform=xform).delete()
+        xform.submission_count(True)
         return async_status(
             FAILED,
             u'Invalid CSV data imported in row(s): {}'.format(

--- a/onadata/libs/utils/csv_import.py
+++ b/onadata/libs/utils/csv_import.py
@@ -444,9 +444,7 @@ def submit_csv(username, xform, csv_file, overwrite=False):
                             instance.user = users[0]
                             instance.save()
                 except Exception as e:
-                    failed_import(rollback_uuids, xform, e, text(e))
-                finally:
-                    xform.submission_count(True)
+                    return failed_import(rollback_uuids, xform, e, text(e))
     except UnicodeDecodeError as e:
         return failed_import(rollback_uuids, xform, e,
                              'CSV file must be utf-8 encoded')


### PR DESCRIPTION
### Changes / Features implemented

- Return failed import async status on exception
- Reset XForm submission count on failed import
- Test that on failed import a response is returned

### Steps taken to verify this change does what is intended

- Added tests

### Side effects of implementing this change

- N/A

Closes #2036 
