### PR TITLE
Propagate project permissions to all KPI Assets

### DIFF
--- a/onadata/libs/tests/utils/test_project_utils.py
+++ b/onadata/libs/tests/utils/test_project_utils.py
@@ -6,15 +6,17 @@ from django.test.utils import override_settings
 
 from kombu.exceptions import OperationalError
 from mock import MagicMock, patch
-from requests import Response, session
+from requests import Response
 
 from onadata.apps.logger.models import Project
 from onadata.apps.main.tests.test_base import TestBase
 from onadata.libs.permissions import DataEntryRole
-from onadata.libs.utils.project_utils import (assign_change_asset_permission,
-                                              retrieve_asset_permissions,
-                                              set_project_perms_to_xform,
-                                              set_project_perms_to_xform_async)
+from onadata.libs.utils.project_utils import (
+    assign_change_asset_permission,
+    retrieve_asset_permissions,
+    set_project_perms_to_xform,
+    set_project_perms_to_xform_async,
+)
 
 
 class TestProjectUtils(TestBase):
@@ -25,7 +27,7 @@ class TestProjectUtils(TestBase):
     def setUp(self):
         super(TestProjectUtils, self).setUp()
 
-        self._create_user('bob', 'bob', create_profile=True)
+        self._create_user("bob", "bob", create_profile=True)
 
     def test_set_project_perms_to_xform(self):
         """
@@ -33,7 +35,7 @@ class TestProjectUtils(TestBase):
         """
         self._publish_transportation_form()
         # Alice has data entry role to default project
-        alice = self._create_user('alice', 'alice', create_profile=True)
+        alice = self._create_user("alice", "alice", create_profile=True)
         DataEntryRole.add(alice, self.project)
         set_project_perms_to_xform(self.xform, self.project)
         self.assertTrue(DataEntryRole.user_has_role(alice, self.xform))
@@ -41,7 +43,8 @@ class TestProjectUtils(TestBase):
 
         # Create other project and transfer xform to new project
         project_b = Project(
-            name='Project B', created_by=self.user, organization=self.user)
+            name="Project B", created_by=self.user, organization=self.user
+        )
         project_b.save()
         self.xform.project = project_b
         self.xform.save()
@@ -56,7 +59,7 @@ class TestProjectUtils(TestBase):
 
     # pylint: disable=invalid-name
     @override_settings(CELERY_TASK_ALWAYS_EAGER=True)
-    @patch('onadata.libs.utils.project_utils.set_project_perms_to_xform')
+    @patch("onadata.libs.utils.project_utils.set_project_perms_to_xform")
     def test_set_project_perms_to_xform_async(self, mock):
         """
         Test that the set_project_perms_to_xform_async task actually calls
@@ -68,7 +71,7 @@ class TestProjectUtils(TestBase):
         args, _kwargs = mock.call_args_list[0]
         self.assertEqual(args[0], self.xform)
         self.assertEqual(args[1], self.project)
-        
+
     def test_assign_change_asset_permission(self):
         """
         Test that the `assign_change_asset_permission` function calls
@@ -81,24 +84,26 @@ class TestProjectUtils(TestBase):
         resp.status_code = 200
         session_mock.post.return_value = resp
 
-        ret = assign_change_asset_permission("http://example.com", asset_id, usernames, session_mock)
+        assign_change_asset_permission(
+            "http://example.com", asset_id, usernames, session_mock
+        )
         session_mock.post.assert_called()
         session_mock.post.assert_called_with(
             f"http://example.com/api/v2/assets/{asset_id}/permission-assignments/bulk/",
             json=[
                 {
-                "user": "http://example.com/api/v2/users/bob/",
-                "permission": "http://example.com/api/v2/permissions/change_asset/"
+                    "user": "http://example.com/api/v2/users/bob/",
+                    "permission": "http://example.com/api/v2/permissions/change_asset/",
                 },
                 {
-                "user": "http://example.com/api/v2/users/john/",
-                "permission": "http://example.com/api/v2/permissions/change_asset/"
+                    "user": "http://example.com/api/v2/users/john/",
+                    "permission": "http://example.com/api/v2/permissions/change_asset/",
                 },
                 {
-                "user": "http://example.com/api/v2/users/doe/",
-                "permission": "http://example.com/api/v2/permissions/change_asset/"
+                    "user": "http://example.com/api/v2/users/doe/",
+                    "permission": "http://example.com/api/v2/permissions/change_asset/",
                 },
-            ]
+            ],
         )
 
     def test_retrieve_asset_permission(self):
