### PR TITLE
Refactor enketo authentication with onadata while retrieving X-OpenRosa-Accept-Content-Length header

### DIFF
--- a/onadata/apps/api/permissions.py
+++ b/onadata/apps/api/permissions.py
@@ -522,7 +522,10 @@ class IsAuthenticatedSubmission(BasePermission):
                 return False
             profile, _ = UserProfile.objects.get_or_create(user=user)
 
-            if profile.require_auth:
+            # For the two request methods being handled at this point
+            # Only raise permission denied exception for POST requests where
+            # request user is anonymous && profile.require_auth is enabled
+            if profile.require_auth and request.method != 'HEAD':
                 # raises a permission denied exception,
                 # forces authentication
                 return False


### PR DESCRIPTION
Allow requests where request method is `HEAD` to not require authentication.
These requests don't return any data, but provide necessary response headers to build the enketo forms for submission collection

### Changes / Features implemented

### Steps taken to verify this change does what is intended
- Included tests

Closes onaio/zebra#6472
