### PR TITLE
Ensure S3 Client is properly configured when generating a presigned URL

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,6 +1,5 @@
 [flake8]
 max-line-length = 88
-...
 select = C,E,F,W,B,B950
 extend-ignore = E203, E501
 per-file-ignores = __init__.py:F401

--- a/onadata/libs/utils/image_tools.py
+++ b/onadata/libs/utils/image_tools.py
@@ -10,6 +10,7 @@ from django.core.files.base import ContentFile
 from django.core.files.storage import get_storage_class
 from django.http import HttpResponse, HttpResponseRedirect
 from botocore.exceptions import ClientError
+from botocore.client import Config
 from wsgiref.util import FileWrapper
 
 from onadata.libs.utils.viewer_tools import get_path
@@ -67,7 +68,11 @@ def generate_aws_media_url(
 ):
     s3 = get_storage_class("storages.backends.s3boto3.S3Boto3Storage")()
     bucket_name = s3.bucket.name
-    s3_client = boto3.client("s3")
+    s3_config = Config(
+        signature_version=getattr("AWS_S3_SIGNATURE_VERSION", "s3v4"),
+        region_name=getattr("AWS_S3_REGION_NAME", ""),
+    )
+    s3_client = boto3.client("s3", config=s3_config)
 
     # Generate a presigned URL for the S3 object
     return s3_client.generate_presigned_url(


### PR DESCRIPTION
### Changes / Features implemented

- Ensure S3 Client is configured when generating pre-signed URL

### Steps taken to verify this change does what is intended

- [ ] QA

### Side effects of implementing this change

- Sets the default signature version for presigned URLs to `s3v4`

Closes #
