### PR TITLE
Ensure the default ignored flake8 errors are actually ignored

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 [flake8]
 max-line-length = 88
 select = C,E,F,W,B,B950
-extend-ignore = E203, E501
+extend-ignore = E203,E501,E126,E121,E123,E126,E226,E24,E704,W503,W504
 per-file-ignores = __init__.py:F401

--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,0 @@
-[flake8]
-max-line-length = 88
-select = C,E,F,W,B,B950
-extend-ignore = E203,E501,E126,E121,E123,E126,E226,E24,E704,W503,W504
-per-file-ignores = __init__.py:F401

--- a/onadata/apps/main/tests/test_style.py
+++ b/onadata/apps/main/tests/test_style.py
@@ -1,4 +1,4 @@
-from subprocess import call
+from subprocess import call, check_output
 
 from django.test import TestCase
 
@@ -9,4 +9,10 @@ class TestStyle(TestCase):
         result = call(
             ['flake8', '--exclude=migrations,src,settings', 'onadata']
         )
+        print(
+            check_output(
+                ['flake8', '--exclude=migrations,src,settings', 'onadata']
+            )
+        )
+        print(f"{result}")
         self.assertEqual(result, 0, "Code is not flake8.")

--- a/onadata/apps/viewer/xls_writer.py
+++ b/onadata/apps/viewer/xls_writer.py
@@ -123,11 +123,11 @@ class XlsWriter(object):
         else:
             i = 1
             unique_name = sheet_name
-            while(unique_name in self._sheets):
+            while (unique_name in self._sheets):
                 number_len = len(text(i))
                 allowed_name_len = self.sheet_name_limit - number_len
                 # make name required len
-                if(len(unique_name) > allowed_name_len):
+                if (len(unique_name) > allowed_name_len):
                     unique_name = unique_name[0:allowed_name_len]
                 unique_name = "{0}{1}".format(unique_name, i)
                 i = i + 1

--- a/setup.cfg
+++ b/setup.cfg
@@ -116,3 +116,9 @@ setup_requires =
 
 [bdist_wheel]
 universal = 1
+
+[flake8]
+max-line-length = 88
+select = C,E,F,W,B,B950
+extend-ignore = E203,E501,E126,E121,E123,E126,E226,E24,E704,W503,W504
+per-file-ignores = __init__.py:F401


### PR DESCRIPTION
### Changes / Features implemented

- Add default ignored codes to `extend-ignore`; Full list of default ignored codes can be seen on `flake8 --help`
- Silence Flake8 `E275` warning

### Steps taken to verify this change does what is intended

N/A

### Side effects of implementing this change

N/A

