### PR TITLE
Remove namespace attribute from returned XML if present

### DIFF
--- a/onadata/apps/api/tests/viewsets/test_briefcase_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_briefcase_viewset.py
@@ -6,6 +6,7 @@ import mock
 from django.core.files.storage import get_storage_class
 from django.urls import reverse
 from django.utils import timezone
+from django.test import override_settings
 from django_digest.test import DigestAuth
 from rest_framework.test import APIRequestFactory
 
@@ -398,6 +399,61 @@ class TestBriefcaseViewSet(test_abstract_viewset.TestAbstractViewSet):
         self.view = XFormViewSet.as_view({'get': 'form'})
         response = self.view(request, pk=xform.pk, format='xls')
         self.assertEqual(response.status_code, 404)
+
+    @mock.patch.object(BriefcaseViewset, 'get_object')
+    def test_view_downloadSubmission_no_xmlns(self, mock_get_object):
+        view = BriefcaseViewset.as_view({'get': 'retrieve'})
+        self._publish_xml_form()
+        self.maxDiff = None
+        self._submit_transport_instance_w_attachment()
+        instanceId = u'5b2cc313-fc09-437e-8149-fcd32f695d41'
+        instance = Instance.objects.get(uuid=instanceId)
+        instance.xml = u'<?xml version=\'1.0\' ?><transportation xlmns="http://opendatakit.org/submission" id="transportation_2011_07_25"><transport><available_transportation_types_to_referral_facility>none</available_transportation_types_to_referral_facility><available_transportation_types_to_referral_facility>none</available_transportation_types_to_referral_facility><loop_over_transport_types_frequency><ambulance /><bicycle /><boat_canoe /><bus /><donkey_mule_cart /><keke_pepe /><lorry /><motorbike /><taxi /><other /></loop_over_transport_types_frequency></transport><meta><instanceID>uuid:5b2cc313-fc09-437e-8149-fcd32f695d41</instanceID></meta></transportation>\n'  # noqa
+        mock_get_object.return_value = instance
+        formId = u'%(formId)s[@version=null and @uiVersion=null]/' \
+                 u'%(formId)s[@key=uuid:%(instanceId)s]' % {
+                     'formId': self.xform.id_string,
+                     'instanceId': instanceId}
+        params = {'formId': formId}
+        auth = DigestAuth(self.login_username, self.login_password)
+        request = self.factory.get(
+            self._download_submission_url, data=params)
+        response = view(request, username=self.user.username)
+        self.assertEqual(response.status_code, 401)
+        request.META.update(auth(request.META, response))
+        response = view(request, username=self.user.username)
+        text = "uuid:%s" % instanceId
+        download_submission_path = os.path.join(
+            self.main_directory, 'fixtures', 'transportation',
+            'view', 'downloadSubmission.xml')
+        with codecs.open(download_submission_path, encoding='utf-8') as f:
+            text = f.read()
+            for var in ((u'{{submissionDate}}',
+                         instance.date_created.isoformat()),
+                        (u'{{form_id}}', str(self.xform.id))):
+                text = text.replace(*var)
+            self.assertNotIn(
+                'transportation id="transportation_2011_07_25"'
+                ' instanceID="uuid:5b2cc313-fc09-437e-8149-fcd32f695d41"'
+                f' submissionDate="{ instance.date_created.isoformat() }" '
+                'xlmns="http://opendatakit.org/submission"',
+                text)
+            self.assertContains(response, instanceId, status_code=200)
+
+        with override_settings(SUPPORT_BRIEFCASE_SUBMISSION_DATE=False):
+            request = self.factory.get(
+                self._download_submission_url, data=params)
+            response = view(request, username=self.user.username)
+            self.assertEqual(response.status_code, 401)
+            request.META.update(auth(request.META, response))
+            response = view(request, username=self.user.username)
+            response.render()
+            self.assertIn(
+                'transportation id="transportation_2011_07_25"'
+                ' instanceID="uuid:5b2cc313-fc09-437e-8149-fcd32f695d41"'
+                f' submissionDate="{ instance.date_created.isoformat() }" '
+                'xlmns="http://opendatakit.org/submission"',
+                response.content.decode('utf-8'))
 
     @mock.patch.object(BriefcaseViewset, 'get_object')
     def test_view_downloadSubmission_multiple_nodes(self, mock_get_object):

--- a/onadata/apps/api/viewsets/briefcase_viewset.py
+++ b/onadata/apps/api/viewsets/briefcase_viewset.py
@@ -1,3 +1,5 @@
+from xml.dom import NotFoundErr
+from django.conf import settings
 from django.core.files import File
 from django.core.validators import ValidationError
 from django.contrib.auth.models import User
@@ -211,6 +213,14 @@ class BriefcaseViewset(mixins.CreateModelMixin,
         submission_xml_root_node.setAttribute(
             'submissionDate', self.object.date_created.isoformat()
         )
+
+        if getattr(settings, "SUPPORT_BRIEFCASE_SUBMISSION_DATE", True):
+            # Remove namespace attribute if any
+            try:
+                submission_xml_root_node.removeAttribute('xmlns')
+            except NotFoundErr:
+                pass
+
         data = {
             'submission_data': submission_xml_root_node.toxml(),
             'media_files': Attachment.objects.filter(instance=self.object),


### PR DESCRIPTION
### Changes / Features implemented

- Add a trigger that can be used to disable the removal of the namespace
- Remove namespace attribute from returned XML if present

### Steps taken to verify this change does what is intended

- Added tests

### Side effects of implementing this change

The  submission XML given to briefcase will now no longer include a namespace; Briefcase adds a namespace when pulling submissions from the server.

### Before submitting this PR for review, please make sure you have:

- [x] Included tests 
- [ ] Updated documentation

Closes #1790
Closes #1763 
