### PR TITLE
Use auth user model for _submitted_by field

### DIFF
--- a/onadata/apps/api/tests/viewsets/test_stats_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_stats_viewset.py
@@ -57,6 +57,16 @@ class TestStatsViewSet(TestBase):
         }
         self.assertDictContainsSubset(data, response.data[0])
 
+        request = self.factory.get('/?group=_submitted_by', **self.extra)
+        response = view(request, pk=formid)
+        self.assertEqual(response.status_code, 200)
+        self.assertIsInstance(response.data, list)
+        data = {
+            u'count': 4
+        }
+
+        self.assertDictContainsSubset(data, response.data[0])
+
     @patch('onadata.apps.logger.models.instance.submission_time')
     def test_submissions_stats_with_xform_in_delete_async_queue(
             self, mock_time):

--- a/onadata/libs/data/query.py
+++ b/onadata/libs/data/query.py
@@ -2,7 +2,8 @@ import logging
 from django.conf import settings
 from django.db import connection
 
-from onadata.libs.utils.common_tags import SUBMISSION_TIME
+from onadata.libs.utils.common_tags import (
+    SUBMISSION_TIME, SUBMITTED_BY)
 from onadata.apps.logger.models.data_view import DataView
 
 
@@ -93,7 +94,7 @@ def _postgres_count_group(field, name, xform, data_view=None):
         additional_filters = _additional_data_view_filters(data_view)
 
     # Use left join to the auth user model for better performance.
-    if field == "_submitted_by":
+    if field == SUBMITTED_BY:
         string_args["json"] = "au.username"
         string_args["join"] = "i LEFT JOIN auth_user au ON au.id = i.user_id"
 

--- a/onadata/libs/data/query.py
+++ b/onadata/libs/data/query.py
@@ -92,14 +92,14 @@ def _postgres_count_group(field, name, xform, data_view=None):
     if data_view:
         additional_filters = _additional_data_view_filters(data_view)
 
-    # Use inner join to the auth user model for better performance.
+    # Use left join to the auth user model for better performance.
     if field == "_submitted_by":
         string_args["json"] = "au.username"
-        string_args["inner_join"] = "i INNER JOIN auth_user au ON au.id = i.user_id"
+        string_args["join"] = "i LEFT JOIN auth_user au ON au.id = i.user_id"
 
     restricted_string = _restricted_query(xform)
     sql_query = "SELECT %(json)s AS \"%(name)s\", COUNT(*) AS count FROM " \
-        "%(table)s %(inner_join)s WHERE " + restricted_string + \
+        "%(table)s %(join)s WHERE " + restricted_string + \
         " AND deleted_at IS NULL " + additional_filters + " GROUP BY %(json)s"\
         " ORDER BY %(json)s"
     sql_query = sql_query % string_args
@@ -170,7 +170,7 @@ def _query_args(field, name, xform, group_by=None):
         'name': name,
         'restrict_field': 'xform_id',
         'restrict_value': xform.pk,
-        'inner_join': '',
+        'join': '',
     }
 
     if xform.is_merged_dataset:


### PR DESCRIPTION
### Changes / Features implemented
Queries for a form collaborators with a lot of submissions  are taking  like 8 mins. We can improve this if we can fetch the data from the user model. 

Testing this and the result are as below
```
Querying using the json field took 528732.595 ms 
Querying with left join took 10016.579 ms
```

### Steps taken to verify this change does what is intended
Tests added and tested on

### Side effects of implementing this change

### Before submitting this PR for review, please make sure you have:

- [x] Included tests 
- [ ] Updated documentation

Closes #2163 
