### PR TITLE
Assign default team project role to users

### DIFF
--- a/onadata/apps/api/tests/viewsets/test_organization_profile_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_organization_profile_viewset.py
@@ -514,7 +514,7 @@ class TestOrganizationProfileViewSet(TestAbstractViewSet):
             "/",
             data=json.dumps(alice_data),
             content_type="application/json",
-            **self.extra
+            **self.extra,
         )
         response = view(request, user="denoinc")
         self.assertEqual(response.status_code, 201)
@@ -827,7 +827,7 @@ class TestOrganizationProfileViewSet(TestAbstractViewSet):
             "/",
             data=json.dumps(alice_data),
             content_type="application/json",
-            **self.extra
+            **self.extra,
         )
         response = view(request, user="denoinc")
         self.assertEqual(response.status_code, 201)
@@ -1034,7 +1034,7 @@ class TestOrganizationProfileViewSet(TestAbstractViewSet):
             "/",
             data=json.dumps(alice_data),
             content_type="application/json",
-            **self.extra
+            **self.extra,
         )
 
         response = view(request, user="denoinc")
@@ -1048,7 +1048,7 @@ class TestOrganizationProfileViewSet(TestAbstractViewSet):
             "/",
             data=json.dumps(alice_data),
             content_type="application/json",
-            **self.extra
+            **self.extra,
         )
         response = view(request, user="denoinc")
         expected_results = ["denoinc"]

--- a/onadata/libs/serializers/organization_member_serializer.py
+++ b/onadata/libs/serializers/organization_member_serializer.py
@@ -68,7 +68,7 @@ def _set_organization_role_to_user(organization, user, role):
         add_user_to_team(members_team, user)
         # add user to org projects
         for project in organization.user.project_org.all():
-            if role != ManagerRole:
+            if role != ManagerRole.name:
                 role = get_team_project_default_permissions(members_team, project)
             else:
                 if project.created_by != user:

--- a/onadata/libs/serializers/organization_member_serializer.py
+++ b/onadata/libs/serializers/organization_member_serializer.py
@@ -7,6 +7,7 @@ from django.core.mail import send_mail
 from django.utils.translation import gettext as _
 
 from rest_framework import serializers
+from onadata.apps.api.models.organization_profile import get_organization_members_team
 
 from onadata.apps.api.tools import (
     _get_owners,
@@ -19,7 +20,13 @@ from onadata.apps.api.tools import (
 )
 from onadata.apps.logger.models.project import Project
 from onadata.apps.main.models.user_profile import UserProfile
-from onadata.libs.permissions import ROLES, OwnerRole, is_organization
+from onadata.libs.permissions import (
+    ROLES,
+    ManagerRole,
+    OwnerRole,
+    get_team_project_default_permissions,
+    is_organization,
+)
 from onadata.libs.serializers.fields.organization_field import OrganizationField
 from onadata.libs.serializers.share_project_serializer import ShareProjectSerializer
 from onadata.libs.utils.project_utils import propagate_project_permissions_async
@@ -39,9 +46,11 @@ def _compose_send_email(organization, user, email_msg, email_subject=None):
 
 def _set_organization_role_to_user(organization, user, role):
     role_cls = ROLES.get(role)
-    role_cls.add(user, organization)
+    if role_cls:
+        role_cls.add(user, organization)
 
     owners_team = get_or_create_organization_owners_team(organization)
+    members_team = get_organization_members_team(organization)
 
     # add user to their respective team
     if role == OwnerRole.name:
@@ -56,13 +65,19 @@ def _set_organization_role_to_user(organization, user, role):
                 serializer.save()
 
     elif role != OwnerRole.name:
+        add_user_to_team(members_team, user)
         # add user to org projects
         for project in organization.user.project_org.all():
+            if role != ManagerRole:
+                role = get_team_project_default_permissions(members_team, project)
+            else:
+                if project.created_by != user:
+                    role = get_team_project_default_permissions(members_team, project)
+
             data = {"project": project.pk, "username": user.username, "role": role}
             serializer = ShareProjectSerializer(data=data)
             if serializer.is_valid():
                 serializer.save()
-
         # remove user from owners team
         remove_user_from_team(owners_team, user)
 
@@ -147,9 +162,7 @@ class OrganizationMemberSerializer(serializers.Serializer):
             user = User.objects.get(username=username)
 
             add_user_to_organization(organization, user)
-
-            if role:
-                _set_organization_role_to_user(organization, user, role)
+            _set_organization_role_to_user(organization, user, role)
 
             if email_msg:
                 _compose_send_email(organization, user, email_msg, email_subject)


### PR DESCRIPTION
### Changes / Features implemented

- test: ensure that the default team role is assigned to new members
- style: add missing ','
- refactor: grant members of an organization the default team permissions
- refactor: allow empty `role` value to be passed to function
- test(org projects): ensure user isn't granted permissions on projects with no default role

### Steps taken to verify this change does what is intended

- [x] Added tests
- [x] QA

### Side effects of implementing this change

This affects how permissions are assigned to managers and regular members of an organization.

- Managers will be granted the `members` team default role on all the organizations project whenever they join an organization; This is a change from how previously managers would be granted the manager role on all the organization projects
- Managers will be granted the `manager` role for all projects they created; This happens when they join an organization as a manager too.
- Members will always be granted the teams default role

**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests