### PR TITLE
Add metadata fields present in the JSON response to the XML response

### DIFF
--- a/.github/workflows/docker-image-build.yml
+++ b/.github/workflows/docker-image-build.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Get the branch name
         id: get-branch-name
         if: github.event_name == 'push'
-        run: echo ::set-output name=BRANCH::${GITHUB_REF/refs/\heads\//}
+        run: echo "##[set-output name=BRANCH;]$(echo ${GITHUB_REF#refs/heads/})"
 
       - name: Login to DockerHub
         uses: docker/login-action@v1

--- a/docs/data.rst
+++ b/docs/data.rst
@@ -132,9 +132,9 @@ Example
 
        curl -X GET https://api.ona.io/api/v1/data?owner=ona
 
-Get Submitted data for a specific form
+GET JSON list of submitted data for a specific form
 ------------------------------------------
-Provides a list of json submitted data for a specific form.
+Provides a JSON list of submitted data for a specific form.
 
 Note: Responses are automatically paginated when requesting a list of data that surpasses 10,000 records.
 
@@ -194,6 +194,68 @@ Response
             },
             ....
         ]
+
+GET XML list of submitted data for a specific form
+--------------------------------------------------
+
+Provides an XML list of submitted data for a specific form.
+
+..  raw:: html
+    <pre class="prettyprint">
+    <b>GET</b> /api/v1/data/<code>{pk}</code>.xml
+    </pre>
+
+Example
+^^^^^^^^
+::
+
+        curl -X GET https://api.ona.io/api/v1/data/574.xml
+
+Response
+^^^^^^^^^
+::
+
+        <submission-batch serverTime="2021-07-02T08:16:24.304534+00:00">
+            <submission-item bambooDatasetId="" dateCreated="2021-07-02T08:16:24.091445+00:00" duration="" edited="False" formVersion="2014111" lastModified="2021-07-02T08:16:24.206278+00:00" mediaAllReceived="True" mediaCount="1" objectID="1957" reviewComment="" reviewStatus="" status="submitted_via_web" submissionTime="2021-07-02T08:16:24" submittedBy="bob" totalMedia="1">
+                <data id="transportation_2011_07_25" version="2014111">
+                    <transport>
+                        <available_transportation_types_to_referral_facility>none</available_transportation_types_to_referral_facility>
+                        <loop_over_transport_types_frequency>
+                            <ambulance></ambulance>
+                            <bicycle></bicycle>
+                            <boat_canoe></boat_canoe>
+                            <bus></bus>
+                            <donkey_mule_cart></donkey_mule_cart>
+                            <keke_pepe></keke_pepe>
+                            <lorry></lorry>
+                            <motorbike></motorbike>
+                            <taxi></taxi>
+                            <other></other>
+                        </loop_over_transport_types_frequency>
+                    </transport>
+                    <image1 type="file">1335783522563.jpg</image1>
+                    <meta>
+                        <instanceID>uuid:5b2cc313-fc09-437e-8149-fcd32f695d41</instanceID>
+                    </meta>
+                </data>
+                <linked-resources>
+                    <attachments>
+                        <id>50</id>
+                        <name>1335783522563.jpg</name>
+                        <xform>574</xform>
+                        <filename>bob/attachments/574_transportation_2011_07_25/1335783522563.jpg</filename>
+                        <instance>1957</instance>
+                        <mimetype>image/jpeg</mimetype>
+                        <download_url>/api/v1/files/50?filename=bob/attachments/574_transportation_2011_07_25/1335783522563.jpg</download_url>
+                        <small_download_url>/api/v1/files/50?filename=bob/attachments/574_transportation_2011_07_25/1335783522563.jpg&amp;suffix=small</small_download_url>
+                        <medium_download_url>/api/v1/files/50?filename=bob/attachments/574_transportation_2011_07_25/1335783522563.jpg&amp;suffix=medium</medium_download_url>
+                    </attachments>
+                </linked-resources>
+            </submission-item>
+            <submission-item>
+                ...
+            </submission-item>
+        </submission-batch>
 
 Get FLOIP flow results for a specific form
 ------------------------------------------
@@ -264,7 +326,7 @@ Response
 
 Paginate data of a specific form
 ---------------------------------
-Returns a list of json submitted data for a specific form using page number and the number of items per page. Use the ``page`` parameter to specify page number and ``page_size`` parameter is used to set the custom page size.
+Returns a list of JSON or XML submitted data for a specific form using page number and the number of items per page. Use the ``page`` parameter to specify page number and ``page_size`` parameter is used to set the custom page size.
 
 - ``page`` - Integer representing the page.
 - ``page_size`` - Integer representing the number of records that should be returned in a single page.
