### PR TITLE
Update requirements

### DIFF
--- a/onadata/apps/api/tests/viewsets/test_project_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_project_viewset.py
@@ -430,7 +430,7 @@ class TestProjectViewSet(TestAbstractViewSet):
         self.assertEqual(
             response.data, {
                 u'non_field_errors':
-                [u'The fields name, organization must make a unique set.']
+                [u'The fields name, owner must make a unique set.']
             }
         )
         final_count = Project.objects.count()

--- a/onadata/apps/api/tests/viewsets/test_xform_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_xform_viewset.py
@@ -1059,7 +1059,7 @@ class TestXFormViewSet(TestAbstractViewSet):
 
             encoded_payload = jwt.encode(
                 payload, JWT_SECRET_KEY,
-                algorithm=JWT_ALGORITHM).decode('utf-8')
+                algorithm=JWT_ALGORITHM)
 
             return_url = "https://enketo.ona.io/_/#YY8M"
             url = "https://enketo.ona.io/_/?jwt=%s#YY8M" % encoded_payload
@@ -1098,7 +1098,7 @@ class TestXFormViewSet(TestAbstractViewSet):
 
             encoded_payload = jwt.encode(
                 payload, JWT_SECRET_KEY,
-                algorithm=JWT_ALGORITHM).decode('utf-8')
+                algorithm=JWT_ALGORITHM)
 
             return_url = "https://enketo.ona.io/::YY8M"
             url = "%s?jwt=%s" % (return_url, encoded_payload)

--- a/onadata/apps/api/viewsets/floip_viewset.py
+++ b/onadata/apps/api/viewsets/floip_viewset.py
@@ -29,15 +29,16 @@ class FlowResultsJSONRenderer(JSONRenderer):
 
     # pylint: disable=too-many-arguments
     @classmethod
-    def build_json_resource_obj(cls, fields, resource, resource_instance,
-                                resource_name, force_type_resolution=False):
+    def build_json_resource_obj(
+            cls, fields, resource, resource_instance,
+            resource_name, serializer, force_type_resolution=False):
         """
         Build a JSON resource object using the id as it appears in the
         resource.
         """
         obj = super(FlowResultsJSONRenderer, cls).build_json_resource_obj(
             fields, resource, resource_instance, resource_name,
-            force_type_resolution)
+            serializer, force_type_resolution)
         obj['id'] = resource['id']
 
         return obj

--- a/onadata/apps/api/viewsets/openid_connect_viewset.py
+++ b/onadata/apps/api/viewsets/openid_connect_viewset.py
@@ -204,7 +204,7 @@ def get_redirect_sso_response(
                        algorithm=settings.JWT_ALGORITHM)
     redirect_response = HttpResponseRedirect(redirect_uri)
     redirect_response.set_cookie('SSO',
-                                 value=value.decode('utf-8'),
+                                 value=value,
                                  max_age=None,
                                  domain=domain)
 

--- a/onadata/libs/serializers/project_serializer.py
+++ b/onadata/libs/serializers/project_serializer.py
@@ -343,11 +343,7 @@ class ProjectSerializer(serializers.HyperlinkedModelSerializer):
 
     class Meta:
         model = Project
-        exclude = ('shared', 'user_stars', 'deleted_by')
-        extra_kwargs = {
-            'organization': {
-                'write_only': True,
-                'required': False, 'lookup_field': 'username'}}
+        exclude = ('shared', 'user_stars', 'deleted_by', 'organization')
 
     def validate(self, attrs):
         name = attrs.get('name')

--- a/requirements/base.pip
+++ b/requirements/base.pip
@@ -20,21 +20,23 @@ alabaster==0.7.12
     # via sphinx
 amqp==2.6.1
     # via kombu
-analytics-python==1.2.9
+analytics-python==1.3.1
     # via onadata
 appoptics-metrics==5.1.0
     # via onadata
 argparse==1.4.0
     # via unittest2
-attrs==20.2.0
+attrs==21.2.0
     # via jsonschema
-babel==2.8.0
+babel==2.9.1
     # via sphinx
-billiard==3.6.3.0
+backoff==1.10.0
+    # via analytics-python
+billiard==3.6.4.0
     # via celery
-boto3==1.15.17
+boto3==1.17.74
     # via tabulator
-botocore==1.18.17
+botocore==1.20.74
     # via
     #   boto3
     #   s3transfer
@@ -42,35 +44,37 @@ cached-property==1.5.2
     # via tableschema
 celery==4.4.7
     # via onadata
-certifi==2020.6.20
+certifi==2020.12.5
     # via requests
