### PR TITLE
Ensure returned pagination headers are correct when querying for specific values

### DIFF
--- a/onadata/apps/api/tests/viewsets/test_data_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_data_viewset.py
@@ -518,10 +518,16 @@ class TestDataViewSet(TestBase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 4)
 
+        # Query param returns correct pagination headers
         request = self.factory.get(
-            '/', data={"page": "invalid", "page-size": "invalid"},
+            '/', data={"page_size": "1", "query": "ambulance"},
             **self.extra)
         response = view(request, pk=formid)
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('Link', response)
+        self.assertEqual(
+            response['Link'],
+            ('<http://testserver/?page=2&page_size=1>; rel="next"'))
 
     def test_sort_query_param_with_invalid_values(self):
         self._make_submissions()

--- a/onadata/apps/api/viewsets/data_viewset.py
+++ b/onadata/apps/api/viewsets/data_viewset.py
@@ -417,8 +417,12 @@ class DataViewSet(AnonymousUserPublicFormsMixin,
         import math
 
         url = self.request.build_absolute_uri()
+        query = self.request.query_params.get('query')
         base_url = url.split('?')[0]
-        num_of_records = xform.num_of_submissions
+        if query:
+            num_of_records = self.object_list.count()
+        else:
+            num_of_records = xform.num_of_submissions
         next_page_url = None
         prev_page_url = None
         first_page_url = None
@@ -660,7 +664,7 @@ class DataViewSet(AnonymousUserPublicFormsMixin,
             self._set_pagination_headers(
                 self.get_object(),
                 current_page=current_page,
-                current_page_size=current_page_size
+                current_page_size=current_page_size,
             )
 
             try:


### PR DESCRIPTION
### Changes / Features implemented

- Test that the pagination headers returned while querying are accurate
- Count returned queryset if the `query` param is present

### Steps taken to verify this change does what is intended

- [x] Updated tests

### Side effects of implementing this change

N/A

### Before submitting this PR for review, please make sure you have:

- [x] Included tests 

Closes #2203 