### PR TITLE
2160 fix users without user profiles

### DIFF
--- a/onadata/apps/api/management/commands/create_user_profiles.py
+++ b/onadata/apps/api/management/commands/create_user_profiles.py
@@ -1,8 +1,5 @@
 # -*- coding: utf-8 -*-
-"""
-Management Command to add missing user profiles to users
-"""
-
+"""Management Command to add missing user profiles to users."""
 from django.core.management.base import BaseCommand
 from django.contrib.auth.models import User
 from django.utils.translation import gettext as _
@@ -12,19 +9,17 @@ from onadata.libs.utils.model_tools import queryset_iterator
 
 
 class Command(BaseCommand):
+    """Create missing user profiles management command."""
     help = _("Build out missing user profiles")
 
     def handle(self, *args, **options):
         # get all users
-        try:
-            users = User.objects.all()
-            for user in queryset_iterator(users):
-                try:
-                    profile = user.profile
-                except UserProfile.DoesNotExist:
-                    profile, _ = UserProfile.objects.get_or_create(user=user)
-                    profile.save()
-        except User.DoesNotExist:
-            pass
+        users = User.objects.all()
+        for user in queryset_iterator(users):
+            try:
+                profile = user.profile
+            except UserProfile.DoesNotExist:
+                profile, _ = UserProfile.objects.get_or_create(user=user)
+                profile.save()
 
         self.stdout.write("User Profiles successfully created.")

--- a/onadata/apps/api/management/commands/create_user_profiles.py
+++ b/onadata/apps/api/management/commands/create_user_profiles.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+"""
+Management Command to add missing user profiles to users
+"""
+
+from django.core.management.base import BaseCommand
+from django.contrib.auth.models import User
+from django.utils.translation import gettext as _
+
+from onadata.apps.main.models.user_profile import UserProfile
+from onadata.libs.utils.model_tools import queryset_iterator
+
+
+class Command(BaseCommand):
+    help = _("Build out missing user profiles")
+
+    def handle(self, *args, **options):
+        # get all users
+        try:
+            users = User.objects.all()
+            for user in queryset_iterator(users):
+                try:
+                    profile = user.profile
+                except UserProfile.DoesNotExist:
+                    profile, _ = UserProfile.objects.get_or_create(user=user)
+                    profile.save()
+        except User.DoesNotExist:
+            pass
+
+        self.stdout.write("User Profiles successfully created.")

--- a/onadata/apps/api/tests/management/commands/test_create_user_profiles.py
+++ b/onadata/apps/api/tests/management/commands/test_create_user_profiles.py
@@ -1,13 +1,20 @@
+# -*- coding: utf-8 -*-
+"""Test create user profile management command."""
 from django.contrib.auth.models import User
 from onadata.apps.main.models.user_profile import UserProfile
 from django.core.management import call_command
 from django.utils.six import StringIO
-
 from onadata.apps.main.tests.test_base import TestBase
 
 
 class CreateUserProfilesTest(TestBase):
+    """Test create user profile management command."""
     def test_create_user_profiles(self):
+        """
+        Test that create_user_profiles management command
+        successfully creates a user profile for users
+        missing profiles.
+        """
         user = User.objects.create(
             username='dave', email='dave@example.com')
         with self.assertRaises(UserProfile.DoesNotExist):

--- a/onadata/apps/api/tests/management/commands/test_create_user_profiles.py
+++ b/onadata/apps/api/tests/management/commands/test_create_user_profiles.py
@@ -1,0 +1,27 @@
+from django.contrib.auth.models import User
+from onadata.apps.main.models.user_profile import UserProfile
+from django.core.management import call_command
+from django.utils.six import StringIO
+
+from onadata.apps.main.tests.test_base import TestBase
+
+
+class CreateUserProfilesTest(TestBase):
+    def test_create_user_profiles(self):
+        user = User.objects.create(
+            username='dave', email='dave@example.com')
+        with self.assertRaises(UserProfile.DoesNotExist):
+            _ = user.profile
+        out = StringIO()
+        call_command(
+            'create_user_profiles',
+            stdout=out
+        )
+        user.refresh_from_db()
+        try:
+            _ = user.profile
+        except UserProfile.DoesNotExist:
+            assert False
+        self.assertEqual(
+            'User Profiles successfully created.\n',
+            out.getvalue())

--- a/onadata/apps/api/tests/management/commands/test_create_user_profiles.py
+++ b/onadata/apps/api/tests/management/commands/test_create_user_profiles.py
@@ -8,6 +8,7 @@ from onadata.apps.main.tests.test_base import TestBase
 
 
 class CreateUserProfilesTest(TestBase):
+    """Test create user profile management command."""
 
     def test_create_user_profiles(self):
         """

--- a/onadata/apps/api/tests/management/commands/test_create_user_profiles.py
+++ b/onadata/apps/api/tests/management/commands/test_create_user_profiles.py
@@ -8,7 +8,7 @@ from onadata.apps.main.tests.test_base import TestBase
 
 
 class CreateUserProfilesTest(TestBase):
-    """Test create user profile management command."""
+
     def test_create_user_profiles(self):
         """
         Test that create_user_profiles management command
@@ -25,10 +25,9 @@ class CreateUserProfilesTest(TestBase):
             stdout=out
         )
         user.refresh_from_db()
-        try:
-            _ = user.profile
-        except UserProfile.DoesNotExist:
-            assert False
+        # Assert profile is retrievable;
+        profile = user.profile
+        self.assertEqual(profile.user, user)
         self.assertEqual(
             'User Profiles successfully created.\n',
             out.getvalue())


### PR DESCRIPTION
### Changes / Features implemented
- Added management command to add user profiles to user/org accounts with missing profiles. Noticed that this might happen if a user is created on python shell.

### Steps taken to verify this change does what is intended
- Added tests to ensure a user without a user profile has one assigned to them on running the management command.

### Side effects of implementing this change
- None

### Before submitting this PR for review, please make sure you have:
- [x] Included tests 
- [ ] Updated documentation

Closes #2160 