@@ -111,7 +116,11 @@ class TestProjectUtils(TestBase):
         service_url = "http://example.com"
         resp = Response()
         resp.status_code = 200
-        resp._content = b'[{"user": "http://example.com/api/v2/users/bob", "url": "http://example.com/api/v2/permission-assignments/some_uuid"}]'
+        # pylint: disable=protected-access
+        resp._content = (
+            b'[{"user": "http://example.com/api/v2/users/bob", "url": '
+            b'"http://example.com/api/v2/permission-assignments/some_uuid"}]'
+        )
         session_mock.get.return_value = resp
 
         ret = retrieve_asset_permissions(service_url, asset_id, session_mock)
@@ -119,15 +128,16 @@ class TestProjectUtils(TestBase):
         session_mock.get.assert_called_with(
             f"{service_url}/api/v2/assets/{asset_id}/permission-assignments/"
         )
-        self.assertEqual(ret, {"bob": ["http://example.com/api/v2/permission-assignments/some_uuid"]})
+        self.assertEqual(
+            ret, {"bob": ["http://example.com/api/v2/permission-assignments/some_uuid"]}
+        )
 
     @override_settings(CELERY_TASK_ALWAYS_EAGER=True)
     @patch(
-        'onadata.libs.utils.project_utils.set_project_perms_to_xform_async.delay'  # noqa
+        "onadata.libs.utils.project_utils.set_project_perms_to_xform_async.delay"  # noqa
     )
-    @patch('onadata.libs.utils.project_utils.set_project_perms_to_xform')
-    def test_rabbitmq_connection_error(self, mock_set_perms_async,
-                                       mock_set_perms):
+    @patch("onadata.libs.utils.project_utils.set_project_perms_to_xform")
+    def test_rabbitmq_connection_error(self, mock_set_perms_async, mock_set_perms):
         """
         Test rabbitmq connection error.
         """

--- a/onadata/libs/utils/project_utils.py
+++ b/onadata/libs/utils/project_utils.py
@@ -21,9 +21,13 @@ from onadata.apps.api.models.team import Team
 from onadata.apps.logger.models.project import Project
 from onadata.apps.logger.models.xform import XForm
 from onadata.celeryapp import app
-from onadata.libs.permissions import (ROLES, OwnerRole,
-                                      get_object_users_with_permissions,
-                                      get_role, is_organization)
+from onadata.libs.permissions import (
+    ROLES,
+    OwnerRole,
+    get_object_users_with_permissions,
+    get_role,
+    is_organization,
+)
 from onadata.libs.utils.common_tags import API_TOKEN, OWNER_TEAM_NAME
 from onadata.libs.utils.common_tools import report_exception
 
@@ -201,20 +205,6 @@ def assign_change_asset_permission(
         )
     return resp
 
