### PR TITLE
Allow geojson file uploads

### DIFF
--- a/onadata/libs/serializers/metadata_serializer.py
+++ b/onadata/libs/serializers/metadata_serializer.py
@@ -173,6 +173,8 @@ class MetaDataSerializer(serializers.HyperlinkedModelSerializer):
 
         if data_file:
             allowed_types = settings.SUPPORTED_MEDIA_UPLOAD_TYPES
+            # add geojson mimetype
+            mimetypes.add_type('application/geo+json', '.geojson')
             data_content_type = (
                 data_file.content_type
                 if data_file.content_type in allowed_types

--- a/onadata/libs/tests/serializers/fixtures/sample.geojson
+++ b/onadata/libs/tests/serializers/fixtures/sample.geojson
@@ -1,0 +1,13 @@
+{
+    "type": "Feature",
+    "geometry": {
+        "type": "Point",
+        "coordinates": [
+            125.6,
+            10.1
+        ]
+    },
+    "properties": {
+        "name": "Dinagat Islands"
+    }
+}

--- a/onadata/libs/tests/serializers/test_metadata_serializer.py
+++ b/onadata/libs/tests/serializers/test_metadata_serializer.py
@@ -97,3 +97,33 @@ class TestMetaDataViewSerializer(TestAbstractViewSet):
             self.assertEqual(
                 serializer.validated_data["data_file_type"], "image/svg+xml"
             )
+
+    def test_geojson_media_files(self):
+        """
+        Test that an geojson file is uploaded ok
+        """
+        self._login_user_and_profile()
+        self._publish_form_with_hxl_support()
+        data_value = 'sample.geojson'
+        path = os.path.join(os.path.dirname(__file__), 'fixtures',
+                            'sample.geojson')
+        with open(path) as f:
+            f = InMemoryUploadedFile(
+                f, 'media', data_value, None, 2324, None)
+            data = {
+                'data_value': data_value,
+                'data_file': f,
+                'data_type': 'media',
+                'xform': self.xform.pk
+            }
+            serializer = MetaDataSerializer(data=data)
+            self.assertTrue(serializer.is_valid())
+            self.assertEqual(
+                serializer.validated_data['data_file_type'],
+                'application/geo+json')
+            self.assertEqual(
+                serializer.validated_data['data_value'],
+                'sample.geojson')
+            self.assertEqual(
+                serializer.validated_data['data_type'],
+                'media')

--- a/onadata/settings/common.py
+++ b/onadata/settings/common.py
@@ -512,6 +512,7 @@ SUPPORTED_MEDIA_UPLOAD_TYPES = [
     "video/3gpp",
     "video/mp4",
     "application/json",
+    "application/geo+json",
     "application/pdf",
     "application/msword",
     "application/vnd.ms-excel",


### PR DESCRIPTION
### Changes / Features implemented
Use [add_mimetypes](https://docs.python.org/3/library/mimetypes.html#mimetypes.add_type) to add `geojson` type
### Steps taken to verify this change does what is intended
Added a test case
### Side effects of implementing this change
N/A
### Before submitting this PR for review, please make sure you have:

- [x] Included tests 
- [ ] Updated documentation

