### PR TITLE
Create default project upon successful user registration

### DIFF
--- a/onadata/apps/main/models/user_profile.py
+++ b/onadata/apps/main/models/user_profile.py
@@ -17,7 +17,10 @@ from rest_framework.authtoken.models import Token
 from onadata.libs.utils.country_field import COUNTRIES
 from onadata.libs.utils.gravatar import get_gravatar_img_link, gravatar_exists
 from onadata.apps.main.signals import (
-    set_api_permissions, send_inactive_user_email, send_activation_email)
+    set_api_permissions,
+    send_inactive_user_email,
+    send_activation_email,
+    set_user_default_project)
 
 REQUIRE_AUTHENTICATION = 'REQUIRE_ODK_AUTHENTICATION'
 
@@ -135,6 +138,9 @@ post_save.connect(set_object_permissions, sender=UserProfile,
 
 post_save.connect(set_kpi_formbuilder_permissions, sender=UserProfile,
                   dispatch_uid='set_kpi_formbuilder_permission')
+
+post_save.connect(set_user_default_project, sender=UserProfile,
+                  dispatch_uid='set_user_default_project')
 
 
 class UserProfileUserObjectPermission(UserObjectPermissionBase):

--- a/onadata/apps/main/signals.py
+++ b/onadata/apps/main/signals.py
@@ -11,6 +11,14 @@ def set_api_permissions(sender, instance=None, created=False, **kwargs):
         set_api_permissions_for_user(instance)
 
 
+def set_user_default_project(
+        _, instance=None, created=False, **_kwargs):
+    """ Create a default project for the user if one doesn't exist. """
+    from onadata.libs.utils.user_auth import get_user_default_project
+    if created:
+        get_user_default_project(instance)
+
+
 def send_inactive_user_email(
         sender, instance=None, created=False, **kwargs):
     if (created and not instance.is_active) and getattr(

--- a/onadata/apps/main/signals.py
+++ b/onadata/apps/main/signals.py
@@ -12,11 +12,11 @@ def set_api_permissions(sender, instance=None, created=False, **kwargs):
 
 
 def set_user_default_project(
-        _, instance=None, created=False, **_kwargs):
+        sender=None, instance=None, created=False, **_):
     """ Create a default project for the user if one doesn't exist. """
     from onadata.libs.utils.user_auth import get_user_default_project
     if created:
-        get_user_default_project(instance)
+        get_user_default_project(instance.user)
 
 
 def send_inactive_user_email(

--- a/onadata/apps/main/tests/test_user_profile.py
+++ b/onadata/apps/main/tests/test_user_profile.py
@@ -7,6 +7,7 @@ from django.test import TestCase
 from django.test.client import Client
 from django.urls import reverse
 from mock import patch
+from onadata.apps.logger.models.project import Project
 
 from onadata.apps.logger.xform_instance_parser import XLSFormError
 from onadata.apps.main.views import profile, api_token
@@ -45,6 +46,15 @@ class TestUserProfile(TestCase):
         self._login_user_and_profile()
         self.assertEqual(self.response.status_code, 302)
         self.assertEqual(self.user.username, 'bob')
+
+    def test_default_project_is_created(self):
+        """Default project is created upon user creation."""
+        self._login_user_and_profile()
+        self.assertEqual(self.response.status_code, 302)
+        project_name = u"{}'s Project".format(self.user.username)
+        project = Project.objects.get(name=project_name)
+        # check from metadata if project is the default one
+        self.assertEqual(project.metadata, {'description': 'Default Project'})
 
     @patch('onadata.apps.main.views.render')
     def test_xlsform_error_returns_400(self, mock_render):


### PR DESCRIPTION
Signed-off-by: Kipchirchir Sigei <arapgodsmack@gmail.com>

### Changes / Features implemented
- Add ability to create default project upon successful user registration

### Steps taken to verify this change does what is intended
- Added `post_save` signal on the user profile model to trigger default project creation upon successful user registration

### Side effects of implementing this change
- We might have to remove the functionality on zebra that creates a default project after a user is created to prevent default project duplication.

### Before submitting this PR for review, please make sure you have:

- [x] Included tests 
- [ ] Updated documentation

Closes https://github.com/onaio/zebra/issues/6820