-@app.task(bind=True, max_retries=3)
-def propagate_project_permissions_async(self, project_id: int, headers: Optional[dict] = None, use_asset_owner_auth: bool = True):
-    """
-    Asynchronously propagates Project Permissions to the Formbuilder assets within the project
-    """
-    try:
-        project = Project.objects.get(id=project_id)
-        propagate_project_permissions(project, headers, use_asset_owner_auth)
-    except (Project.DoesNotExist, ExternalServiceRequestError) as e:
-        if self.request.retries > 3:
-            msg = f"Failed to propagate asset permissions for Project {project_id}"
-            report_exception(msg, e, sys.exc_info())
-        self.retry(exc=e, countdown=60 * self.request.retries)
-
 
 @app.task(bind=True, max_retries=3)
 def propagate_project_permissions_async(
@@ -224,7 +214,8 @@ def propagate_project_permissions_async(
     use_asset_owner_auth: bool = True,
 ):
     """
-    Asynchronously propagates Project Permissions to the Formbuilder assets within the project
+    Asynchronously propagates Project Permissions to the Formbuilder assets
+    within the project
     """
     try:
         project = Project.objects.get(id=project_id)

--- a/onadata/libs/utils/project_utils.py
+++ b/onadata/libs/utils/project_utils.py
@@ -2,33 +2,36 @@
 """
 project_utils module - apply project permissions to a form.
 """
+import re
 import sys
-import requests
-
-from typing import List, Optional, Tuple
+from typing import Dict, List, Optional
 from urllib.parse import urljoin
+
 from django.conf import settings
 from django.db import IntegrityError
+from django.db.models import Q
 
+import jwt
+import requests
 from multidb.pinning import use_master
+from requests.adapters import Retry
+from requests.sessions import HTTPAdapter
 
+from onadata.apps.api.models.team import Team
 from onadata.apps.logger.models.project import Project
 from onadata.apps.logger.models.xform import XForm
-from onadata.apps.main.models import MetaData
 from onadata.celeryapp import app
-from onadata.libs.permissions import (
-    ROLES,
-    OwnerRole,
-    get_object_users_with_permissions,
-    get_role,
-    is_organization,
-)
-from onadata.libs.utils.common_tags import OWNER_TEAM_NAME
+from onadata.libs.permissions import (ROLES, OwnerRole,
+                                      get_object_users_with_permissions,
+                                      get_role, is_organization)
+from onadata.libs.utils.common_tags import API_TOKEN, OWNER_TEAM_NAME
 from onadata.libs.utils.common_tools import report_exception
 
 
 class ExternalServiceRequestError(Exception):
-    pass
+    """
+    Custom Exception class for External service requests i.e Formbuilder
+    """
 
 
 def get_project_users(project):
@@ -148,25 +151,122 @@ def set_project_perms_to_xform_async(self, xform_id, project_id):
         report_exception(msg, e, sys.exc_info())
 
 
-def propagate_project_permissions(project_id: int, headers: Optional[dict] = None) -> None:
+def retrieve_asset_permissions(
+    service_url: str, asset_id: str, session: requests.Session
+) -> Dict[str, List[str]]:
+    """
+    Retrieves the currently assigned asset permissions for each user on KPI
+    """
+    ret = {}
+    resp = session.get(
+        urljoin(service_url, f"/api/v2/assets/{asset_id}/permission-assignments/")
+    )
+    if resp.status_code != 200:
+        raise ExternalServiceRequestError(
+            "Failed to retrieve current asset permission "
+            f"assignments for {asset_id}: {resp.status_code}"
+        )
+
+    data = resp.json()
+    for permission in data:
+        user = permission.get("user")
+        user = re.findall(r"\S\/api\/v2\/users\/(\w+)", user)[0]
+
+        if user not in ret:
+            ret[user] = []
+        ret[user].append(permission.get("url"))
+    return ret
+
+
+def assign_change_asset_permission(
+    service_url: str, asset_id: str, usernames: List[str], session: requests.Session
+) -> requests.Response:
+    """
+    Bulk assigns the `change_asset` permission to a group of users on KPI
+    """
+    asset_url = urljoin(
+        service_url, f"/api/v2/assets/{asset_id}/permission-assignments/bulk/"
+    )
+    payload = [
+        {
+            "user": urljoin(service_url, f"/api/v2/users/{username}/"),
+            "permission": urljoin(service_url, "/api/v2/permissions/change_asset/"),
+        }
+        for username in usernames
+    ]
+    resp = session.post(asset_url, json=payload)
+    if resp.status_code != 200:
+        raise ExternalServiceRequestError(
+            f"Failed to assign permissions for {asset_id}: {resp.status_code}"
+        )
+    return resp
+
+
+@app.task(bind=True, max_retries=3)
+def propagate_project_permissions_async(
+    self,
+    project_id: int,
+    headers: Optional[dict] = None,
+    use_asset_owner_auth: bool = True,
+):
+    """
+    Asynchronously propagates Project Permissions to the Formbuilder assets within the project
+    """
+    try:
+        project = Project.objects.get(id=project_id)
+        propagate_project_permissions(project, headers, use_asset_owner_auth)
+    except (Project.DoesNotExist, ExternalServiceRequestError) as e:
+        if self.request.retries > 3:
+            msg = f"Failed to propagate asset permissions for Project {project_id}"
+            report_exception(msg, e, sys.exc_info())
+        self.retry(exc=e, countdown=60 * self.request.retries)
+
+
+def propagate_project_permissions(
+    project: Project, headers: Optional[dict] = None, use_asset_owner_auth: bool = True
+) -> None:
     """
     Propagates Project permissions to external services(KPI)
     """
-    if getattr(settings, "PROPAGATE_PERMISSIONS", False) and getattr(
-        settings, "KPI_SERVICE_URL", None
-    ):
-        service_url = settings["KPI_SERVICE_URL"]
+    if getattr(settings, "KPI_INTERNAL_SERVICE_URL", None):
+        service_url = settings.KPI_INTERNAL_SERVICE_URL
+
+        # Create request session for the Internal KPI calls
         session = requests.session()
+        session.mount(
+            "http",
+            HTTPAdapter(
+                max_retries=Retry(
+                    total=5,
+                    backoff_factor=2,
+                    method_whitelist=["GET", "POST", "DELETE"],
+                    status_forcelist=[502, 503, 504],
+                )
+            ),
+        )
+
         if headers:
             session.headers.update(headers)
 
-        project: Project = Project.objects.get(id=project_id)
-        users: dict[str, dict] = get_project_users(project)
-        collaborators: List[Tuple[str, str]] = [
-            (username, str(data.get("role")))
-            for username, data in users.items()
+        # Retrieve users who have access to the project
+        collaborators: List[str] = [
+            username
+            for username, data in get_project_users(project).items()
             if data.get("role") != "owner" and data.get("role") in ["editor"]
         ]
+
+        if is_organization(project.organization.profile):
+            owners_team = Team.objects.get(
+                name=f"{project.organization.username}#{Team.OWNER_TEAM_NAME}"
+            )
+            owners_team = list(
+                owners_team.user_set.filter(
+                    ~Q(username=project.organization.username)
+                ).values_list("username", flat=True)
+            )
+            collaborators += owners_team
+            collaborators = list(set(collaborators))
+
         form_ids: List[int] = list(
             project.xform_set.filter(deleted_at__isnull=True).values_list(
                 "id", flat=True
@@ -176,29 +276,49 @@ def propagate_project_permissions(project_id: int, headers: Optional[dict] = Non
         # Propagate permissions for XForms that were published by
         # Formbuilder
         for form_id in form_ids:
+            asset: XForm = XForm.objects.get(id=form_id)
             if (
-                MetaData.objects.filter(
-                    object_id=form_id,
-                    data_type="published_by_formbuilder",
-                    data_value=True,
+                asset.metadata_set.filter(
+                    data_type="published_by_formbuilder", data_value=True
                 ).count()
                 > 0
             ):
-                form: str = XForm.objects.get(id=form_id).id_string
-                asset_url = urljoin(
-                    service_url, f"/api/v2/assets/{form}/permission-assignments/bulk/"
+                if use_asset_owner_auth:
+                    session.headers.update(
+                        {
+                            "X-ONADATA-KOBOCAT-AUTH": jwt.encode(
+                                {API_TOKEN: asset.created_by.auth_token.key},
+                                getattr(settings, "JWT_SECRET_KEY", "jwt"),
+                                algorithm=getattr(settings, "JWT_ALGORITHM", "HS256"),
+                            )
+                        }
+                    )
+                assigned_permissions = retrieve_asset_permissions(
+                    service_url, asset.id_string, session
                 )
-                payload = [
-                    {
-                        "user": urljoin(service_url, f"/api/v2/users/{username}"),
-                        "permission": urljoin(
-                            service_url, "/api/v2/permissions/change_asset/"
-                        ),
-                    }
-                    for username, _ in collaborators
+                new_users = [
+                    username
+                    for username in collaborators
+                    if username not in assigned_permissions
                 ]
-                resp = session.post(asset_url, json=json.dumps(payload))
-                if resp.status_code != 200:
-                    raise ExternalServiceRequestError(
-                        f"Failed to propagate permissions for {form}: {resp.status_code}"
+                removed_permissions = [
+                    (username, permissions)
+                    for username, permissions in assigned_permissions.items()
+                    if username not in collaborators
+                ]
+
+                # Unassign permissions granted to users who no longer have permissions
+                for _, permission_assignments in removed_permissions:
+                    _ = [
+                        session.delete(permission_assignment)
+                        for permission_assignment in permission_assignments
+                    ]
+
+                # Assign permissions to the new users
+                if new_users:
+                    assign_change_asset_permission(
+                        service_url,
+                        asset.id_string,
+                        new_users,
+                        session,
                     )


### PR DESCRIPTION
### Changes / Features implemented

- [x] Ensure permissions are created for Owners on KPI published assets
- [x] Ensure permissions are removed from KPI published assets once a users' role is downgraded/removed
- [x] Cleanup

### Steps taken to verify this change does what is intended

- [x] QA

### Side effects of implementing this change

_TODO_


**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  - [ ] Updated documentation

Closes #1060