-cffi==1.14.3
+cffi==1.14.5
     # via cryptography
-chardet==3.0.4
+chardet==4.0.0
     # via
     #   datapackage
     #   requests
     #   tabulator
-click==7.1.2
+click==8.0.0
     # via
     #   datapackage
     #   tableschema
     #   tabulator
-cryptography==3.1.1
-    # via onadata
-datapackage==1.15.1
+cryptography==3.4.7
+    # via
+    #   jwcrypto
+    #   onadata
+datapackage==1.15.2
     # via pyfloip
-defusedxml==0.6.0
+defusedxml==0.7.1
     # via djangorestframework-xml
 deprecated==1.2.12
     # via onadata
 dict2xml==1.7.0
     # via onadata
-django-activity-stream==0.9.0
+django-activity-stream==0.10.0
     # via onadata
-django-cors-headers==3.5.0
+django-cors-headers==3.7.0
     # via onadata
-django-debug-toolbar==3.1.1
+django-debug-toolbar==3.2.1
     # via onadata
 django-filter==2.4.0
     # via onadata
@@ -80,23 +84,23 @@ django-guardian==2.3.0
     #   onadata
 django-nose==1.4.7
     # via onadata
-django-oauth-toolkit==1.3.2
+django-oauth-toolkit==1.5.0
     # via onadata
-django-ordered-model==3.4.1
+django-ordered-model==3.4.3
     # via onadata
-django-query-builder==1.2.0
+django-query-builder==2.0.1
     # via onadata
-django-registration-redux==2.8
+django-registration-redux==2.9
     # via onadata
 django-render-block==0.8.1
     # via django-templated-email
-django-reversion==3.0.8
+django-reversion==3.0.9
     # via onadata
-django-taggit==1.3.0
+django-taggit==1.4.0
     # via onadata
 django-templated-email==2.3.0
     # via onadata
-django==2.2.20
+django==2.2.23
     # via
     #   django-cors-headers
     #   django-debug-toolbar
@@ -112,36 +116,36 @@ django==2.2.20
     #   djangorestframework-jsonapi
     #   jsonfield
     #   onadata
-djangorestframework-csv==2.1.0
+djangorestframework-csv==2.1.1
     # via onadata
-djangorestframework-gis==0.16
+djangorestframework-gis==0.17
     # via onadata
 djangorestframework-guardian==0.3.0
     # via onadata
-djangorestframework-jsonapi==3.2.0
+djangorestframework-jsonapi==4.2.0
     # via onadata
 djangorestframework-jsonp==1.0.2
     # via onadata
 djangorestframework-xml==2.0.0
     # via onadata
-djangorestframework==3.11.2
+djangorestframework==3.12.4
     # via
     #   djangorestframework-csv
     #   djangorestframework-gis
     #   djangorestframework-guardian
     #   djangorestframework-jsonapi
     #   onadata
-docutils==0.16
+docutils==0.17.1
     # via sphinx
 dpath==2.0.1
     # via onadata
 elaphe3==0.2.0
     # via onadata
-et-xmlfile==1.0.1
+et-xmlfile==1.1.0
     # via openpyxl
-flake8==3.8.4
+flake8==3.9.2
     # via onadata
-fleming==0.5.0
+fleming==0.6.0
     # via django-query-builder
 formencode==1.3.1
     # via pyxform
@@ -149,32 +153,33 @@ future==0.18.2
     # via python-json2xlsclient
 geojson==2.5.0
     # via onadata
-httmock==1.3.0
+greenlet==1.1.0
+    # via sqlalchemy
+httmock==1.4.0
     # via onadata
-httplib2==0.18.1
+httplib2==0.19.1
     # via
     #   oauth2client
     #   onadata
 idna==2.10
     # via requests
-ijson==3.1.2
+ijson==3.1.4
     # via tabulator
 imagesize==1.2.0
     # via sphinx
-importlib-metadata==2.0.0
+importlib-metadata==4.0.1
     # via
     #   flake8
     #   jsonpickle
     #   jsonschema
     #   kombu
     #   markdown
+    #   sqlalchemy
 inflection==0.5.1
     # via djangorestframework-jsonapi
 isodate==0.6.0
     # via tableschema
-jdcal==1.4.1
-    # via openpyxl
-jinja2==2.11.2
+jinja2==2.11.3
     # via sphinx
 jmespath==0.10.0
     # via
@@ -182,49 +187,55 @@ jmespath==0.10.0
     #   botocore
 jsonfield==0.9.23
     # via onadata
-jsonlines==1.2.0
+jsonlines==2.0.0
     # via tabulator
-jsonpickle==1.4.1
+jsonpickle==2.0.0
     # via onadata
