### PR TITLE
Ensure project owners are able to view all their collaborators from the project list

### DIFF
--- a/onadata/apps/api/tests/viewsets/test_organization_profile_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_organization_profile_viewset.py
@@ -358,7 +358,12 @@ class TestOrganizationProfileViewSet(TestAbstractViewSet):
         request = self.factory.get('/', **self.extra)
         response = view(request)
         self.assertEqual(response.status_code, 200)
-        self.assertDictEqual(dict(response.data[0]), expected_data)
+        response_data = dict(response.data[0])
+        returned_users = response_data.pop('users')
+        expected_users = expected_data.pop('users')
+        self.assertDictEqual(response_data, expected_data)
+        for user in expected_users:
+            self.assertIn(user, returned_users)
 
     def test_role_for_org_non_owner(self):
         # creating org with member

--- a/onadata/apps/api/tests/viewsets/test_project_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_project_viewset.py
@@ -2452,16 +2452,6 @@ class TestProjectViewSet(TestAbstractViewSet):
                        'is_org': False, 'role': 'readonly', 'user': u'alice',
                        'metadata': {}}, users)
 
-        request = self.factory.get('/', **self.extra)
-        response = view(request, pk=projectid)
-
-        # Should not list collaborators
-        users = response.data[0]['users']
-        self.assertEqual(response.status_code, 200)
-        self.assertNotIn({'first_name': u'Bob', 'last_name': u'erama',
-                          'is_org': False, 'role': 'readonly',
-                          'user': u'alice', 'metadata': {}}, users)
-
     def test_projects_soft_delete(self):
         self._project_create()
 

--- a/onadata/libs/serializers/project_serializer.py
+++ b/onadata/libs/serializers/project_serializer.py
@@ -139,7 +139,7 @@ def get_users(project, context, all_perms=True):
 
             if all_perms or user in [
                     context['request'].user, project.organization
-            ]:
+            ] or context['request'].user == project.organization:
                 data[perm.user_id] = {
                     'permissions': [],
                     'is_org': is_organization(user.profile),

--- a/onadata/libs/serializers/project_serializer.py
+++ b/onadata/libs/serializers/project_serializer.py
@@ -16,8 +16,8 @@ from onadata.apps.api.models import OrganizationProfile
 from onadata.apps.api.tools import (get_organization_members_team,
                                     get_or_create_organization_owners_team)
 from onadata.apps.logger.models import Project, XForm
-from onadata.libs.permissions import (OwnerRole, ReadOnlyRole, get_role,
-                                      is_organization)
+from onadata.libs.permissions import (
+    OwnerRole, ReadOnlyRole,  ManagerRole, get_role, is_organization)
 from onadata.libs.serializers.dataview_serializer import \
     DataViewMinimalSerializer
 from onadata.libs.serializers.fields.json_field import JsonField
@@ -133,13 +133,20 @@ def get_users(project, context, all_perms=True):
             return users
 
     data = {}
+    request_user_perms = [
+        perm.permission.codename
+        for perm in project.projectuserobjectpermission_set.filter(
+            user=context["request"].user)]
+    request_user_role = get_role(request_user_perms, project)
+    request_user_is_admin = request_user_role in [
+        OwnerRole.name, ManagerRole.name]
     for perm in project.projectuserobjectpermission_set.all():
         if perm.user_id not in data:
             user = perm.user
 
             if all_perms or user in [
                     context['request'].user, project.organization
-            ] or context['request'].user == project.organization:
+            ] or request_user_is_admin:
                 data[perm.user_id] = {
                     'permissions': [],
                     'is_org': is_organization(user.profile),


### PR DESCRIPTION
### Changes / Features implemented

- Test that project owners are able to see a list of all the users their project has been shared too

### Steps taken to verify this change does what is intended

- Updated tests

### Side effects of implementing this change

Users with manager or owner level permissions will now be able to view all the users the project has been shared to

### Before submitting this PR for review, please make sure you have:

- [x] Included tests 
- [ ] ~Updated documentation~

Closes #2069 
