### PR TITLE
Prevent numeric usernames on user creation

### DIFF
--- a/onadata/libs/serializers/user_profile_serializer.py
+++ b/onadata/libs/serializers/user_profile_serializer.py
@@ -310,6 +310,10 @@ class UserProfileSerializer(serializers.HyperlinkedModelSerializer):
         """
         username = value.lower() if isinstance(value, str) else value
 
+        if username.isdigit():
+            raise serializers.ValidationError(
+                _("Username cannot be purely numeric.")
+            )
         if username in RESERVED_NAMES:
             raise serializers.ValidationError(
                 _(f"{username} is a reserved name, please choose another")

--- a/onadata/libs/tests/serializers/test_user_profile_serializer.py
+++ b/onadata/libs/tests/serializers/test_user_profile_serializer.py
@@ -104,12 +104,11 @@ class TestUserProfileSerializer(TestAbstractViewSet):
         self.assertEqual(alice_profile.user.username,
                          alice_serializer.data['username'])
 
-    def test_username_not_allowed_if_numeric(self):
+    def test_numeric_user_not_allowed(self):
         """
         Test ValidationError raised for numeric usernames
         """
-        # create a form instance with a purely numeric username
-        request = APIRequestFactory().get('/')
+        # create a user instance with a purely numeric username
         user_data = {
             'username': '1234',
             'email': 'numerica@example.ke',
@@ -122,12 +121,7 @@ class TestUserProfileSerializer(TestAbstractViewSet):
             'home_page': '',
             'twitter': ''
         }
-        user_prof = self._create_user_profile(extra_post_data=user_data)
-        request.user = user_prof.user
-        user_serializer = UserProfileSerializer(
-            data=user_data,
-            context={'request': request}
-        )
+        user_serializer = UserProfileSerializer(data=user_data)
         # assert that the data is not valid
         self.assertFalse(user_serializer.is_valid())
          # assert that a validation error was raised for the username field

--- a/onadata/libs/tests/serializers/test_user_profile_serializer.py
+++ b/onadata/libs/tests/serializers/test_user_profile_serializer.py
@@ -103,3 +103,33 @@ class TestUserProfileSerializer(TestAbstractViewSet):
                          bob_serializer.data['username'])
         self.assertEqual(alice_profile.user.username,
                          alice_serializer.data['username'])
+
+    def test_username_not_allowed_if_numeric(self):
+        """
+        Test ValidationError raised for numeric usernames
+        """
+        # create a form instance with a purely numeric username
+        request = APIRequestFactory().get('/')
+        user_data = {
+            'username': '1234',
+            'email': 'numerica@example.ke',
+            'password1': 'num123',
+            'password2': 'num123',
+            'name': 'Num',
+            'city': 'Nai',
+            'country': 'KE',
+            'organization': '',
+            'home_page': '',
+            'twitter': ''
+        }
+        user_prof = self._create_user_profile(extra_post_data=user_data)
+        request.user = user_prof.user
+        user_serializer = UserProfileSerializer(
+            data=user_data,
+            context={'request': request}
+        )
+        # assert that the data is not valid
+        self.assertFalse(user_serializer.is_valid())
+         # assert that a validation error was raised for the username field
+        self.assertEqual(user_serializer.errors['username'],
+                         ["Username cannot be purely numeric."])


### PR DESCRIPTION
### Changes / Features implemented
- Display error message when users register using numeric usernames

### Steps taken to verify this change does what is intended
- Tests
### Side effects of implementing this change
- No user will be allowed to register to the platform with numeric usernames

**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  - [ ] Updated documentation

Closes #2406 
