### PR TITLE
Bump version to `2.5.15`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,19 @@ Changelog for Onadata
 
 ``* represents releases that introduce new migrations``
 
+v2.5.15(2022-02-09)
+-------------------
+
+- Handle uncaught `StopIteration` exception
+  `PR #2192 <https://github.com/onaio/onadata/pull/2174>`_
+  [@DavisRayM]
+- Add management command that can send out an email with an attachment
+  `PR #2193 <https://github.com/onaio/onadata/pull/2193>`_
+  [@DavisRayM]
+- Utilize queryset iterators for permission retrieval
+  `PR #2189 <https://github.com/onaio/onadata/pull/2189>`_
+  [@DavisRayM]
+
 v2.5.14(2022-02-01)
 -------------------
 

--- a/onadata/__init__.py
+++ b/onadata/__init__.py
@@ -6,7 +6,7 @@ visualization.
 """
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "2.5.14"
+__version__ = "2.5.15"
 
 
 # This will make sure the app is always imported when


### PR DESCRIPTION
### Changes / Features implemented

- Handle uncaught `StopIteration` exception. PR #2192 
- Add a management command that can send out an email with an attachment. PR #2193
- Utilize queryset iterators for permission retrieval. PR #2189
