### PR TITLE
Tag release v2.5.12

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,7 @@ Changelog for Onadata
 
 ``* represents releases that introduce new migrations``
 
-v2.5.11(2021-11-17)
+v2.5.12(2021-11-19)
 -------------------
 
 - Ignore form permissions when an Export is from a public form
@@ -19,7 +19,7 @@ v2.5.11(2021-11-17)
   `PR #2167 <https://github.com/onaio/onadata/pull/2167>`_
   [@denniswambua]
 
-v2.5.10(2021-11-01)
+v2.5.11(2021-11-01)
 -------------------
 
 - Bump the `ona-oidc` requirement to v0.0.8.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,7 @@ Changelog for Onadata
 
 ``* represents releases that introduce new migrations``
 
-v2.5.12(2021-11-19)
+v2.5.12(2021-11-26)
 -------------------
 
 - Ignore form permissions when an Export is from a public form
@@ -18,6 +18,12 @@ v2.5.12(2021-11-19)
 - Use auth user model for _submitted_by field stats query
   `PR #2167 <https://github.com/onaio/onadata/pull/2167>`_
   [@denniswambua]
+- Bump ona-oidc version to `86d8cd`
+  `PR #2169 <https://github.com/onaio/onadata/pull/2169>`_
+  [@DavisRayM]
+- Default response format to JSON for the Charts endpoint
+  `PR #2170 <https://github.com/onaio/onadata/pull/2170>`_
+  [@DavisRayM]
 
 v2.5.11(2021-11-01)
 -------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,22 @@ Changelog for Onadata
 
 ``* represents releases that introduce new migrations``
 
+v2.5.11(2021-11-17)
+-------------------
+
+- Ignore form permissions when an Export is from a public form
+  `PR #2164 <https://github.com/onaio/onadata/pull/2164>`_
+  [@DavisRayM]
+- Fix charts group by multiple fields and check content type
+  `PR #2151 <https://github.com/onaio/onadata/pull/2151>`_
+  [@LeonRomo]
+- Fix csv import overwrite which only updated the soft deleted submissions.
+  `PR #2166 <https://github.com/onaio/onadata/pull/2166>`_
+  [@denniswambua]
+- Use auth user model for _submitted_by field stats query
+  `PR #2167 <https://github.com/onaio/onadata/pull/2167>`_
+  [@denniswambua]
+
 v2.5.10(2021-11-01)
 -------------------
 

--- a/onadata/__init__.py
+++ b/onadata/__init__.py
@@ -6,7 +6,7 @@ visualization.
 """
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "2.5.11"
+__version__ = "2.5.12"
 
 
 # This will make sure the app is always imported when


### PR DESCRIPTION
### Changes / Features implemented

- Ignore form permissions when an Export is from a public form. PR #2164 [@DavisRayM]
- Fix charts group by multiple fields and check content type. PR #2151 [@LeonRomo]
- Fix CSV import overwrite which only updated the soft-deleted submissions. PR #2166 [@denniswambua]
- Use auth user model for _submitted_by field stats query. PR #2167 [@denniswambua]
- Bump ona-oidc version to `86d8cd`. PR #2169 [@DavisRayM]
- Default response format to JSON for the Charts endpoint. PR #2170 [@DavisRayM]

### Steps taken to verify this change does what is intended

- [x] QA

### Side effects of implementing these changes

- XForm permissions will be ignored for exports made for public XForms
- CSV Import `override` functionality will now always re-create an Instance; It will not take into account the previously imported `UUID`
- The chart endpoint will default to a JSON response if the requested format is not supported
