### PR TITLE
Add `error_message` field to the Export serializer

### DIFF
--- a/docs/forms.rst
+++ b/docs/forms.rst
@@ -308,14 +308,24 @@ Response
         "job_status": "SUCCESS",
         "task_id": "54b7159b-3b53-4e3c-b2a7-a5ed51adcfe9",
         "type": "xls",
-        "xform": "http://api.ona.io/api/v1/forms/1"
+        "xform": "http://api.ona.io/api/v1/forms/1",
+        "error_message": ""
     },
     {
         "id": 2,
         "job_status": "PENDING",
         "task_id": "54b7159b-3b53-4e3c-b2a7-a5ed51adcde9",
         "type": "xls",
-        "xform": "http://api.ona.io/api/v1/forms/17"
+        "xform": "http://api.ona.io/api/v1/forms/17",
+        "error_message": ""
+    },
+    {
+        "id": 3,
+        "job_status": "FAILED",
+        "task_id": "54b7159b-3b53-4e3c-b2a7-a5ed51adcfe9",
+        "type": "xls",
+        "xform": "http://api.ona.io/api/v1/forms/20",
+        "error_message": "Something unexpected happened"
     }]
 
 Get a list of exports on a form
@@ -341,7 +351,8 @@ Response
         "job_status": "SUCCESS",
         "task_id": "54b7159b-3b53-4e3c-b2a7-a5ed51adcfe9",
         "type": "xls",
-        "xform": "http://api.ona.io/api/v1/forms/1"
+        "xform": "http://api.ona.io/api/v1/forms/1",
+        "error_message": ""
     }]
 
 Export form data asynchronously

--- a/onadata/apps/api/tests/viewsets/test_export_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_export_viewset.py
@@ -496,3 +496,29 @@ class TestExportViewSet(TestBase):
         request = self.factory.get('/export', **extra)
         response = self.view(request, pk=export.pk)
         self.assertEqual(response.status_code, 200)
+
+    def test_export_failure_reason_returned(self):
+        """
+        Test that the reason an export failed is returned on the API
+        """
+        self._create_user_and_login()
+        self._publish_transportation_form()
+        export = Export.objects.create(
+            xform=self.xform,
+            internal_status=Export.FAILED,
+            error_message="Something unexpected happened")
+
+        extra = {
+            'HTTP_AUTHORIZATION': f'Token {self.user.auth_token.key}',
+        }
+
+        view = ExportViewSet.as_view({'get': 'list'})
+        request = self.factory.get(
+            '/export', {'xform': self.xform.pk}, **extra)
+        force_authenticate(request)
+        response = view(request)
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('error_message', response.data[0].keys())
+        self.assertEqual(
+            response.data[0]['error_message'],
+            'Something unexpected happened')

--- a/onadata/apps/api/tests/viewsets/test_export_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_export_viewset.py
@@ -503,7 +503,7 @@ class TestExportViewSet(TestBase):
         """
         self._create_user_and_login()
         self._publish_transportation_form()
-        export = Export.objects.create(
+        Export.objects.create(
             xform=self.xform,
             internal_status=Export.FAILED,
             error_message="Something unexpected happened")

--- a/onadata/libs/serializers/export_serializer.py
+++ b/onadata/libs/serializers/export_serializer.py
@@ -15,7 +15,8 @@ class ExportSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = Export
         fields = ('id', 'job_status', 'type', 'task_id', 'xform',
-                  'date_created', 'filename', 'options', 'export_url')
+                  'date_created', 'filename', 'options', 'export_url',
+                  'error_message')
 
     def get_job_status(self, obj):
         return status_msg.get(obj.internal_status)

--- a/onadata/libs/tests/serializers/test_export_serializer.py
+++ b/onadata/libs/tests/serializers/test_export_serializer.py
@@ -12,7 +12,7 @@ from onadata.apps.viewer.tasks import create_async_export
 
 
 class TestExportSerializer(TestAbstractViewSet):
-    def test_project_serializer(self):
+    def test_export_serializer(self):
         request = APIRequestFactory().get('/')
         self._publish_xls_form_to_project()
         temp_dir = settings.MEDIA_ROOT
@@ -34,7 +34,8 @@ class TestExportSerializer(TestAbstractViewSet):
         self.assertEqual(list(serializer.data), ['id', 'job_status', 'type',
                                                  'task_id', 'xform',
                                                  'date_created', 'filename',
-                                                 'options', 'export_url'])
+                                                 'options', 'export_url',
+                                                 'error_message'])
         self.assertEqual(
             serializer.data.get('export_url'),
             'http://testserver/api/v1/export/%s.csv' % export[0].id


### PR DESCRIPTION
### Changes / Features implemented

- Add `error_message` field to the export serializer
- Add test
- Update documentation

### Steps taken to verify this change does what is intended

- Added tests

### Side effects of implementing this change

- N/A

### Before submitting this PR for review, please make sure you have:

- [x] Included tests 
- [x] Updated documentation

Closes #1936 
