### PR TITLE
Query data endpoint by submission review. Filter `NULL` review status

### DIFF
--- a/docs/data.rst
+++ b/docs/data.rst
@@ -628,6 +628,47 @@ Query submissions where age is 21 or name is hosee
 
     curl -X GET https://api.ona.io/api/v1/data/22845?query={"$or": [{"age": "21", "name": "hosee"}]}
 
+Example VIII
+^^^^^^^^^^^^
+Query submissions with APPROVED submission review status
+
+::
+
+    curl -X GET https://api.ona.io/api/v1/data/22845?query={"_review_status" : "1"}
+
+Example IX
+^^^^^^^^^^^^
+Query submissions with REJECTED submission review status
+
+::
+
+    curl -X GET https://api.ona.io/api/v1/data/22845?query={"_review_status" : "2"}
+
+Example X
+^^^^^^^^^^
+Query submissions with PENDING submission review status
+
+::
+
+    curl -X GET https://api.ona.io/api/v1/data/22845?query={"_review_status" : "3"}
+
+Example XI
+^^^^^^^^^^
+Query submissions with pending submission review status or NULL
+
+::
+
+    curl -X GET https://api.ona.io/api/v1/data/22845?query={"$or": [{"_review_status": "3"}, {"_review_status": null}]}
+
+Example XII
+^^^^^^^^^^^
+Query submissions with `NULL` submission review status 
+
+::
+
+    curl -X GET https://api.ona.io/api/v1/data/22845?query={"_review_status": null}
+
+
 All Filters Options
 
 ==================================================

--- a/onadata/apps/api/tests/viewsets/test_data_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_data_viewset.py
@@ -28,7 +28,6 @@ from onadata.apps.api.tests.viewsets.test_abstract_viewset import \
 from onadata.apps.api.viewsets.data_viewset import DataViewSet
 from onadata.apps.api.viewsets.project_viewset import ProjectViewSet
 from onadata.apps.api.viewsets.xform_viewset import XFormViewSet
-
 from onadata.apps.logger.models import \
     Instance, SurveyType, XForm, Attachment, SubmissionReview
 from onadata.apps.logger.models.instance import InstanceHistory
@@ -755,10 +754,9 @@ class TestDataViewSet(TestBase):
         instance.refresh_from_db()
 
         # Confirm xform submission review enabled
-        self.assertTrue(self.xform.instances.all()[0].has_a_review)
+        self.assertTrue(instance.has_a_review)
         # Confirm instance json now has _review_status field
-        self.assertIn('_review_status', dict(
-                        self.xform.instances.all()[0].json))
+        self.assertIn('_review_status', dict(instance.json))
         # Confirm instance submission review status
         self.assertEquals('1', self.xform.instances.all(
                             )[0].json['_review_status'])

--- a/onadata/apps/api/tests/viewsets/test_data_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_data_viewset.py
@@ -758,8 +758,7 @@ class TestDataViewSet(TestBase):
         # Confirm instance json now has _review_status field
         self.assertIn('_review_status', dict(instance.json))
         # Confirm instance submission review status
-        self.assertEquals('1', self.xform.instances.all(
-                            )[0].json['_review_status'])
+        self.assertEquals('1', instance.json['_review_status'])
 
         # Query xform data by submission review status 3
         query_str = '{"_review_status": 3}'

--- a/onadata/apps/viewer/parsed_instance_tools.py
+++ b/onadata/apps/viewer/parsed_instance_tools.py
@@ -78,7 +78,9 @@ def _parse_where(query, known_integers, known_decimals, or_where, or_params):
             if field_key in NONE_JSON_FIELDS:
                 where.append("{} = %s".format(NONE_JSON_FIELDS[field_key]))
                 where_params.extend([text(field_value)])
-            elif field_value:
+            elif field_value is None:
+                where.append(f"json->>'{field_key}' IS NULL")
+            else:
                 where.append(u"json->>%s = %s")
                 where_params.extend((field_key, text(field_value)))
 
@@ -120,17 +122,14 @@ def get_where_clause(query, form_integer_fields=None,
             if isinstance(query, list):
                 query = query[0]
 
-            if isinstance(query, dict):
-                for k, v in query.items():
-                    if v is None:
-                        or_where.extend([u"json->>'{}' IS NULL".format(k)])
-            elif isinstance(query, dict) and '$or' in list(query):
+            if isinstance(query, dict) and '$or' in list(query):
                 or_dict = query.pop('$or')
 
                 for or_query in or_dict:
                     for k, v in or_query.items():
                         if v is None:
-                            or_where.extend([u"json->>'{}' IS NULL".format(k)])
+                            or_where.extend(
+                                [u"json->>'{}' IS NULL".format(k)])
                         elif isinstance(v, list):
                             for value in v:
                                 or_where.extend(["json->>%s = %s"])
@@ -141,6 +140,7 @@ def get_where_clause(query, form_integer_fields=None,
                             or_params.extend([k, v])
 
                 or_where = [u"".join([u"(", u" OR ".join(or_where), u")"])]
+
             where, where_params = _parse_where(query, known_integers,
                                                known_decimals, or_where,
                                                or_params)


### PR DESCRIPTION
### Changes / Features implemented
- Test ability to query data whose submission review status is `NULL`

### Steps taken to verify this change does what is intended
- [x] Included tests
- [x] Updated documentation
- [ ] QA

### Side effects of having these changes
- Submission review status `PENDING` can be thought of in 2 ways:
    - Status `3` - For instances when the user had already provided a status, i.e approved/rejected and would like to return submission review status to pending.
    - Status `NULL` - By default, if no review has been provided for the submission.

### Before submitting this PR for review, please make sure you have:

- [x] Included tests 


Closes #2112 
