### PR TITLE
Set status to `imported_via_csv` for CSV Imported submissions

### DIFF
--- a/onadata/apps/logger/models/instance.py
+++ b/onadata/apps/logger/models/instance.py
@@ -518,7 +518,9 @@ class Instance(models.Model, InstanceBaseClass):
 
     # ODK keeps track of three statuses for an instance:
     # incomplete, submitted, complete
-    # we add a fourth status: submitted_via_web
+    # we add a more statuses:
+    # - submitted_via_web
+    # - imported_via_csv
     status = models.CharField(max_length=20,
                               default=u'submitted_via_web')
     uuid = models.CharField(max_length=249, default=u'', db_index=True)

--- a/onadata/apps/logger/models/instance.py
+++ b/onadata/apps/logger/models/instance.py
@@ -518,7 +518,7 @@ class Instance(models.Model, InstanceBaseClass):
 
     # ODK keeps track of three statuses for an instance:
     # incomplete, submitted, complete
-    # we add a more statuses:
+    # we add the following additional statuses:
     # - submitted_via_web
     # - imported_via_csv
     status = models.CharField(max_length=20,

--- a/onadata/libs/tests/utils/test_csv_import.py
+++ b/onadata/libs/tests/utils/test_csv_import.py
@@ -218,6 +218,23 @@ class CSVImportTestCase(TestBase):
         self.assertEqual(Instance.objects.count(), 1,
                          'submit_csv edits #1 test Failed!')
 
+    def test_csv_imports_are_tracked(self):
+        """
+        Test that submissions created via CSV Import are tracked
+        """
+        self.xls_file_path = os.path.join(self.fixtures_dir,
+                                          'form_with_multiple_select.xlsx')
+        self._publish_xls_file(self.xls_file_path)
+        self.xform = XForm.objects.get()
+
+        good_csv = open(
+            os.path.join(self.fixtures_dir,
+                         'csv_import_with_multiple_select.csv'),
+            'rb')
+        csv_import.submit_csv(self.user.username, self.xform, good_csv)
+        self.assertEqual(Instance.objects.count(), 1)
+        self.assertEqual(Instance.objects.first().status, 'imported_via_csv')
+
     def test_csv_with_repeats_import(self):
         self.xls_file_path = os.path.join(self.this_directory, 'fixtures',
                                           'csv_export',

--- a/onadata/libs/utils/csv_import.py
+++ b/onadata/libs/utils/csv_import.py
@@ -407,7 +407,9 @@ def submit_csv(username, xform, csv_file, overwrite=False):
 
                     try:
                         error, instance = safe_create_instance(
-                            username, xml_file, [], xform.uuid, None)
+                            username, xml_file, [], xform.uuid, None,
+                            instance_status='imported_via_csv'
+                        )
                     except ValueError as e:
                         error = e
 

--- a/onadata/libs/utils/logger_tools.py
+++ b/onadata/libs/utils/logger_tools.py
@@ -510,7 +510,9 @@ def create_instance(username,
 
 
 @use_master
-def safe_create_instance(username, xml_file, media_files, uuid, request):
+def safe_create_instance(
+        username, xml_file, media_files, uuid, request,
+        instance_status: str = 'submitted_via_web'):
     """Create an instance and catch exceptions.
 
     :returns: A list [error, instance] where error is None if there was no
@@ -520,7 +522,8 @@ def safe_create_instance(username, xml_file, media_files, uuid, request):
 
     try:
         instance = create_instance(
-            username, xml_file, media_files, uuid=uuid, request=request)
+            username, xml_file, media_files, uuid=uuid, request=request,
+            status=instance_status)
     except InstanceInvalidUserError:
         error = OpenRosaResponseBadRequest(_(u"Username or ID required."))
     except InstanceEmptyError:


### PR DESCRIPTION
### Changes / Features implemented

- Update `safe_create_instance` function. _Add new argument `instance_status`_
- Set instance status to `imported_via_csv` for CSV Imported submissions

### Steps taken to verify this change does what is intended

- Updated questions

### Side effects of implementing this change

- N/A

### Before submitting this PR for review, please make sure you have:

- [x] Included tests 
- [ ] Updated documentation

Closes #1983 
