### PR TITLE
Handle columns in groups and repeats in get_columns_by_type()

### DIFF
--- a/onadata/libs/tests/utils/test_csv_import.py
+++ b/onadata/libs/tests/utils/test_csv_import.py
@@ -22,6 +22,7 @@ from onadata.libs.utils import csv_import
 from onadata.libs.utils.common_tags import IMPORTED_VIA_CSV_BY
 from onadata.libs.utils.csv_import import get_submission_meta_dict
 from onadata.libs.utils.user_auth import get_user_default_project
+from onadata.libs.utils.csv_import import get_columns_by_type
 
 
 def strip_xml_uuid(s):
@@ -539,13 +540,16 @@ class CSVImportTestCase(TestBase):
             columns, ["section_A/date_of_survey", "section_B/year_established"]
         )
         good_csv = open(
-            os.path.join(self.fixtures_dir, "csv_import_with_multiple_select.csv"), "rb"
+            os.path.join(
+                self.fixtures_dir, "csv_import_with_multiple_select.csv"
+            ), "rb"
         )
         csv_import.submit_csv(self.user.username, xform, good_csv)
         self.assertEqual(Instance.objects.count(), 1)
         submission = Instance.objects.first()
         self.assertEqual(submission.status, "imported_via_csv")
-        self.assertEqual(submission.json["section_A/date_of_survey"], "2015-09-10")
+        self.assertEqual(submission.json["section_A/date_of_survey"],
+                         "2015-09-10")
         self.assertTrue(
             submission.json["section_B/year_established"].startswith("1890")
         )

--- a/onadata/libs/utils/csv_import.py
+++ b/onadata/libs/utils/csv_import.py
@@ -611,10 +611,22 @@ def get_columns_by_type(type_list, form_json):
     within the type_list
     :rtype: list
     """
-    return [
-        dt.get('name') for dt in form_json.get('children')
-        if dt.get('type') in type_list
-    ]
+
+    def _column_by_type(item_list, prefix=""):
+        found = []
+        for item in item_list:
+            if item["type"] in ["group", "repeat"]:
+                prefix = "/".join([prefix, item["name"]]) if prefix else item["name"]
+                found.extend(_column_by_type(item["children"], prefix))
+                prefix = ""  # Reset prefix to blank
+            else:
+                if item["type"] in type_list:
+                    name = "%s/%s" % (prefix, item["name"]) if prefix else item["name"]
+                    found.append(name)
+
+        return found
+
+    return _column_by_type(form_json["children"])
 
 
 def validate_row(row, columns):

--- a/onadata/libs/utils/csv_import.py
+++ b/onadata/libs/utils/csv_import.py
@@ -616,12 +616,16 @@ def get_columns_by_type(type_list, form_json):
         found = []
         for item in item_list:
             if item["type"] in ["group", "repeat"]:
-                prefix = "/".join([prefix, item["name"]]) if prefix else item["name"]
+                prefix = "/".join(
+                    [prefix, item["name"]]
+                ) if prefix else item["name"]
                 found.extend(_column_by_type(item["children"], prefix))
                 prefix = ""  # Reset prefix to blank
             else:
                 if item["type"] in type_list:
-                    name = "%s/%s" % (prefix, item["name"]) if prefix else item["name"]
+                    name = "%s/%s" % (
+                        prefix, item["name"]
+                    ) if prefix else item["name"]
                     found.append(name)
 
         return found


### PR DESCRIPTION
### Changes / Features implemented

Add support for handling CSV columns when the field is a group or a repeat. Ensure's the correct validation and field formatting especially for dates is applied to fields in during a CSV import of data.

### Steps taken to verify this change does what is intended

Added a test.

### Side effects of implementing this change

None

### Before submitting this PR for review, please make sure you have:

- [ x] Included tests 
- [ ] Updated documentation

Closes #