-jsonpointer==2.0
+jsonpointer==2.1
     # via datapackage
 jsonschema==3.2.0
     # via
     #   datapackage
     #   tableschema
+jwcrypto==0.8
+    # via django-oauth-toolkit
 kombu==4.6.11
     # via celery
 linear-tsv==1.1.0
     # via tabulator
 linecache2==1.0.0
     # via traceback2
-lxml==4.5.2
+lxml==4.6.3
     # via onadata
-markdown==3.3.1
+markdown==3.3.4
     # via onadata
 markupsafe==1.1.1
-    # via jinja2
+    # via
+    #   jinja2
+    #   sphinx
 mccabe==0.6.1
     # via flake8
-mock==4.0.2
+mock==4.0.3
     # via onadata
 modilabs-python-utils==0.1.5
     # via onadata
+monotonic==1.6
+    # via analytics-python
 nose==1.3.7
     # via django-nose
-numpy==1.19.2
+numpy==1.19.5
     # via onadata
 oauthlib==3.1.0
     # via django-oauth-toolkit
-openpyxl==3.0.5
+openpyxl==3.0.7
     # via
     #   onadata
     #   tabulator
-packaging==20.4
+packaging==20.9
     # via sphinx
 paho-mqtt==1.5.1
     # via onadata
-pillow==8.0.0
+pillow==8.2.0
     # via
     #   elaphe3
     #   onadata
@@ -237,22 +248,24 @@ pyasn1==0.4.8
     #   oauth2client
     #   pyasn1-modules
     #   rsa
-pycodestyle==2.6.0
+pycodestyle==2.7.0
     # via flake8
 pycparser==2.20
     # via cffi
-pyflakes==2.2.0
+pyflakes==2.3.1
     # via flake8
-pygments==2.7.1
+pygments==2.9.0
     # via sphinx
-pyjwt==1.7.1
+pyjwt==2.1.0
     # via onadata
 pylibmc==1.6.1
     # via onadata
-pymongo==3.11.0
+pymongo==3.11.4
     # via onadata
 pyparsing==2.4.7
-    # via packaging
+    # via
+    #   httplib2
+    #   packaging
 pyrsistent==0.17.3
     # via jsonschema
 python-dateutil==2.8.1
@@ -264,7 +277,7 @@ python-dateutil==2.8.1
     #   tableschema
 python-memcached==1.59
     # via onadata
-pytz==2020.1
+pytz==2021.1
     # via
     #   babel
     #   celery
@@ -272,7 +285,7 @@ pytz==2020.1
     #   django-query-builder
     #   fleming
     #   onadata
-pyxform==1.4.0
+pyxform==1.5.0
     # via
     #   onadata
     #   pyfloip
@@ -280,9 +293,9 @@ raven==6.10.0
     # via onadata
 recaptcha-client==1.0.6
     # via onadata
-requests-mock==1.8.0
+requests-mock==1.9.2
     # via onadata
-requests==2.24.0
+requests==2.25.1
     # via
     #   analytics-python
     #   datapackage
@@ -294,40 +307,38 @@ requests==2.24.0
     #   sphinx
     #   tableschema
     #   tabulator
-rfc3986==1.4.0
+rfc3986==1.5.0
     # via tableschema
-rsa==4.6
+rsa==4.7.2
     # via oauth2client
-s3transfer==0.3.3
+s3transfer==0.4.2
     # via boto3
 savreaderwriter==3.4.2
     # via onadata
 simplejson==3.17.2
     # via onadata
-six==1.15.0
+six==1.16.0
     # via
     #   analytics-python
     #   appoptics-metrics
-    #   cryptography
     #   datapackage
+    #   django-oauth-toolkit
     #   django-query-builder
     #   django-templated-email
     #   djangorestframework-csv
     #   isodate
-    #   jsonlines
     #   jsonschema
     #   linear-tsv
     #   oauth2client
-    #   packaging
     #   python-dateutil
     #   python-memcached
     #   requests-mock
     #   tableschema
     #   tabulator
     #   unittest2
-snowballstemmer==2.0.0
+snowballstemmer==2.1.0
     # via sphinx
-sphinx==3.2.1
+sphinx==4.0.1
     # via onadata
 sphinxcontrib-applehelp==1.0.2
     # via sphinx
@@ -341,20 +352,22 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.4
     # via sphinx
-sqlalchemy==1.3.20
+sqlalchemy==1.4.15
     # via tabulator
 sqlparse==0.4.1
     # via
     #   django
     #   django-debug-toolbar
-tableschema==1.20.0
+tableschema==1.20.2
     # via datapackage
