### PR TITLE
Default response format to JSON

### DIFF
--- a/onadata/apps/api/tests/viewsets/test_charts_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_charts_viewset.py
@@ -160,16 +160,6 @@ class TestChartsViewSet(TestBase):
         self.assertEqual(response.data['data'][0]['gender'], 'Male')
         self.assertEqual(response.data['data'][1]['gender'], 'Female')
 
-    def test_return_bad_request_on_non_json_request_with_field_name(self):
-        request = self.factory.get('/charts/%s.html' % self.xform.id)
-        force_authenticate(request, user=self.user)
-        response = self.view(
-            request,
-            pk=self.xform.id
-        )
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(response.status_text.upper(), u'BAD REQUEST')
-
     def test_get_on_date_field(self):
         data = {'field_name': 'date'}
         request = self.factory.get('/charts', data)

--- a/onadata/apps/api/tests/viewsets/test_charts_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_charts_viewset.py
@@ -491,3 +491,11 @@ class TestChartsViewSet(TestBase):
         }
         self.assertEqual(200, response.status_code)
         self.assertDictContainsSubset(expected, response.data)
+
+        # If content-type is not returned; Assume that the desired
+        # response is JSON
+        request = self.factory.get('/')
+        force_authenticate(request, user=self.user)
+        response = self.view(request, pk=self.xform.pk)
+        self.assertEqual(200, response.status_code)
+        self.assertDictContainsSubset(expected, response.data)

--- a/onadata/apps/api/viewsets/charts_viewset.py
+++ b/onadata/apps/api/viewsets/charts_viewset.py
@@ -84,15 +84,13 @@ class ChartsViewSet(AnonymousUserPublicFormsMixin, AuthenticateHeaderMixin,
         field_name = request.query_params.get('field_name')
         field_xpath = request.query_params.get('field_xpath')
         fields = request.query_params.get('fields')
-        content_type = request.content_type
         group_by = request.query_params.get('group_by')
         fmt = kwargs.get('format')
 
         xform = self.get_object()
         serializer = self.get_serializer(xform)
-        # This is to update the format to be json
-        # when the content_type has been provided.
-        if fmt is None and content_type == 'application/json':
+        # Default format to JSON if format is not specified
+        if fmt is None and request.accepted_media_type == "application/json":
             fmt = 'json'
 
         if fields:


### PR DESCRIPTION
### Changes / Features implemented

- Default the response format on the charts endpoint to `JSON` if not format is passed

### Steps taken to verify this change does what is intended

- Updated tests

### Side effects of implementing this change

The charts endpoint will always return a JSON response if the `format` query param is empty

### Before submitting this PR for review, please make sure you have:

- [x] Included tests 
- [ ] Updated documentation

Related to #2151 

_Main reason for the update is because the browser would still return a `Not supported` error with the changes introduced in #2151; Which wasn't the ideal scenario for an API.... If the format is not specified we should always default to JSON IMO_
