### PR TITLE
Add pagination for the messaging endpoint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ services:
   - postgresql
 
 env:
-  - TESTFOLDER="onadata/libs onadata/apps/main onadata/apps/restservice onadata/apps/sms_support onadata/apps/viewer"
+  - TESTFOLDER="onadata/libs onadata/apps/main onadata/apps/restservice onadata/apps/sms_support onadata/apps/viewer onadata/apps/messaging"
   - TESTFOLDER="onadata/apps/api onadata/apps/logger"
 
 before_install:

--- a/docs/messaging.rst
+++ b/docs/messaging.rst
@@ -117,3 +117,42 @@ Response
             "timestamp": "2021-02-26T03:49:57.799647-05:00"
         }
     ]
+
+GET Paginate events messages for a specific verb
+------------------------------------------------
+
+Lists out event messages using page number and the number of items per page. Use the ``page`` parameter to specify page number and ``page_size`` parameter is used to set the custom page size.
+
+- ``page`` - Integer representing the page.
+- ``page_size`` - Integer representing the number of records that should be returned in a single page.
+
+There are a few important facts to note about retrieving paginated data:
+
+#. The maximum number of items that can be requested in a page via the ``page_size`` query param is 10,000
+#. Information regrading transversal of the paginated responses can be found in `the Link header <https://tools.ietf.org/html/rfc5988>`_ returned in the response. *Note: Some relational links may not be present depending on the page accessed i.e the ``first`` relational page link won't be present on the first page response*
+
+Example
+^^^^^^^^
+::
+
+      curl -X GET https://api.ona.io/api/v1/messaging?target_type=xform&target_id=1&verb=message&page=1&page_size=1
+
+Sample response with link header
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+**Response Header:** ::
+
+      ...
+      Link: <https://api.ona.io/api/v1/messaging?target_type=xform&target_id=1&verb=message&page=2&page_size=1>; rel="next", <https://api.ona.io/api/v1/messaging?target_type=xform&target_id=1&verb=message&page=3&page_size=1>; rel="last"
+
+**Response:** ::
+
+      [
+          {
+              "id": 16485370,
+              "verb": "message",
+              "message": "Hey there",
+              "user": "bob",
+              "timestamp": "2021-02-26T03:32:57.799647-05:00"
+          }
+      ]

--- a/onadata/apps/main/tests/test_form_api.py
+++ b/onadata/apps/main/tests/test_form_api.py
@@ -49,8 +49,7 @@ class TestFormAPI(TestBase):
         data = {'query': query}
         response = self.client.get(self.api_url, data)
         self.assertEqual(response.status_code, 200)
-        d = dict_for_mongo_without_userform_id(
-            self.xform.instances.all()[0].parsed_instance)
+        d = self.xform.instances.all()[0].json
         find_d = json.loads(response.content)[0]
         self.assertEqual(find_d, d)
 

--- a/onadata/apps/messaging/tests/test_backends_mqtt.py
+++ b/onadata/apps/messaging/tests/test_backends_mqtt.py
@@ -22,6 +22,7 @@ class TestMQTTBackend(TestCase):
     """
     Test MQTT Backend
     """
