### PR TITLE
Add filter by email query parameter on users endpoint

### DIFF
--- a/docs/users.rst
+++ b/docs/users.rst
@@ -95,3 +95,34 @@ Response
            },
            ...
        ]
+
+
+Filter users using email
+------------------------------
+
+
+Example
+^^^^^^^
+
+::
+
+      curl -X GET https://api.ona.io/api/v1/users?email=demo@email.com
+
+Response
+^^^^^^^^
+
+::
+
+       [
+           {
+               "username": "demo",
+               "first_name": "First",
+               "last_name": "Last"
+           },
+           {
+               "username": "another_demo",
+               "first_name": "Another",
+               "last_name": "Demo"
+           },
+           ...
+       ]

--- a/onadata/apps/api/permissions.py
+++ b/onadata/apps/api/permissions.py
@@ -191,7 +191,6 @@ class SubmissionReviewPermissions(XFormPermissions):
         is_authenticated = request and request.user.is_authenticated
 
         if is_authenticated and view.action == "create":
-
             # Handle bulk create
             # if doing a bulk create we will fail the entire process if the
             # user lacks permissions for even one instance
@@ -306,7 +305,6 @@ class AbstractHasPermissionMixin:  # pylint: disable=too-few-public-methods
             and (request.user.is_authenticated or not self.authenticated_users_only)
             and request.user.has_perms(perms)
         ):
-
             return True
 
         return False
