### PR TITLE
Add azure token to media files urls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,6 +158,7 @@ jobs:
           pip install -U pip
           pip install -r requirements/base.pip
           pip install -r requirements/dev.pip
+          pip install -r requirements/azure.pip
 
       - name: Run tests
         run: |

--- a/onadata/apps/api/tests/viewsets/test_metadata_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_metadata_viewset.py
@@ -1,5 +1,6 @@
 import os
 from builtins import open
+from mock import patch
 
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
@@ -132,6 +133,30 @@ class TestMetaDataViewSet(TestAbstractViewSet):
         response = view(request, pk=self.project.pk)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data, [data])
+
+    @patch('onadata.libs.serializers.metadata_serializer.is_azure_storage')
+    @patch('azure.storage.blob.generate_blob_sas')
+    def test_forms_endpoint_with_metadata_and_azure_storage(
+            self, mock_generate_blob_sas, mock_is_azure_storage):
+        sas_token = 'sc=date+randomText'
+        mock_is_azure_storage.return_value = True
+        mock_generate_blob_sas.return_value = sas_token
+
+        self._add_form_metadata(self.xform, 'media',
+                                self.data_value, self.path)
+        self.xform.refresh_from_db()
+
+        # /forms
+        view = XFormViewSet.as_view({
+            'get': 'retrieve'
+        })
+        formid = self.xform.pk
+        request = self.factory.get('/', **self.extra)
+        response = view(request, pk=formid)
+        self.assertEqual(response.status_code, 200)
+        data = XFormSerializer(self.xform, context={'request': request}).data
+        self.assertEqual(response.data, data)
+        self.assertIn(f"?{sas_token}", data["metadata"][0]["media_url"])
 
     def test_get_metadata_with_file_attachment(self):
         for data_type in ['supporting_doc', 'media', 'source']:

--- a/onadata/apps/api/tests/viewsets/test_metadata_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_metadata_viewset.py
@@ -156,7 +156,7 @@ class TestMetaDataViewSet(TestAbstractViewSet):
         self.assertEqual(response.status_code, 200)
         data = XFormSerializer(self.xform, context={'request': request}).data
         self.assertEqual(response.data, data)
-        self.assertIn(f"?{sas_token}", data["metadata"][0]["media_url"])
+        self.assertIn(f"?{sas_token}", str(data))
 
     def test_get_metadata_with_file_attachment(self):
         for data_type in ['supporting_doc', 'media', 'source']:

--- a/onadata/libs/serializers/metadata_serializer.py
+++ b/onadata/libs/serializers/metadata_serializer.py
@@ -32,6 +32,7 @@ from onadata.libs.utils.common_tags import (
     SUBMISSION_REVIEW,
     XFORM_META_PERMS,
 )
+from onadata.libs.utils.image_tools import is_azure_storage, generate_media_url_with_sas
 
 UNIQUE_TOGETHER_ERROR = "Object already exists"
 
@@ -145,7 +146,12 @@ class MetaDataSerializer(serializers.HyperlinkedModelSerializer):
             and getattr(obj, "data_file")
             and getattr(obj.data_file, "url")
         ):
-            return obj.data_file.url
+            media_name = obj.data_file.name
+            return (
+                generate_media_url_with_sas(media_name)
+                if media_name and is_azure_storage()
+                else obj.data_file.url
+            )
         if obj.data_type in [MEDIA_TYPE] and obj.is_linked_dataset:
             request = self.context.get("request")
             kwargs = {

--- a/onadata/libs/utils/image_tools.py
+++ b/onadata/libs/utils/image_tools.py
@@ -190,18 +190,21 @@ def resize_local_env(filename, extension):
             settings.DEFAULT_IMG_FILE_TYPE if extension == "non" else extension,
         )
 
+def is_azure_storage():
+    default_storage = get_storage_class()()
+    azure = None
+    try:
+        azure = get_storage_class("storages.backends.azure_storage.AzureStorage")()
+    except ModuleNotFoundError:
+        pass
+    return isinstance(default_storage, type(azure))
+
 
 def image_url(attachment, suffix):
     """Return url of an image given size(@param suffix)
     e.g large, medium, small, or generate required thumbnail
     """
     url = attachment.media_file.url
-    azure = None
-
-    try:
-        azure = get_storage_class("storages.backends.azure_storage.AzureStorage")()
-    except ModuleNotFoundError:
-        pass
 
     if suffix == "original":
         return url
@@ -221,7 +224,7 @@ def image_url(attachment, suffix):
                 file_path = get_path(filename, size)
                 url = (
                     generate_media_url_with_sas(file_path)
-                    if isinstance(default_storage, type(azure))
+                    if is_azure_storage()
                     else default_storage.url(file_path)
                 )
             else:

--- a/onadata/libs/utils/image_tools.py
+++ b/onadata/libs/utils/image_tools.py
@@ -192,6 +192,7 @@ def resize_local_env(filename, extension):
 
 
 def is_azure_storage():
+    """Checks if azure storage is in use"""
     default_storage = get_storage_class()()
     azure = None
     try:

--- a/onadata/libs/utils/image_tools.py
+++ b/onadata/libs/utils/image_tools.py
@@ -190,6 +190,7 @@ def resize_local_env(filename, extension):
             settings.DEFAULT_IMG_FILE_TYPE if extension == "non" else extension,
         )
 
+
 def is_azure_storage():
     default_storage = get_storage_class()()
     azure = None


### PR DESCRIPTION
### Changes / Features implemented
Adds azure token to metadata media file urls to allow downloading of media files

### Steps taken to verify this change does what is intended
Added test to confirm if the token is included on the url

### Side effects of implementing this change


**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  - [ ] Updated documentation

partof https://github.com/onaio/zebra/issues/7403