-tabulator==1.52.4
+tabulator==1.53.5
     # via
     #   datapackage
     #   tableschema
 traceback2==1.4.0
     # via unittest2
+typing-extensions==3.10.0.0
+    # via importlib-metadata
 unicodecsv==0.14.1
     # via
     #   datapackage
@@ -365,7 +378,7 @@ unicodecsv==0.14.1
     #   tabulator
 unittest2==1.1.0
     # via pyxform
-urllib3==1.25.10
+urllib3==1.26.4
     # via
     #   botocore
     #   requests
@@ -386,7 +399,7 @@ xlwt==1.3.0
     # via onadata
 xmltodict==0.12.0
     # via onadata
-zipp==3.3.1
+zipp==3.4.1
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/base.pip
+++ b/requirements/base.pip
@@ -18,7 +18,7 @@
     # via -r requirements/base.in
 alabaster==0.7.12
     # via sphinx
-amqp==2.6.1
+amqp==5.0.6
     # via kombu
 analytics-python==1.3.1
     # via onadata
@@ -42,7 +42,7 @@ botocore==1.20.74
     #   s3transfer
 cached-property==1.5.2
     # via tableschema
-celery==4.4.7
+celery==5.0.5
     # via onadata
 certifi==2020.12.5
     # via requests
@@ -53,8 +53,18 @@ chardet==4.0.0
     #   datapackage
     #   requests
     #   tabulator
-click==8.0.0
+click-didyoumean==0.0.3
+    # via celery
+click-plugins==1.1.1
+    # via celery
+click-repl==0.1.6
+    # via celery
+click==7.1.2
     # via
+    #   celery
+    #   click-didyoumean
+    #   click-plugins
+    #   click-repl
     #   datapackage
     #   tableschema
     #   tabulator
@@ -199,7 +209,7 @@ jsonschema==3.2.0
     #   tableschema
 jwcrypto==0.8
     # via django-oauth-toolkit
-kombu==4.6.11
+kombu==5.0.2
     # via celery
 linear-tsv==1.1.0
     # via tabulator
@@ -239,6 +249,8 @@ pillow==8.2.0
     # via
     #   elaphe3
     #   onadata
+prompt-toolkit==3.0.18
+    # via click-repl
 psycopg2==2.8.6
     # via onadata
 pyasn1-modules==0.2.8
@@ -321,6 +333,7 @@ six==1.16.0
     # via
     #   analytics-python
     #   appoptics-metrics
+    #   click-repl
     #   datapackage
     #   django-oauth-toolkit
     #   django-query-builder
@@ -384,10 +397,12 @@ urllib3==1.26.4
     #   requests
 uwsgi==2.0.19.1
     # via onadata
-vine==1.3.0
+vine==5.0.0
     # via
     #   amqp
     #   celery
+wcwidth==0.2.5
+    # via prompt-toolkit
 wrapt==1.12.1
     # via deprecated
 xlrd==1.2.0

--- a/requirements/dev.pip
+++ b/requirements/dev.pip
@@ -18,7 +18,7 @@
     # via -r requirements/base.in
 alabaster==0.7.12
     # via sphinx
-amqp==2.6.1
+amqp==5.0.6
     # via kombu
 analytics-python==1.3.1
     # via onadata
@@ -46,7 +46,7 @@ botocore==1.20.74
     #   s3transfer
 cached-property==1.5.2
     # via tableschema
-celery==4.4.7
+celery==5.0.5
     # via onadata
 certifi==2020.12.5
     # via requests
@@ -57,8 +57,18 @@ chardet==4.0.0
     #   datapackage
     #   requests
     #   tabulator
-click==8.0.0
+click-didyoumean==0.0.3
+    # via celery
+click-plugins==1.1.1
+    # via celery
+click-repl==0.1.6
+    # via celery
+click==7.1.2
     # via
+    #   celery
+    #   click-didyoumean
+    #   click-plugins
+    #   click-repl
     #   datapackage
     #   tableschema
     #   tabulator
@@ -222,7 +232,7 @@ jsonschema==3.2.0
     #   tableschema
 jwcrypto==0.8
     # via django-oauth-toolkit
-kombu==4.6.11
+kombu==5.0.2
     # via celery
 lazy-object-proxy==1.6.0
     # via astroid
@@ -273,7 +283,9 @@ pillow==8.2.0
     #   elaphe3
     #   onadata
 prompt-toolkit==3.0.18
-    # via ipython
+    # via
+    #   click-repl
+    #   ipython
 psycopg2==2.8.6
     # via onadata
 ptyprocess==0.7.0
