### PR TITLE
Return an `AuthenticationFailed` exception instead of a 404 when Enketo token is not retrievable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,5 +76,8 @@ bob
 .vscode/
 tags
 
+# vim
+.vim
+
 .bash_history
 .inputrc

--- a/onadata/libs/authentication.py
+++ b/onadata/libs/authentication.py
@@ -10,7 +10,6 @@ from django.conf import settings
 from django.contrib.auth.models import User, update_last_login
 from django.core.signing import BadSignature
 from django.db import DataError
-from django.shortcuts import get_object_or_404
 from django.utils import timezone
 from django.utils.translation import ugettext as _
 
@@ -86,13 +85,14 @@ def get_api_token(cookie_jwt):
         jwt_payload = jwt.decode(
             cookie_jwt, JWT_SECRET_KEY, algorithms=[JWT_ALGORITHM]
         )
-        api_token = get_object_or_404(Token, key=jwt_payload.get(API_TOKEN))
-
+        api_token = Token.objects.get(key=jwt_payload.get(API_TOKEN))
         return api_token
     except BadSignature as e:
         raise exceptions.AuthenticationFailed(_("Bad Signature: %s" % e))
     except jwt.DecodeError as e:
         raise exceptions.AuthenticationFailed(_("JWT DecodeError: %s" % e))
+    except Token.DoesNotExist:
+        raise exceptions.AuthenticationFailed(_("Invalid token"))
 
 
 class DigestAuthentication(BaseAuthentication):


### PR DESCRIPTION
### Changes / Features implemented

- Update the `get_api_token` function to raise an `AuthenticationFailed` expection instead of a 404

### Steps taken to verify this change does what is intended

- [ ] QA

### Side effects of implementing this change

- A 404 status code will no longer be raised if the provided cookie does not point to an existing token object

### Before submitting this PR for review, please make sure you have:

- [x] Included tests 
- [ ] Updated documentation

Closes #2218