@@ -387,9 +385,8 @@ class UserViewSetPermissions(DjangoModelPermissionsOrAnonReadOnly):
     """
 
     def has_permission(self, request, view):
-
         if request.user.is_anonymous and view.action == "list":
-            if request.GET.get("search"):
+            if request.GET.get("search") or request.GET.get("email"):
                 raise exceptions.NotAuthenticated()
 
         return super().has_permission(request, view)

--- a/onadata/apps/api/tests/viewsets/test_user_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_user_viewset.py
@@ -1,3 +1,6 @@
+"""
+Test /users API endpoint implementation.
+"""
 from onadata.apps.api.tests.viewsets.test_abstract_viewset import TestAbstractViewSet
 from onadata.apps.api.viewsets.user_viewset import UserViewSet
 

--- a/onadata/apps/api/tests/viewsets/test_user_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_user_viewset.py
@@ -1,73 +1,76 @@
-from onadata.apps.api.tests.viewsets.test_abstract_viewset import\
-    TestAbstractViewSet
+from onadata.apps.api.tests.viewsets.test_abstract_viewset import TestAbstractViewSet
 from onadata.apps.api.viewsets.user_viewset import UserViewSet
 
 
 class TestUserViewSet(TestAbstractViewSet):
-
     def setUp(self):
         super(self.__class__, self).setUp()
-        self.data = {'id': self.user.pk, 'username': u'bob',
-                     'first_name': u'Bob', 'last_name': u'erama'}
+        self.data = {
+            "id": self.user.pk,
+            "username": "bob",
+            "first_name": "Bob",
+            "last_name": "erama",
+        }
 
     def test_user_get(self):
         """Test authenticated user can access user info"""
-        request = self.factory.get('/', **self.extra)
+        request = self.factory.get("/", **self.extra)
 
         # users list
-        view = UserViewSet.as_view({'get': 'list'})
+        view = UserViewSet.as_view({"get": "list"})
         response = view(request)
-        self.assertNotEqual(response.get('Cache-Control'), None)
+        self.assertNotEqual(response.get("Cache-Control"), None)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data, [self.data])
 
         # user with username bob
-        view = UserViewSet.as_view({'get': 'retrieve'})
-        response = view(request, username='bob')
-        self.assertNotEqual(response.get('Cache-Control'), None)
+        view = UserViewSet.as_view({"get": "retrieve"})
+        response = view(request, username="bob")
+        self.assertNotEqual(response.get("Cache-Control"), None)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data, self.data)
 
         # user with username BoB, mixed case
-        view = UserViewSet.as_view({'get': 'retrieve'})
-        response = view(request, username='BoB')
+        view = UserViewSet.as_view({"get": "retrieve"})
+        response = view(request, username="BoB")
         self.assertEqual(response.status_code, 200)
-        self.assertNotEqual(response.get('Cache-Control'), None)
+        self.assertNotEqual(response.get("Cache-Control"), None)
         self.assertEqual(response.data, self.data)
 
         # Test can retrieve profile for usernames with _ . @ symbols
         alice_data = {
-            'username': 'alice.test@gmail.com', 'email': 'alice@localhost.com'}
+            "username": "alice.test@gmail.com",
+            "email": "alice@localhost.com",
+        }
         alice_profile = self._create_user_profile(alice_data)
-        extra = {
-            'HTTP_AUTHORIZATION': f'Token {alice_profile.user.auth_token}'}
+        extra = {"HTTP_AUTHORIZATION": f"Token {alice_profile.user.auth_token}"}
 
-        request = self.factory.get('/', **extra)
-        response = view(request, username='alice.test@gmail.com')
+        request = self.factory.get("/", **extra)
+        response = view(request, username="alice.test@gmail.com")
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.data['username'], alice_data['username'])
+        self.assertEqual(response.data["username"], alice_data["username"])
 
         # user bob is_active = False
         self.user.is_active = False
         self.user.save()
 
-        view = UserViewSet.as_view({'get': 'retrieve'})
-        response = view(request, username='BoB')
+        view = UserViewSet.as_view({"get": "retrieve"})
+        response = view(request, username="BoB")
         self.assertEqual(response.status_code, 404)
 
     def test_user_anon(self):
         """Test anonymous user can access user info"""
-        request = self.factory.get('/')
+        request = self.factory.get("/")
 
         # users list endpoint
-        view = UserViewSet.as_view({'get': 'list'})
+        view = UserViewSet.as_view({"get": "list"})
         response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data, [self.data])
 
         # user with username bob
-        view = UserViewSet.as_view({'get': 'retrieve'})
-        response = view(request, username='bob')
+        view = UserViewSet.as_view({"get": "retrieve"})
+        response = view(request, username="bob")
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data, self.data)
 
@@ -76,37 +79,46 @@ class TestUserViewSet(TestAbstractViewSet):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data, self.data)
 
-    def test_get_user_using_email(self):
-        alice_data = {'username': 'alice', 'email': 'alice@localhost.com',
-                      'first_name': u'Alice', 'last_name': u'Kamande'}
-        alice_profile = self._create_user_profile(alice_data)
-        data = [{'id': alice_profile.user.pk, 'username': u'alice',
-                'first_name': u'Alice', 'last_name': u'Kamande'}]
-        get_params = {
-            'search': alice_profile.user.email,
+    def test_search_user_using_email(self):
+        """Searching by email using query param `search` works"""
+        alice_data = {
+            "username": "alice",
+            "email": "alice@localhost.com",
+            "first_name": "Alice",
+            "last_name": "Kamande",
         }
-        view = UserViewSet.as_view(
-            {'get': 'list'}
-        )
-        request = self.factory.get('/', data=get_params)
+        alice_profile = self._create_user_profile(alice_data)
+        data = [
+            {
+                "id": alice_profile.user.pk,
+                "username": "alice",
+                "first_name": "Alice",
+                "last_name": "Kamande",
+            }
+        ]
+        get_params = {
+            "search": alice_profile.user.email,
+        }
+        view = UserViewSet.as_view({"get": "list"})
+        request = self.factory.get("/", data=get_params)
 
         response = view(request)
         self.assertEqual(response.status_code, 401)
-        error = {'detail': 'Authentication credentials were not provided.'}
+        error = {"detail": "Authentication credentials were not provided."}
         self.assertEqual(response.data, error)
 
         # authenticated
-        request = self.factory.get('/', data=get_params, **self.extra)
+        request = self.factory.get("/", data=get_params, **self.extra)
         response = view(request)
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data, data)
 
         get_params = {
-            'search': 'doesnotexist@email.com',
+            "search": "doesnotexist@email.com",
         }
 
-        request = self.factory.get('/', data=get_params, **self.extra)
+        request = self.factory.get("/", data=get_params, **self.extra)
         response = view(request)
 
         self.assertEqual(response.status_code, 200)
@@ -114,10 +126,10 @@ class TestUserViewSet(TestAbstractViewSet):
         self.assertEqual(response.data, [])
 
         get_params = {
-            'search': 'invalid@email.com',
+            "search": "invalid@email.com",
         }
 
-        request = self.factory.get('/', data=get_params, **self.extra)
+        request = self.factory.get("/", data=get_params, **self.extra)
         response = view(request)
 
         self.assertEqual(response.status_code, 200)
@@ -127,22 +139,108 @@ class TestUserViewSet(TestAbstractViewSet):
     def test_get_non_org_users(self):
         self._org_create()
 
-        view = UserViewSet.as_view(
-            {'get': 'list'}
-        )
+        view = UserViewSet.as_view({"get": "list"})
 
-        all_users_request = self.factory.get('/')
+        all_users_request = self.factory.get("/")
         all_users_response = view(all_users_request)
 
         self.assertEqual(all_users_response.status_code, 200)
-        self.assertEqual(len(
-            [u for u in all_users_response.data if u['username'] == 'denoinc']
-        ), 1)
+        self.assertEqual(
+            len([u for u in all_users_response.data if u["username"] == "denoinc"]), 1
+        )
 
-        no_orgs_request = self.factory.get('/', data={'orgs': 'false'})
+        no_orgs_request = self.factory.get("/", data={"orgs": "false"})
         no_orgs_response = view(no_orgs_request)
 
         self.assertEqual(no_orgs_response.status_code, 200)
-        self.assertEqual(len(
-            [u for u in no_orgs_response.data if u['username'] == 'denoinc']),
-            0)
+        self.assertEqual(
+            len([u for u in no_orgs_response.data if u["username"] == "denoinc"]), 0
+        )
+
+    def test_filter_users_by_email(self):
+        """Filtering by email using query param `email` works"""
+        alice_data = {
+            "username": "alice",
+            "email": "alice@localhost.com",
+            "first_name": "Alice",
+            "last_name": "Kamande",
+        }
+        jane_data = {
+            "username": "jane",
+            "email": "jane@localhost.com",
+            "first_name": "Jane",
+            "last_name": "Doe",
+        }
+        alice_profile = self._create_user_profile(alice_data)
+        jane_profile = self._create_user_profile(jane_data)
+        get_params = {
+            "email": "alice@localhost.com",
+        }
+        view = UserViewSet.as_view({"get": "list"})
+        # requires authentication
+        request = self.factory.get("/", data=get_params)
+        response = view(request)
+        self.assertEqual(response.status_code, 401)
+        error = {"detail": "Authentication credentials were not provided."}
+        self.assertEqual(response.data, error)
+        # authenticated
+        request = self.factory.get("/", data=get_params, **self.extra)
+        response = view(request)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.data,
+            [
+                {
+                    "id": alice_profile.user.pk,
+                    "username": "alice",
+                    "first_name": "Alice",
+                    "last_name": "Kamande",
+                }
+            ],
+        )
+        # is case insensitive
+        request = self.factory.get(
+            "/", data={"email": "ALIcE@Localhost.com"}, **self.extra
+        )
+        response = view(request)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.data,
+            [
+                {
+                    "id": alice_profile.user.pk,
+                    "username": "alice",
+                    "first_name": "Alice",
+                    "last_name": "Kamande",
+                }
+            ],
+        )
+        # matches all emails that contains query value
+        request = self.factory.get("/", data={"email": "localhost"}, **self.extra)
+        response = view(request)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.data,
+            [
+                {
+                    "id": alice_profile.user.pk,
+                    "username": "alice",
+                    "first_name": "Alice",
+                    "last_name": "Kamande",
+                },
+                {
+                    "id": jane_profile.user.pk,
+                    "username": "jane",
+                    "first_name": "Jane",
+                    "last_name": "Doe",
+                },
+            ],
+        )
+        # no match returns an empty list
+        request = self.factory.get("/", data={"email": "bamboocha"}, **self.extra)
+        response = view(request)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.data,
+            [],
+        )

--- a/onadata/apps/api/tests/viewsets/test_user_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_user_viewset.py
@@ -216,7 +216,7 @@ class TestUserViewSet(TestAbstractViewSet):
             ],
         )
         # matches all emails that contains query value
-        request = self.factory.get("/", data={"email": "localhost"}, **self.extra)
+        request = self.factory.get("/", data={"email": "loc"}, **self.extra)
         response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(

--- a/onadata/apps/api/tests/viewsets/test_user_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_user_viewset.py
@@ -215,7 +215,7 @@ class TestUserViewSet(TestAbstractViewSet):
                 }
             ],
         )
-        # matches all emails that contains query value
+        # partial matches works
         request = self.factory.get("/", data={"email": "loc"}, **self.extra)
         response = view(request)
         self.assertEqual(response.status_code, 200)

--- a/onadata/apps/api/viewsets/user_viewset.py
+++ b/onadata/apps/api/viewsets/user_viewset.py
@@ -7,12 +7,14 @@ from django.contrib.auth import get_user_model
 from rest_framework.generics import get_object_or_404
 from rest_framework.viewsets import ReadOnlyModelViewSet
 from rest_framework import filters
+from django_filters.rest_framework import DjangoFilterBackend
 
 from onadata.libs.filters import UserNoOrganizationsFilter
 from onadata.libs.mixins.authenticate_header_mixin import AuthenticateHeaderMixin
 from onadata.libs.mixins.cache_control_mixin import CacheControlMixin
 from onadata.libs.mixins.etags_mixin import ETagsMixin
 from onadata.libs.serializers.user_serializer import UserSerializer
+from onadata.libs.filters import UserFilterSet
 from onadata.apps.api import permissions
 from onadata.apps.api.tools import get_baseviewset_class
 
@@ -41,8 +43,10 @@ class UserViewSet(
     filter_backends = (
         filters.SearchFilter,
         UserNoOrganizationsFilter,
+        DjangoFilterBackend,
     )
     search_fields = ("=email",)
+    filterset_class = UserFilterSet
 
     def get_object(self):
         """Lookup a  username by pk else use lookup_field"""

--- a/onadata/libs/filters.py
+++ b/onadata/libs/filters.py
@@ -743,6 +743,7 @@ class UserFilterSet(django_filter_filters.FilterSet):
         field_name="email", lookup_expr="icontains"
     )
 
+    # pylint: disable=missing-class-docstring
     class Meta:
         model = User
         fields = [

--- a/onadata/libs/filters.py
+++ b/onadata/libs/filters.py
@@ -147,8 +147,8 @@ class OrganizationPermissionFilter(ObjectPermissionsFilter):
 
         filtered_queryset = super().filter_queryset(request, queryset, view)
         org_users = set(
-            [group.team.organization for group in request.user.groups.all()] +
-            [o.user for o in filtered_queryset]
+            [group.team.organization for group in request.user.groups.all()]
+            + [o.user for o in filtered_queryset]
         )
 
         return queryset.model.objects.filter(user__in=org_users, user__is_active=True)
@@ -335,17 +335,19 @@ class XFormPermissionFilterMixin:
         if dataview:
             int_or_parse_error(
                 dataview,
-                "Invalid value for dataview ID. It must be a positive integer."
+                "Invalid value for dataview ID. It must be a positive integer.",
             )
             self.dataview = get_object_or_404(DataView, pk=dataview)
             # filter with fitlered dataset query
             dataview_kwargs = self._add_instance_prefix_to_dataview_filter_kwargs(
-                get_filter_kwargs(self.dataview.query))
+                get_filter_kwargs(self.dataview.query)
+            )
             xform_qs = XForm.objects.filter(pk=self.dataview.xform.pk)
         elif merged_xform:
             int_or_parse_error(
                 merged_xform,
-                "Invalid value for Merged Dataset ID. It must be a positive integer.")
+                "Invalid value for Merged Dataset ID. It must be a positive integer.",
+            )
             self.merged_xform = get_object_or_404(MergedXForm, pk=merged_xform)
             xform_qs = self.merged_xform.xforms.all()
         elif xform:
@@ -363,10 +365,7 @@ class XFormPermissionFilterMixin:
             xforms = xform_qs.filter(shared_data=True)
         else:
             xforms = super().filter_queryset(request, xform_qs, view) | public_forms
-        return {
-            **{f"{keyword}__in": xforms},
-            **dataview_kwargs
-        }
+        return {**{f"{keyword}__in": xforms}, **dataview_kwargs}
 
     def _xform_filter_queryset(self, request, queryset, view, keyword):
         kwarg = self._xform_filter(request, view, keyword)
@@ -515,7 +514,6 @@ class AttachmentFilter(XFormPermissionFilterMixin, ObjectPermissionsFilter):
     """Attachment filter."""
 
     def filter_queryset(self, request, queryset, view):
-
         queryset = self._xform_filter_queryset(
             request, queryset, view, "instance__xform"
         )
@@ -697,10 +695,9 @@ class ExportFilter(XFormPermissionFilterMixin, ObjectPermissionsFilter):
         public_xform_id = _public_xform_id_or_none(view.kwargs.get("pk"))
         if public_xform_id:
             form_exports = queryset.filter(xform_id=public_xform_id)
-            current_user_form_exports = (
-                form_exports.filter(*has_submitted_by_key)
-                .filter(options__query___submitted_by=request.user.username)
-            )
+            current_user_form_exports = form_exports.filter(
+                *has_submitted_by_key
+            ).filter(options__query___submitted_by=request.user.username)
             other_form_exports = form_exports.exclude(*has_submitted_by_key)
             return current_user_form_exports | other_form_exports
 
@@ -735,3 +732,19 @@ class PublicDatasetsFilter:
             return queryset.filter(shared=True)
 
         return queryset
+
+
+class UserFilterSet(django_filter_filters.FilterSet):
+    """
+    User FilterSet implemented using django-filter
+    """
+
+    email = django_filter_filters.CharFilter(
+        field_name="email", lookup_expr="icontains"
+    )
+
+    class Meta:
+        model = User
+        fields = [
+            "email",
+        ]


### PR DESCRIPTION
### Changes / Features implemented

Enable partial matching filter by email on endpoint `GET /api/v1/users` endpoint by adding the `email` query param `GET /api/v1/users?email-janedoe`

### Steps taken to verify this change does what is intended

Tested locally
Added tests

### Side effects of implementing this change

Enables partial filtering by email on the `GET /api/v1/users?email=janedoe` 

**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  - [x] Updated documentation

Closes #2422 