@@ -370,6 +382,7 @@ six==1.16.0
     #   analytics-python
     #   appoptics-metrics
     #   astroid
+    #   click-repl
     #   datapackage
     #   django-oauth-toolkit
     #   django-query-builder
@@ -439,7 +452,7 @@ urllib3==1.26.4
     #   requests
 uwsgi==2.0.19.1
     # via onadata
-vine==1.3.0
+vine==5.0.0
     # via
     #   amqp
     #   celery

--- a/requirements/dev.pip
+++ b/requirements/dev.pip
@@ -20,7 +20,7 @@ alabaster==0.7.12
     # via sphinx
 amqp==2.6.1
     # via kombu
-analytics-python==1.2.9
+analytics-python==1.3.1
     # via onadata
 appoptics-metrics==5.1.0
     # via onadata
@@ -28,17 +28,19 @@ argparse==1.4.0
     # via unittest2
 astroid==1.6.6
     # via pylint
-attrs==20.2.0
+attrs==21.2.0
     # via jsonschema
-babel==2.8.0
+babel==2.9.1
     # via sphinx
 backcall==0.2.0
     # via ipython
-billiard==3.6.3.0
+backoff==1.10.0
+    # via analytics-python
+billiard==3.6.4.0
     # via celery
-boto3==1.15.17
+boto3==1.17.74
     # via tabulator
-botocore==1.18.17
+botocore==1.20.74
     # via
     #   boto3
     #   s3transfer
@@ -46,41 +48,43 @@ cached-property==1.5.2
     # via tableschema
 celery==4.4.7
     # via onadata
-certifi==2020.6.20
+certifi==2020.12.5
     # via requests
-cffi==1.14.3
+cffi==1.14.5
     # via cryptography
-chardet==3.0.4
+chardet==4.0.0
     # via
     #   datapackage
     #   requests
     #   tabulator
-click==7.1.2
+click==8.0.0
     # via
     #   datapackage
     #   tableschema
     #   tabulator
-cryptography==3.1.1
-    # via onadata
-datapackage==1.15.1
+cryptography==3.4.7
+    # via
+    #   jwcrypto
+    #   onadata
+datapackage==1.15.2
     # via pyfloip
-decorator==4.4.2
+decorator==5.0.9
     # via
     #   ipython
     #   traitlets
-defusedxml==0.6.0
+defusedxml==0.7.1
     # via djangorestframework-xml
 deprecated==1.2.12
     # via onadata
 dict2xml==1.7.0
     # via onadata
-django-activity-stream==0.9.0
+django-activity-stream==0.10.0
     # via onadata
-django-cors-headers==3.5.0
+django-cors-headers==3.7.0
     # via onadata
-django-debug-toolbar==3.1.1
+django-debug-toolbar==3.2.1
     # via onadata
-django-extensions==3.0.9
+django-extensions==3.1.3
     # via -r requirements/dev.in
 django-filter==2.4.0
     # via onadata
@@ -90,26 +94,27 @@ django-guardian==2.3.0
     #   onadata
 django-nose==1.4.7
     # via onadata
-django-oauth-toolkit==1.3.2
+django-oauth-toolkit==1.5.0
     # via onadata
-django-ordered-model==3.4.1
+django-ordered-model==3.4.3
     # via onadata
-django-query-builder==1.2.0
+django-query-builder==2.0.1
     # via onadata
-django-registration-redux==2.8
+django-registration-redux==2.9
     # via onadata
 django-render-block==0.8.1
     # via django-templated-email
-django-reversion==3.0.8
+django-reversion==3.0.9
     # via onadata
-django-taggit==1.3.0
+django-taggit==1.4.0
     # via onadata
 django-templated-email==2.3.0
     # via onadata
-django==2.2.20
+django==2.2.23
     # via
     #   django-cors-headers
     #   django-debug-toolbar
+    #   django-extensions
     #   django-filter
     #   django-guardian
     #   django-oauth-toolkit
@@ -122,36 +127,36 @@ django==2.2.20
     #   djangorestframework-jsonapi
     #   jsonfield
     #   onadata
-djangorestframework-csv==2.1.0
+djangorestframework-csv==2.1.1
     # via onadata
-djangorestframework-gis==0.16
+djangorestframework-gis==0.17
     # via onadata
 djangorestframework-guardian==0.3.0
     # via onadata
-djangorestframework-jsonapi==3.2.0
+djangorestframework-jsonapi==4.2.0
     # via onadata
 djangorestframework-jsonp==1.0.2
     # via onadata
 djangorestframework-xml==2.0.0
     # via onadata
