### PR TITLE
Ensure excel exports are in xlsx format

### DIFF
--- a/onadata/apps/api/tests/viewsets/test_dataview_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_dataview_viewset.py
@@ -819,7 +819,7 @@ class TestDataViewViewSet(TestAbstractViewSet):
 
         request = self.factory.get(
             "/",
-            data={"format": "xls", "force_xlsx": "true", "include_labels": "true"},
+            data={"format": "xlsx", "force_xlsx": "true", "include_labels": "true"},
             **self.extra,
         )
         response = view(request, pk=self.data_view.pk)
@@ -1554,7 +1554,7 @@ class TestDataViewViewSet(TestAbstractViewSet):
         request = self.factory.get(
             "/",
             data={
-                "format": "xls",
+                "format": "xlsx",
                 "force_xlsx": "true",
                 "include_labels": "true",
                 "query": query_str,

--- a/onadata/apps/api/tests/viewsets/test_legacy_exports.py
+++ b/onadata/apps/api/tests/viewsets/test_legacy_exports.py
@@ -71,7 +71,7 @@ class TestLegacyExports(TestBase):
 
         # xls
         request = self.factory.get('/', **self.extra)
-        response = view(request, pk=formid, format='xls')
+        response = view(request, pk=formid, format='xlsx')
         self.assertEqual(response.status_code, 200)
         headers = dict(response.items())
         content_disposition = headers['Content-Disposition']

--- a/onadata/apps/api/tests/viewsets/test_xform_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_xform_viewset.py
@@ -818,14 +818,14 @@ class TestXFormViewSet(TestAbstractViewSet):
             )
 
             # XLS format
-            response = view(request, pk=formid, format="xls")
+            response = view(request, pk=formid, format="xlsx")
             self.assertEqual(response.status_code, 200)
             self.assertNotEqual(response.get("Cache-Control"), None)
 
             # test correct file name
             self.assertEqual(
                 response.get("Content-Disposition"),
-                "attachment; filename=" + self.xform.id_string + "." + "xls",
+                "attachment; filename=" + self.xform.id_string + "." + "xlsx",
             )
 
             xml_path = os.path.join(
@@ -2209,7 +2209,7 @@ nhMo+jI88L3qfm4/rtWKuQ9/a268phlNj34uQeoDDHuRViQo00L5meE/pFptm
             request = self.factory.get("/", data=data, **self.extra)
             with HTTMock(external_mock):
                 # External export
-                response = view(request, pk=formid, format="xls")
+                response = view(request, pk=formid, format="xlsx")
                 self.assertEqual(response.status_code, 302)
                 expected_url = "http://xls_server/xls/ee3ff9d8f5184fc4a8fdebc2547cc059"
                 self.assertEqual(response.url, expected_url)
@@ -2251,7 +2251,7 @@ nhMo+jI88L3qfm4/rtWKuQ9/a268phlNj34uQeoDDHuRViQo00L5meE/pFptm
             request = self.factory.get("/", data=data, **self.extra)
             with HTTMock(external_mock_single_instance):
                 # External export
-                response = view(request, pk=formid, format="xls")
+                response = view(request, pk=formid, format="xlsx")
                 self.assertEqual(response.status_code, 302)
                 expected_url = "http://xls_server/xls/ee3ff9d8f5184fc4a8fdebc2547cc059"
                 self.assertEqual(response.url, expected_url)
@@ -2289,7 +2289,7 @@ nhMo+jI88L3qfm4/rtWKuQ9/a268phlNj34uQeoDDHuRViQo00L5meE/pFptm
             request = self.factory.get("/", data=data, **self.extra)
 
             # External export
-            response = view(request, pk=formid, format="xls")
+            response = view(request, pk=formid, format="xlsx")
 
             self.assertEqual(response.status_code, 400)
             self.assertEqual(response.get("Cache-Control"), None)
@@ -3540,32 +3540,6 @@ nhMo+jI88L3qfm4/rtWKuQ9/a268phlNj34uQeoDDHuRViQo00L5meE/pFptm
                 export = Export.objects.get(task_id=task_id)
                 self.assertTrue(export.is_successful)
 
-    @override_settings(CELERY_TASK_ALWAYS_EAGER=True)
-    def test_raises_exception_for_xls_export_formats(self):
-        with HTTMock(enketo_mock):
-            self._publish_xls_form_to_project()
-            view = XFormViewSet.as_view(
-                {
-                    "get": "export_async",
-                }
-            )
-            formid = self.xform.pk
-
-            with self.assertRaises(ExportTypeError):
-                request = self.factory.get("/", data={"format": "xls"}, **self.extra)
-                response = view(request, pk=formid)
-                self.assertIsNotNone(response.data)
-                self.assertEqual(response.status_code, 202)
-                self.assertTrue("job_uuid" in response.data)
-                task_id = response.data.get("job_uuid")
-                get_data = {"job_uuid": task_id}
-                request = self.factory.get("/", data=get_data, **self.extra)
-                response = view(request, pk=formid)
-
-                self.assertEqual(response.status_code, 202)
-                export = Export.objects.get(task_id=task_id)
-                self.assertTrue(export.is_successful)
-
     def test_xform_retrieve_osm_format(self):
         with HTTMock(enketo_mock):
             self._publish_xls_form_to_project()
@@ -3695,7 +3669,7 @@ nhMo+jI88L3qfm4/rtWKuQ9/a268phlNj34uQeoDDHuRViQo00L5meE/pFptm
             with HTTMock(external_mock):
                 # External export
                 request = self.factory.get(
-                    "/", data={"format": "xls", "meta": metadata.pk}, **self.extra
+                    "/", data={"format": "xlsx", "meta": metadata.pk}, **self.extra
                 )
                 response = view(request, pk=formid)
 
@@ -3707,7 +3681,7 @@ nhMo+jI88L3qfm4/rtWKuQ9/a268phlNj34uQeoDDHuRViQo00L5meE/pFptm
             get_data = {"job_uuid": data.get("job_uuid")}
 
             request = self.factory.get("/", data=get_data, **self.extra)
-            response = view(request, pk=formid, format="xls")
+            response = view(request, pk=formid, format="xlsx")
             self.assertTrue(async_result.called)
             self.assertEqual(response.status_code, 202)
 
@@ -3752,7 +3726,7 @@ nhMo+jI88L3qfm4/rtWKuQ9/a268phlNj34uQeoDDHuRViQo00L5meE/pFptm
                 request = self.factory.get(
                     "/",
                     data={
-                        "format": "xls",
+                        "format": "xlsx",
                         "meta": metadata.pk,
                         "data_id": self.xform.instances.all()[0].pk,
                     },
@@ -3768,7 +3742,7 @@ nhMo+jI88L3qfm4/rtWKuQ9/a268phlNj34uQeoDDHuRViQo00L5meE/pFptm
             get_data = {"job_uuid": data.get("job_uuid")}
 
             request = self.factory.get("/", data=get_data, **self.extra)
-            response = view(request, pk=formid, format="xls")
+            response = view(request, pk=formid, format="xlsx")
             self.assertTrue(async_result.called)
             self.assertEqual(response.status_code, 202)
 
@@ -3821,7 +3795,7 @@ nhMo+jI88L3qfm4/rtWKuQ9/a268phlNj34uQeoDDHuRViQo00L5meE/pFptm
 
             with HTTMock(external_mock_single_instance):
                 # External export
-                response = view(request, pk=formid, format="xls")
+                response = view(request, pk=formid, format="xlsx")
                 self.assertEqual(response.status_code, 302)
                 expected_url = "http://xls_server/xls/ee3ff9d8f5184fc4a8fdebc2547cc059"
                 self.assertEqual(response.url, expected_url)
@@ -3832,7 +3806,7 @@ nhMo+jI88L3qfm4/rtWKuQ9/a268phlNj34uQeoDDHuRViQo00L5meE/pFptm
 
             with HTTMock(external_mock_single_instance2):
                 # External export
-                response = view(request, pk=formid, format="xls")
+                response = view(request, pk=formid, format="xlsx")
                 self.assertEqual(response.status_code, 302)
                 expected_url = "http://xls_server/xls/ee3ff9d8f5184fc4a8fdebc2547cc057"
                 self.assertEqual(response.url, expected_url)

--- a/onadata/apps/api/viewsets/dataview_viewset.py
+++ b/onadata/apps/api/viewsets/dataview_viewset.py
@@ -261,13 +261,13 @@ class DataViewViewSet(
         return Response(data)
 
     @action(methods=["GET"], detail=True)
-    def xls_export(self, request, *args, **kwargs):
+    def xlsx_export(self, request, *args, **kwargs):
         """Returns the data views XLS export files."""
         dataview = self.get_object()
         xform = dataview.xform
 
         token = None
-        export_type = "xls"
+        export_type = "xlsx"
         query = request.query_params.get("query", {})
         meta = request.GET.get("meta")
 

--- a/onadata/apps/main/tests/test_form_errors.py
+++ b/onadata/apps/main/tests/test_form_errors.py
@@ -44,7 +44,7 @@ class TestFormErrors(TestBase):
         self.assertEqual(default_storage.exists(path), True)
         default_storage.delete(path)
         self.assertEqual(default_storage.exists(path), False)
-        url = reverse('xls_export', kwargs={'username': self.user.username,
+        url = reverse('xlsx_export', kwargs={'username': self.user.username,
                       'id_string': self.xform.id_string})
         response = self.anon.get(url)
         self.assertEqual(response.status_code, 404)
@@ -53,7 +53,7 @@ class TestFormErrors(TestBase):
         self._create_xform()
         self.xform.xls = "blah"
         self.xform.save()
-        url = reverse('xls_export', kwargs={'username': self.user.username,
+        url = reverse('xlsx_export', kwargs={'username': self.user.username,
                       'id_string': self.xform.id_string})
         response = self.anon.get(url)
         self.assertEqual(response.status_code, 403)

--- a/onadata/apps/main/tests/test_form_exports.py
+++ b/onadata/apps/main/tests/test_form_exports.py
@@ -25,7 +25,7 @@ class TestFormExports(TestBase):
         self.csv_url = reverse('csv_export', kwargs={
             'username': self.user.username,
             'id_string': self.xform.id_string})
-        self.xls_url = reverse('xls_export', kwargs={
+        self.xls_url = reverse('xlsx_export', kwargs={
             'username': self.user.username,
             'id_string': self.xform.id_string})
 
@@ -115,7 +115,7 @@ class TestFormExports(TestBase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response['Content-Disposition'], 'attachment;')
 
-    def test_restrict_xls_export_if_not_shared(self):
+    def test_restrict_xlsx_export_if_not_shared(self):
         response = self.anon.get(self.xls_url)
         self.assertEqual(response.status_code, 403)
 
@@ -144,7 +144,7 @@ class TestFormExports(TestBase):
         response = self.anon.get(self.csv_url)
         self.assertEqual(response.status_code, 200)
 
-    def test_allow_xls_export_if_shared(self):
+    def test_allow_xlsx_export_if_shared(self):
         self.xform.shared_data = True
         self.xform.save()
         response = self.anon.get(self.xls_url)
@@ -170,7 +170,7 @@ class TestFormExports(TestBase):
         response = self.client.get(self.csv_url)
         self.assertEqual(response.status_code, 200)
 
-    def test_allow_xls_export(self):
+    def test_allow_xlsx_export(self):
         response = self.client.get(self.xls_url)
         self.assertEqual(response.status_code, 200)
 
@@ -194,7 +194,7 @@ class TestFormExports(TestBase):
         response = self.anon.get(self.csv_url, **extra)
         self.assertEqual(response.status_code, 200)
 
-    def test_allow_xls_export_for_basic_auth(self):
+    def test_allow_xlsx_export_for_basic_auth(self):
         extra = {
             'HTTP_AUTHORIZATION': http_auth_string(self.login_username,
                                                    self.login_password)

--- a/onadata/apps/main/tests/test_process.py
+++ b/onadata/apps/main/tests/test_process.py
@@ -554,19 +554,19 @@ class TestProcess(TestBase, SerializeMixin):
                     this_list.append(("transport/" + k, v))
             self.assertEqual(test_dict, dict(this_list))
 
-    def test_xls_export_content(self):
+    def test_xlsx_export_content(self):
         """Test publish and export XLS content."""
         self._publish_xls_file()
         self._make_submissions()
         self._update_dynamic_data()
-        self._check_xls_export()
+        self._check_xlsx_export()
 
-    def _check_xls_export(self):
-        xls_export_url = reverse(
-            "xls_export",
+    def _check_xlsx_export(self):
+        xlsx_export_url = reverse(
+            "xlsx_export",
             kwargs={"username": self.user.username, "id_string": self.xform.id_string},
         )
-        response = self.client.get(xls_export_url)
+        response = self.client.get(xlsx_export_url)
         expected_xls = openpyxl.open(
             filename=os.path.join(
                 self.this_directory,

--- a/onadata/apps/main/urls.py
+++ b/onadata/apps/main/urls.py
@@ -227,7 +227,7 @@ urlpatterns = [
         r"^(?P<username>\w+)/forms/(?P<id_string>[^/]+)/data\.xls",
         viewer_views.data_export,
         name="xls_export",
-        kwargs={"export_type": "xls"},
+        kwargs={"export_type": "xlsx"},
     ),
     re_path(
         r"^(?P<username>\w+)/forms/(?P<id_string>[^/]+)/data\.csv.zip",

--- a/onadata/apps/main/urls.py
+++ b/onadata/apps/main/urls.py
@@ -226,7 +226,7 @@ urlpatterns = [
     re_path(
         r"^(?P<username>\w+)/forms/(?P<id_string>[^/]+)/data\.xls",
         viewer_views.data_export,
-        name="xls_export",
+        name="xlsx_export",
         kwargs={"export_type": "xlsx"},
     ),
     re_path(
@@ -252,7 +252,7 @@ urlpatterns = [
     ),
     re_path(
         r"^(?P<username>\w+)/forms/(?P<id_string>[^/]+)/gdocs$",
-        viewer_views.google_xls_export,
+        viewer_views.google_xlsx_export,
     ),
     re_path(
         r"^(?P<username>\w+)/forms/(?P<id_string>[^/]+)/map_embed",

--- a/onadata/apps/viewer/models/export.py
+++ b/onadata/apps/viewer/models/export.py
@@ -68,6 +68,7 @@ class Export(models.Model):
     """
 
     XLS_EXPORT = "xls"
+    XLSX_EXPORT = "xlsx"
     CSV_EXPORT = "csv"
     KML_EXPORT = "kml"
     ZIP_EXPORT = "zip"

--- a/onadata/apps/viewer/models/export.py
+++ b/onadata/apps/viewer/models/export.py
@@ -94,7 +94,7 @@ class Export(models.Model):
     }
 
     EXPORT_TYPES = [
-        (XLS_EXPORT, "Excel"),
+        (XLSX_EXPORT, "Excel"),
         (CSV_EXPORT, "CSV"),
         (ZIP_EXPORT, "ZIP"),
         (KML_EXPORT, "kml"),

--- a/onadata/apps/viewer/models/export.py
+++ b/onadata/apps/viewer/models/export.py
@@ -67,7 +67,6 @@ class Export(models.Model):
     Class representing a data export from an XForm
     """
 
-    XLS_EXPORT = "xls"
     XLSX_EXPORT = "xlsx"
     CSV_EXPORT = "csv"
     KML_EXPORT = "kml"
@@ -137,7 +136,7 @@ class Export(models.Model):
     # Required fields
     xform = models.ForeignKey("logger.XForm", on_delete=models.CASCADE)
     export_type = models.CharField(
-        max_length=10, choices=EXPORT_TYPES, default=XLS_EXPORT
+        max_length=10, choices=EXPORT_TYPES, default=XLSX_EXPORT
     )
 
     # optional fields

--- a/onadata/apps/viewer/tasks.py
+++ b/onadata/apps/viewer/tasks.py
@@ -88,7 +88,7 @@ def create_async_export(xform, export_type, query, force_xlsx, options=None):
     )
 
     export_types = {
-        Export.XLS_EXPORT: create_xls_export,
+        Export.XLSX_EXPORT: create_xls_export,
         Export.GOOGLE_SHEETS_EXPORT: create_google_sheet_export,
         Export.CSV_EXPORT: create_csv_export,
         Export.CSV_ZIP_EXPORT: create_csv_zip_export,
@@ -127,12 +127,10 @@ def create_async_export(xform, export_type, query, force_xlsx, options=None):
 @app.task(track_started=True)
 def create_xls_export(username, id_string, export_id, **options):
     """
-    XLS export task.
+    XLSX export task.
     """
     # we re-query the db instead of passing model objects according to
     # http://docs.celeryproject.org/en/latest/userguide/tasks.html#state
-    force_xlsx = options.get("force_xlsx", True)
-    options["extension"] = "xlsx" if force_xlsx else "xls"
 
     try:
         export = _get_export_object(export_id)
@@ -143,8 +141,9 @@ def create_xls_export(username, id_string, export_id, **options):
     # though export is not available when for has 0 submissions, we
     # catch this since it potentially stops celery
     try:
+        # generate xlsx export as default
         gen_export = generate_export(
-            Export.XLS_EXPORT, export.xform, export_id, options
+            Export.XLSX_EXPORT, export.xform, export_id, options
         )
     except (Exception, NoRecordsFoundError) as e:
         export.internal_status = Export.FAILED

--- a/onadata/apps/viewer/tasks.py
+++ b/onadata/apps/viewer/tasks.py
@@ -88,7 +88,7 @@ def create_async_export(xform, export_type, query, force_xlsx, options=None):
     )
 
     export_types = {
-        Export.XLSX_EXPORT: create_xls_export,
+        Export.XLSX_EXPORT: create_xlsx_export,
         Export.GOOGLE_SHEETS_EXPORT: create_google_sheet_export,
         Export.CSV_EXPORT: create_csv_export,
         Export.CSV_ZIP_EXPORT: create_csv_zip_export,
@@ -125,7 +125,7 @@ def create_async_export(xform, export_type, query, force_xlsx, options=None):
 
 
 @app.task(track_started=True)
-def create_xls_export(username, id_string, export_id, **options):
+def create_xlsx_export(username, id_string, export_id, **options):
     """
     XLSX export task.
     """

--- a/onadata/apps/viewer/templates/map_embed.html
+++ b/onadata/apps/viewer/templates/map_embed.html
@@ -49,7 +49,7 @@ var mapTitle = "{{ content_user.username }} / {{ xform.title }}";
 var mapDescription = '<table class="table table-condensed table-striped"><tr><th>Total submissions</th><td>{{ xform.submission_count }}</td></tr><tr><th>Submissions with Points</th><td>{{ xform.geocoded_submission_count }}</td></tr><tr><th>Last submission</th><td>{{ xform.time_of_last_submission|date:"N d, Y" }}</td></tr></table><p>Please refresh this page to be able to click on your newly added points.</p>';
 
 var csv_url = "{% url "csv_export" content_user.username xform.id_string %}";
-var xls_url = "{% url "xls_export" content_user.username xform.id_string %}";
+var xls_url = "{% url "xlsx_export" content_user.username xform.id_string %}";
 var kml_url = "{% url "kml-export" content_user.username xform.id_string %}";
 
 $(document).ready(function() {

--- a/onadata/apps/viewer/tests/test_export_list.py
+++ b/onadata/apps/viewer/tests/test_export_list.py
@@ -106,7 +106,7 @@ class TestExportList(TestBase):
         kwargs = {
             "username": self.user.username,
             "id_string": self.xform.id_string,
-            "export_type": Export.XLS_EXPORT,
+            "export_type": Export.XLSX_EXPORT,
         }
         url = reverse(export_list, kwargs=kwargs)
         response = self.client.get(url)

--- a/onadata/apps/viewer/tests/test_export_list.py
+++ b/onadata/apps/viewer/tests/test_export_list.py
@@ -102,7 +102,7 @@ class TestExportList(TestBase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
 
-    def test_xls_export_list(self):
+    def test_xlsx_export_list(self):
         kwargs = {
             "username": self.user.username,
             "id_string": self.xform.id_string,
@@ -239,10 +239,10 @@ class TestDataExportURL(TestBase):
         # Test export data returned is xform headers list
         self.assertEqual(xform_headers, export_data[0])
 
-    def test_xls_export_url(self):
+    def test_xlsx_export_url(self):
         self._submit_transport_instance()
         url = reverse(
-            "xls_export",
+            "xlsx_export",
             kwargs={
                 "username": self.user.username.upper(),
                 "id_string": self.xform.id_string.upper(),

--- a/onadata/apps/viewer/tests/test_exports.py
+++ b/onadata/apps/viewer/tests/test_exports.py
@@ -131,7 +131,7 @@ class TestExports(TestBase):
         # test xls
 
         export = generate_export(
-            Export.XLS_EXPORT,
+            Export.XLSX_EXPORT,
             self.xform,
             None,
             self.options)
@@ -153,12 +153,12 @@ class TestExports(TestBase):
 
         # test xls with existing export_id
         existing_export = Export.objects.create(xform=self.xform,
-                                                export_type=Export.XLS_EXPORT)
-        self.options["extension"] = "xls"
+                                                export_type=Export.XLSX_EXPORT)
+        self.options["extension"] = "xlsx"
         self.options["export_id"] = existing_export.id
 
         export = generate_export(
-            Export.XLS_EXPORT,
+            Export.XLSX_EXPORT,
             self.xform,
             existing_export.id,
             self.options)
@@ -169,7 +169,7 @@ class TestExports(TestBase):
         self._submit_transport_instance()
 
         export = generate_export(
-            Export.XLS_EXPORT,
+            Export.XLSX_EXPORT,
             self.xform,
             None,
             self.options)
@@ -185,7 +185,7 @@ class TestExports(TestBase):
         self.options["id_string"] = self.xform.id_string
 
         export = generate_export(
-            Export.XLS_EXPORT,
+            Export.XLSX_EXPORT,
             self.xform,
             None,
             self.options)
@@ -201,7 +201,7 @@ class TestExports(TestBase):
         delete_url = reverse(delete_export, kwargs={
             'username': self.user.username,
             'id_string': self.xform.id_string,
-            'export_type': 'xls'
+            'export_type': 'xlsx'
         })
         post_data = {'export_id': export.id}
         response = self.client.post(delete_url, post_data)
@@ -213,7 +213,7 @@ class TestExports(TestBase):
         # create first export
 
         first_export = generate_export(
-            Export.XLS_EXPORT,
+            Export.XLSX_EXPORT,
             self.xform,
             None,
             self.options)
@@ -221,7 +221,7 @@ class TestExports(TestBase):
         # create exports that exceed set limit
         for i in range(Export.MAX_EXPORTS):
             generate_export(
-                Export.XLS_EXPORT,
+                Export.XLSX_EXPORT,
                 self.xform,
                 None,
                 self.options)
@@ -236,7 +236,7 @@ class TestExports(TestBase):
         create_export_url = reverse(create_export, kwargs={
             'username': self.user.username,
             'id_string': 'random_id_string',
-            'export_type': Export.XLS_EXPORT
+            'export_type': Export.XLSX_EXPORT
         })
 
         response = self.client.post(create_export_url)
@@ -250,7 +250,7 @@ class TestExports(TestBase):
         create_export_url = reverse(create_export, kwargs={
             'username': self.user.username,
             'id_string': self.xform.id_string,
-            'export_type': Export.XLS_EXPORT
+            'export_type': Export.XLSX_EXPORT
         })
 
         # anonymous user has to login first
@@ -266,7 +266,7 @@ class TestExports(TestBase):
         create_export_url = reverse(create_export, kwargs={
             'username': self.user.username,
             'id_string': 'random_id_string',
-            'export_type': Export.XLS_EXPORT
+            'export_type': Export.XLSX_EXPORT
         })
 
         response = self.client.post(create_export_url)
@@ -279,7 +279,7 @@ class TestExports(TestBase):
         self.options["id_string"] = self.xform.id_string
 
         export = generate_export(
-            Export.XLS_EXPORT,
+            Export.XLSX_EXPORT,
             self.xform,
             None,
             self.options)
@@ -288,7 +288,7 @@ class TestExports(TestBase):
         delete_url = reverse(delete_export, kwargs={
             'username': self.user.username,
             'id_string': self.xform.id_string,
-            'export_type': 'xls'
+            'export_type': 'xlsx'
         })
         post_data = {'export_id': export.id}
 
@@ -306,7 +306,7 @@ class TestExports(TestBase):
         delete_url = reverse(delete_export, kwargs={
             'username': self.user.username,
             'id_string': 'random_id_string',
-            'export_type': 'xls'
+            'export_type': 'xlsx'
         })
         response = self.client.post(delete_url, post_data)
         self.assertEqual(response.status_code, 404)
@@ -319,7 +319,7 @@ class TestExports(TestBase):
         # create exports
         for i in range(2):
             generate_export(
-                Export.XLS_EXPORT,
+                Export.XLSX_EXPORT,
                 self.xform,
                 None,
                 self.options)
@@ -330,7 +330,7 @@ class TestExports(TestBase):
         progress_url = reverse(export_progress, kwargs={
             'username': self.user.username,
             'id_string': 'random_id_string',
-            'export_type': 'xls'
+            'export_type': 'xlsx'
         })
         response = self.client.get(progress_url, get_data)
         self.assertEqual(response.status_code, 404)
@@ -339,7 +339,7 @@ class TestExports(TestBase):
         progress_url = reverse(export_progress, kwargs={
             'username': self.user.username,
             'id_string': self.xform.id_string,
-            'export_type': 'xls'
+            'export_type': 'xlsx'
         })
         response = self.client.get(progress_url, get_data)
         content = json.loads(response.content)
@@ -355,7 +355,7 @@ class TestExports(TestBase):
         export_list_url = reverse(export_list, kwargs={
             'username': self.user.username,
             'id_string': self.xform.id_string,
-            'export_type': Export.XLS_EXPORT
+            'export_type': Export.XLSX_EXPORT
         })
         self.client.get(export_list_url)
         self.assertEqual(Export.objects.count(), num_exports + 1)
@@ -367,14 +367,14 @@ class TestExports(TestBase):
         create_export_url = reverse(create_export, kwargs={
             'username': self.user.username,
             'id_string': self.xform.id_string,
-            'export_type': Export.XLS_EXPORT
+            'export_type': Export.XLSX_EXPORT
         })
         self.client.post(create_export_url)
         num_exports = Export.objects.count()
         export_list_url = reverse(export_list, kwargs={
             'username': self.user.username,
             'id_string': self.xform.id_string,
-            'export_type': Export.XLS_EXPORT
+            'export_type': Export.XLSX_EXPORT
         })
         self.client.get(export_list_url)
         self.assertEqual(Export.objects.count(), num_exports)
@@ -385,16 +385,16 @@ class TestExports(TestBase):
         # create export
 
         generate_export(
-            Export.XLS_EXPORT,
+            Export.XLSX_EXPORT,
             self.xform,
             None,
             self.options)
         num_exports = Export.objects.filter(
-            xform=self.xform, export_type=Export.XLS_EXPORT).count()
+            xform=self.xform, export_type=Export.XLSX_EXPORT).count()
         # check that our function knows there are no more submissions
         self.assertFalse(
             Export.exports_outdated(xform=self.xform,
-                                    export_type=Export.XLS_EXPORT))
+                                    export_type=Export.XLSX_EXPORT))
         sleep(1)
         # force new  last submission date on xform
         last_submission = self.xform.instances.order_by('-date_created')[0]
@@ -404,17 +404,17 @@ class TestExports(TestBase):
 
         self.assertTrue(
             Export.exports_outdated(xform=self.xform,
-                                    export_type=Export.XLS_EXPORT))
+                                    export_type=Export.XLSX_EXPORT))
         # check that requesting list url will generate a new export
         export_list_url = reverse(export_list, kwargs={
             'username': self.user.username,
             'id_string': self.xform.id_string,
-            'export_type': Export.XLS_EXPORT
+            'export_type': Export.XLSX_EXPORT
         })
         self.client.get(export_list_url)
         self.assertEqual(
             Export.objects.filter(xform=self.xform,
-                                  export_type=Export.XLS_EXPORT).count(),
+                                  export_type=Export.XLSX_EXPORT).count(),
             num_exports + 1)
         # make sure another export type causes auto-generation
         num_exports = Export.objects.filter(
@@ -436,7 +436,7 @@ class TestExports(TestBase):
         # create export
 
         export = generate_export(
-            Export.XLS_EXPORT,
+            Export.XLSX_EXPORT,
             self.xform,
             None,
             self.options)
@@ -444,7 +444,7 @@ class TestExports(TestBase):
         export.time_of_last_submission = None
         export.save()
         self.assertTrue(Export.exports_outdated(xform=self.xform,
-                                                export_type=Export.XLS_EXPORT))
+                                                export_type=Export.XLSX_EXPORT))
 
     def test_invalid_export_type(self):
         self._publish_transportation_form()
@@ -539,16 +539,16 @@ class TestExports(TestBase):
         self.assertEqual(response.status_code, 200)
 
         # test xls
-        self.options["extension"] = "xls"
+        self.options["extension"] = "xlsx"
         export = generate_export(
-            Export.XLS_EXPORT,
+            Export.XLSX_EXPORT,
             self.xform,
             None,
             self.options)
         xls_export_url = reverse(export_download, kwargs={
             "username": self.user.username,
             "id_string": self.xform.id_string,
-            "export_type": Export.XLS_EXPORT,
+            "export_type": Export.XLSX_EXPORT,
             "filename": export.filename
         })
         response = self.client.get(xls_export_url)
@@ -663,14 +663,14 @@ class TestExports(TestBase):
         self._submit_transport_instance()
         # create an in-complete export
         export = Export.objects.create(id=1234, xform=self.xform,
-                                       export_type=Export.XLS_EXPORT,
+                                       export_type=Export.XLSX_EXPORT,
                                        options=self.options)
         self.assertEqual(export.pk, 1234)
         export_list_url = reverse(
             export_list, kwargs={
                 "username": self.user.username,
                 "id_string": self.xform.id_string,
-                "export_type": Export.XLS_EXPORT
+                "export_type": Export.XLSX_EXPORT
             })
         response = self.client.get(export_list_url)
         self.assertContains(response, '#delete-1234"')
@@ -685,12 +685,12 @@ class TestExports(TestBase):
         self._publish_transportation_form()
         # generate an export that fails because of the NoRecordsFound exception
         export = Export.objects.create(xform=self.xform,
-                                       export_type=Export.XLS_EXPORT)
+                                       export_type=Export.XLSX_EXPORT)
         # check that progress url says pending
         progress_url = reverse(export_progress, kwargs={
             'username': self.user.username,
             'id_string': self.xform.id_string,
-            'export_type': 'xls'
+            'export_type': 'xlsx'
         })
         params = {'export_ids': [export.id]}
         response = self.client.get(progress_url, params)
@@ -704,7 +704,7 @@ class TestExports(TestBase):
         progress_url = reverse(export_progress, kwargs={
             'username': self.user.username,
             'id_string': self.xform.id_string,
-            'export_type': 'xls'
+            'export_type': 'xlsx'
         })
         params = {'export_ids': [export.id]}
         response = self.client.get(progress_url, params)
@@ -737,7 +737,7 @@ class TestExports(TestBase):
         initial_num_csv_exports = Export.objects.filter(
             xform=self.xform, export_type=Export.CSV_EXPORT).count()
         initial_num_xls_exports = Export.objects.filter(
-            xform=self.xform, export_type=Export.XLS_EXPORT).count()
+            xform=self.xform, export_type=Export.XLSX_EXPORT).count()
         # request a direct csv export
         csv_export_url = reverse('csv_export', kwargs={
             'username': self.user.username,
@@ -768,14 +768,14 @@ class TestExports(TestBase):
         response = self.client.get(xls_export_url)
         self.assertEqual(response.status_code, 200)
         num_xls_exports = Export.objects.filter(
-            xform=self.xform, export_type=Export.XLS_EXPORT).count()
+            xform=self.xform, export_type=Export.XLSX_EXPORT).count()
         self.assertEqual(num_xls_exports, initial_num_xls_exports + 1)
 
         # make sure xls doesnt re-generate if data hasn't changed
         response = self.client.get(xls_export_url)
         self.assertEqual(response.status_code, 200)
         num_xls_exports = Export.objects.filter(
-            xform=self.xform, export_type=Export.XLS_EXPORT).count()
+            xform=self.xform, export_type=Export.XLSX_EXPORT).count()
         self.assertEqual(num_xls_exports, initial_num_xls_exports + 1)
 
         sleep(1)
@@ -812,7 +812,7 @@ class TestExports(TestBase):
         self._submit_transport_instance()
         # create a bad export
         export = Export.objects.create(
-            xform=self.xform, export_type=Export.XLS_EXPORT,
+            xform=self.xform, export_type=Export.XLSX_EXPORT,
             internal_status=Export.FAILED)
         self.assertTrue(
             Export.exports_outdated(self.xform, export.export_type))
@@ -822,7 +822,7 @@ class TestExports(TestBase):
         self._submit_transport_instance()
         # create a pending export
         export = Export.objects.create(
-            xform=self.xform, export_type=Export.XLS_EXPORT,
+            xform=self.xform, export_type=Export.XLSX_EXPORT,
             internal_status=Export.PENDING)
         self.assertFalse(
             Export.exports_outdated(self.xform, export.export_type))
@@ -887,12 +887,12 @@ class TestExports(TestBase):
         create_csv_export_url = reverse(create_export, kwargs={
             'username': self.user.username,
             'id_string': self.xform.id_string,
-            'export_type': 'xls'
+            'export_type': 'xlsx'
         })
         response = self.client.post(create_csv_export_url, default_params)
         self.assertEqual(response.status_code, 302)
         export = Export.objects.filter(
-            xform=self.xform, export_type='xls').latest('created_on')
+            xform=self.xform, export_type='xlsx').latest('created_on')
         self.assertTrue(bool(export.filepath))
         data = self._get_xls_data(export.full_filepath)
         self.assertTrue(AMBULANCE_KEY in data)
@@ -904,7 +904,7 @@ class TestExports(TestBase):
         response = self.client.post(create_csv_export_url, custom_params)
         self.assertEqual(response.status_code, 302)
         export = Export.objects.filter(
-            xform=self.xform, export_type='xls').latest('created_on')
+            xform=self.xform, export_type='xlsx').latest('created_on')
         self.assertTrue(bool(export.filepath))
         data = self._get_xls_data(export.full_filepath)
         self.assertTrue(AMBULANCE_KEY_DOTS in data)
@@ -975,13 +975,13 @@ class TestExports(TestBase):
         create_xls_export_url = reverse(create_export, kwargs={
             'username': self.user.username,
             'id_string': self.xform.id_string,
-            'export_type': 'xls'
+            'export_type': 'xlsx'
         })
         # test xls with default split select multiples
         response = self.client.post(create_xls_export_url, default_params)
         self.assertEqual(response.status_code, 302)
         export = Export.objects.filter(
-            xform=self.xform, export_type='xls').latest('created_on')
+            xform=self.xform, export_type='xlsx').latest('created_on')
         self.assertTrue(bool(export.filepath))
         data = self._get_xls_data(export.full_filepath)
         # we should have transport/available_transportation_types_to_referral_f
@@ -993,7 +993,7 @@ class TestExports(TestBase):
         response = self.client.post(create_xls_export_url, custom_params)
         self.assertEqual(response.status_code, 302)
         export = Export.objects.filter(
-            xform=self.xform, export_type='xls').latest('created_on')
+            xform=self.xform, export_type='xlsx').latest('created_on')
         self.assertTrue(bool(export.filepath))
         data = self._get_xls_data(export.full_filepath)
         # transport/available_transportation_types_to_referral_facility/ambulan

--- a/onadata/apps/viewer/tests/test_exports.py
+++ b/onadata/apps/viewer/tests/test_exports.py
@@ -21,7 +21,7 @@ from onadata.apps.main.tests.test_base import TestBase
 from onadata.apps.main.views import delete_data
 from onadata.apps.viewer.models.export import Export
 from onadata.apps.viewer.models.parsed_instance import query_data
-from onadata.apps.viewer.tasks import create_xls_export
+from onadata.apps.viewer.tasks import create_xlsx_export
 from onadata.apps.viewer.tests.export_helpers import viewer_fixture_path
 from onadata.apps.viewer.views import delete_export, export_list, \
     create_export, export_progress, export_download
@@ -545,13 +545,13 @@ class TestExports(TestBase):
             self.xform,
             None,
             self.options)
-        xls_export_url = reverse(export_download, kwargs={
+        xlsx_export_url = reverse(export_download, kwargs={
             "username": self.user.username,
             "id_string": self.xform.id_string,
             "export_type": Export.XLSX_EXPORT,
             "filename": export.filename
         })
-        response = self.client.get(xls_export_url)
+        response = self.client.get(xlsx_export_url)
         self.assertEqual(response.status_code, 200)
 
     def test_404_on_export_io_error(self):
@@ -715,7 +715,7 @@ class TestExports(TestBase):
         # make a submission and create a valid export
         self._submit_transport_instance()
 
-        create_xls_export(
+        create_xlsx_export(
             self.user.username,
             self.xform.id_string,
             export.id,
@@ -736,14 +736,14 @@ class TestExports(TestBase):
 
         initial_num_csv_exports = Export.objects.filter(
             xform=self.xform, export_type=Export.CSV_EXPORT).count()
-        initial_num_xls_exports = Export.objects.filter(
+        initial_num_xlsx_exports = Export.objects.filter(
             xform=self.xform, export_type=Export.XLSX_EXPORT).count()
         # request a direct csv export
         csv_export_url = reverse('csv_export', kwargs={
             'username': self.user.username,
             'id_string': self.xform.id_string
         })
-        xls_export_url = reverse('xls_export', kwargs={
+        xlsx_export_url = reverse('xlsx_export', kwargs={
             'username': self.user.username,
             'id_string': self.xform.id_string
         })
@@ -765,18 +765,18 @@ class TestExports(TestBase):
 
         # this should not affect a direct XLS export
         # and XLS should still re-generate
-        response = self.client.get(xls_export_url)
+        response = self.client.get(xlsx_export_url)
         self.assertEqual(response.status_code, 200)
-        num_xls_exports = Export.objects.filter(
+        num_xlsx_exports = Export.objects.filter(
             xform=self.xform, export_type=Export.XLSX_EXPORT).count()
-        self.assertEqual(num_xls_exports, initial_num_xls_exports + 1)
+        self.assertEqual(num_xlsx_exports, initial_num_xlsx_exports + 1)
 
         # make sure xls doesnt re-generate if data hasn't changed
-        response = self.client.get(xls_export_url)
+        response = self.client.get(xlsx_export_url)
         self.assertEqual(response.status_code, 200)
-        num_xls_exports = Export.objects.filter(
+        num_xlsx_exports = Export.objects.filter(
             xform=self.xform, export_type=Export.XLSX_EXPORT).count()
-        self.assertEqual(num_xls_exports, initial_num_xls_exports + 1)
+        self.assertEqual(num_xlsx_exports, initial_num_xlsx_exports + 1)
 
         sleep(1)
         # check that data edits cause a re-generation
@@ -972,13 +972,13 @@ class TestExports(TestBase):
             'transport/available_transportation_types_to_referral_facility'
         ].split(" "))
 
-        create_xls_export_url = reverse(create_export, kwargs={
+        create_xlsx_export_url = reverse(create_export, kwargs={
             'username': self.user.username,
             'id_string': self.xform.id_string,
             'export_type': 'xlsx'
         })
         # test xls with default split select multiples
-        response = self.client.post(create_xls_export_url, default_params)
+        response = self.client.post(create_xlsx_export_url, default_params)
         self.assertEqual(response.status_code, 302)
         export = Export.objects.filter(
             xform=self.xform, export_type='xlsx').latest('created_on')
@@ -990,7 +990,7 @@ class TestExports(TestBase):
 
         sleep(1)
         # test xls without default split select multiples
-        response = self.client.post(create_xls_export_url, custom_params)
+        response = self.client.post(create_xlsx_export_url, custom_params)
         self.assertEqual(response.status_code, 302)
         export = Export.objects.filter(
             xform=self.xform, export_type='xlsx').latest('created_on')
@@ -1261,7 +1261,7 @@ class TestExports(TestBase):
         }
         self.assertEqual(sorted(data), sorted(expected_data))
 
-    def test_create_xls_export_non_existent_id(self):
+    def test_create_xlsx_export_non_existent_id(self):
         self._publish_transportation_form()
 
         # make a submission and create a valid export
@@ -1270,7 +1270,7 @@ class TestExports(TestBase):
         username = self.options.get("username")
         id_string = self.options.get("id_string")
 
-        result = create_xls_export(
+        result = create_xlsx_export(
             username, id_string, non_existent_id, **self.options)
 
         self.assertEqual(result, None)

--- a/onadata/apps/viewer/tests/test_tasks.py
+++ b/onadata/apps/viewer/tests/test_tasks.py
@@ -25,7 +25,7 @@ class TestExportTasks(TestBase):
         options = {"group_delimiter": "/",
                    "remove_group_name": False,
                    "split_select_multiples": True}
-        export_types = ((Export.XLS_EXPORT, {}),
+        export_types = ((Export.XLSX_EXPORT, {}),
                         (Export.GOOGLE_SHEETS_EXPORT, {}),
                         (Export.CSV_EXPORT, {}),
                         (Export.CSV_ZIP_EXPORT, {}),

--- a/onadata/apps/viewer/views.py
+++ b/onadata/apps/viewer/views.py
@@ -777,7 +777,7 @@ def kml_export(request, username, id_string):
     return response
 
 
-def google_xls_export(request, username, id_string):
+def google_xlsx_export(request, username, id_string):
     """
     Google export view, uploads an excel export to google drive and then
     redirects to the uploaded google sheet.
@@ -795,7 +795,7 @@ def google_xls_export(request, username, id_string):
 
     if token is None:
         request.session["google_redirect_url"] = reverse(
-            google_xls_export, kwargs={"username": username, "id_string": id_string}
+            google_xlsx_export, kwargs={"username": username, "id_string": id_string}
         )
         google_flow = create_flow()
         return HttpResponseRedirect(

--- a/onadata/apps/viewer/views.py
+++ b/onadata/apps/viewer/views.py
@@ -306,8 +306,7 @@ def data_export(request, username, id_string, export_type):  # noqa C901
     extension = export_type
 
     # check if we should force xlsx
-    force_xlsx = request.GET.get("xls") != "true"
-    if export_type == Export.XLS_EXPORT and force_xlsx:
+    if export_type == Export.XLSX_EXPORT:
         extension = "xlsx"
     elif export_type in [Export.CSV_ZIP_EXPORT, Export.SAV_ZIP_EXPORT]:
         extension = "zip"

--- a/onadata/libs/templates/topbar.html
+++ b/onadata/libs/templates/topbar.html
@@ -45,7 +45,7 @@
                     </a>
                 </li>
                 <li>
-                    <a href="{% url "xls_export" content_user.username xform.id_string %}">
+                    <a href="{% url "xlsx_export" content_user.username xform.id_string %}">
                         {% translate "xls" %}
                     </a>
                 </li>

--- a/onadata/libs/tests/utils/test_export_builder.py
+++ b/onadata/libs/tests/utils/test_export_builder.py
@@ -448,7 +448,7 @@ class TestExportBuilder(TestBase):
 
         shutil.rmtree(temp_dir)
 
-    def test_xls_export_with_osm_data(self):
+    def test_xlsx_export_with_osm_data(self):
         """
         Tests that osm data is included in xls export
         """
@@ -457,7 +457,7 @@ class TestExportBuilder(TestBase):
         export_builder = ExportBuilder()
         export_builder.set_survey(survey, xform)
         with NamedTemporaryFile(suffix=".xlsx") as temp_xls_file:
-            export_builder.to_xls_export(temp_xls_file.name, self.osm_data)
+            export_builder.to_xlsx_export(temp_xls_file.name, self.osm_data)
             temp_xls_file.seek(0)
             workbook = load_workbook(temp_xls_file.name)
             osm_data_sheet = workbook["osm"]
@@ -1170,7 +1170,7 @@ class TestExportBuilder(TestBase):
             self.assertIn(b"sport", [x[0:5] for x in rows[0]])
 
     # pylint: disable=invalid-name
-    def test_xls_export_works_with_unicode(self):
+    def test_xlsx_export_works_with_unicode(self):
         survey = create_survey_from_xls(
             _logger_fixture_path("childrens_survey_unicode.xlsx"),
             default_name="childrenss_survey_unicode",
@@ -1178,7 +1178,7 @@ class TestExportBuilder(TestBase):
         export_builder = ExportBuilder()
         export_builder.set_survey(survey)
         with NamedTemporaryFile(suffix=".xlsx") as temp_xls_file:
-            export_builder.to_xls_export(temp_xls_file.name, self.data_utf8)
+            export_builder.to_xlsx_export(temp_xls_file.name, self.data_utf8)
             temp_xls_file.seek(0)
             # check that values for red\'s and blue\'s are set to true
             workbook = load_workbook(temp_xls_file.name)
@@ -1189,7 +1189,7 @@ class TestExportBuilder(TestBase):
             self.assertFalse(data["children.info/fav_colors/pink's"])
 
     # pylint: disable=invalid-name
-    def test_xls_export_with_hxl_adds_extra_row(self):
+    def test_xlsx_export_with_hxl_adds_extra_row(self):
         # hxl_example.xlsx contains `instance::hxl` column whose value is #age
         xlsform_path = os.path.join(
             settings.PROJECT_ROOT,
@@ -1218,7 +1218,7 @@ class TestExportBuilder(TestBase):
             survey_elements
         )
 
-        export_builder.to_xls_export(
+        export_builder.to_xlsx_export(
             temp_xls_file.name, self.data_utf8, columns_with_hxl=columns_with_hxl
         )
         temp_xls_file.seek(0)
@@ -1271,7 +1271,7 @@ class TestExportBuilder(TestBase):
         export_builder = ExportBuilder()
         export_builder.set_survey(survey)
         with NamedTemporaryFile(suffix=".xlsx") as temp_xls_file:
-            export_builder.to_xls_export(temp_xls_file, xdata)
+            export_builder.to_xlsx_export(temp_xls_file, xdata)
             temp_xls_file.seek(0)
             workbook = load_workbook(temp_xls_file)
             children_sheet = workbook["exp"]
@@ -1595,13 +1595,13 @@ class TestExportBuilder(TestBase):
         ][0]
         self.assertEqual(expected_section["elements"][0]["title"], match["title"])
 
-    def test_to_xls_export_works(self):
+    def test_to_xlsx_export_works(self):
         survey = self._create_childrens_survey()
         export_builder = ExportBuilder()
         export_builder.set_survey(survey)
         with NamedTemporaryFile(suffix=".xlsx") as xls_file:
             filename = xls_file.name
-            export_builder.to_xls_export(filename, self.data)
+            export_builder.to_xlsx_export(filename, self.data)
             xls_file.seek(0)
             workbook = load_workbook(filename)
             # check that we have childrens_survey, children, children_cartoons
@@ -1718,14 +1718,14 @@ class TestExportBuilder(TestBase):
             )
 
     # pylint: disable=invalid-name
-    def test_to_xls_export_respects_custom_field_delimiter(self):
+    def test_to_xlsx_export_respects_custom_field_delimiter(self):
         survey = self._create_childrens_survey()
         export_builder = ExportBuilder()
         export_builder.GROUP_DELIMITER = ExportBuilder.GROUP_DELIMITER_DOT
         export_builder.set_survey(survey)
         with NamedTemporaryFile(suffix=".xlsx") as xls_file:
             filename = xls_file.name
-            export_builder.to_xls_export(filename, self.data)
+            export_builder.to_xlsx_export(filename, self.data)
             xls_file.seek(0)
             workbook = load_workbook(filename)
 
@@ -1789,7 +1789,7 @@ class TestExportBuilder(TestBase):
         self.assertEqual(generated_sheet_name, expected_sheet_name)
 
     # pylint: disable=invalid-name
-    def test_to_xls_export_generates_valid_sheet_names(self):
+    def test_to_xlsx_export_generates_valid_sheet_names(self):
         survey = create_survey_from_xls(
             _logger_fixture_path("childrens_survey_with_a_very_long_name.xlsx"),
             default_name="childrens_survey_with_a_very_long_name",
@@ -1798,7 +1798,7 @@ class TestExportBuilder(TestBase):
         export_builder.set_survey(survey)
         with NamedTemporaryFile(suffix=".xlsx") as xls_file:
             filename = xls_file.name
-            export_builder.to_xls_export(filename, self.data)
+            export_builder.to_xlsx_export(filename, self.data)
             xls_file.seek(0)
             workbook = load_workbook(filename)
             # check that we have childrens_survey, children, children_cartoons
@@ -1821,7 +1821,7 @@ class TestExportBuilder(TestBase):
         export_builder.set_survey(survey)
         with NamedTemporaryFile(suffix=".xlsx") as xls_file:
             filename = xls_file.name
-            export_builder.to_xls_export(filename, self.long_survey_data)
+            export_builder.to_xlsx_export(filename, self.long_survey_data)
             xls_file.seek(0)
             workbook = load_workbook(filename)
 
@@ -1919,7 +1919,7 @@ class TestExportBuilder(TestBase):
         ]
         # create export file
         with NamedTemporaryFile(suffix=".xlsx") as temp_xls_file:
-            export_builder.to_xls_export(temp_xls_file.name, data)
+            export_builder.to_xlsx_export(temp_xls_file.name, data)
         # this should error if there is a problem, not sure what to assert
 
     def test_convert_types(self):
@@ -2074,7 +2074,7 @@ class TestExportBuilder(TestBase):
         self.assertEqual(field_name, expected_field_name)
 
     # pylint: disable=invalid-name
-    def test_xls_export_remove_group_name(self):
+    def test_xlsx_export_remove_group_name(self):
         survey = create_survey_from_xls(
             _logger_fixture_path("childrens_survey_unicode.xlsx"),
             default_name="childrens_survey_unicode",
@@ -2083,7 +2083,7 @@ class TestExportBuilder(TestBase):
         export_builder.TRUNCATE_GROUP_TITLE = True
         export_builder.set_survey(survey)
         with NamedTemporaryFile(suffix=".xlsx") as temp_xls_file:
-            export_builder.to_xls_export(temp_xls_file.name, self.data_utf8)
+            export_builder.to_xlsx_export(temp_xls_file.name, self.data_utf8)
             temp_xls_file.seek(0)
             # check that values for red\'s and blue\'s are set to true
             workbook = load_workbook(temp_xls_file.name)
@@ -2150,7 +2150,7 @@ class TestExportBuilder(TestBase):
             # check that red and blue are set to true
         shutil.rmtree(temp_dir)
 
-    def test_xls_export_with_labels(self):
+    def test_xlsx_export_with_labels(self):
         survey = create_survey_from_xls(
             _logger_fixture_path("childrens_survey_unicode.xlsx"),
             default_name="childrens_survey_unicode",
@@ -2160,7 +2160,7 @@ class TestExportBuilder(TestBase):
         export_builder.INCLUDE_LABELS = True
         export_builder.set_survey(survey)
         with NamedTemporaryFile(suffix=".xlsx") as temp_xls_file:
-            export_builder.to_xls_export(temp_xls_file.name, self.data_utf8)
+            export_builder.to_xlsx_export(temp_xls_file.name, self.data_utf8)
             temp_xls_file.seek(0)
             # check that values for red\'s and blue\'s are set to true
             workbook = load_workbook(temp_xls_file.name)
@@ -2180,7 +2180,7 @@ class TestExportBuilder(TestBase):
             self.assertFalse(data["fav_colors/pink's"])
 
     # pylint: disable=invalid-name
-    def test_xls_export_with_labels_only(self):
+    def test_xlsx_export_with_labels_only(self):
         survey = create_survey_from_xls(
             _logger_fixture_path("childrens_survey_unicode.xlsx"),
             default_name="childrens_survey_unicode",
@@ -2190,7 +2190,7 @@ class TestExportBuilder(TestBase):
         export_builder.INCLUDE_LABELS_ONLY = True
         export_builder.set_survey(survey)
         temp_xls_file = NamedTemporaryFile(suffix=".xlsx")
-        export_builder.to_xls_export(temp_xls_file.name, self.data_utf8)
+        export_builder.to_xlsx_export(temp_xls_file.name, self.data_utf8)
         temp_xls_file.seek(0)
         # check that values for red\'s and blue\'s are set to true
         wb = load_workbook(temp_xls_file.name)
@@ -2424,7 +2424,7 @@ class TestExportBuilder(TestBase):
             _test_sav_file(section_name)
 
     # pylint: disable=invalid-name
-    def test_xls_export_with_english_labels(self):
+    def test_xlsx_export_with_english_labels(self):
         survey = create_survey_from_xls(
             _logger_fixture_path("childrens_survey_en.xlsx"),
             default_name="childrens_survey_en",
@@ -2436,7 +2436,7 @@ class TestExportBuilder(TestBase):
         export_builder.INCLUDE_LABELS = True
         export_builder.set_survey(survey)
         with NamedTemporaryFile(suffix=".xlsx") as temp_xls_file:
-            export_builder.to_xls_export(temp_xls_file.name, self.data)
+            export_builder.to_xlsx_export(temp_xls_file.name, self.data)
             temp_xls_file.seek(0)
             workbook = load_workbook(temp_xls_file.name)
             childrens_survey_sheet = workbook["childrens_survey_en"]
@@ -2450,7 +2450,7 @@ class TestExportBuilder(TestBase):
             self.assertEqual(labels["fav_colors/blue"], "fav_colors/Blue")
 
     # pylint: disable=invalid-name
-    def test_xls_export_with_swahili_labels(self):
+    def test_xlsx_export_with_swahili_labels(self):
         survey = create_survey_from_xls(
             _logger_fixture_path("childrens_survey_sw.xlsx"),
             default_name="childrens_survey_sw",
@@ -2462,7 +2462,7 @@ class TestExportBuilder(TestBase):
         export_builder.INCLUDE_LABELS = True
         export_builder.set_survey(survey)
         with NamedTemporaryFile(suffix=".xlsx") as temp_xls_file:
-            export_builder.to_xls_export(temp_xls_file.name, self.data)
+            export_builder.to_xlsx_export(temp_xls_file.name, self.data)
             temp_xls_file.seek(0)
             workbook = load_workbook(temp_xls_file.name)
             childrens_survey_sheet = workbook["childrens_survey_sw"]
@@ -2713,7 +2713,7 @@ class TestExportBuilder(TestBase):
         shutil.rmtree(temp_dir)
 
     # pylint: disable=invalid-name
-    def test_xls_export_has_submission_review_fields(self):
+    def test_xlsx_export_has_submission_review_fields(self):
         """
         Test that review comment, status and date fields are in xls exports
         """
@@ -2724,7 +2724,7 @@ class TestExportBuilder(TestBase):
         export_builder.INCLUDE_REVIEW = True
         export_builder.set_survey(survey, xform, include_reviews=True)
         with NamedTemporaryFile(suffix=".xlsx") as temp_xls_file:
-            export_builder.to_xls_export(temp_xls_file.name, self.osm_data)
+            export_builder.to_xlsx_export(temp_xls_file.name, self.osm_data)
             temp_xls_file.seek(0)
             workbook = load_workbook(temp_xls_file.name)
             osm_data_sheet = workbook["osm"]
@@ -2959,7 +2959,7 @@ class TestExportBuilder(TestBase):
         export_builder.set_survey(survey)
         temp_xls_file = NamedTemporaryFile(suffix=".xlsx")
         data = [{"name": "Maria", "age": 25, "fruit": "1"}]  # yapf: disable
-        export_builder.to_xls_export(temp_xls_file, data)
+        export_builder.to_xlsx_export(temp_xls_file, data)
         temp_xls_file.seek(0)
         children_sheet = load_workbook(temp_xls_file)["data"]
         self.assertTrue(children_sheet)
@@ -2993,7 +2993,7 @@ class TestExportBuilder(TestBase):
         export_builder.set_survey(survey)
         temp_xls_file = NamedTemporaryFile(suffix=".xlsx")
         data = [{"name": "Maria", "age": 25, "fruit": "1"}]  # yapf: disable
-        export_builder.to_xls_export(temp_xls_file, data)
+        export_builder.to_xlsx_export(temp_xls_file, data)
         temp_xls_file.seek(0)
         children_sheet = load_workbook(temp_xls_file)["data"]
         self.assertTrue(children_sheet)
@@ -3027,7 +3027,7 @@ class TestExportBuilder(TestBase):
         export_builder.set_survey(survey)
         temp_xls_file = NamedTemporaryFile(suffix=".xlsx")
         data = [{"name": "Maria", "age": 25, "fruit": "1 2"}]  # yapf: disable
-        export_builder.to_xls_export(temp_xls_file, data)
+        export_builder.to_xlsx_export(temp_xls_file, data)
         temp_xls_file.seek(0)
         children_sheet = load_workbook(temp_xls_file)["data"]
         self.assertTrue(children_sheet)
@@ -3062,7 +3062,7 @@ class TestExportBuilder(TestBase):
         export_builder.set_survey(survey)
         temp_xls_file = NamedTemporaryFile(suffix=".xlsx")
         data = [{"name": "Maria", "age": 25, "fruit": "1 2"}]  # yapf: disable
-        export_builder.to_xls_export(temp_xls_file, data)
+        export_builder.to_xlsx_export(temp_xls_file, data)
         temp_xls_file.seek(0)
         children_sheet = load_workbook(temp_xls_file)["data"]
         self.assertTrue(children_sheet)
@@ -3098,7 +3098,7 @@ class TestExportBuilder(TestBase):
         export_builder.set_survey(survey)
         temp_xls_file = NamedTemporaryFile(suffix=".xlsx")
         data = [{"name": "Maria", "age": 25, "fruit": "1 2"}]  # yapf: disable
-        export_builder.to_xls_export(temp_xls_file, data)
+        export_builder.to_xlsx_export(temp_xls_file, data)
         temp_xls_file.seek(0)
         children_sheet = load_workbook(temp_xls_file)["data"]
         self.assertTrue(children_sheet)
@@ -3138,7 +3138,7 @@ class TestExportBuilder(TestBase):
         export_builder.set_survey(survey)
         temp_xls_file = NamedTemporaryFile(suffix=".xlsx")
         data = [{"name": "Maria", "age": 25, "fruit": "1 3"}]  # yapf: disable
-        export_builder.to_xls_export(temp_xls_file, data)
+        export_builder.to_xlsx_export(temp_xls_file, data)
         temp_xls_file.seek(0)
         children_sheet = load_workbook(temp_xls_file)["data"]
         self.assertTrue(children_sheet)
@@ -3174,7 +3174,7 @@ class TestExportBuilder(TestBase):
         export_builder.set_survey(survey)
         temp_xls_file = NamedTemporaryFile(suffix=".xlsx")
         data = [{"name": "Maria", "age": 25, "fruit": "1 3"}]  # yapf: disable
-        export_builder.to_xls_export(temp_xls_file, data)
+        export_builder.to_xlsx_export(temp_xls_file, data)
         temp_xls_file.seek(0)
         children_sheet = load_workbook(temp_xls_file)["data"]
         self.assertTrue(children_sheet)
@@ -3215,7 +3215,7 @@ class TestExportBuilder(TestBase):
         export_builder.set_survey(survey)
         temp_xls_file = NamedTemporaryFile(suffix=".xlsx")
         data = [{"name": "Maria", "age": 25, "fruit": "1 3"}]  # yapf: disable
-        export_builder.to_xls_export(temp_xls_file, data)
+        export_builder.to_xlsx_export(temp_xls_file, data)
         temp_xls_file.seek(0)
         children_sheet = load_workbook(temp_xls_file)["data"]
         self.assertTrue(children_sheet)
@@ -3256,7 +3256,7 @@ class TestExportBuilder(TestBase):
         export_builder.set_survey(survey)
         temp_xls_file = NamedTemporaryFile(suffix=".xlsx")
         data = [{"name": "Maria", "age": 25, "fruit": "1 3"}]  # yapf: disable
-        export_builder.to_xls_export(temp_xls_file, data)
+        export_builder.to_xlsx_export(temp_xls_file, data)
         temp_xls_file.seek(0)
         children_sheet = load_workbook(temp_xls_file)["data"]
         self.assertTrue(children_sheet)
@@ -3307,7 +3307,7 @@ class TestExportBuilder(TestBase):
         temp_xls_file = NamedTemporaryFile(suffix=".xlsx")
 
         data = [{"banks_deal": "1 2 3 4", "primary_bank": "3"}]  # yapf: disable
-        export_builder.to_xls_export(temp_xls_file, data)
+        export_builder.to_xlsx_export(temp_xls_file, data)
         temp_xls_file.seek(0)
         children_sheet = load_workbook(temp_xls_file)["data"]
         self.assertTrue(children_sheet)

--- a/onadata/libs/tests/utils/test_export_tools.py
+++ b/onadata/libs/tests/utils/test_export_tools.py
@@ -801,7 +801,7 @@ class TestExportTools(TestBase, TestAbstractViewSet):
 
         self.assertEqual(export, test_export)
 
-        test_export = check_pending_export(self.xform, Export.XLS_EXPORT, {})
+        test_export = check_pending_export(self.xform, Export.XLSX_EXPORT, {})
 
         self.assertIsNone(test_export)
 

--- a/onadata/libs/utils/api_export_tools.py
+++ b/onadata/libs/utils/api_export_tools.py
@@ -75,7 +75,7 @@ EXTERNAL_EXPORT_TYPES = ["xls"]
 
 EXPORT_EXT = {
     "xls": Export.XLS_EXPORT,
-    "xlsx": Export.XLS_EXPORT,
+    "xlsx": Export.XLSX_EXPORT,
     "csv": Export.CSV_EXPORT,
     "csvzip": Export.CSV_ZIP_EXPORT,
     "savzip": Export.SAV_ZIP_EXPORT,

--- a/onadata/libs/utils/api_export_tools.py
+++ b/onadata/libs/utils/api_export_tools.py
@@ -71,10 +71,9 @@ from onadata.libs.utils.logger_tools import response_with_mimetype_and_name
 from onadata.libs.utils.model_tools import get_columns_with_hxl
 
 # Supported external exports
-EXTERNAL_EXPORT_TYPES = ["xls"]
+EXTERNAL_EXPORT_TYPES = ["xlsx"]
 
 EXPORT_EXT = {
-    "xls": Export.XLS_EXPORT,
     "xlsx": Export.XLSX_EXPORT,
     "csv": Export.CSV_EXPORT,
     "csvzip": Export.CSV_ZIP_EXPORT,
@@ -406,7 +405,7 @@ def _set_start_end_params(request, query):
 def _get_extension_from_export_type(export_type):
     extension = export_type
 
-    if export_type == Export.XLS_EXPORT:
+    if export_type == Export.XLSX_EXPORT:
         extension = "xlsx"
     elif export_type in [Export.CSV_ZIP_EXPORT, Export.SAV_ZIP_EXPORT]:
         extension = "zip"

--- a/onadata/libs/utils/export_builder.py
+++ b/onadata/libs/utils/export_builder.py
@@ -978,7 +978,7 @@ class ExportBuilder:
         return generated_name
 
     # pylint: disable=too-many-locals,too-many-statements,unused-argument
-    def to_xls_export(self, path, data, *args, **kwargs):
+    def to_xlsx_export(self, path, data, *args, **kwargs):
         """Export data to a spreadsheet document."""
 
         def write_row(data, work_sheet, fields, work_sheet_titles):

--- a/onadata/libs/utils/export_tools.py
+++ b/onadata/libs/utils/export_tools.py
@@ -135,7 +135,7 @@ def generate_export(export_type, xform, export_id=None, options=None):  # noqa C
     start = options.get("start")
 
     export_type_func_map = {
-        Export.XLS_EXPORT: "to_xls_export",
+        Export.XLSX_EXPORT: "to_xls_export",
         Export.CSV_EXPORT: "to_flat_csv_export",
         Export.CSV_ZIP_EXPORT: "to_zipped_csv",
         Export.SAV_ZIP_EXPORT: "to_zipped_sav",

--- a/onadata/libs/utils/export_tools.py
+++ b/onadata/libs/utils/export_tools.py
@@ -135,7 +135,7 @@ def generate_export(export_type, xform, export_id=None, options=None):  # noqa C
     start = options.get("start")
 
     export_type_func_map = {
-        Export.XLSX_EXPORT: "to_xls_export",
+        Export.XLSX_EXPORT: "to_xlsx_export",
         Export.CSV_EXPORT: "to_flat_csv_export",
         Export.CSV_ZIP_EXPORT: "to_zipped_csv",
         Export.SAV_ZIP_EXPORT: "to_zipped_sav",


### PR DESCRIPTION
### Changes / Features implemented
- Ensure excel exports are in `xlsx` format instead of `xls`
### Steps taken to verify this change does what is intended
- Tests
### Side effects of implementing this change
- All excel exports will be in the `xlsx` format

**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  - [ ] Updated documentation

Closes #
