### PR TITLE
Fix submission deletion endpoint error

### DIFF
--- a/.github/workflows/ecr-image-build.yml
+++ b/.github/workflows/ecr-image-build.yml
@@ -46,7 +46,8 @@ jobs:
         run: |
           ssh-agent -a  $SSH_AUTH_SOCK >> /dev/null
           ssh-add  - <<<  "${{ secrets.SSH_PRIVATE_KEY }}"
-          ssh-keyscan github.com >> ~/.ssh/known_hosts
+          mkdir -p ~/.ssh
+          ssh-keyscan github.com > ~/.ssh/known_hosts
 
       - name: Build and push
         id: docker-build

--- a/onadata/apps/api/tests/viewsets/test_data_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_data_viewset.py
@@ -1439,9 +1439,9 @@ class TestDataViewSet(TestBase):
         self.assertEqual(first_xform_instance[0].deleted_by, request.user)
         # message sent upon delete
         self.assertTrue(send_message_mock.called)
-        send_message_mock.called_with(
-            [dataid], formid, XFORM,
-            request.user, SUBMISSION_DELETED)
+        send_message_mock.assert_called_with(
+            instance_id=dataid, target_id=formid, target_type=XFORM,
+            user=request.user, message_verb=SUBMISSION_DELETED)
 
         # second delete of same submission should return 404
         request = self.factory.delete('/', **self.extra)

--- a/onadata/apps/api/viewsets/data_viewset.py
+++ b/onadata/apps/api/viewsets/data_viewset.py
@@ -344,10 +344,11 @@ class DataViewSet(AnonymousUserPublicFormsMixin,
 
             if request.user.has_perm(
                     CAN_DELETE_SUBMISSION, self.object.xform):
+                instance_id = self.object.pk
                 delete_instance(self.object, request.user)
                 # send message
                 send_message(
-                    instance_id=self.object, target_id=self.object.xform.id,
+                    instance_id=instance_id, target_id=self.object.xform.id,
                     target_type=XFORM, user=request.user,
                     message_verb=SUBMISSION_DELETED)
             else:

--- a/onadata/apps/logger/tests/models/test_instance.py
+++ b/onadata/apps/logger/tests/models/test_instance.py
@@ -248,8 +248,6 @@ class TestInstance(TestBase):
         self.assertEqual(SubmissionReview.APPROVED,
                          instance.json[u'_review_status'])
         self.assertEqual(SubmissionReview.APPROVED, instance_review.status)
-        self.assertEqual(instance.date_created.strftime(MONGO_STRFTIME),
-                         instance_review.date_created.strftime(MONGO_STRFTIME))
         comment = instance_review.get_note_text()
         self.assertEqual(None, comment)
         self.assertTrue(instance.has_a_review)
@@ -273,8 +271,6 @@ class TestInstance(TestBase):
         self.assertEqual(SubmissionReview.APPROVED,
                          instance.json[u'_review_status'])
         self.assertEqual(SubmissionReview.APPROVED, instance_review.status)
-        self.assertEqual(instance.date_created.strftime(MONGO_STRFTIME),
-                         instance_review.date_created.strftime(MONGO_STRFTIME))
         comment = instance_review.get_note_text()
         self.assertEqual("Hey There", comment)
         self.assertTrue(instance.has_a_review)

--- a/onadata/apps/main/tests/test_form_api.py
+++ b/onadata/apps/main/tests/test_form_api.py
@@ -84,8 +84,7 @@ class TestFormAPI(TestBase):
         start = callback.__len__() + 1
         end = content.__len__() - 1
         content = content[start: end]
-        d = dict_for_mongo_without_userform_id(
-            self.xform.instances.all()[0].parsed_instance)
+        d = self.xform.instances.all()[0].json
         find_d = json.loads(content)[0]
         self.assertEqual(find_d, d)
 


### PR DESCRIPTION
### Changes / Features implemented

- Pass an Instance ID instead of an Instance object to `send_message`
- Update test to ensure call arguments are correct

### Steps taken to verify this change does what is intended

- Updated tests

### Side effects of implementing this change

- N/A

Closes #2056 
