### PR TITLE
Open ID - Add `name` claim splitting functionality

### DIFF
--- a/onadata/apps/api/tests/viewsets/test_openid_connect_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_openid_connect_viewset.py
@@ -138,11 +138,10 @@ class TestOpenIDConnectViewSet(TestAbstractViewSet):
             'email': 'john@doe.com'
         }
         data = {'id_token': 124, 'username': 'john'}
-        user_count = User.objects.filter(username='john').count()
         request = self.factory.post('/', data=data)
         response = self.view(request, openid_connect_provider='msft')
         self.assertEqual(
-            user_count + 1, User.objects.filter(username='john').count())
+            1, User.objects.filter(username='john').count())
         self.assertEqual(response.status_code, 302)
 
         # Uses last_name as first_name if missing
@@ -151,16 +150,30 @@ class TestOpenIDConnectViewSet(TestAbstractViewSet):
             'email': 'davis@justdavis.com'
         }
         data = {'id_token': 124, 'username': 'davis'}
-        user_count = User.objects.filter(username='davis').count()
         request = self.factory.post('/', data=data)
         response = self.view(request, openid_connect_provider='msft')
         self.assertEqual(
-            user_count + 1, User.objects.filter(username='john').count())
+            1, User.objects.filter(username='davis').count())
         self.assertEqual(response.status_code, 302)
         user = User.objects.get(username='davis')
         self.assertEqual(user.first_name, 'davis')
 
-        # Returns a 400 response if both family_name and given_name
+        # Uses name to get `first_name` & `last_name` if missing
+        mock_get_decoded_id_token.return_value = {
+            'name': 'Davis Just Davis',
+            'email': 'davis@jstdavis.com'
+        }
+        data = {'id_token': 124, 'username': 'dray'}
+        request = self.factory.post('/', data=data)
+        response = self.view(request, openid_connect_provider='msft')
+        self.assertEqual(
+            1, User.objects.filter(username='dray').count())
+        self.assertEqual(response.status_code, 302)
+        user = User.objects.get(username='dray')
+        self.assertEqual(user.first_name, 'Davis')
+        self.assertEqual(user.last_name, 'Just Davis')
+
+        # Returns a 400 response if name, family_name and given_name
         # are missing
         mock_get_decoded_id_token.return_value = {
             'email': 'jake@doe.com'

--- a/onadata/apps/api/viewsets/openid_connect_viewset.py
+++ b/onadata/apps/api/viewsets/openid_connect_viewset.py
@@ -17,7 +17,7 @@ from rest_framework.response import Response
 
 from onadata.apps.main.models import UserProfile
 from onadata.libs.utils.openid_connect_tools import (
-    EMAIL, FIRST_NAME, LAST_NAME, NONCE, OpenIDHandler)
+    EMAIL, FIRST_NAME, LAST_NAME, NAME, NONCE, OpenIDHandler)
 
 
 class OpenIDConnectViewSet(viewsets.ViewSet):
@@ -104,7 +104,7 @@ class OpenIDConnectViewSet(viewsets.ViewSet):
         decoded_token = oidc_handler.verify_and_decode_id_token(
             id_token, cached_nonce=True, openid_provider=openid_provider)
         claim_values = oidc_handler.get_claim_values(
-                [EMAIL, FIRST_NAME, LAST_NAME],
+                [EMAIL, FIRST_NAME, LAST_NAME, NAME],
                 decoded_token)
 
         if username:
@@ -129,11 +129,17 @@ class OpenIDConnectViewSet(viewsets.ViewSet):
 
                 last_name = claim_values.get(LAST_NAME)
                 first_name = claim_values.get(FIRST_NAME)
+                name = claim_values.get(NAME)
                 if not first_name and not last_name:
-                    return HttpResponseBadRequest(
-                        json.dumps(
-                            _('Missing required claims/fields:'
-                              f' {FIRST_NAME}, {LAST_NAME}')))
+                    if name:
+                        split_name = name.split(' ')
+                        first_name = ' '.join(split_name[:1])
+                        last_name = ' '.join(split_name[1:])
+                    else:
+                        return HttpResponseBadRequest(
+                            json.dumps(
+                                _('Missing required claims/fields:'
+                                  f' {FIRST_NAME}, {LAST_NAME}')))
                 else:
                     first_name = first_name or last_name
 

--- a/onadata/apps/api/viewsets/openid_connect_viewset.py
+++ b/onadata/apps/api/viewsets/openid_connect_viewset.py
@@ -79,6 +79,8 @@ class OpenIDConnectViewSet(viewsets.ViewSet):
         provider_config, openid_provider = retrieve_provider_config(
             **kwargs)
         id_token = request.POST.get('id_token')
+        code = request.POST.get('code') or request.query_params.get(
+            'code')
         data = {
             'logo_data_uri':
             getattr(settings, 'OIDC_LOGO_DATA_URI',
@@ -92,9 +94,9 @@ class OpenIDConnectViewSet(viewsets.ViewSet):
 
         if not id_token:
             # Use Authorization code if present to retrieve ID Token
-            if request.query_params.get('code'):
+            if code:
                 id_token = oidc_handler.obtain_id_token_from_code(
-                    request.query_params.get('code'),
+                    code,
                     openid_provider=openid_provider)
             else:
                 return HttpResponseBadRequest()

--- a/onadata/libs/utils/openid_connect_tools.py
+++ b/onadata/libs/utils/openid_connect_tools.py
@@ -12,6 +12,7 @@ import requests
 from jwt.algorithms import RSAAlgorithm
 
 EMAIL = 'email'
+NAME = 'name'
 FIRST_NAME = 'given_name'
 LAST_NAME = 'family_name'
 NONCE = 'nonce'


### PR DESCRIPTION
### Changes / Features implemented

- Retrieve `first_name` & `last_name` from `name` claim if present
- Retrieve `code` value from either `POST` data or query params

### Steps taken to verify this change does what is intended

- Added tests

### Side effects of implementing this change

N/A

### Before submitting this PR for review, please make sure you have:

- [x] Included tests 
- [ ] Updated documentation

Closes #2110 
