### PR TITLE
Prefix keys in filtered dataset kwargs with 'instance__'

### DIFF
--- a/onadata/apps/api/tests/viewsets/test_dataview_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_dataview_viewset.py
@@ -156,6 +156,7 @@ class TestDataViewViewSet(TestAbstractViewSet):
             "project": f"http://testserver/api/v1/projects/{self.project.pk}",
             # ensure there's an attachment column(photo) in you dataview
             "columns": '["name", "age", "gender", "photo"]',
+            "query": '[{"column":"pizza_fan","filter":"=","value":"no"}]',
         }
 
         self._create_dataview(data=data)
@@ -179,11 +180,12 @@ class TestDataViewViewSet(TestAbstractViewSet):
         request = self.factory.get("/?dataview=" + str(self.data_view.pk), **self.extra)
         response = attachment_list_view(request)
         self.assertEqual(1, len(response.data))
-        self.assertEqual(self.data_view.query, {})
+        self.assertEqual(self.data_view.query,
+                         [{'value': 'no', 'column': 'pizza_fan', 'filter': '='}])
         serialized_attachments = AttachmentSerializer(
-                Attachment.objects.filter(
-                    instance__xform=self.data_view.xform),
-                many=True, context={'request': request}).data
+            Attachment.objects.filter(
+                instance__xform=self.data_view.xform),
+            many=True, context={'request': request}).data
         self.assertEqual(
             serialized_attachments,
             response.data)
@@ -959,14 +961,14 @@ class TestDataViewViewSet(TestAbstractViewSet):
         project = self.project
         # add pizza_type column which is has choice labels
         data = {
-                "name": "My DataView",
-                "xform": f"http://testserver/api/v1/forms/{xform.pk}",
-                "project": f"http://testserver/api/v1/projects/{project.pk}",
-                "columns": '["name", "age", "gender", "pizza_type"]',
-                "query": (
+            "name": "My DataView",
+            "xform": f"http://testserver/api/v1/forms/{xform.pk}",
+            "project": f"http://testserver/api/v1/projects/{project.pk}",
+            "columns": '["name", "age", "gender", "pizza_type"]',
+            "query": (
                     '[{"column":"age","filter":"=","value":"28"}]'
-                ),
-            }
+            ),
+        }
         self._create_dataview(data=data)
 
         view = DataViewViewSet.as_view(
@@ -1059,14 +1061,14 @@ class TestDataViewViewSet(TestAbstractViewSet):
         project = self.project
         # add pizza_type column which is has choice labels
         data = {
-                "name": "My DataView",
-                "xform": f"http://testserver/api/v1/forms/{xform.pk}",
-                "project": f"http://testserver/api/v1/projects/{project.pk}",
-                "columns": '["name", "age", "gender", "pizza_type"]',
-                "query": (
+            "name": "My DataView",
+            "xform": f"http://testserver/api/v1/forms/{xform.pk}",
+            "project": f"http://testserver/api/v1/projects/{project.pk}",
+            "columns": '["name", "age", "gender", "pizza_type"]',
+            "query": (
                     '[{"column":"age","filter":"=","value":"28"}]'
-                ),
-            }
+            ),
+        }
         self._create_dataview(data=data)
 
         view = DataViewViewSet.as_view(

--- a/onadata/libs/filters.py
+++ b/onadata/libs/filters.py
@@ -318,6 +318,13 @@ class TagFilter(filters.BaseFilterBackend):
 class XFormPermissionFilterMixin:
     """XForm permission filter."""
 
+    def _add_instance_prefix_to_dataview_filter_kwargs(self, filter_kwargs):
+        prefixed_filter_kwargs = {}
+        for kwarg in filter_kwargs:
+            prefixed_filter_kwargs["instance__" + kwarg] = filter_kwargs[kwarg]
+
+        return prefixed_filter_kwargs
+
     def _xform_filter(self, request, view, keyword):
         """Use XForm permissions"""
         xform = request.query_params.get("xform")
@@ -330,7 +337,8 @@ class XFormPermissionFilterMixin:
                 "Invalid value for dataview ID. It must be a positive integer."
             )
             self.dataview = get_object_or_404(DataView, pk=dataview)
-            kwargs = get_filter_kwargs(self.dataview.query)
+            kwargs = self._add_instance_prefix_to_dataview_filter_kwargs(
+                get_filter_kwargs(self.dataview.query))
             return {
                 **kwargs,
                 **{f"{keyword}": self.dataview.xform}

--- a/onadata/libs/filters.py
+++ b/onadata/libs/filters.py
@@ -331,26 +331,24 @@ class XFormPermissionFilterMixin:
         dataview = request.query_params.get("dataview")
         merged_xform = request.query_params.get("merged_xform")
         public_forms = XForm.objects.none()
+        dataview_kwargs = {}
         if dataview:
             int_or_parse_error(
                 dataview,
                 "Invalid value for dataview ID. It must be a positive integer."
             )
             self.dataview = get_object_or_404(DataView, pk=dataview)
-            kwargs = self._add_instance_prefix_to_dataview_filter_kwargs(
+            # filter with fitlered dataset query
+            dataview_kwargs = self._add_instance_prefix_to_dataview_filter_kwargs(
                 get_filter_kwargs(self.dataview.query))
-            return {
-                **kwargs,
-                **{f"{keyword}": self.dataview.xform}
-            }
-        if merged_xform:
+            xform_qs = XForm.objects.filter(pk=self.dataview.xform.pk)
+        elif merged_xform:
             int_or_parse_error(
                 merged_xform,
                 "Invalid value for Merged Dataset ID. It must be a positive integer.")
             self.merged_xform = get_object_or_404(MergedXForm, pk=merged_xform)
-            xforms = self.merged_xform.xforms.all()
-            return {f"{keyword}__in": xforms}
-        if xform:
+            xform_qs = self.merged_xform.xforms.all()
+        elif xform:
             int_or_parse_error(
                 xform, "Invalid value for formid. It must be a positive integer."
             )
@@ -365,7 +363,10 @@ class XFormPermissionFilterMixin:
             xforms = xform_qs.filter(shared_data=True)
         else:
             xforms = super().filter_queryset(request, xform_qs, view) | public_forms
-        return {f"{keyword}__in": xforms}
+        return {
+            **{f"{keyword}__in": xforms},
+            **dataview_kwargs
+        }
 
     def _xform_filter_queryset(self, request, queryset, view, keyword):
         kwarg = self._xform_filter(request, view, keyword)


### PR DESCRIPTION
### Changes / Features implemented
- [Prefix keys in filtered dataset kwargs with 'instance__'](https://github.com/onaio/onadata/pull/2380/commits/18b95bc49ebed1e2e359d8197f10a627b75b5524)
     - This will allow filtering attachments using the filtered dataset query
### Steps taken to verify this change does what is intended
- [x] Replicated the issue locally with a failing tests and fixed it
- [x] QAed


**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  - [ ] Updated documentation

Closes https://github.com/onaio/onadata/issues/2379
