### PR TITLE
Add netcat to allow liveness/readiness probes that make use of open port checks.

### DIFF
--- a/docker/onadata-uwsgi/Dockerfile
+++ b/docker/onadata-uwsgi/Dockerfile
@@ -60,6 +60,7 @@ RUN apt-get update -q &&\
         libpcre3 \
         libpcre3-dev \
         locales && \
+        netcat && \
     rm -rf /var/lib/apt/lists/*
 
 # Generate and set en_US.UTF-8 locale


### PR DESCRIPTION


[ci-skip]

### Changes / Features implemented

### Steps taken to verify this change does what is intended

### Side effects of implementing this change


**Before submitting this PR for review, please make sure you have:**

  - [ ] Included tests
  - [ ] Updated documentation

Closes #
