### PR TITLE
fix bug NoneType object has no attribute push

### DIFF
--- a/onadata/apps/restservice/signals.py
+++ b/onadata/apps/restservice/signals.py
@@ -6,6 +6,7 @@ import django.dispatch
 from django.conf import settings
 
 from onadata.apps.restservice.tasks import call_service_async
+from onadata.apps.restservice.utils import call_service
 
 ASYNC_POST_SUBMISSION_PROCESSING_ENABLED = getattr(
     settings, "ASYNC_POST_SUBMISSION_PROCESSING_ENABLED", False
@@ -23,7 +24,7 @@ def call_webhooks(sender, **kwargs):  # pylint: disable=unused-argument
     if ASYNC_POST_SUBMISSION_PROCESSING_ENABLED:
         call_service_async.apply_async(args=[instance_id], countdown=1)
     else:
-        call_service_async(instance_id)
+        call_service(instance_id)
 
 
 trigger_webhook.connect(call_webhooks, dispatch_uid="call_webhooks")

--- a/onadata/apps/restservice/signals.py
+++ b/onadata/apps/restservice/signals.py
@@ -4,6 +4,7 @@ RestService signals module
 """
 import django.dispatch
 from django.conf import settings
+from multidb.pinning import use_master
 
 from onadata.apps.restservice.tasks import call_service_async
 from onadata.apps.restservice.utils import call_service
@@ -25,14 +26,15 @@ def call_webhooks(sender, **kwargs):  # pylint: disable=unused-argument
     if ASYNC_POST_SUBMISSION_PROCESSING_ENABLED:
         call_service_async.apply_async(args=[instance_id], countdown=1)
     else:
-        try:
-            instance = Instance.objects.get(pk=instance_id)
-        except Instance.DoesNotExist:
-            # if the instance has already been removed we do not send it to the
-            # service
-            pass
-        else:
-            call_service(instance)
+        with use_master:
+            try:
+                instance = Instance.objects.get(pk=instance_id)
+            except Instance.DoesNotExist:
+                # if the instance has already been removed we do not send it to the
+                # service
+                pass
+            else:
+                call_service(instance)
 
 
 trigger_webhook.connect(call_webhooks, dispatch_uid="call_webhooks")

--- a/onadata/libs/utils/logger_tools.py
+++ b/onadata/libs/utils/logger_tools.py
@@ -473,7 +473,7 @@ def save_submission(
     if instance.xform is not None:
         instance.save()
         with use_master:
-            pi, created = ParsedInstance.objects.get_or_create(instance=instance) 
+            pi, created = ParsedInstance.objects.get_or_create(instance=instance)
             if not created:
                 pi.save()  # noqa"""
     return instance

--- a/onadata/libs/utils/logger_tools.py
+++ b/onadata/libs/utils/logger_tools.py
@@ -474,7 +474,7 @@ def save_submission(
         instance.save()
         pi, created = ParsedInstance.objects.get_or_create(instance=instance)
         if not created:
-            pi.save()  # noqa"""
+            pi.save()  # noqa
 
     return instance
 

--- a/onadata/libs/utils/logger_tools.py
+++ b/onadata/libs/utils/logger_tools.py
@@ -472,12 +472,10 @@ def save_submission(
 
     if instance.xform is not None:
         instance.save()
-
         with use_master:
             pi, created = ParsedInstance.objects.get_or_create(instance=instance) 
             if not created:
                 pi.save()  # noqa"""
-
     return instance
 
 

--- a/onadata/libs/utils/logger_tools.py
+++ b/onadata/libs/utils/logger_tools.py
@@ -474,8 +474,7 @@ def save_submission(
         instance.save()
 
         with use_master:
-            pi, created = ParsedInstance.objects.get_or_create(instance=instance)
-            
+            pi, created = ParsedInstance.objects.get_or_create(instance=instance) 
             if not created:
                 pi.save()  # noqa"""
 

--- a/onadata/libs/utils/logger_tools.py
+++ b/onadata/libs/utils/logger_tools.py
@@ -472,9 +472,12 @@ def save_submission(
 
     if instance.xform is not None:
         instance.save()
-        pi, created = ParsedInstance.objects.get_or_create(instance=instance)
-        if not created:
-            pi.save()  # noqa
+
+        with use_master:
+            pi, created = ParsedInstance.objects.get_or_create(instance=instance)
+            
+            if not created:
+                pi.save()  # noqa"""
 
     return instance
 

--- a/onadata/libs/utils/logger_tools.py
+++ b/onadata/libs/utils/logger_tools.py
@@ -472,10 +472,10 @@ def save_submission(
 
     if instance.xform is not None:
         instance.save()
-        with use_master:
-            pi, created = ParsedInstance.objects.get_or_create(instance=instance)
-            if not created:
-                pi.save()  # noqa"""
+        pi, created = ParsedInstance.objects.get_or_create(instance=instance)
+        if not created:
+            pi.save()  # noqa"""
+
     return instance
 
 


### PR DESCRIPTION
### Changes / Features implemented

the bug was raised by Celery and succeeded the bug `ParsedInstance DoesNotExist`. The ParsedInstance was being read immediately after being created which means it was not guranteed to be available in the replica. The fix applied is to read the created ParsedInstance from the master database


### Steps taken to verify this change does what is intended

### Side effects of implementing this change


**Before submitting this PR for review, please make sure you have:**

  - [ ] Included tests
  - [ ] Updated documentation

Closes #2282 
