### PR TITLE
Check if user is an AnonymousUser before trying to retrieve their project role

### DIFF
--- a/onadata/apps/api/tests/viewsets/test_project_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_project_viewset.py
@@ -1773,6 +1773,25 @@ class TestProjectViewSet(TestAbstractViewSet):
 
         self.assertEqual(response.status_code, 404)
 
+    def test_anon_project_list_endpoint(self):
+        self._project_create()
+        self._publish_xls_form_to_project()
+
+        view = ProjectViewSet.as_view({
+            'get': 'list'
+        })
+        self.project.shared = True
+        self.project.save()
+
+        public_projects = Project.objects.filter(
+            shared=True).count()
+
+        request = self.factory.get('/')
+        response = view(request)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), public_projects)
+
     def test_project_manager_can_delete_xform(self):
         # create project and publish form to project
         self._publish_xls_form_to_project()

--- a/onadata/libs/serializers/project_serializer.py
+++ b/onadata/libs/serializers/project_serializer.py
@@ -133,19 +133,26 @@ def get_users(project, context, all_perms=True):
             return users
 
     data = {}
-    request_user_perms = [
-        perm.permission.codename
-        for perm in project.projectuserobjectpermission_set.filter(
-            user=context["request"].user)]
-    request_user_role = get_role(request_user_perms, project)
-    request_user_is_admin = request_user_role in [
-        OwnerRole.name, ManagerRole.name]
+
+    request_user = context['request'].user
+
+    if not request_user.is_anonymous:
+        request_user_perms = [
+            perm.permission.codename
+            for perm in project.projectuserobjectpermission_set.filter(
+                user=request_user)]
+        request_user_role = get_role(request_user_perms, project)
+        request_user_is_admin = request_user_role in [
+            OwnerRole.name, ManagerRole.name]
+    else:
+        request_user_is_admin = False
+
     for perm in project.projectuserobjectpermission_set.all():
         if perm.user_id not in data:
             user = perm.user
 
             if all_perms or user in [
-                    context['request'].user, project.organization
+                    request_user, project.organization
             ] or request_user_is_admin:
                 data[perm.user_id] = {
                     'permissions': [],


### PR DESCRIPTION
### Changes / Features implemented

- Test that anonymous users are able to list all public projects
- Check if the user is an anonymous user before retrieving their project role

### Steps taken to verify this change does what is intended

- Updated tests

### Side effects of implementing this change

- N/A

### Before submitting this PR for review, please make sure you have:

- [x] Included tests 
- [ ] Updated documentation

Closes #2082 
