### PR TITLE
Fix org members permissions

### DIFF
--- a/onadata/apps/api/tests/viewsets/test_organization_profile_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_organization_profile_viewset.py
@@ -23,7 +23,7 @@ from onadata.apps.api.viewsets.organization_profile_viewset import (
 from onadata.apps.api.viewsets.project_viewset import ProjectViewSet
 from onadata.apps.api.viewsets.user_profile_viewset import UserProfileViewSet
 from onadata.apps.main.models import UserProfile
-from onadata.libs.permissions import OwnerRole
+from onadata.libs.permissions import OwnerRole, EditorRole
 
 
 # pylint: disable=too-many-public-methods
@@ -283,7 +283,6 @@ class TestOrganizationProfileViewSet(TestAbstractViewSet):
         request = self.factory.post(
             "/", data=json.dumps(data), content_type="application/json", **self.extra
         )
-
         response = view(request, user="denoinc")
         self.assertEqual(response.status_code, 201)
         self.assertEqual(set(response.data), set(["denoinc", "aboy"]))
@@ -541,6 +540,38 @@ class TestOrganizationProfileViewSet(TestAbstractViewSet):
         self._project_create(project_data)
         self._publish_xls_form_to_project()
         self.assertTrue(OwnerRole.user_has_role(self.user, self.xform))
+
+    def test_publish_xls_form_to_organization_project_perms(self):
+        # create org
+        self._org_create()
+        project_data = {"owner": self.company_data["user"]}
+
+        # create project under org
+        self._project_create(project_data)
+        self._publish_xls_form_to_project()
+
+        # add member to org
+        view = OrganizationProfileViewSet.as_view({"post": "members"})
+
+        # create new user
+        self.profile_data["username"] = "aboy"
+        self.profile_data["email"] = "aboy@org.com"
+        self._create_user_profile()
+        data = {"username": "aboy", "role": "editor"}
+
+        # add new user as member to org with editor permissions
+        request = self.factory.post(
+            "/", data=json.dumps(data), content_type="application/json", **self.extra
+        )
+        response = view(request, user="denoinc")
+        self.assertEqual(response.status_code, 201)
+
+        member = User.objects.get(username="aboy")
+
+        # Assert that user has xform and project permissions
+        self.assertTrue(EditorRole.user_has_role(member, self.xform))
+        self.assertTrue(EditorRole.user_has_role(member, self.project))
+        
 
     def test_put_change_role(self):
         self._org_create()

--- a/onadata/apps/api/tests/viewsets/test_organization_profile_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_organization_profile_viewset.py
@@ -541,38 +541,6 @@ class TestOrganizationProfileViewSet(TestAbstractViewSet):
         self._publish_xls_form_to_project()
         self.assertTrue(OwnerRole.user_has_role(self.user, self.xform))
 
-    def test_publish_xls_form_to_organization_project_perms(self):
-        # create org
-        self._org_create()
-        project_data = {"owner": self.company_data["user"]}
-
-        # create project under org
-        self._project_create(project_data)
-        self._publish_xls_form_to_project()
-
-        # add member to org
-        view = OrganizationProfileViewSet.as_view({"post": "members"})
-
-        # create new user
-        self.profile_data["username"] = "aboy"
-        self.profile_data["email"] = "aboy@org.com"
-        self._create_user_profile()
-        data = {"username": "aboy", "role": "editor"}
-
-        # add new user as member to org with editor permissions
-        request = self.factory.post(
-            "/", data=json.dumps(data), content_type="application/json", **self.extra
-        )
-        response = view(request, user="denoinc")
-        self.assertEqual(response.status_code, 201)
-
-        member = User.objects.get(username="aboy")
-
-        # Assert that user has xform and project permissions
-        self.assertTrue(EditorRole.user_has_role(member, self.xform))
-        self.assertTrue(EditorRole.user_has_role(member, self.project))
-        
-
     def test_put_change_role(self):
         self._org_create()
         newname = "aboy"
@@ -842,6 +810,37 @@ class TestOrganizationProfileViewSet(TestAbstractViewSet):
         self.assertIn("denoinc", users_in_users)
         self.assertIn("aboy", users_in_users)
         self.assertIn("alice", users_in_users)
+
+    def test_member_added_to_org_with_correct_perms(self):
+        # create org
+        self._org_create()
+        project_data = {"owner": self.company_data["user"]}
+
+        # create project under org
+        self._project_create(project_data)
+        self._publish_xls_form_to_project()
+
+        # add member to org
+        view = OrganizationProfileViewSet.as_view({"post": "members"})
+
+        # create new user
+        self.profile_data["username"] = "aboy"
+        self.profile_data["email"] = "aboy@org.com"
+        self._create_user_profile()
+        data = {"username": "aboy", "role": "editor"}
+
+        # add new user as member to org with editor permissions
+        request = self.factory.post(
+            "/", data=json.dumps(data), content_type="application/json", **self.extra
+        )
+        response = view(request, user="denoinc")
+        self.assertEqual(response.status_code, 201)
+
+        member = User.objects.get(username="aboy")
+
+        # Assert that user has xform and project permissions
+        self.assertTrue(EditorRole.user_has_role(member, self.xform))
+        self.assertTrue(EditorRole.user_has_role(member, self.project))
 
     def test_put_role_user_none_existent(self):
         self._org_create()

--- a/onadata/libs/serializers/organization_member_serializer.py
+++ b/onadata/libs/serializers/organization_member_serializer.py
@@ -17,9 +17,12 @@ from onadata.apps.api.tools import (
     remove_user_from_organization,
     remove_user_from_team,
 )
-from onadata.libs.models.share_project import ShareProject
+from onadata.apps.api.models.organization_profile import (
+    get_organization_members_team,
+)
 from onadata.libs.permissions import ROLES, OwnerRole, is_organization
 from onadata.libs.serializers.fields.organization_field import OrganizationField
+from onadata.libs.serializers.share_project_serializer import ShareProjectSerializer
 from onadata.settings.common import DEFAULT_FROM_EMAIL, SHARE_ORG_SUBJECT
 
 User = get_user_model()
@@ -39,17 +42,22 @@ def _set_organization_role_to_user(organization, user, role):
     role_cls.add(user, organization)
 
     owners_team = get_or_create_organization_owners_team(organization)
+    members_team = get_organization_members_team(organization)
+    current_team = owners_team if role == OwnerRole.name else members_team
 
-    # add the owner to owners team
-    if role == OwnerRole.name:
-        role_cls.add(user, organization.userprofile_ptr)
-        add_user_to_team(owners_team, user)
-        # add user to org projects
-        for project in organization.user.project_org.all():
-            ShareProject(project, user.username, role).save()
-
-    if role != OwnerRole.name:
-        remove_user_from_team(owners_team, user)
+    # add user to their respective team
+    role_cls.add(user, organization.userprofile_ptr)
+    add_user_to_team(current_team, user)
+    # add user to org projects
+    for project in organization.user.project_org.all():
+        data = {
+            "project": project.pk,
+            "username": user.username,
+            "role": role
+        }
+        serializer = ShareProjectSerializer(data=data)
+        if serializer.is_valid():
+            serializer.save()
 
 
 class OrganizationMemberSerializer(serializers.Serializer):


### PR DESCRIPTION
### Changes / Features implemented
- Set organization role to org members and ensure that the org project is shared with the members team in an organization

### Steps taken to verify this change does what is intended
- Added test to ensure that xform and project permissions are correctly applied to org members

### Side effects of implementing this change
- None

**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  - [ ] Updated documentation

Closes #2322
