### PR TITLE
Use xlsx file object instead of absolute path

### DIFF
--- a/onadata/apps/main/tests/test_process.py
+++ b/onadata/apps/main/tests/test_process.py
@@ -100,6 +100,10 @@ class TestProcess(TestBase):
         """Test publishing an XLSX file."""
         self._publish_xlsx_file()
 
+    def test_publish_xlsx_file_with_external_choices(self):
+        """Test publishing an XLSX file with external choices"""
+        self._publish_xlsx_file_with_external_choices()
+
     @patch("onadata.apps.main.forms.requests")
     def test_google_url_upload(self, mock_requests):
         """Test uploading an XLSForm from a Google Docs SpreadSheet URL."""

--- a/onadata/apps/viewer/models/data_dictionary.py
+++ b/onadata/apps/viewer/models/data_dictionary.py
@@ -71,9 +71,9 @@ def sheet_to_csv(xls_content, sheet_name):
     :param xls_content: Excel file contents
     :param sheet_name: the name of the excel sheet to generate the csv file
 
-    :returns: a (StrionIO) csv file object
+    :returns: a (StringIO) csv file object
     """
-    workbook = openpyxl.load_workbook(xls_content.path)
+    workbook = openpyxl.load_workbook(xls_content)
 
     sheet = workbook.get_sheet_by_name(sheet_name)
 


### PR DESCRIPTION
Signed-off-by: Kipchirchir Sigei <arapgodsmack@gmail.com>

### Changes / Features implemented
- Upadate to use file object intsead of absolute file path when loading excel workbook
### Steps taken to verify this change does what is intended
- The following exception is being thrown when uploading a form with external choices
```
File "/srv/onadata/./onadata/apps/viewer/models/data_dictionary.py", line 246, in set_object_permissions
    f = sheet_to_csv(instance.xls, "external_choices")
  File "/srv/onadata/./onadata/apps/viewer/models/data_dictionary.py", line 76, in sheet_to_csv
    workbook = openpyxl.load_workbook(xls_content.path)
  File "/usr/local/lib/python3.9/dist-packages/django/db/models/fields/files.py", line 59, in path
    return self.storage.path(self.name)
  File "/usr/local/lib/python3.9/dist-packages/django/core/files/storage.py", line 128, in path
    raise NotImplementedError("This backend doesn't support absolute paths.")
```
### Side effects of implementing this change


**Before submitting this PR for review, please make sure you have:**

  - [ ] Included tests
  - [ ] Updated documentation

Closes #2258 
