### PR TITLE
Use sentry-sdk

### DIFF
--- a/onadata/apps/api/tests/viewsets/test_data_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_data_viewset.py
@@ -2927,7 +2927,7 @@ class TestOSM(TestAbstractViewSet):
         files = [open(path, "rb") for path in paths]
         count = Attachment.objects.filter(extension="osm").count()
         self._make_submission(submission_path, media_file=files)
-        self.assertTrue(Attachment.objects.filter(extension="osm").count() > count)
+        self.assertEqual(Attachment.objects.filter(extension="osm").count(), count + 2)
 
         formid = self.xform.pk
         dataid = self.xform.instances.latest("date_created").pk

--- a/onadata/apps/api/tests/viewsets/test_data_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_data_viewset.py
@@ -2903,13 +2903,15 @@ class TestOSM(TestAbstractViewSet):
     """
 
     def setUp(self):
-        super(TestOSM, self).setUp()
+        super().setUp()
         self._login_user_and_profile()
         self.factory = RequestFactory()
         self.extra = {"HTTP_AUTHORIZATION": "Token %s" % self.user.auth_token}
 
-    @flaky
+    # pylint: disable=invalid-name,too-many-locals
+    @flaky(max_runs=3)
     def test_data_retrieve_instance_osm_format(self):
+        """Test /data endpoint OSM format."""
         filenames = [
             "OSMWay234134797.osm",
             "OSMWay34298972.osm",

--- a/onadata/celery.py
+++ b/onadata/celery.py
@@ -6,41 +6,38 @@ from __future__ import absolute_import, unicode_literals
 
 import os
 
-import celery
 from django.conf import settings
 
-import raven
-from raven.contrib.celery import register_logger_signal, register_signal
+import celery
+import sentry_sdk
+from sentry_sdk.integrations.celery import CeleryIntegration
 
 # set the default Django settings module for the 'celery' program.
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'onadata.settings.common')
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "onadata.settings.common")
 
 
 class Celery(celery.Celery):
     """
     Celery class that allows Sentry configuration.
     """
+
     def on_configure(self):  # pylint: disable=method-hidden
         """
         Register Sentry for celery tasks.
         """
-        if getattr(settings, 'RAVEN_CONFIG', None):
-            client = raven.Client(settings.RAVEN_CONFIG['dsn'])
-
-            # register a custom filter to filter out duplicate logs
-            register_logger_signal(client)
-
-            # hook into the Celery error handler
-            register_signal(client)
+        if getattr(settings, "RAVEN_CONFIG", None):
+            sentry_sdk.init(
+                dsn=settings.RAVEN_CONFIG["dsn"], integrations=[CeleryIntegration()]
+            )
 
 
 app = Celery(__name__)  # pylint: disable=invalid-name
 
 # Using a string here means the worker will not have to
 # pickle the object when using Windows.
-app.config_from_object('django.conf:settings', namespace='CELERY')
+app.config_from_object("django.conf:settings", namespace="CELERY")
 app.autodiscover_tasks(lambda: settings.INSTALLED_APPS)
-app.conf.broker_transport_options = {'visibility_timeout': 10}
+app.conf.broker_transport_options = {"visibility_timeout": 10}
 
 
 @app.task

--- a/onadata/libs/utils/common_tools.py
+++ b/onadata/libs/utils/common_tools.py
@@ -17,8 +17,8 @@ from django.core.mail import mail_admins
 from django.db import OperationalError
 from django.utils.translation import gettext as _
 
+import sentry_sdk
 import six
-from raven.contrib.django.raven_compat.models import client
 
 TRUE_VALUES = ["TRUE", "T", "1", 1]
 
@@ -68,7 +68,7 @@ def report_exception(subject, info, exc_info=None):
 
         # send to sentry
         try:
-            client.captureException(exc_info)
+            sentry_sdk.capture_exception(exc_info)
         except Exception:  # pylint: disable=broad-except
             logging.exception(_("Sending to Sentry failed."))
     else:

--- a/requirements/base.pip
+++ b/requirements/base.pip
@@ -53,7 +53,9 @@ cachetools==5.0.0
 celery==5.2.6
     # via onadata
 certifi==2021.10.8
-    # via requests
+    # via
+    #   requests
+    #   sentry-sdk
 cffi==1.15.0
     # via cryptography
 chardet==4.0.0
@@ -304,8 +306,6 @@ pyxform==1.10.0
     # via
     #   onadata
     #   pyfloip
-raven==6.10.0
-    # via onadata
 recaptcha-client==1.0.6
     # via onadata
 redis==4.2.2
@@ -330,6 +330,8 @@ rsa==4.8
     # via google-auth
 s3transfer==0.5.2
     # via boto3
+sentry-sdk==1.5.12
+    # via onadata
 simplejson==3.17.6
     # via onadata
 six==1.16.0
@@ -386,6 +388,7 @@ urllib3==1.26.9
     # via
     #   botocore
     #   requests
+    #   sentry-sdk
 uwsgi==2.0.20
     # via onadata
 vine==5.0.0

--- a/requirements/dev.pip
+++ b/requirements/dev.pip
@@ -63,7 +63,9 @@ cachetools==5.2.0
 celery==5.2.7
     # via onadata
 certifi==2022.5.18.1
-    # via requests
+    # via
+    #   requests
+    #   sentry-sdk
 cffi==1.15.0
     # via cryptography
 chardet==4.0.0
@@ -412,8 +414,6 @@ pyxform==1.10.0
     #   pyfloip
 pyyaml==6.0
     # via prospector
-raven==6.10.0
-    # via onadata
 recaptcha-client==1.0.6
     # via onadata
 redis==4.3.3
@@ -444,6 +444,8 @@ rsa==4.8
     # via google-auth
 s3transfer==0.6.0
     # via boto3
+sentry-sdk==1.5.12
+    # via onadata
 setoptconf-tmp==0.3.1
     # via prospector
 simplejson==3.17.6
@@ -522,6 +524,7 @@ urllib3==1.26.9
     # via
     #   botocore
     #   requests
+    #   sentry-sdk
 uwsgi==2.0.20
     # via onadata
 vine==5.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -92,8 +92,8 @@ install_requires =
     requests
     simplejson
     uwsgi
-    raven
     django-activity-stream
+    sentry-sdk
     paho-mqtt
     cryptography
     #Monitoring


### PR DESCRIPTION
### Changes / Features implemented

Switched to using [`sentry-sdk`](https://docs.sentry.io/platforms/python/migration/) instead of  `raven` which is now under maintenance mode.

### Steps taken to verify this change does what is intended

### Side effects of implementing this change


**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests - N/A
  - [x] Updated documentation - N/A

Closes #2250