@@ -274,8 +336,8 @@ There are a few important facts to note about retrieving paginated data:
 1. The maximum number of items that can be requested in a page via the ``page_size`` query param is 10,000
 2. Information regrading transversal of the paginated responses can be found in `the Link header <https://tools.ietf.org/html/rfc5988>`_ returned in the response. *Note: Some relational links may not be present depending on the page accessed i.e the ``first`` relational page link won't be present on the first page response*
 
-Example
-^^^^^^^^
+JSON Example
+^^^^^^^^^^^^^
 ::
 
       curl -X GET https://api.ona.io/api/v1/data/328.json?page=1&page_size=4
@@ -292,7 +354,7 @@ Sample response with link header
       ...
       Link: <http://localhost:8000/api/v1/data/2?page=2&page_size=1>; rel="next", <http://localhost:8000/api/v1/data/2?page=3&page_size=1>; rel="last"
 
-**Response:** ::
+**JSON Response:** ::
 
       [
         {

--- a/onadata/apps/api/tests/viewsets/test_data_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_data_viewset.py
@@ -2623,7 +2623,7 @@ class TestDataViewSet(TestBase):
         server_time = ET.fromstring(returned_xml).attrib.get('serverTime')
         edited = instance.last_edited is not None
         submission_time = instance.date_created.strftime(MONGO_STRFTIME)
-        attachment_name = instance.attachments.first().media_file.name
+        attachment = instance.attachments.first()
         expected_xml = (
             '<?xml version="1.0" encoding="utf-8"?>\n'
             f'<submission-batch serverTime="{server_time}">'  # noqa
@@ -2640,7 +2640,7 @@ class TestDataViewSet(TestBase):
             '</transportation>'
             '<linked-resources>'
             '<attachments>'
-            f'<id>1</id><name>1335783522563.jpg</name><xform>1</xform><filename>{ attachment_name }</filename><instance>1</instance><mimetype>image/jpeg</mimetype><download_url>/api/v1/files/1?filename={ attachment_name }</download_url><small_download_url>/api/v1/files/1?filename={ attachment_name }&amp;suffix=small</small_download_url><medium_download_url>/api/v1/files/1?filename={ attachment_name }&amp;suffix=medium</medium_download_url></attachments>'  # noqa
+            f'<id>{attachment.id}</id><name>1335783522563.jpg</name><xform>{instance.xform.id}</xform><filename>{ attachment.media_file.name }</filename><instance>{ instance.id }</instance><mimetype>image/jpeg</mimetype><download_url>/api/v1/files/{attachment.id}?filename={ attachment.media_file.name }</download_url><small_download_url>/api/v1/files/{attachment.id}?filename={ attachment.media_file.name }&amp;suffix=small</small_download_url><medium_download_url>/api/v1/files/{attachment.id}?filename={ attachment.media_file.name }&amp;suffix=medium</medium_download_url></attachments>'  # noqa
             '</linked-resources>'
             '</submission-item>'
             '</submission-batch>'

--- a/onadata/apps/api/tests/viewsets/test_data_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_data_viewset.py
@@ -2598,20 +2598,16 @@ class TestDataViewSet(TestBase):
 
     def test_data_list_xml_format(self):
         """Test DataViewSet list XML"""
-        # create form
-        xls_file_path = os.path.join(
-            os.path.dirname(os.path.abspath(__file__)),
-            "../fixtures/tutorial/tutorial.xls"
-        )
-        self._publish_xls_file_and_set_xform(xls_file_path)
-
         # create submission
-        xml_submission_file_path = os.path.join(
-            os.path.dirname(os.path.abspath(__file__)),
-            "..", "fixtures", "tutorial", "instances",
-            "tutorial_2012-06-27_11-27-53_w_uuid.xml"
-        )
-        self._make_submission(xml_submission_file_path)
+        media_file = "1335783522563.jpg"
+        self._make_submission_w_attachment(os.path.join(
+            self.this_directory, 'fixtures',
+            'transportation', 'instances', 'transport_2011-07-25_19-05-49_2',
+            'transport_2011-07-25_19-05-49_2.xml'),
+            os.path.join(self.this_directory, 'fixtures',
+                         'transportation', 'instances',
+                         'transport_2011-07-25_19-05-49_2', media_file))
+
         view = DataViewSet.as_view({'get': 'list'})
         request = self.factory.get('/', **self.extra)
         formid = self.xform.pk
@@ -2627,23 +2623,25 @@ class TestDataViewSet(TestBase):
         server_time = ET.fromstring(returned_xml).attrib.get('serverTime')
         edited = instance.last_edited is not None
         submission_time = instance.date_created.strftime(MONGO_STRFTIME)
+        attachment_name = instance.attachments.first().media_file.name
         expected_xml = (
             '<?xml version="1.0" encoding="utf-8"?>\n'
-            f'<submission-batch serverTime="{server_time}">'
+            f'<submission-batch serverTime="{server_time}">'  # noqa
             f'<submission-item bambooDatasetId="" dateCreated="{instance.date_created.isoformat()}" duration="" edited="{edited}" formVersion="{instance.version}"'  # noqa
             f' lastModified="{instance.date_modified.isoformat()}" mediaAllReceived="{instance.media_all_received}" mediaCount="{ instance.media_count }" objectID="{instance.id}" reviewComment="" reviewStatus=""'  # noqa
-            f' status="{instance.status}" submissionTime="{submission_time}" submittedBy="{instance.user.username}" totalMedia="1">'  # noqa
-            '<tutorial id="tutorial">'
-            '<name>Larry\n        Again</name>'
-            '<age>23</age>'
-            '<picture>1333604907194.jpg</picture>'
-            '<has_children>0</has_children>'
-            '<gps>-1.2836198 36.8795437 0.0 1044.0</gps>'
-            '<web_browsers>firefox chrome safari</web_browsers>'
-            '<meta>'
-            '<instanceID>uuid:729f173c688e482486a48661700455ff</instanceID>'
-            '</meta>'
-            '</tutorial>'
+            f' status="{instance.status}" submissionTime="{submission_time}" submittedBy="{instance.user.username}" totalMedia="{ instance.total_media }">'  # noqa
+            f'<transportation id="{instance.xform.id_string}" version="{instance.version}">'  # noqa
+            '<transport>'
+            '<available_transportation_types_to_referral_facility>none</available_transportation_types_to_referral_facility>'  # noqa
+            '<loop_over_transport_types_frequency><ambulance></ambulance><bicycle></bicycle><boat_canoe></boat_canoe><bus></bus><donkey_mule_cart></donkey_mule_cart><keke_pepe></keke_pepe><lorry></lorry><motorbike></motorbike><taxi></taxi><other></other></loop_over_transport_types_frequency>'  # noqa
+            '</transport>'
+            '<image1 type="file">1335783522563.jpg</image1>'
+            '<meta><instanceID>uuid:5b2cc313-fc09-437e-8149-fcd32f695d41</instanceID></meta>'  # noqa
+            '</transportation>'
+            '<linked-resources>'
+            '<attachments>'
+            f'<id>1</id><name>1335783522563.jpg</name><xform>1</xform><filename>{ attachment_name }</filename><instance>1</instance><mimetype>image/jpeg</mimetype><download_url>/api/v1/files/1?filename={ attachment_name }</download_url><small_download_url>/api/v1/files/1?filename={ attachment_name }&amp;suffix=small</small_download_url><medium_download_url>/api/v1/files/1?filename={ attachment_name }&amp;suffix=medium</medium_download_url></attachments>'  # noqa
+            '</linked-resources>'
             '</submission-item>'
             '</submission-batch>'
         )

--- a/onadata/apps/api/tests/viewsets/test_data_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_data_viewset.py
@@ -2625,13 +2625,28 @@ class TestDataViewSet(TestBase):
         instance = self.xform.instances.first()
         returned_xml = response.content.decode('utf-8')
         server_time = ET.fromstring(returned_xml).attrib.get('serverTime')
+        edited = instance.last_edited is not None
+        submission_time = instance.date_created.strftime(MONGO_STRFTIME)
         expected_xml = (
-            f'<?xml version="1.0" encoding="utf-8"?>\n<submission-batch serverTime="{server_time}">'  # noqa
-            f'<submission-item dateCreated="{instance.date_created.isoformat()}" formVersion="{instance.version}" lastModified="{instance.date_modified.isoformat()}" objectID="{instance.id}">'  # noqa
-            '<tutorial id="tutorial"><name>Larry\n        Again</name><age>23</age><picture>1333604907194.jpg</picture>'  # noqa
-            '<has_children>0</has_children><gps>-1.2836198 36.8795437 0.0 1044.0</gps><web_browsers>firefox chrome safari'  # noqa
-            '</web_browsers><meta><instanceID>uuid:729f173c688e482486a48661700455ff</instanceID></meta></tutorial>'  # noqa
-            '</submission-item></submission-batch>')
+            '<?xml version="1.0" encoding="utf-8"?>\n'
+            f'<submission-batch serverTime="{server_time}">'
+            f'<submission-item bambooDatasetId="" dateCreated="{instance.date_created.isoformat()}" duration="" edited="{edited}" formVersion="{instance.version}"'  # noqa
+            f' lastModified="{instance.date_modified.isoformat()}" mediaAllReceived="{instance.media_all_received}" mediaCount="{ instance.media_count }" objectID="{instance.id}" reviewComment="" reviewStatus=""'  # noqa
+            f' status="{instance.status}" submissionTime="{submission_time}" submittedBy="{instance.user.username}" totalMedia="1">'  # noqa
+            '<tutorial id="tutorial">'
+            '<name>Larry\n        Again</name>'
+            '<age>23</age>'
+            '<picture>1333604907194.jpg</picture>'
+            '<has_children>0</has_children>'
+            '<gps>-1.2836198 36.8795437 0.0 1044.0</gps>'
+            '<web_browsers>firefox chrome safari</web_browsers>'
+            '<meta>'
+            '<instanceID>uuid:729f173c688e482486a48661700455ff</instanceID>'
+            '</meta>'
+            '</tutorial>'
+            '</submission-item>'
+            '</submission-batch>'
+        )
         self.assertEqual(expected_xml, returned_xml)
 
     def test_invalid_xml_elements_not_present(self):

--- a/onadata/libs/serializers/data_serializer.py
+++ b/onadata/libs/serializers/data_serializer.py
@@ -150,6 +150,15 @@ class DataInstanceXMLSerializer(serializers.ModelSerializer):
             ret.update({
                 f"@{attrib}": meta_value
             })
+
+        # Include linked resources
+        linked_resources = {
+            'linked-resources': {
+                'attachments': instance.json.get(ATTACHMENTS),
+                'notes': instance.json.get(NOTES)
+            }
+        }
+        ret.update(linked_resources)
         return ret
 
 

--- a/onadata/libs/serializers/data_serializer.py
+++ b/onadata/libs/serializers/data_serializer.py
@@ -13,6 +13,9 @@ from rest_framework.reverse import reverse
 from onadata.apps.logger.models.instance import Instance, InstanceHistory
 from onadata.apps.logger.models.xform import XForm
 from onadata.libs.serializers.fields.json_field import JsonField
+from onadata.libs.utils.common_tags import (
+    METADATA_FIELDS, NOTES, TAGS, DATE_MODIFIED, VERSION, GEOLOCATION,
+    XFORM_ID, ATTACHMENTS, XFORM_ID_STRING, UUID)
 from onadata.libs.utils.logger_tools import remove_metadata_fields
 from onadata.libs.utils.dict_tools import (dict_lists2strings, dict_paths2dict,
                                            query_list_to_dict,
@@ -110,6 +113,15 @@ class DataInstanceXMLSerializer(serializers.ModelSerializer):
         model = Instance
         fields = ('xml', )
 
+    def _convert_metadata_field_to_attribute(self, field: str) -> str:
+        """
+        Converts a metadata field such as `_review_status` into
+        a camel cased attribute `reviewStatus`
+        """
+        split_field = field.split('_')[1:]
+        return split_field[0] + ''.join(
+            word.title() for word in split_field[1:])
+
     def to_representation(self, instance):
         ret = super(
             DataInstanceXMLSerializer, self).to_representation(instance)
@@ -124,6 +136,20 @@ class DataInstanceXMLSerializer(serializers.ModelSerializer):
             '@objectID': str(instance.id)
         }
         ret.update(instance_attributes)
+        excluded_metadata = [
+            NOTES, TAGS, GEOLOCATION, XFORM_ID, DATE_MODIFIED, VERSION,
+            ATTACHMENTS, XFORM_ID_STRING, UUID]
+        additional_attributes = [
+            (self._convert_metadata_field_to_attribute(metadata), metadata)
+            for metadata in METADATA_FIELDS
+            if metadata not in excluded_metadata]
+        for attrib, meta_field in additional_attributes:
+            meta_value = instance.json.get(meta_field, "")
+            if not isinstance(meta_value, str):
+                meta_value = str(meta_value)
+            ret.update({
+                f"@{attrib}": meta_value
+            })
         return ret
 
 


### PR DESCRIPTION
### Changes / Features implemented

- Add non-list metadata fields to the XML attributes
- Update test to ensure the attributes are present

### Steps taken to verify this change does what is intended

Included tests

### Side effects of implementing this change

N/A

### Before submitting this PR for review, please make sure you have:

- [x] Included tests 
- [x] Updated documentation

### API Response Change

This PR makes changes to the API Responses expected on the data endpoint `/api/v1/data/<id>.xml`. The following is the new structure suggested in this PR:

```
<submission-batch>
  <submission-item submissionData="" dateCreated="" formVersion="" objectID="" ...>
    <data/>
    <linked-resources>
       <notes/>
       <tags/>
       <attachments />
     <linked-resources/>
   <submission-item/>
<submission-batch/>
```

Why the `server-meta` -> `linked-resources` change ? It made more sense to name the node `linked-resources` since it predominantly includes resources linked to the submission rather than metadata for the submission.

Closes #2107