### PR TITLE
Allow authenticated users to download public form exports

### DIFF
--- a/onadata/apps/api/tests/viewsets/test_export_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_export_viewset.py
@@ -185,6 +185,8 @@ class TestExportViewSet(TestBase):
                                  self.xform,
                                  None,
                                  {"extension": "csv"})
+        export.options = {"query": {"_submitted_by": 'not_bob'}}
+        export.save()
         response = self.view(request, pk=export.pk)
         self.assertEqual(status.HTTP_200_OK, response.status_code)
         # sav export

--- a/onadata/apps/api/tests/viewsets/test_export_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_export_viewset.py
@@ -167,6 +167,34 @@ class TestExportViewSet(TestBase):
         response = self.view(request, pk=export.pk)
         self.assertEqual(status.HTTP_200_OK, response.status_code)
 
+    def test_export_public_not_owner_authenticated(self):
+        """
+        Test export of a public form for authenticated users.
+        Not owners of the form.
+        """
+        self._create_user_and_login()
+        self._publish_transportation_form()
+        self.xform.shared_data = True
+        self.xform.shared = True
+        self.xform.save()
+        test_user = self._create_user('not_bob', 'pass')
+        request = self.factory.get('/export')
+        force_authenticate(request, user=test_user)
+        # csv export
+        export = generate_export(Export.CSV_EXPORT,
+                                 self.xform,
+                                 None,
+                                 {"extension": "csv"})
+        response = self.view(request, pk=export.pk)
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
+        # sav export
+        export = generate_export(Export.SAV_ZIP_EXPORT,
+                                 self.xform,
+                                 None,
+                                 {"extension": "zip"})
+        response = self.view(request, pk=export.pk)
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
+
     def test_export_non_public_export(self):
         """
         Test export of a private form for anonymous users results in

--- a/onadata/libs/filters.py
+++ b/onadata/libs/filters.py
@@ -361,11 +361,11 @@ class XFormPermissionFilterMixin:
 
         if request.user.is_anonymous:
             xforms = xform_qs.filter(shared_data=True)
+        elif public_export:
+            export = get_object_or_404(Export, pk=view.kwargs.get("pk"))
+            xforms = XForm.objects.filter(pk=export.xform.pk)
         else:
             xforms = super().filter_queryset(request, xform_qs, view) | public_forms
-            if not xforms and public_export:
-                export = get_object_or_404(Export, pk=view.kwargs.get("pk"))
-                xforms = XForm.objects.filter(pk=export.xform.pk)
         return {
             **{f"{keyword}__in": xforms},
             **dataview_kwargs

--- a/onadata/libs/filters.py
+++ b/onadata/libs/filters.py
@@ -28,7 +28,7 @@ from onadata.libs.utils.numeric import int_or_parse_error
 User = get_user_model()
 
 
-def _public_export_id_or_none(export_id: int):
+def _public_xform_id_or_none(export_id: int):
     export = Export.objects.filter(pk=export_id).first()
 
     if export and (export.xform.shared_data or export.xform.shared):
@@ -694,7 +694,7 @@ class ExportFilter(XFormPermissionFilterMixin, ObjectPermissionsFilter):
                 request, queryset, view, "xform_id"
             ).exclude(*has_submitted_by_key)
 
-        public_xform_id = _public_export_id_or_none(view.kwargs.get("pk"))
+        public_xform_id = _public_xform_id_or_none(view.kwargs.get("pk"))
         if public_xform_id:
             form_exports = queryset.filter(xform_id=public_xform_id)
             current_user_form_exports = (

--- a/onadata/libs/renderers/renderers.py
+++ b/onadata/libs/renderers/renderers.py
@@ -164,7 +164,7 @@ class CSVZIPRenderer(BaseRenderer):  # pylint: disable=too-few-public-methods
         if isinstance(data, six.text_type):
             return data.encode("utf-8")
         if isinstance(data, dict):
-            return json.dumps(data)
+            return json.dumps(data).encode("utf-8")
         return data
 
 
@@ -181,7 +181,7 @@ class SAVZIPRenderer(BaseRenderer):  # pylint: disable=too-few-public-methods
         if isinstance(data, six.text_type):
             return data.encode("utf-8")
         if isinstance(data, dict):
-            return json.dumps(data)
+            return json.dumps(data).encode("utf-8")
         return data
 
 
@@ -552,7 +552,7 @@ class ZipRenderer(BaseRenderer):  # pylint: disable=too-few-public-methods
         if isinstance(data, six.text_type):
             return data.encode("utf-8")
         if isinstance(data, dict):
-            return json.dumps(data)
+            return json.dumps(data).encode("utf-8")
         return data
 
 


### PR DESCRIPTION
### Changes / Features implemented
- Allow authenticated users to download public form exports
- Fixes `AssertionError: renderer returned unicode, and did not specify a charset value` for .zip, .savzip and .csvzip exports

### Steps taken to verify this change does what is intended
- Added tests

### Side effects of implementing this change


**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  - [ ] Updated documentation

Part of  https://github.com/onaio/zebra/issues/7439