+    maxDiff = None
 
     def test_mqtt_get_topic(self):
         """
@@ -93,12 +94,26 @@ class TestMQTTBackend(TestCase):
                     'metadata': {
                         'id': to_user.pk,
                         'name': to_user.get_full_name()
-                    }
+                    },
+                    'verb': 'message'
                 },
                 'message': "I love oov"
             }
         }
-        self.assertEqual(json.dumps(payload), get_payload(instance))
+        self.assertEqual(
+            json.dumps(payload), get_payload(instance, verbose_payload=True))
+
+        expected_payload = {
+            'id': instance.id,
+            'verb': instance.verb,
+            'message': "I love oov",
+            'user': from_user.username,
+            'timestamp': instance.timestamp.isoformat()
+        }
+
+        self.assertEqual(
+            json.dumps(expected_payload), get_payload(
+                instance, verbose_payload=False))
 
     @patch('onadata.apps.messaging.backends.mqtt.publish.single')
     def test_mqtt_send(self, mocked):

--- a/onadata/apps/messaging/tests/test_messaging_viewset.py
+++ b/onadata/apps/messaging/tests/test_messaging_viewset.py
@@ -5,6 +5,7 @@ Tests Messaging app viewsets.
 from __future__ import unicode_literals
 
 from builtins import str as text
+from collections import OrderedDict
 
 from actstream.models import Action
 from django.test import TestCase
@@ -101,7 +102,10 @@ class TestMessagingViewSet(TestCase):
         force_authenticate(request, user=user)
         response = view(request=request)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.data, [message_data])
+        message_data.pop('target_id')
+        message_data.pop('target_type')
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(dict(response.data[0]), message_data)
 
         # returns empty list when a target type does not have any records
         request = self.factory.get(
@@ -155,6 +159,8 @@ class TestMessagingViewSet(TestCase):
         force_authenticate(request, user=user)
         response = view(request=request, pk=message_data['id'])
         self.assertEqual(response.status_code, 200)
+        message_data.pop('target_id')
+        message_data.pop('target_type')
         self.assertDictEqual(response.data, message_data)
 
     def test_authentication_required(self):
@@ -280,7 +286,7 @@ class TestMessagingViewSet(TestCase):
         self.assertEqual(
             response['Link'],
             ('<http://testserver/messaging?target_type=user&'
-             'target_id=2page=2&page_size=2>; rel="next"'))
+             f'target_id={user.pk}&page=2&page_size=2>; rel="next"'))
 
         # Test the retrieval threshold is respected
         with override_settings(MESSAGE_RETRIEVAL_THRESHOLD=2):

--- a/onadata/apps/messaging/tests/test_messaging_viewset.py
+++ b/onadata/apps/messaging/tests/test_messaging_viewset.py
@@ -284,8 +284,10 @@ class TestMessagingViewSet(TestCase):
         self.assertIn('Link', response)
         self.assertEqual(
             response['Link'],
-            ('<http://testserver/messaging?target_type=user&'
-             f'target_id={user.pk}&page=2&page_size=2>; rel="next"'))
+            (f'<http://testserver/messaging?page=2&page_size=2&'
+             f'target_id={user.pk}&target_type=user>; rel="next",'
+             ' <http://testserver/messaging?page=2&page_size=2&'
+             f'target_id={user.pk}&target_type=user>; rel="last"'))
 
         # Test the retrieval threshold is respected
         with override_settings(MESSAGE_RETRIEVAL_THRESHOLD=2):
@@ -298,6 +300,13 @@ class TestMessagingViewSet(TestCase):
             response = view(request=request)
             self.assertEqual(response.status_code, 200, response.data)
             self.assertEqual(len(response.data), 2)
+            self.assertIn('Link', response)
+            self.assertEqual(
+                response['Link'],
+                (f'<http://testserver/messaging?page=2&'
+                 f'target_id={user.pk}&target_type=user>; rel="next",'
+                 ' <http://testserver/messaging?page=2&'
+                 f'target_id={user.pk}&target_type=user>; rel="last"'))
 
     @override_settings(USE_TZ=False)
     def test_messaging_timestamp_filter(self):

--- a/onadata/apps/messaging/tests/test_messaging_viewset.py
+++ b/onadata/apps/messaging/tests/test_messaging_viewset.py
@@ -277,6 +277,18 @@ class TestMessagingViewSet(TestCase):
         self.assertEqual(response.status_code, 200, response.data)
         self.assertEqual(len(response.data), 2)
 
+        # Test the retrieval threshold is respected
+        with override_settings(MESSAGE_RETRIEVAL_THRESHOLD=2):
+            request = self.factory.get(
+                '/messaging', data={
+                    "target_type": "user", "target_id": user.pk
+                }
+            )
+            force_authenticate(request, user=user)
+            response = view(request=request)
+            self.assertEqual(response.status_code, 200, response.data)
+            self.assertEqual(len(response.data), 2)
+
     @override_settings(USE_TZ=False)
     def test_messaging_timestamp_filter(self):
         """

--- a/onadata/apps/messaging/tests/test_messaging_viewset.py
+++ b/onadata/apps/messaging/tests/test_messaging_viewset.py
@@ -276,6 +276,11 @@ class TestMessagingViewSet(TestCase):
         response = view(request=request)
         self.assertEqual(response.status_code, 200, response.data)
         self.assertEqual(len(response.data), 2)
