### PR TITLE
[DNM] Use correct metadata cache key when retrieving xform metadata from cache

### DIFF
--- a/onadata/apps/main/models/meta_data.py
+++ b/onadata/apps/main/models/meta_data.py
@@ -563,7 +563,7 @@ def clear_cached_metadata_instance_object(
     """
     Clear the cache for the metadata object.
     """
-    safe_delete(f"{XFORM_METADATA_CACHE}{instance.object_id}")
+    safe_delete(f"{XFORM_METADATA_CACHE}{instance.content_object.pk}")
 
 
 # pylint: disable=unused-argument


### PR DESCRIPTION
### Changes / Features implemented
- Use xform id instead of metadata object id for metadata cache key

### Steps taken to verify this change does what is intended

### Side effects of implementing this change


**Before submitting this PR for review, please make sure you have:**

  - [ ] Included tests
  - [ ] Updated documentation

Closes #
