### PR TITLE
Ensure exports are generated on submission delete

### DIFF
--- a/onadata/apps/api/viewsets/data_viewset.py
+++ b/onadata/apps/api/viewsets/data_viewset.py
@@ -312,6 +312,7 @@ class DataViewSet(AnonymousUserPublicFormsMixin,
                     self.object.instances.filter(
                         deleted_at__isnull=True).update(
                             deleted_at=timezone.now(),
+                            date_modified=timezone.now(),
                             deleted_by=request.user)
                 else:
                     instance_ids = [
@@ -327,6 +328,7 @@ class DataViewSet(AnonymousUserPublicFormsMixin,
                         deleted_at__isnull=True
                     ).update(
                         deleted_at=timezone.now(),
+                        date_modified=timezone.now(),
                         deleted_by=request.user)
 
                 # updates the num_of_submissions for the form.


### PR DESCRIPTION
### Changes / Features implemented

- Ensure exports are generated when a submission is deleted

### Steps taken to verify this change does what is intended

- Added test

### Side effects of implementing this change

N/A

### Before submitting this PR for review, please make sure you have:

- [x] Included tests 
- [ ] Updated documentation

Closes #2130 