+        self.assertIn('Link', response)
+        self.assertEqual(
+            response['Link'],
+            ('<http://testserver/messaging?target_type=user&'
+             'target_id=2page=2&page_size=2>; rel="next"'))
 
         # Test the retrieval threshold is respected
         with override_settings(MESSAGE_RETRIEVAL_THRESHOLD=2):

--- a/onadata/apps/messaging/tests/test_messaging_viewset.py
+++ b/onadata/apps/messaging/tests/test_messaging_viewset.py
@@ -5,7 +5,6 @@ Tests Messaging app viewsets.
 from __future__ import unicode_literals
 
 from builtins import str as text
-from collections import OrderedDict
 
 from actstream.models import Action
 from django.test import TestCase

--- a/onadata/apps/messaging/tests/test_signals.py
+++ b/onadata/apps/messaging/tests/test_signals.py
@@ -33,7 +33,8 @@ class TestSignals(TestCase):
         messaging_backends_handler(Action, instance=Action(id=9), created=True)
         self.assertTrue(call_backend_async_mock.called)
         call_backend_async_mock.assert_called_with(
-            'onadata.apps.messaging.backends.base.BaseBackend', 9, None)
+            ('onadata.apps.messaging.backends.base.BaseBackend', 9, None),
+            countdown=2)
 
     @override_settings(NOTIFICATION_BACKENDS={
         'mqtt': {

--- a/onadata/apps/messaging/tests/test_tasks.py
+++ b/onadata/apps/messaging/tests/test_tasks.py
@@ -27,7 +27,7 @@ class TestTasks(TestCase):
         instance = _create_message(from_user, to_user, 'I love oov')
 
         with self.assertRaises(NotImplementedError):
-            call_backend_async.apply_async(
+            call_backend_async(
                 backend='onadata.apps.messaging.backends.base.BaseBackend',
                 instance_id=instance.id,
                 backend_options=None).get()

--- a/onadata/apps/messaging/viewsets.py
+++ b/onadata/apps/messaging/viewsets.py
@@ -17,7 +17,8 @@ from onadata.apps.messaging.filters import (
     UserFilterBackend)
 from onadata.apps.messaging.permissions import TargetObjectPermissions
 from onadata.apps.messaging.serializers import MessageSerializer
-from onadata.libs.pagination import StandardPageNumberPagination
+from onadata.libs.pagination import (
+    StandardPageNumberPagination, generate_pagination_headers)
 
 
 # pylint: disable=too-many-ancestors
@@ -38,6 +39,7 @@ class MessagingViewSet(mixins.CreateModelMixin, mixins.ListModelMixin,
 
     def list(self, request, *args, **kwargs):
         queryset = self.filter_queryset(self.get_queryset())
+        no_of_records = queryset.count()
         retrieval_threshold = getattr(
             settings, "MESSAGE_RETRIEVAL_THRESHOLD", 10000)
         pagination_keys = [self.paginator.page_query_param,
@@ -45,7 +47,14 @@ class MessagingViewSet(mixins.CreateModelMixin, mixins.ListModelMixin,
         query_param_keys = self.request.query_params
         should_paginate = any(
             [k in query_param_keys for k in pagination_keys]) or \
-            queryset.count() > retrieval_threshold
+            no_of_records > retrieval_threshold
+        current_page_size = self.request.query_params.get(
+            self.paginator.page_size_query_param) or retrieval_threshold
+        current_page = self.request.query_params.get(
+            self.paginator.page_query_param) or 1
+        headers = generate_pagination_headers(
+            self.request, no_of_records, current_page_size, current_page
+        )
 
         if should_paginate and \
                 "page_size" not in self.request.query_params.keys():
@@ -57,4 +66,4 @@ class MessagingViewSet(mixins.CreateModelMixin, mixins.ListModelMixin,
         else:
             serializer = self.get_serializer(queryset, many=True)
 
-        return Response(serializer.data)
+        return Response(serializer.data, headers=headers)

--- a/onadata/libs/pagination.py
+++ b/onadata/libs/pagination.py
@@ -1,7 +1,12 @@
+import math
+from typing import Union
+from urllib.parse import urlparse, parse_qs
+
 from django.core.paginator import Paginator
 from django.conf import settings
 from rest_framework.pagination import (
     PageNumberPagination, InvalidPage, NotFound)
+from rest_framework.request import Request
 
 
 class StandardPageNumberPagination(PageNumberPagination):
@@ -57,3 +62,73 @@ class CountOverridablePageNumberPagination(StandardPageNumberPagination):
 
         self.request = request
         return list(self.page)
+
+
+def generate_pagination_headers(
+    request: Request, no_of_records: int, current_page_size: Union[int, str],
+    current_page: Union[int, str]
+) -> dict:
+    url = urlparse(request.build_absolute_uri())
+    base_url = f"{url.scheme}://{url.netloc}{url.path}?"
+    if url.query:
+        query_params = parse_qs(url.query)
+        query_string = None
+        for param_key, param_values in query_params.items():
+            if param_key not in ['page_size', 'page']:
+                param_value = ','.join(param_values)
+                query = f'{param_key}={param_value}&'
+                if not query_string:
+                    query_string = query
+                else:
+                    query_string += query
+
+        base_url += f'{query_string}'
+
+    next_page_url = None
+    prev_page_url = None
+    first_page_url = None
+    last_page_url = None
+    links = []
+
+    if isinstance(current_page, str):
+        try:
+            current_page = int(current_page)
+        except ValueError:
+            return
+
+    if isinstance(current_page_size, str):
+        try:
+            current_page_size = int(current_page_size)
+        except ValueError:
+            return
+
+    if (current_page * current_page_size) < no_of_records:
+        next_page_url = (
+            f"{base_url}page={current_page + 1}&"
+            f"page_size={current_page_size}")
+
+    if current_page > 1:
+        prev_page_url = (
+            f"{base_url}page={current_page - 1}"
+            f"&page_size={current_page_size}")
+
+    last_page = math.ceil(no_of_records / current_page_size)
+    if last_page != current_page and last_page != current_page + 1:
+        last_page_url = (
+            f"{base_url}page={last_page}&page_size={current_page_size}"
+        )
+
+    if current_page != 1:
+        first_page_url = (
+            f"{base_url}page=1&page_size={current_page_size}"
+        )
+
+    for rel, link in (
+            ('prev', prev_page_url),
+            ('next', next_page_url),
+            ('last', last_page_url),
+            ('first', first_page_url)):
+        if link:
+            links.append(f'<{link}>; rel="{rel}"')
+
+    return {'Link': ', '.join(links)}

--- a/onadata/libs/pagination.py
+++ b/onadata/libs/pagination.py
@@ -1,11 +1,8 @@
-import math
-from typing import Union
-from urllib.parse import urlparse, parse_qs
-
 from django.core.paginator import Paginator
 from django.conf import settings
+from django.db.models import QuerySet
 from rest_framework.pagination import (
-    PageNumberPagination, InvalidPage, NotFound)
+    PageNumberPagination, InvalidPage, NotFound, replace_query_param)
 from rest_framework.request import Request
 
 
@@ -14,6 +11,45 @@ class StandardPageNumberPagination(PageNumberPagination):
     page_size_query_param = 'page_size'
     max_page_size = getattr(
         settings, "STANDARD_PAGINATION_MAX_PAGE_SIZE", 10000)
+
+    def get_first_page_link(self):
+        if self.page.number == 1:
+            return None
+        url = self.request.build_absolute_uri()
+        return replace_query_param(url, self.page_query_param, 1)
+
+    def get_last_page_link(self):
+        if self.page.number == self.paginator.num_pages:
+            return None
+        url = self.request.build_absolute_uri()
+        return replace_query_param(
+            url, self.page_query_param, self.paginator.num_pages)
+
+    def generate_link_header(
+            self, request: Request, queryset: QuerySet
+    ):
+        links = []
+        page_size = self.get_page_size(request)
+        if not page_size:
+            return {}
+        page_number = request.query_params.get(self.page_query_param, 1)
+        self.paginator = self.django_paginator_class(queryset, page_size)
+        self.request = request
+
+        try:
+            self.page = self.paginator.page(page_number)
+        except InvalidPage:
+            return {}
+
+        for rel, link in (
+                ('prev', self.get_previous_link()),
+                ('next', self.get_next_link()),
+                ('last', self.get_last_page_link()),
+                ('first', self.get_first_page_link())):
+            if link:
+                links.append(f'<{link}>; rel="{rel}"')
+
+        return {'Link': ', '.join(links)}
 
 
 class CountOverridablePaginator(Paginator):
@@ -62,73 +98,3 @@ class CountOverridablePageNumberPagination(StandardPageNumberPagination):
 
         self.request = request
         return list(self.page)
-
-
-def generate_pagination_headers(
-    request: Request, no_of_records: int, current_page_size: Union[int, str],
-    current_page: Union[int, str]
-) -> dict:
-    url = urlparse(request.build_absolute_uri())
-    base_url = f"{url.scheme}://{url.netloc}{url.path}?"
-    if url.query:
-        query_params = parse_qs(url.query)
-        query_string = None
-        for param_key, param_values in query_params.items():
-            if param_key not in ['page_size', 'page']:
-                param_value = ','.join(param_values)
-                query = f'{param_key}={param_value}&'
-                if not query_string:
-                    query_string = query
-                else:
-                    query_string += query
-
-        base_url += f'{query_string}'
-
-    next_page_url = None
-    prev_page_url = None
-    first_page_url = None
-    last_page_url = None
-    links = []
-
-    if isinstance(current_page, str):
-        try:
-            current_page = int(current_page)
-        except ValueError:
-            return
-
-    if isinstance(current_page_size, str):
-        try:
-            current_page_size = int(current_page_size)
-        except ValueError:
-            return
-
-    if (current_page * current_page_size) < no_of_records:
-        next_page_url = (
-            f"{base_url}page={current_page + 1}&"
-            f"page_size={current_page_size}")
-
-    if current_page > 1:
-        prev_page_url = (
-            f"{base_url}page={current_page - 1}"
-            f"&page_size={current_page_size}")
-
-    last_page = math.ceil(no_of_records / current_page_size)
-    if last_page != current_page and last_page != current_page + 1:
-        last_page_url = (
-            f"{base_url}page={last_page}&page_size={current_page_size}"
-        )
-
-    if current_page != 1:
-        first_page_url = (
-            f"{base_url}page=1&page_size={current_page_size}"
-        )
-
-    for rel, link in (
-            ('prev', prev_page_url),
-            ('next', next_page_url),
-            ('last', last_page_url),
-            ('first', first_page_url)):
-        if link:
-            links.append(f'<{link}>; rel="{rel}"')
-
-    return {'Link': ', '.join(links)}

--- a/onadata/libs/tests/test_pagination.py
+++ b/onadata/libs/tests/test_pagination.py
@@ -1,0 +1,38 @@
+"""
+Tests onadata.libs.pagination module
+"""
+from django.http.request import HttpRequest
+
+from onadata.apps.main.tests.test_base import TestBase
+from onadata.libs.pagination import generate_pagination_headers
+
+
+class TestPaginationModule(TestBase):
+    """
+    Tests for onadata.libs.pagination module
+    """
+
+    def test_generate_pagination_headers(self):
+        req = HttpRequest()
+        req.META['SERVER_NAME'] = 'testserver'
+        req.META['SERVER_PORT'] = '80'
+        out = generate_pagination_headers(
+            req, 200, 50, 1
+        )
+        expected_out = {
+            'Link': '<http://testserver?page=2&page_size=50>; rel="next",'
+                    ' <http://testserver?page=4&page_size=50>; rel="last"'
+        }
+        self.assertEqual(out, expected_out)
+
+        # Test that initial query params are kept
+        req.META['QUERY_STRING'] = "filter_name=davis&sort=12"
+        out = generate_pagination_headers(
+            req, 200, 50, 1
+        )
+        expected_out = {
+            'Link': '<http://testserver?filter_name=davis&sort=12&page=2&'
+            'page_size=50>; rel="next", <http://testserver?filter_name=davis&'
+            'sort=12&page=4&page_size=50>; rel="last"'
+        }
+        self.assertEqual(out, expected_out)


### PR DESCRIPTION
### Changes / Features implemented

- Add pagination for the messaging endpoint. Added `page` and `page_size` query params
- Add message retrieval limit
- Add `Link` header to paginated responses
- Add `generate_pagination_headers` utility function

### Steps taken to verify this change does what is intended

- Add/Updated tests

### Side effects of implementing this change

The messaging viewset will now not return all the messages that are currently available if the number of messages surpasses the retrieval threshold.

### Before submitting this PR for review, please make sure you have:

- [x] Included tests 
- [x] Updated documentation

Closes #2064 
