### PR TITLE
Ensure user profiles exist when building user permissions dict

### DIFF
--- a/onadata/apps/api/tools.py
+++ b/onadata/apps/api/tools.py
@@ -145,7 +145,7 @@ def create_organization(name, creator):
     try:
         organization_profile = organization.profile
     except OrganizationProfile.DoesNotExist:
-        organization_profile = OrganizationProfile.objects.get_or_create(
+        organization_profile, _ = OrganizationProfile.objects.get_or_create(
             user=organization, creator=creator
         )
     return organization_profile

--- a/onadata/apps/api/tools.py
+++ b/onadata/apps/api/tools.py
@@ -142,9 +142,12 @@ def create_organization(name, creator):
 
     """
     organization, _created = User.objects.get_or_create(username__iexact=name)
-    organization_profile = OrganizationProfile.objects.create(
-        user=organization, creator=creator
-    )
+    try:
+        organization_profile = organization.profile
+    except OrganizationProfile.DoesNotExist:
+        organization_profile = OrganizationProfile.objects.get_or_create(
+            user=organization, creator=creator
+        )
     return organization_profile
 
 

--- a/onadata/apps/api/tools.py
+++ b/onadata/apps/api/tools.py
@@ -143,12 +143,9 @@ def create_organization(name, creator):
 
     """
     organization, _created = User.objects.get_or_create(username__iexact=name)
-    try:
-        organization_profile = organization.profile
-    except UserProfile.DoesNotExist:
-        organization_profile, _ = OrganizationProfile.objects.get_or_create(
-            user=organization, creator=creator
-        )
+    organization_profile, _ = OrganizationProfile.objects.get_or_create(
+        user=organization, creator=creator
+    )
     return organization_profile
 
 
@@ -665,7 +662,7 @@ def get_xform_users(xform):
             try:
                 profile = user.profile
             except UserProfile.DoesNotExist:
-                profile, _ = UserProfile.objects.get_or_create(user=user)
+                profile = UserProfile.objects.create(user=user)
 
             if is_organization(user.profile):
                 org_members = get_team_members(user.username)
@@ -686,7 +683,7 @@ def get_xform_users(xform):
         try:
             profile = user.profile
         except UserProfile.DoesNotExist:
-            profile, _ = UserProfile.objects.get_or_create(user=user)
+            profile = UserProfile.objects.create(user=user)
 
         if user not in data:
             data[user] = {

--- a/onadata/apps/main/models/user_profile.py
+++ b/onadata/apps/main/models/user_profile.py
@@ -4,6 +4,7 @@ UserProfile model class
 """
 from django.conf import settings
 from django.contrib.auth import get_user_model
+from django.db import models
 from django.db.models.signals import post_save, pre_save
 from django.utils.translation import gettext_lazy
 
@@ -109,6 +110,7 @@ def create_auth_token(sender, instance=None, created=False, **kwargs):
     if created:
         Token.objects.create(user=instance)
 
+
 # pylint: disable=unused-argument
 def create_user_profile(sender, instance=None, created=False, **kwargs):
     """
@@ -118,7 +120,8 @@ def create_user_profile(sender, instance=None, created=False, **kwargs):
         try:
             _ = instance.profile
         except UserProfile.DoesNotExist:
-            UserProfile.objects.get_or_create(user=instance)
+            _ = UserProfile.objects.get_or_create(user=instance)
+
 
 # pylint: disable=unused-argument
 def set_object_permissions(sender, instance=None, created=False, **kwargs):

--- a/onadata/apps/main/models/user_profile.py
+++ b/onadata/apps/main/models/user_profile.py
@@ -112,18 +112,6 @@ def create_auth_token(sender, instance=None, created=False, **kwargs):
 
 
 # pylint: disable=unused-argument
-def create_user_profile(sender, instance=None, created=False, **kwargs):
-    """
-    Creates an default User Profile.
-    """
-    if created:
-        try:
-            _ = instance.profile
-        except UserProfile.DoesNotExist:
-            _ = UserProfile.objects.get_or_create(user=instance)
-
-
-# pylint: disable=unused-argument
 def set_object_permissions(sender, instance=None, created=False, **kwargs):
     """
     Assign's permission to the user that created the profile.
@@ -160,8 +148,6 @@ def set_kpi_formbuilder_permissions(sender, instance=None, created=False, **kwar
 
 
 post_save.connect(create_auth_token, sender=User, dispatch_uid="auth_token")
-post_save.connect(
-    create_user_profile, sender=User, dispatch_uid="create_user_profile")
 post_save.connect(
     send_inactive_user_email, sender=User, dispatch_uid="send_inactive_user_email"
 )

--- a/onadata/apps/main/models/user_profile.py
+++ b/onadata/apps/main/models/user_profile.py
@@ -4,7 +4,6 @@ UserProfile model class
 """
 from django.conf import settings
 from django.contrib.auth import get_user_model
-from django.db import models
 from django.db.models.signals import post_save, pre_save
 from django.utils.translation import gettext_lazy
 
@@ -110,6 +109,16 @@ def create_auth_token(sender, instance=None, created=False, **kwargs):
     if created:
         Token.objects.create(user=instance)
 
+# pylint: disable=unused-argument
+def create_user_profile(sender, instance=None, created=False, **kwargs):
+    """
+    Creates an default User Profile.
+    """
+    if created:
+        try:
+            _ = instance.profile
+        except UserProfile.DoesNotExist:
+            UserProfile.objects.get_or_create(user=instance)
 
 # pylint: disable=unused-argument
 def set_object_permissions(sender, instance=None, created=False, **kwargs):
@@ -148,6 +157,8 @@ def set_kpi_formbuilder_permissions(sender, instance=None, created=False, **kwar
 
 
 post_save.connect(create_auth_token, sender=User, dispatch_uid="auth_token")
+post_save.connect(
+    create_user_profile, sender=User, dispatch_uid="create_user_profile")
 post_save.connect(
     send_inactive_user_email, sender=User, dispatch_uid="send_inactive_user_email"
 )

--- a/onadata/libs/permissions.py
+++ b/onadata/libs/permissions.py
@@ -563,24 +563,18 @@ def get_object_users_with_permissions(
             obj, attach_perms=True, with_group_users=with_group_users
         ).items()
 
-        result = []
-        for user, permissions in users_with_perms:
-            try:
-                profile = user.profile
-            except UserProfile.DoesNotExist:
-                profile, _ = UserProfile.objects.get_or_create(user=user)
-
-            result.append(
-                {
-                    "user": user.username if username else user,
-                    "first_name": user.first_name,
-                    "last_name": user.last_name,
-                    "role": get_role(permissions, obj),
-                    "is_org": is_organization(profile),
-                    "gravatar": profile.gravatar,
-                    "metadata": profile.metadata,
-                }
-            )
+        result = [
+            {
+                "user": user.username if username else user,
+                "first_name": user.first_name,
+                "last_name": user.last_name,
+                "role": get_role(permissions, obj),
+                "is_org": is_organization(user.profile),
+                "gravatar": user.profile.gravatar,
+                "metadata": user.profile.metadata,
+            }
+            for user, permissions in users_with_perms
+        ]
 
     return result
 

--- a/onadata/libs/permissions.py
+++ b/onadata/libs/permissions.py
@@ -563,18 +563,22 @@ def get_object_users_with_permissions(
             obj, attach_perms=True, with_group_users=with_group_users
         ).items()
 
-        result = [
-            {
+        result = []
+        for user, permissions in users_with_perms:
+            try:
+                profile = user.profile
+            except UserProfile.DoesNotExist:
+                profile, _ = UserProfile.objects.get_or_create(user=user)
+
+            result.append({
                 "user": user.username if username else user,
                 "first_name": user.first_name,
                 "last_name": user.last_name,
                 "role": get_role(permissions, obj),
-                "is_org": is_organization(user.profile),
-                "gravatar": user.profile.gravatar,
-                "metadata": user.profile.metadata,
-            }
-            for user, permissions in users_with_perms
-        ]
+                "is_org": is_organization(profile),
+                "gravatar": profile.gravatar,
+                "metadata": profile.metadata,
+            })
 
     return result
 

--- a/onadata/libs/permissions.py
+++ b/onadata/libs/permissions.py
@@ -565,10 +565,11 @@ def get_object_users_with_permissions(
 
         result = []
         for user, permissions in users_with_perms:
+            # create missing user profile
             try:
                 profile = user.profile
             except UserProfile.DoesNotExist:
-                profile, _ = UserProfile.objects.get_or_create(user=user)
+                profile = UserProfile.objects.create(user=user)
 
             result.append({
                 "user": user.username if username else user,

--- a/onadata/libs/permissions.py
+++ b/onadata/libs/permissions.py
@@ -563,18 +563,24 @@ def get_object_users_with_permissions(
             obj, attach_perms=True, with_group_users=with_group_users
         ).items()
 
-        result = [
-            {
-                "user": user.username if username else user,
-                "first_name": user.first_name,
-                "last_name": user.last_name,
-                "role": get_role(permissions, obj),
-                "is_org": is_organization(user.profile),
-                "gravatar": user.profile.gravatar,
-                "metadata": user.profile.metadata,
-            }
-            for user, permissions in users_with_perms
-        ]
+        result = []
+        for user, permissions in users_with_perms:
+            try:
+                profile = user.profile
+            except UserProfile.DoesNotExist:
+                profile, _ = UserProfile.objects.get_or_create(user=user)
+
+            result.append(
+                {
+                    "user": user.username if username else user,
+                    "first_name": user.first_name,
+                    "last_name": user.last_name,
+                    "role": get_role(permissions, obj),
+                    "is_org": is_organization(profile),
+                    "gravatar": profile.gravatar,
+                    "metadata": profile.metadata,
+                }
+            )
 
     return result
 

--- a/onadata/libs/serializers/organization_member_serializer.py
+++ b/onadata/libs/serializers/organization_member_serializer.py
@@ -18,6 +18,7 @@ from onadata.apps.api.tools import (
     remove_user_from_team,
 )
 from onadata.apps.logger.models.project import Project
+from onadata.apps.main.models.user_profile import UserProfile
 from onadata.libs.permissions import ROLES, OwnerRole, is_organization
 from onadata.libs.serializers.fields.organization_field import OrganizationField
 from onadata.libs.serializers.share_project_serializer import ShareProjectSerializer
@@ -96,7 +97,13 @@ class OrganizationMemberSerializer(serializers.Serializer):
             if not user.is_active:
                 raise serializers.ValidationError(_("User is not active"))
 
-            if is_organization(user.profile):
+            # create user profile if missing
+            try:
+                profile = user.profile
+            except UserProfile.DoesNotExist:
+                profile = UserProfile.objects.create(user=user)
+
+            if is_organization(profile):
                 raise serializers.ValidationError(
                     _(f"Cannot add org account `{user.username}` as member.")
                 )

--- a/onadata/libs/serializers/organization_serializer.py
+++ b/onadata/libs/serializers/organization_serializer.py
@@ -17,6 +17,7 @@ from onadata.apps.api.tools import (
     get_organization_owners,
 )
 from onadata.apps.main.forms import RegistrationFormUserProfile
+from onadata.apps.main.models.user_profile import UserProfile
 from onadata.libs.permissions import get_role_in_org
 from onadata.libs.serializers.fields.json_field import JsonField
 
@@ -122,16 +123,21 @@ class OrganizationSerializer(serializers.HyperlinkedModelSerializer):
         """
 
         def _create_user_list(user_list):
-            return [
-                {
+            users_list = []
+            for u in user_list:
+                try:
+                    profile = u.profile
+                except UserProfile.DoesNotExist:
+                    profile, _ = UserProfile.objects.get_or_create(user=u)
+
+                users_list.append({
                     "user": u.username,
                     "role": get_role_in_org(u, obj),
                     "first_name": u.first_name,
                     "last_name": u.last_name,
-                    "gravatar": u.profile.gravatar,
-                }
-                for u in user_list
-            ]
+                    "gravatar": profile.gravatar,
+                })
+            return users_list
 
         members = get_organization_members(obj) if obj else []
         owners = get_organization_owners(obj) if obj else []

--- a/onadata/libs/serializers/organization_serializer.py
+++ b/onadata/libs/serializers/organization_serializer.py
@@ -128,7 +128,7 @@ class OrganizationSerializer(serializers.HyperlinkedModelSerializer):
                 try:
                     profile = u.profile
                 except UserProfile.DoesNotExist:
-                    profile, _ = UserProfile.objects.get_or_create(user=u)
+                    profile = UserProfile.objects.create(user=u)
 
                 users_list.append({
                     "user": u.username,

--- a/onadata/libs/serializers/project_serializer.py
+++ b/onadata/libs/serializers/project_serializer.py
@@ -174,7 +174,7 @@ def get_users(project, context, all_perms=True):
             try:
                 profile = user.profile
             except UserProfile.DoesNotExist:
-                profile, _ = UserProfile.objects.get_or_create(user=user)
+                profile = UserProfile.objects.create(user=user)
 
             if (
                 all_perms

--- a/onadata/libs/serializers/project_serializer.py
+++ b/onadata/libs/serializers/project_serializer.py
@@ -16,6 +16,7 @@ from onadata.apps.api.models.organization_profile import (
     get_or_create_organization_owners_team,
     get_organization_members_team,
 )
+from onadata.apps.main.models.user_profile import UserProfile
 from onadata.apps.logger.models.project import Project
 from onadata.apps.logger.models.xform import XForm
 from onadata.libs.permissions import (
@@ -169,6 +170,12 @@ def get_users(project, context, all_perms=True):
         if perm.user_id not in data:
             user = perm.user
 
+            # create default user profile if missing
+            try:
+                profile = user.profile
+            except UserProfile.DoesNotExist:
+                profile, _ = UserProfile.objects.get_or_create(user=user)
+
             if (
                 all_perms
                 or user in [request_user, project.organization]
@@ -176,8 +183,8 @@ def get_users(project, context, all_perms=True):
             ):
                 data[perm.user_id] = {
                     "permissions": [],
-                    "is_org": is_organization(user.profile),
-                    "metadata": user.profile.metadata,
+                    "is_org": is_organization(profile),
+                    "metadata": profile.metadata,
                     "first_name": user.first_name,
                     "last_name": user.last_name,
                     "user": user.username,

--- a/onadata/libs/serializers/xform_serializer.py
+++ b/onadata/libs/serializers/xform_serializer.py
@@ -207,7 +207,7 @@ class XFormMixin:
                 try:
                     profile = user.profile
                 except UserProfile.DoesNotExist:
-                    profile, _ = UserProfile.objects.get_or_create(user=user)
+                    profile = UserProfile.objects.create(user=user)
 
                 data[perm.user_id] = {
                     "permissions": [],

--- a/onadata/libs/serializers/xform_serializer.py
+++ b/onadata/libs/serializers/xform_serializer.py
@@ -25,6 +25,7 @@ from rest_framework.reverse import reverse
 from onadata.libs.utils.api_export_tools import get_metadata_format
 from onadata.apps.logger.models import DataView, Instance, XForm, XFormVersion
 from onadata.apps.main.models.meta_data import MetaData
+from onadata.apps.main.models.user_profile import UserProfile
 from onadata.libs.exceptions import EnketoError
 from onadata.libs.permissions import get_role, is_organization
 from onadata.libs.serializers.dataview_serializer import DataViewMinimalSerializer
@@ -202,10 +203,16 @@ class XFormMixin:
             if perm.user_id not in data:
                 user = perm.user
 
+                # create default user profile if missing
+                try:
+                    profile = user.profile
+                except UserProfile.DoesNotExist:
+                    profile, _ = UserProfile.objects.get_or_create(user=user)
+
                 data[perm.user_id] = {
                     "permissions": [],
-                    "is_org": is_organization(user.profile),
-                    "metadata": user.profile.metadata,
+                    "is_org": is_organization(profile),
+                    "metadata": profile.metadata,
                     "first_name": user.first_name,
                     "last_name": user.last_name,
                     "user": user.username,

--- a/onadata/libs/tests/test_permissions.py
+++ b/onadata/libs/tests/test_permissions.py
@@ -157,10 +157,7 @@ class TestPermissions(TestBase):
         missing user profiles
         """
         alice = self._create_user('alice', 'alice')
-        # assert that user profile exists
-        # courtesy of the post_save signal
-        self.assertTrue(hasattr(alice, "profile"))
-
+        UserProfile.objects.get_or_create(user=alice)
         org_user = tools.create_organization("modilabs", alice).user
         demo_grp = Group.objects.create(name='demo')
         alice.groups.add(demo_grp)

--- a/onadata/libs/tests/test_permissions.py
+++ b/onadata/libs/tests/test_permissions.py
@@ -128,6 +128,28 @@ class TestPermissions(TestBase):
         self.assertIn('metadata', users_with_perms_first_keys)
         self.assertIn('is_org', users_with_perms_first_keys)
 
+    # pylint: disable=C0103
+    def test_user_profile_exists_for_users_with_perms(self):
+        """
+        Test user profile exists when retrieving users with perms
+        """
+        alice = self._create_user('alice', 'alice')
+        # do not manually create user profile for alice, should be
+        # handled by get_object_users_with_permissions()
+        org_user = tools.create_organization("modilabs", alice).user
+        demo_grp = Group.objects.create(name='demo')
+        alice.groups.add(demo_grp)
+        self._publish_transportation_form()
+        EditorRole.add(org_user, self.xform)
+        EditorRole.add(demo_grp, self.xform)
+        users_with_perms = get_object_users_with_permissions(
+            self.xform, with_group_users=True)
+        self.assertTrue(org_user in [d['user'] for d in users_with_perms])
+        self.assertTrue(alice in [d['user'] for d in users_with_perms])
+        for d in users_with_perms:
+            user_obj = d['user']
+            self.assertTrue(hasattr(user_obj, "profile"))
+
     def test_readonly_no_downloads_has_role(self):
         """
         Test readonly no downloads role.


### PR DESCRIPTION
### Changes / Features implemented
- Ensure user profiles are created before building user permissions object

### Steps taken to verify this change does what is intended
- Tests
### Side effects of implementing this change
- N/A

**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  - [ ] Updated documentation

Closes #2343 