-djangorestframework==3.11.2
+djangorestframework==3.12.4
     # via
     #   djangorestframework-csv
     #   djangorestframework-gis
     #   djangorestframework-guardian
     #   djangorestframework-jsonapi
     #   onadata
-docutils==0.16
+docutils==0.17.1
     # via sphinx
 dpath==2.0.1
     # via onadata
 elaphe3==0.2.0
     # via onadata
-et-xmlfile==1.0.1
+et-xmlfile==1.1.0
     # via openpyxl
-flake8==3.8.4
+flake8==3.9.2
     # via onadata
-fleming==0.5.0
+fleming==0.6.0
     # via django-query-builder
 formencode==1.3.1
     # via pyxform
@@ -159,25 +164,28 @@ future==0.18.2
     # via python-json2xlsclient
 geojson==2.5.0
     # via onadata
-httmock==1.3.0
+greenlet==1.1.0
+    # via sqlalchemy
+httmock==1.4.0
     # via onadata
-httplib2==0.18.1
+httplib2==0.19.1
     # via
     #   oauth2client
     #   onadata
 idna==2.10
     # via requests
-ijson==3.1.2
+ijson==3.1.4
     # via tabulator
 imagesize==1.2.0
     # via sphinx
-importlib-metadata==2.0.0
+importlib-metadata==4.0.1
     # via
     #   flake8
     #   jsonpickle
     #   jsonschema
     #   kombu
     #   markdown
+    #   sqlalchemy
 inflection==0.5.1
     # via djangorestframework-jsonapi
 ipdb==0.13.7
@@ -188,15 +196,13 @@ ipython==7.16.1
     # via ipdb
 isodate==0.6.0
     # via tableschema
-isort==5.6.4
+isort==5.8.0
     # via
     #   -r requirements/dev.in
     #   pylint
-jdcal==1.4.1
-    # via openpyxl
-jedi==0.17.2
+jedi==0.18.0
     # via ipython
-jinja2==2.11.2
+jinja2==2.11.3
     # via sphinx
 jmespath==0.10.0
     # via
@@ -204,67 +210,73 @@ jmespath==0.10.0
     #   botocore
 jsonfield==0.9.23
     # via onadata
-jsonlines==1.2.0
+jsonlines==2.0.0
     # via tabulator
-jsonpickle==1.4.1
+jsonpickle==2.0.0
     # via onadata
-jsonpointer==2.0
+jsonpointer==2.1
     # via datapackage
 jsonschema==3.2.0
     # via
     #   datapackage
     #   tableschema
+jwcrypto==0.8
+    # via django-oauth-toolkit
 kombu==4.6.11
     # via celery
-lazy-object-proxy==1.5.1
+lazy-object-proxy==1.6.0
     # via astroid
 linear-tsv==1.1.0
     # via tabulator
 linecache2==1.0.0
     # via traceback2
-lxml==4.5.2
+lxml==4.6.3
     # via onadata
-markdown==3.3.1
+markdown==3.3.4
     # via onadata
 markupsafe==1.1.1
-    # via jinja2
+    # via
+    #   jinja2
+    #   sphinx
 mccabe==0.6.1
     # via
     #   flake8
     #   pylint
-mock==4.0.2
+mock==4.0.3
     # via onadata
 modilabs-python-utils==0.1.5
     # via onadata
+monotonic==1.6
+    # via analytics-python
 nose==1.3.7
     # via django-nose
-numpy==1.19.2
+numpy==1.19.5
     # via onadata
 oauthlib==3.1.0
     # via django-oauth-toolkit
-openpyxl==3.0.5
+openpyxl==3.0.7
     # via
     #   onadata
     #   tabulator
-packaging==20.4
+packaging==20.9
     # via sphinx
 paho-mqtt==1.5.1
     # via onadata
-parso==0.7.1
+parso==0.8.2
     # via jedi
 pexpect==4.8.0
     # via ipython
 pickleshare==0.7.5
     # via ipython
-pillow==8.0.0
+pillow==8.2.0
     # via
     #   elaphe3
     #   onadata
-prompt-toolkit==3.0.8
+prompt-toolkit==3.0.18
     # via ipython
 psycopg2==2.8.6
     # via onadata
-ptyprocess==0.6.0
+ptyprocess==0.7.0
     # via pexpect
 pyasn1-modules==0.2.8
     # via oauth2client
@@ -273,17 +285,17 @@ pyasn1==0.4.8
     #   oauth2client
     #   pyasn1-modules
     #   rsa
-pycodestyle==2.6.0
+pycodestyle==2.7.0
     # via flake8
 pycparser==2.20
     # via cffi
