### PR TITLE
Remove username `max_length` constraint in ShareProjectSerializer

### DIFF
--- a/onadata/libs/serializers/share_project_serializer.py
+++ b/onadata/libs/serializers/share_project_serializer.py
@@ -30,7 +30,7 @@ class ShareProjectSerializer(serializers.Serializer):
     """
 
     project = ProjectField()
-    username = serializers.CharField(max_length=255)
+    username = serializers.CharField(required=True)
     role = serializers.CharField(max_length=50)
 
     def create(self, validated_data):


### PR DESCRIPTION
Signed-off-by: Kipchirchir Sigei <arapgodsmack@gmail.com>

### Changes / Features implemented
- Remove username max_length constraint in ShareProjectSerializer
### Steps taken to verify this change does what is intended

### Side effects of implementing this change


**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  - [ ] Updated documentation

Closes #2308 
