### PR TITLE
Fix charts groupby multiple fields and check content type 

### DIFF
--- a/onadata/apps/api/tests/viewsets/test_charts_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_charts_viewset.py
@@ -1,6 +1,7 @@
 import json
 import os
 import mock
+
 from django.utils import timezone
 from django.core.cache import cache
 from rest_framework.test import APIClient

--- a/onadata/apps/api/tests/viewsets/test_charts_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_charts_viewset.py
@@ -475,3 +475,53 @@ class TestChartsViewSet(TestBase):
             "xform": self.xform.pk
         }
         self.assertEqual(expected, res)
+
+    def test_charts_groupby_two_fields(self):
+        data = {
+            'field_name': 'age',
+            'group_by': 'gender,pizza_fan'
+        }
+        request = self.factory.get('/charts', data)
+        force_authenticate(request, user=self.user)
+        response = self.view(
+            request,
+            pk=self.xform.id,
+            format='json')
+
+        expected = {
+            'data': [
+                {
+                    'gender': ['Female'],
+                    'pizza_fan': ['No'],
+                    'count': 1,
+                    'sum': 23.0,
+                    'mean': 23.0
+                },
+                {
+                    'gender': ['Female'],
+                    'pizza_fan': ['Yes'],
+                    'count': 1,
+                    'sum': 23.0,
+                    'mean': 23.0
+                },
+                {
+                    'gender': ['Male'],
+                    'pizza_fan': ['No'],
+                    'count': 1,
+                    'sum': 35.0,
+                    'mean': 35.0
+                }
+            ],
+            'data_type': 'numeric',
+            'field_label': 'How old are you?',
+            'field_xpath': 'age',
+            'field_name': 'age',
+            'field_type': 'integer',
+            'grouped_by': ['gender', 'pizza_fan'],
+            'xform': self.xform.pk
+            }
+
+        renderer = DecimalJSONRenderer()
+        res = json.loads(renderer.render(response.data).decode('utf-8'))
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(expected, res)

--- a/onadata/apps/api/tests/viewsets/test_charts_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_charts_viewset.py
@@ -1,5 +1,7 @@
 import json
+from onadata.apps.logger.models import xform
 import os
+from django.http import request, response
 import mock
 
 from django.utils import timezone
@@ -525,3 +527,19 @@ class TestChartsViewSet(TestBase):
         res = json.loads(renderer.render(response.data).decode('utf-8'))
         self.assertEqual(200, response.status_code)
         self.assertEqual(expected, res)
+
+    def test_on_charts_with_content_type(self):
+        request = self.factory.get('/charts', content_type="application/json")
+        force_authenticate(request, user=self.user)
+        response = self.view(
+            request,
+            pk=self.xform.pk,
+            id_string=self.xform.id_string
+            )
+        expected = {
+            'id': self.xform.pk,
+            'id_string': self.xform.id_string,
+            'url': 'http://testserver/api/v1/charts/{}'.format(self.xform.pk)
+        }
+        self.assertEqual(200, response.status_code)
+        self.assertDictContainsSubset(expected, response.data)

--- a/onadata/apps/api/tests/viewsets/test_charts_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_charts_viewset.py
@@ -521,8 +521,8 @@ class TestChartsViewSet(TestBase):
             'xform': self.xform.pk
             }
 
-        renderer = DecimalJSONRenderer()
-        res = json.loads(renderer.render(response.data).decode('utf-8'))
+        response.render()
+        res = json.loads(response.content.decode('utf-8'))
         self.assertEqual(200, response.status_code)
         self.assertEqual(expected, res)
 

--- a/onadata/apps/api/tests/viewsets/test_charts_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_charts_viewset.py
@@ -1,9 +1,6 @@
 import json
-from onadata.apps.logger.models import xform
 import os
-from django.http import request, response
 import mock
-
 from django.utils import timezone
 from django.core.cache import cache
 from rest_framework.test import APIClient

--- a/onadata/apps/api/tests/viewsets/test_charts_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_charts_viewset.py
@@ -476,56 +476,6 @@ class TestChartsViewSet(TestBase):
         }
         self.assertEqual(expected, res)
 
-    def test_charts_groupby_two_fields(self):
-        data = {
-            'field_name': 'age',
-            'group_by': 'gender,pizza_fan'
-        }
-        request = self.factory.get('/charts', data)
-        force_authenticate(request, user=self.user)
-        response = self.view(
-            request,
-            pk=self.xform.id,
-            format='json')
-
-        expected = {
-            'data': [
-                {
-                    'gender': ['Female'],
-                    'pizza_fan': ['No'],
-                    'count': 1,
-                    'sum': 23.0,
-                    'mean': 23.0
-                },
-                {
-                    'gender': ['Female'],
-                    'pizza_fan': ['Yes'],
-                    'count': 1,
-                    'sum': 23.0,
-                    'mean': 23.0
-                },
-                {
-                    'gender': ['Male'],
-                    'pizza_fan': ['No'],
-                    'count': 1,
-                    'sum': 35.0,
-                    'mean': 35.0
-                }
-            ],
-            'data_type': 'numeric',
-            'field_label': 'How old are you?',
-            'field_xpath': 'age',
-            'field_name': 'age',
-            'field_type': 'integer',
-            'grouped_by': ['gender', 'pizza_fan'],
-            'xform': self.xform.pk
-            }
-
-        response.render()
-        res = json.loads(response.content.decode('utf-8'))
-        self.assertEqual(200, response.status_code)
-        self.assertEqual(expected, res)
-
     def test_on_charts_with_content_type(self):
         request = self.factory.get('/charts', content_type="application/json")
         force_authenticate(request, user=self.user)

--- a/onadata/apps/api/viewsets/charts_viewset.py
+++ b/onadata/apps/api/viewsets/charts_viewset.py
@@ -86,7 +86,7 @@ class ChartsViewSet(AnonymousUserPublicFormsMixin, AuthenticateHeaderMixin,
         fields = request.query_params.get('fields')
         content_type = request.content_type
         group_by = request.query_params.get('group_by')
-        fmt = kwargs.get('json')
+        fmt = kwargs.get('format')
 
         xform = self.get_object()
         serializer = self.get_serializer(xform)

--- a/onadata/apps/api/viewsets/charts_viewset.py
+++ b/onadata/apps/api/viewsets/charts_viewset.py
@@ -84,11 +84,16 @@ class ChartsViewSet(AnonymousUserPublicFormsMixin, AuthenticateHeaderMixin,
         field_name = request.query_params.get('field_name')
         field_xpath = request.query_params.get('field_xpath')
         fields = request.query_params.get('fields')
+        content_type = request.content_type
         group_by = request.query_params.get('group_by')
-        fmt = kwargs.get('format')
+        fmt = kwargs.get('json')
 
         xform = self.get_object()
         serializer = self.get_serializer(xform)
+        # This is to update the format to be json
+        # when the content_type has been provided.
+        if fmt is None and content_type == 'application/json':
+            fmt = 'json'
 
         if fields:
             if fmt is not None and fmt != 'json':


### PR DESCRIPTION
### Changes / Features implemented
test on charts by grouping multiple fields.
test on charts with content-type as application/JSON
update the format to JSON in the even content type has been provided

### Steps taken to verify this change does what is intended
tested locally and used the unit test
### Side effects of implementing this change
N/A
### Before submitting this PR for review, please make sure you have:

- [ x] Included tests 
- [ ] Updated documentation

Closes #
#2089