-pyflakes==2.2.0
+pyflakes==2.3.1
     # via flake8
-pygments==2.7.1
+pygments==2.9.0
     # via
     #   ipython
     #   sphinx
-pyjwt==1.7.1
+pyjwt==2.1.0
     # via onadata
 pylibmc==1.6.1
     # via onadata
@@ -291,15 +303,17 @@ pylint-django==0.11.1
     # via -r requirements/dev.in
 pylint-plugin-utils==0.6
     # via pylint-django
-pylint==1.9.4
+pylint==1.9.5
     # via
     #   -r requirements/dev.in
     #   pylint-django
     #   pylint-plugin-utils
-pymongo==3.11.0
+pymongo==3.11.4
     # via onadata
 pyparsing==2.4.7
-    # via packaging
+    # via
+    #   httplib2
+    #   packaging
 pyrsistent==0.17.3
     # via jsonschema
 python-dateutil==2.8.1
@@ -311,7 +325,7 @@ python-dateutil==2.8.1
     #   tableschema
 python-memcached==1.59
     # via onadata
-pytz==2020.1
+pytz==2021.1
     # via
     #   babel
     #   celery
@@ -319,7 +333,7 @@ pytz==2020.1
     #   django-query-builder
     #   fleming
     #   onadata
-pyxform==1.4.0
+pyxform==1.5.0
     # via
     #   onadata
     #   pyfloip
@@ -327,9 +341,9 @@ raven==6.10.0
     # via onadata
 recaptcha-client==1.0.6
     # via onadata
-requests-mock==1.8.0
+requests-mock==1.9.2
     # via onadata
-requests==2.24.0
+requests==2.25.1
     # via
     #   analytics-python
     #   datapackage
@@ -341,32 +355,30 @@ requests==2.24.0
     #   sphinx
     #   tableschema
     #   tabulator
-rfc3986==1.4.0
+rfc3986==1.5.0
     # via tableschema
-rsa==4.6
+rsa==4.7.2
     # via oauth2client
-s3transfer==0.3.3
+s3transfer==0.4.2
     # via boto3
 savreaderwriter==3.4.2
     # via onadata
 simplejson==3.17.2
     # via onadata
-six==1.15.0
+six==1.16.0
     # via
     #   analytics-python
     #   appoptics-metrics
     #   astroid
-    #   cryptography
     #   datapackage
+    #   django-oauth-toolkit
     #   django-query-builder
     #   django-templated-email
     #   djangorestframework-csv
     #   isodate
-    #   jsonlines
     #   jsonschema
     #   linear-tsv
     #   oauth2client
-    #   packaging
     #   pylint
     #   python-dateutil
     #   python-memcached
@@ -375,9 +387,9 @@ six==1.15.0
     #   tabulator
     #   traitlets
     #   unittest2
-snowballstemmer==2.0.0
+snowballstemmer==2.1.0
     # via sphinx
-sphinx==3.2.1
+sphinx==4.0.1
     # via onadata
 sphinxcontrib-applehelp==1.0.2
     # via sphinx
@@ -391,15 +403,15 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.4
     # via sphinx
-sqlalchemy==1.3.20
+sqlalchemy==1.4.15
     # via tabulator
 sqlparse==0.4.1
     # via
     #   django
     #   django-debug-toolbar
-tableschema==1.20.0
+tableschema==1.20.2
     # via datapackage
-tabulator==1.52.4
+tabulator==1.53.5
     # via
     #   datapackage
     #   tableschema
@@ -409,6 +421,8 @@ traceback2==1.4.0
     # via unittest2
 traitlets==4.3.3
     # via ipython
+typing-extensions==3.10.0.0
+    # via importlib-metadata
 unicodecsv==0.14.1
     # via
     #   datapackage
@@ -419,7 +433,7 @@ unicodecsv==0.14.1
     #   tabulator
 unittest2==1.1.0
     # via pyxform
-urllib3==1.25.10
+urllib3==1.26.4
     # via
     #   botocore
     #   requests
@@ -444,9 +458,9 @@ xlwt==1.3.0
     # via onadata
 xmltodict==0.12.0
     # via onadata
-yapf==0.30.0
+yapf==0.31.0
     # via -r requirements/dev.in
-zipp==3.3.1
+zipp==3.4.1
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/s3.pip
+++ b/requirements/s3.pip
@@ -4,15 +4,15 @@
 #
 #    pip-compile --output-file=requirements/s3.pip requirements/s3.in
 #
-boto3==1.17.64
+boto3==1.17.74
     # via -r requirements/s3.in
