### PR TITLE
Avoid `RuntimeError` caused by using keys modified in loop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.6
+          python-version: 3.8
           architecture: 'x64'
 
       - name: Get pip cache dir
@@ -58,17 +58,17 @@ jobs:
           path: ${{ steps.pip-cache.outputs.dir }}
           key: ${{ runner.os }}-pip-${{ hashFiles('requirements/base.pip') }}
 
-      - name: Install Pip requirements
-        run: |
-          pip install -U pip
-          pip install -r requirements/base.pip
-          pip install flake8
-
       - name: Install APT requirements
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends libjpeg-dev zlib1g-dev software-properties-common ghostscript libxslt1-dev binutils libproj-dev gdal-bin memcached libmemcached-dev
           sudo rm -rf /var/lib/apt/lists/*
+
+      - name: Install Pip requirements
+        run: |
+          pip install -U pip
+          pip install -r requirements/base.pip
+          pip install flake8
 
       - name: Run tests
         run: |

--- a/onadata/apps/api/tests/fixtures/Transportation Form.xml
+++ b/onadata/apps/api/tests/fixtures/Transportation Form.xml
@@ -60,7 +60,7 @@
       <bind nodeset="/data/transport/loop_over_transport_types_frequency/taxi/frequency_to_referral_facility" relevant="selected( /data/transport/available_transportation_types_to_referral_facility , 'taxi')" type="string"/>
       <bind nodeset="/data/image1" type="binary"/>
       <bind jr:preload="uid" nodeset="/data/meta/instanceID" readonly="true()" type="string"/>
-      <bind calculate="'%(form_uuid)s'" nodeset="/data/formhub/uuid" type="string"/>
+      <bind nodeset="/data/formhub/uuid" type="string" calculate="'%(form_uuid)s'"/>
     </model>
   </h:head>
   <h:body>

--- a/onadata/apps/api/tests/viewsets/test_briefcase_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_briefcase_viewset.py
@@ -485,10 +485,10 @@ class TestBriefcaseViewSet(test_abstract_viewset.TestAbstractViewSet):
             response = view(request, username=self.user.username)
             response.render()
             self.assertIn(
-                'transportation id="transportation_2011_07_25"'
+                'transportation xlmns="http://opendatakit.org/submission"'
+                ' id="transportation_2011_07_25"'
                 ' instanceID="uuid:5b2cc313-fc09-437e-8149-fcd32f695d41"'
-                f' submissionDate="{ instance.date_created.isoformat() }" '
-                'xlmns="http://opendatakit.org/submission"',
+                f' submissionDate="{ instance.date_created.isoformat() }"',
                 response.content.decode('utf-8'))
 
     @mock.patch.object(BriefcaseViewset, 'get_object')

--- a/onadata/apps/main/tests/fixtures/transportation/transportation.xml
+++ b/onadata/apps/main/tests/fixtures/transportation/transportation.xml
@@ -60,7 +60,7 @@
       <bind nodeset="/data/transport/loop_over_transport_types_frequency/taxi/frequency_to_referral_facility" relevant="selected( /data/transport/available_transportation_types_to_referral_facility , 'taxi')" type="string"/>
       <bind nodeset="/data/image1" type="binary"/>
       <bind jr:preload="uid" nodeset="/data/meta/instanceID" readonly="true()" type="string"/>
-      <bind calculate="''" nodeset="/data/formhub/uuid" type="string"/>
+      <bind nodeset="/data/formhub/uuid" type="string" calculate="''"/>
     </model>
   </h:head>
   <h:body>

--- a/onadata/apps/main/tests/fixtures/transportation/view/downloadSubmission.xml
+++ b/onadata/apps/main/tests/fixtures/transportation/view/downloadSubmission.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8' ?>
 <submission xmlns="http://opendatakit.org/submissions" xmlns:orx="http://openrosa.org/xforms">
     <data>
-        <transportation id="transportation_2011_07_25" instanceID="uuid:5b2cc313-fc09-437e-8149-fcd32f695d41" submissionDate="{{submissionDate}}" version="2014111"><transport><available_transportation_types_to_referral_facility>none</available_transportation_types_to_referral_facility><loop_over_transport_types_frequency><ambulance/><bicycle/><boat_canoe/><bus/><donkey_mule_cart/><keke_pepe/><lorry/><motorbike/><taxi/><other/></loop_over_transport_types_frequency></transport><image1>1335783522563.jpg</image1><meta><instanceID>uuid:5b2cc313-fc09-437e-8149-fcd32f695d41</instanceID></meta></transportation>
+        <transportation id="transportation_2011_07_25" version="2014111" instanceID="uuid:5b2cc313-fc09-437e-8149-fcd32f695d41" submissionDate="{{submissionDate}}"><transport><available_transportation_types_to_referral_facility>none</available_transportation_types_to_referral_facility><loop_over_transport_types_frequency><ambulance/><bicycle/><boat_canoe/><bus/><donkey_mule_cart/><keke_pepe/><lorry/><motorbike/><taxi/><other/></loop_over_transport_types_frequency></transport><image1>1335783522563.jpg</image1><meta><instanceID>uuid:5b2cc313-fc09-437e-8149-fcd32f695d41</instanceID></meta></transportation>
     </data>
     <mediaFile>
         <filename>1335783522563.jpg</filename>

--- a/onadata/apps/restservice/services/textit.py
+++ b/onadata/apps/restservice/services/textit.py
@@ -42,7 +42,7 @@ class ServiceDefinition(RestServiceInterface):
         :param record: list containing a couple of dictionaries
         :return: record with keys without slashes
         """
-        for key in record:
+        for key in list(record):
             value = record[key]
             # Ensure both key and value are string
             if not isinstance(value, string_types):


### PR DESCRIPTION
### Changes / Features implemented

- Generate a copy of the JSON `keys` instead of using the original keys within the dict

### Steps taken to verify this change does what is intended


### Side effects of implementing this change

N/A

### Before submitting this PR for review, please make sure you have:

- [ ] Included tests 
- [ ] Updated documentation

Closes #2196 
