### PR TITLE
ignore .python-version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ celerybeat.pid
 .virtualenv
 *.ropeproject
 .noseids
+.python-version
 
 gunicorn_cfg.py
 run_gunicorn.sh


### PR DESCRIPTION
pyenv-virtualenv uses the file **.python-version** to automatically activate the local environment for the project. 