-botocore==1.20.64
+botocore==1.20.74
     # via
     #   boto3
     #   s3transfer
 django-storages==1.11.1
     # via -r requirements/s3.in
-django==2.2.21
+django==2.2.23
     # via
     #   -r requirements/s3.in
     #   django-storages
@@ -26,7 +26,7 @@ pytz==2021.1
     # via django
 s3transfer==0.4.2
     # via boto3
-six==1.15.0
+six==1.16.0
     # via python-dateutil
 sqlparse==0.4.1
     # via django

--- a/requirements/s3.pip
+++ b/requirements/s3.pip
@@ -4,15 +4,15 @@
 #
 #    pip-compile --output-file=requirements/s3.pip requirements/s3.in
 #
-boto3==1.15.14
+boto3==1.17.64
     # via -r requirements/s3.in
-botocore==1.18.14
+botocore==1.20.64
     # via
     #   boto3
     #   s3transfer
-django-storages==1.10.1
+django-storages==1.11.1
     # via -r requirements/s3.in
-django==2.2.20
+django==2.2.21
     # via
     #   -r requirements/s3.in
     #   django-storages
@@ -22,13 +22,13 @@ jmespath==0.10.0
     #   botocore
 python-dateutil==2.8.1
     # via botocore
-pytz==2020.1
+pytz==2021.1
     # via django
-s3transfer==0.3.3
+s3transfer==0.4.2
     # via boto3
 six==1.15.0
     # via python-dateutil
 sqlparse==0.4.1
     # via django
-urllib3==1.25.10
+urllib3==1.26.4
     # via botocore

--- a/requirements/ses.pip
+++ b/requirements/ses.pip
@@ -4,17 +4,17 @@
 #
 #    pip-compile --output-file=requirements/ses.pip requirements/ses.in
 #
-boto3==1.15.14
+boto3==1.17.64
     # via django-ses
 boto==2.49.0
     # via -r requirements/ses.in
-botocore==1.18.14
+botocore==1.20.64
     # via
     #   boto3
     #   s3transfer
-django-ses==1.0.3
+django-ses==2.0.0
     # via -r requirements/ses.in
-django==2.2.20
+django==2.2.21
     # via
     #   -r requirements/ses.in
     #   django-ses
@@ -26,15 +26,15 @@ jmespath==0.10.0
     #   botocore
 python-dateutil==2.8.1
     # via botocore
-pytz==2020.1
+pytz==2021.1
     # via
     #   django
     #   django-ses
-s3transfer==0.3.3
+s3transfer==0.4.2
     # via boto3
 six==1.15.0
     # via python-dateutil
 sqlparse==0.4.1
     # via django
-urllib3==1.25.10
+urllib3==1.26.4
     # via botocore

--- a/requirements/ses.pip
+++ b/requirements/ses.pip
@@ -4,17 +4,17 @@
 #
 #    pip-compile --output-file=requirements/ses.pip requirements/ses.in
 #
-boto3==1.17.64
+boto3==1.17.74
     # via django-ses
 boto==2.49.0
     # via -r requirements/ses.in
-botocore==1.20.64
+botocore==1.20.74
     # via
     #   boto3
     #   s3transfer
 django-ses==2.0.0
     # via -r requirements/ses.in
-django==2.2.21
+django==2.2.23
     # via
     #   -r requirements/ses.in
     #   django-ses
@@ -32,7 +32,7 @@ pytz==2021.1
     #   django-ses
 s3transfer==0.4.2
     # via boto3
-six==1.15.0
+six==1.16.0
     # via python-dateutil
 sqlparse==0.4.1
     # via django

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
         "django-ordered-model",
         # generic relation
         "django-query-builder",
-        "celery<5",
+        "celery",
         # cors
         "django-cors-headers",
         "django-debug-toolbar",

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ setup(
         "dict2xml",
         "lxml",
         # pyxform
-        "pyxform >= 1.4.0",
+        "pyxform",
         # spss
         "savreaderwriter",
         # tests


### PR DESCRIPTION
### Changes / Features implemented

- Update requirements
- Removes unused `organization` project serializer field; The field was not being used for any apparent purpose as the `owner` field already maps directly to the `organization`. Including the `organization` as a `write_only` field caused issues since it tried to enforce a `UniqueTogether` validation on a non existent `owner` model field.
- Remove `decode()` call. PyJWTs `decode` function now returns strings
- Update `build_json_resource_obj` function; Include new `serializer` arguement

### Steps taken to verify this change does what is intended

- [x] QA

### Side effects of implementing this change

N/A

### Before submitting this PR for review, please make sure you have:

- [x] Included tests 
- [ ] Updated documentation

Closes #2048 