### PR TITLE
Add `refresh` query param to invalidate charts cache

### DIFF
--- a/docs/charts.rst
+++ b/docs/charts.rst
@@ -79,6 +79,19 @@ Response
  - ``html`` format response is a html, javascript and css to the chart
  - ``json`` format response is the ``JSON`` data that can be passed to a charting library
 
+Note: When retrieving a chart for a specific field is that the resulting response is cached for ten minutes. The cache can be invalidated by passing in an optional ``refresh`` query parameter.
+
+.. raw:: html
+
+   <pre class="prettyprint">
+   <b>GET</b> /api/v1/charts/<code>{formid}</code>.<code>{format}</code>?field_name=<code>field_name</code>&refresh=true</pre>
+
+Example
+^^^^^^^
+::
+
+   curl -X GET https://api.ona.io/api/v1/charts/4240.html?field_name=age&refresh=true
+
 Get a chart for field grouped by another field in the form
 ----------------------------------------------------------
 

--- a/onadata/apps/api/viewsets/charts_viewset.py
+++ b/onadata/apps/api/viewsets/charts_viewset.py
@@ -16,6 +16,7 @@ from rest_framework.response import Response
 from onadata.apps.api.permissions import XFormPermissions
 from onadata.apps.logger.models.xform import XForm
 from onadata.libs import filters
+from onadata.libs.utils.common_tools import str_to_bool
 from onadata.libs.mixins.anonymous_user_public_forms_mixin import \
     AnonymousUserPublicFormsMixin
 from onadata.libs.mixins.authenticate_header_mixin import \
@@ -90,6 +91,7 @@ class ChartsViewSet(AnonymousUserPublicFormsMixin, AuthenticateHeaderMixin,
         fields = request.query_params.get('fields')
         group_by = request.query_params.get('group_by')
         fmt = kwargs.get('format')
+        refresh_cache = str_to_bool(request.query_params.get('refresh'))
 
         xform = self.get_object()
         serializer = self.get_serializer(xform)
@@ -113,7 +115,8 @@ class ChartsViewSet(AnonymousUserPublicFormsMixin, AuthenticateHeaderMixin,
                                               group_by, fmt)
 
             data = cache.get(cache_key)
-            if not data:
+
+            if not data or refresh_cache:
                 data = get_chart_data_for_field(field_name, xform, fmt,
                                                 group_by, field_xpath)
 


### PR DESCRIPTION
## Changes

Adds a `refresh` query param that can be used to invalidate the Charts
cache and recalculate the updated cache

Related to: https://github.com/onaio/zebra/issues/6628