### PR TITLE
Fix external choices form uploads

### DIFF
--- a/onadata/apps/main/tests/test_base.py
+++ b/onadata/apps/main/tests/test_base.py
@@ -137,6 +137,16 @@ class TestBase(PyxformMarkdown, TransactionTestCase):
         # make sure publishing the survey worked
         self.assertEqual(XForm.objects.count(), pre_count + 1)
 
+    def _publish_xlsx_file_with_large_external_choices(self):
+        # test with form that has > 5k external choices
+        path = os.path.join(
+            self.this_directory, "fixtures", "Registration_of_fac.xlsx"
+        )
+        pre_count = XForm.objects.count()
+        TestBase._publish_xls_file(self, path)
+        # make sure publishing the survey worked
+        self.assertEqual(XForm.objects.count(), pre_count + 1)
+
     def _publish_xls_file_and_set_xform(self, path):
         count = XForm.objects.count()
         self._publish_xls_file(path)

--- a/onadata/apps/viewer/models/data_dictionary.py
+++ b/onadata/apps/viewer/models/data_dictionary.py
@@ -105,11 +105,11 @@ def sheet_to_csv(xls_content, sheet_name):
             elif sheet.cell(index, name_column).is_date:
                 date_fields = True
 
-    for row in range(1, sheet.max_row):
+    for row, value in enumerate(sheet.iter_rows()):
         if integer_fields or date_fields:
             # convert integers to string/datetime if name has numbers/dates
             row_values = []
-            for index, val in enumerate(list(sheet.values)[row]):
+            for index, val in enumerate(value):
                 if sheet.cell(row, index).data_type == "n":
                     try:
                         val = str(float(val) if (float(val) > int(val)) else int(val))
@@ -120,8 +120,8 @@ def sheet_to_csv(xls_content, sheet_name):
                 row_values.append(val)
             writer.writerow([v for v, m in zip(row_values, mask) if m])
         else:
-            writer.writerow([v for v, m in zip(list(sheet.values)[row], mask) if m])
-
+            single_row = [cell.value for cell in value]
+            writer.writerow([v for v, m in zip(single_row, mask) if m])
     return csv_file
 
 


### PR DESCRIPTION
### Changes / Features implemented
- Use `iter_rows` when iterating through openpyxl workbook rows
### Steps taken to verify this change does what is intended
- Added tests to load xform with > 5k external choice rows
### Side effects of implementing this change


**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  - [ ] Updated documentation

Closes #
