### PR TITLE
Isolate flaky test cases

### DIFF
--- a/.github/workflows/docker-image-build.yml
+++ b/.github/workflows/docker-image-build.yml
@@ -50,7 +50,7 @@ jobs:
         id: docker_build
         uses: docker/build-push-action@v2
         with:
-          context: ./docker/onadata-uwsgi
+          context: .
           file: ./docker/onadata-uwsgi/Dockerfile.ubuntu
           platforms: linux/amd64,linux/arm64
           build-args: |

--- a/onadata/apps/api/tests/viewsets/test_xform_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_xform_viewset.py
@@ -4028,7 +4028,7 @@ nhMo+jI88L3qfm4/rtWKuQ9/a268phlNj34uQeoDDHuRViQo00L5meE/pFptm
                     "tests",
                     "fixtures",
                     "hxl_test",
-                    "hxl_example.xml",
+                    "hxl_example_2.xml",
                 ),
                 forced_submission_time=_submission_time,
             )
@@ -4054,30 +4054,16 @@ nhMo+jI88L3qfm4/rtWKuQ9/a268phlNj34uQeoDDHuRViQo00L5meE/pFptm
 
             content = get_response_content(response)
 
-            expected_content_py2 = (
-                "\ufeffage,\ufeffname,\ufeffmeta/instanceID,\ufeff_id,"
-                "\ufeff_uuid,\ufeff_submission_time,\ufeff_date_modified,"
-                "\ufeff_tags,\ufeff_notes,\ufeff_version,\ufeff_duration,"
-                "\ufeff_submitted_by,\ufeff_total_media,\ufeff_media_count,"
-                "\ufeff_media_all_received\n"
-                "\ufeff#age,,,,,,,,,,,,,\n29,"
-                "\ufeffLionel Messi,"
-                "\ufeffuuid:74ee8b73-48aa-4ced-9072-862f93d49c16,%s,"
-                "\ufeff74ee8b73-48aa-4ced-9072-862f93d49c16,"
-                "\ufeff2013-02-18T15:54:01,%s,\ufeff,\ufeff,\ufeff"
-                "201604121155,\ufeff,\ufeffbob,0,0,True\n" % (data_id, date_modified)
-            )
-
-            expected_content_py3 = (
+            expected_content = (
                 "\ufeffage,name,meta/instanceID,_id,_uuid,_submission_time,"
                 "_date_modified,_tags,_notes,_version,_duration,_submitted_by,"
                 "_total_media,_media_count,_media_all_received\n\ufeff#age"
                 ",,,,,,,,,,,,,,\n\ufeff"
-                "29,Lionel Messi,uuid:74ee8b73-48aa-4ced-9072-862f93d49c16,"
-                "%s,74ee8b73-48aa-4ced-9072-862f93d49c16,2013-02-18T15:54:01,"
+                "38,CR7,uuid:74ee8b73-48aa-4ced-9089-862f93d49c16,"
+                "%s,74ee8b73-48aa-4ced-9089-862f93d49c16,2013-02-18T15:54:01,"
                 "%s,,,201604121155,,bob,0,0,True\n" % (data_id, date_modified)
             )
-            self.assertIn(content, [expected_content_py2, expected_content_py3])
+            self.assertEqual(content, expected_content)
             headers = dict(response.items())
             self.assertEqual(headers["Content-Type"], "application/csv")
             content_disposition = headers["Content-Disposition"]
@@ -4096,8 +4082,8 @@ nhMo+jI88L3qfm4/rtWKuQ9/a268phlNj34uQeoDDHuRViQo00L5meE/pFptm
                 "_date_modified,_tags,_notes,_version,_duration,_submi"
                 "tted_by,_total_media,_media_count,_media_all_received\n"
                 "#age,,,,,,,,,,,,,,\n"
-                "29,Lionel Messi,uuid:74ee8b73-48aa-4ced-9072-862f93d49c16"
-                ",%s,74ee8b73-48aa-4ced-9072-862f93d49c16,2013-02-18T15:54:01,"
+                "38,CR7,uuid:74ee8b73-48aa-4ced-9089-862f93d49c16"
+                ",%s,74ee8b73-48aa-4ced-9089-862f93d49c16,2013-02-18T15:54:01,"
                 "%s,,,201604121155,,bob,0,0,True\n" % (data_id, date_modified)
             )
 

--- a/onadata/apps/logger/tests/test_briefcase_client.py
+++ b/onadata/apps/logger/tests/test_briefcase_client.py
@@ -10,13 +10,12 @@ from django.conf import settings
 from django.contrib.auth import authenticate
 from django.core.files.storage import get_storage_class
 from django.core.files.uploadedfile import UploadedFile
-from django.test import RequestFactory, override_settings
+from django.test import RequestFactory
 from django.urls import reverse
 
 import requests
 import requests_mock
 from django_digest.test import Client as DigestClient
-from flaky import flaky
 from six.moves.urllib.parse import urljoin
 
 from onadata.apps.logger.models import Instance, XForm
@@ -131,7 +130,6 @@ def get_streaming_content(res):
     return content
 
 
-@flaky()
 class TestBriefcaseClient(TestBase):
     """Test briefcase_client module."""
 
@@ -202,7 +200,6 @@ class TestBriefcaseClient(TestBase):
         )
         self.assertTrue(storage.exists(media_path))
 
-    @flaky(max_runs=3, min_passes=2)
     def test_push(self):
         """Test ODK briefcase client push function."""
         xforms = XForm.objects.filter(
@@ -230,7 +227,8 @@ class TestBriefcaseClient(TestBase):
         )
         self.assertEqual(instances.count(), 1)
 
-    def tearDown(self):
+    @classmethod
+    def tearDownClass(cls):
         # remove media files
         for username in ["bob", "deno"]:
             if storage.exists(username):

--- a/onadata/apps/main/tests/fixtures/hxl_test/hxl_example_2.xml
+++ b/onadata/apps/main/tests/fixtures/hxl_test/hxl_example_2.xml
@@ -1,0 +1,10 @@
+<hxl_example id="hxl_example" version="201604121155">
+  <formhub>
+    <uuid>55abe8dae02f46a6af59ff8b25beedf8</uuid>
+  </formhub>
+  <age hxl="#age">38</age>
+  <name>CR7</name>
+  <meta>
+    <instanceID>uuid:74ee8b73-48aa-4ced-9089-862f93d49c16</instanceID>
+  </meta>
+</hxl_example>


### PR DESCRIPTION
### Changes / Features implemented

- test(xform): drop support for python2
- test(briefcase): split briefcase client tests into separate test cases

### Steps taken to verify this change does what is intended

N/A

### Side effects of implementing this change

Less flaky tests
