### PR TITLE
[csv_builder] handle data only repeat structure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
         env:
           DJANGO_SETTINGS_MODULE: onadata.settings.github_actions_test
         run: |
-          pip install prospector
+          pip install prospector==1.7.7 pylint==2.14.5
           pip install -r requirements/azure.pip
           prospector -X -s veryhigh onadata
 


### PR DESCRIPTION

### Changes / Features implemented

Handles the case of a repeat construct in the data but the form
has no repeat construct defined using begin repeat, for example
when you have a hidden value that has a repeat_count set within
 a group.

### Steps taken to verify this change does what is intended
- imported the client data and attempted to do CSV exports; export was successful.

 Closes https://github.com/onaio/onadata/issues/2217
