### PR TITLE
Query optimization for the Briefcase viewset

### DIFF
--- a/onadata/apps/api/viewsets/briefcase_viewset.py
+++ b/onadata/apps/api/viewsets/briefcase_viewset.py
@@ -146,8 +146,8 @@ class BriefcaseViewset(mixins.CreateModelMixin,
 
         # Using len() instead of .count() to prevent an extra
         # database call; len() will load the instances in memory allowing
-        # as to use them when generating the response and remove the need
-        # to perform a count on the database.
+        # us to pre-load the queryset before generating the response 
+        # and removes the need to perform a count on the database.
         instance_count = len(instances)
 
         if instance_count:

--- a/onadata/apps/api/viewsets/briefcase_viewset.py
+++ b/onadata/apps/api/viewsets/briefcase_viewset.py
@@ -146,7 +146,7 @@ class BriefcaseViewset(mixins.CreateModelMixin,
 
         # Using len() instead of .count() to prevent an extra
         # database call; len() will load the instances in memory allowing
-        # us to pre-load the queryset before generating the response 
+        # us to pre-load the queryset before generating the response
         # and removes the need to perform a count on the database.
         instance_count = len(instances)
 

--- a/onadata/apps/api/viewsets/briefcase_viewset.py
+++ b/onadata/apps/api/viewsets/briefcase_viewset.py
@@ -150,7 +150,7 @@ class BriefcaseViewset(mixins.CreateModelMixin,
         # and removes the need to perform a count on the database.
         instance_count = len(instances)
 
-        if instance_count:
+        if instance_count > 0:
             last_instance = instances[instance_count - 1]
             self.resumptionCursor = last_instance.get('pk')
         elif instance_count == 0 and cursor:

--- a/onadata/apps/api/viewsets/briefcase_viewset.py
+++ b/onadata/apps/api/viewsets/briefcase_viewset.py
@@ -143,13 +143,12 @@ class BriefcaseViewset(mixins.CreateModelMixin,
         num_entries = _parse_int(num_entries)
         if num_entries:
             instances = instances[:num_entries]
-            # Using len() instead of .count() to prevent an extra
-            # database call; len() will load the instances in memory allowing
-            # as to use them when generating the response and remove the need
-            # to perform a count on the database.
-            instance_count = len(instances)
-        else:
-            instance_count = xform.num_of_submissions
+
+        # Using len() instead of .count() to prevent an extra
+        # database call; len() will load the instances in memory allowing
+        # as to use them when generating the response and remove the need
+        # to perform a count on the database.
+        instance_count = len(instances)
 
         if instance_count:
             last_instance = instances[instance_count - 1]

--- a/onadata/apps/api/viewsets/briefcase_viewset.py
+++ b/onadata/apps/api/viewsets/briefcase_viewset.py
@@ -142,11 +142,14 @@ class BriefcaseViewset(mixins.CreateModelMixin,
         num_entries = _parse_int(num_entries)
         if num_entries:
             instances = instances[:num_entries]
+            instance_count = instances.count()
+        else:
+            instance_count = xform.num_of_submissions
 
-        if instances.count():
-            last_instance = instances[instances.count() - 1]
+        if instance_count:
+            last_instance = instances[instance_count - 1]
             self.resumptionCursor = last_instance.pk
-        elif instances.count() == 0 and cursor:
+        elif instance_count == 0 and cursor:
             self.resumptionCursor = cursor
         else:
             self.resumptionCursor = 0


### PR DESCRIPTION
### Changes / Features implemented

- Utilize XForm `num_of_submissions` instead of trying to count all the instances when `numEntries` is not specified
  - Count `instances` using `len()` instead of `count()` to avoid an additional Database query & preload the `instances` before the render
- Only retrieve the `pk` & `uuid` columns from the database instead of all the instance table columns; The briefcase viewset does not utilize any of the other columns

### Steps taken to verify this change does what is intended

- N/A

### Side effects of implementing this change

Improved performance on the briefcase viewset. Performance gain

- Decreased no. of queries for requests with numEntries query param:
- Decreased no. of queries for requests with the numEntries query param:

_Tests were done on a form with 4601 submissions_

#### With changes & numEntries query param

![Screenshot from 2021-09-16 14-00-29](https://user-images.githubusercontent.com/25849009/133601181-619a5ca4-1bc0-4419-af1c-7c197bcd7411.png)

#### Without changes & numEntries query param

![Screenshot from 2021-09-16 14-05-16](https://user-images.githubusercontent.com/25849009/133601336-0016e33b-a741-494b-aaae-e0476bd0c409.png)

#### With changes & No query param

![Screenshot from 2021-09-16 15-01-48](https://user-images.githubusercontent.com/25849009/133608639-e74ff753-27f4-43e2-9d73-6080e9b5f342.png)

#### Without changes & No query param

![Screenshot from 2021-09-16 15-03-07](https://user-images.githubusercontent.com/25849009/133608794-c5598572-e7cf-43ee-9737-37ec7cc025ac.png)

### Before submitting this PR for review, please make sure you have:

- [ ] Included tests 
- [ ] Updated documentation

Closes #
