### PR TITLE
Use the `GITHUB_REF` environment variable instead of `GITHUB`

### DIFF
--- a/.github/workflows/docker-image-build.yml
+++ b/.github/workflows/docker-image-build.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Get the branch name
         id: get-branch-name
         if: github.event_name == 'push'
-        run: echo ::set-output name=BRANCH::${GITHUB/refs/\heads\//}
+        run: echo ::set-output name=BRANCH::${GITHUB_REF/refs/\heads\//}
 
       - name: Login to DockerHub
         uses: docker/login-action@v1


### PR DESCRIPTION
### Changes / Features implemented

- Use `GITHUB_REF` instead of `GITHUB`
