### PR TITLE
Ensure internal routing is supported on the onadata-uwsgi docker image

### DIFF
--- a/docker/onadata-uwsgi/Dockerfile
+++ b/docker/onadata-uwsgi/Dockerfile
@@ -55,7 +55,8 @@ RUN apt-get update -q &&\
         automake \
         libtool \
         openjdk-11-jre-headless \
-        uwsgi \
+        libpcre3 \
+        libpcre3-dev \
         locales && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
### Changes / Features implemented

- Ensure the `libpcre3` packages required to enable uWSGIs  [internal routing](https://uwsgi-docs.readthedocs.io/en/latest/InternalRouting.html) are present

### Steps taken to verify this change does what is intended

- Run the docker image

### Side effects of implementing this change

N/A

### Before submitting this PR for review, please make sure you have:

~- [ ] Included tests~
~- [ ] Updated documentation~
