### PR TITLE
Add ability to permanently delete submissions

### DIFF
--- a/docs/data.rst
+++ b/docs/data.rst
@@ -1099,6 +1099,43 @@ Response
     {"status_code": 200, "message": "3 records were deleted"}
 
 
+Permanent Deletion of Submissions
+------------------------------------
+
+**Permanently Delete a specific submission instance**
+
+`DELETE /api/v1/data/{pk}/{dataid}`
+
+A POST payload of parameter `permanent_delete` with the value 'True'. The value is 'False' by default.
+
+**Payload**
+::
+
+    permanent_delete = 'True'
+
+
+Response
+^^^^^^^^^
+
+::
+    HTTP 204 No Content
+
+**Permanently Delete a subset of submissions**
+
+`DELETE /api/v1/data/{pk}?permanent_delete=true&instance_ids=1,2,3`
+
+Response
+^^^^^^^^^
+
+::
+
+    {
+        "status_code": "200",
+        "message": "3 records were deleted"
+    }
+
+
+
 GEOJSON
 -------
 

--- a/docs/data.rst
+++ b/docs/data.rst
@@ -1113,6 +1113,11 @@ A POST payload of parameter `permanent_delete` with the value 'True'. The value 
 
     permanent_delete = 'True'
 
+Example
+^^^^^^^^^
+::
+
+    `curl -X DELETE https://api.ona.io/api/v1/data/28058' -d permanent_delete = 'True'`
 
 Response
 ^^^^^^^^^
@@ -1122,7 +1127,13 @@ Response
 
 **Permanently Delete a subset of submissions**
 
-`DELETE /api/v1/data/{pk}?permanent_delete=true&instance_ids=1,2,3`
+`DELETE /api/v1/data/{pk}`
+
+Example
+^^^^^^^^^
+::
+
+    `curl -X DELETE https://api.ona.io/api/v1/data/28058' -d permanent_delete = 'True' -d instance_ids=101425,108428,1974624`
 
 Response
 ^^^^^^^^^
@@ -1133,7 +1144,6 @@ Response
         "status_code": "200",
         "message": "3 records were deleted"
     }
-
 
 
 GEOJSON

--- a/docs/data.rst
+++ b/docs/data.rst
@@ -1108,6 +1108,8 @@ Permanent Deletion of Submissions
 
 A POST payload of parameter `permanent_delete` with the value 'True'. The value is 'False' by default.
 
+Note: This functionality is only enabled when the ``ENABLE_SUBMISSION_PERMANENT_DELETE`` setting is set to `True` within the application
+
 **Payload**
 ::
 
@@ -1117,7 +1119,7 @@ Example
 ^^^^^^^^^
 ::
 
-    `curl -X DELETE https://api.ona.io/api/v1/data/28058' -d permanent_delete = 'True'`
+    `curl -X DELETE https://api.ona.io/api/v1/data/28058' -d 'permanent_delete=True'`
 
 Response
 ^^^^^^^^^
@@ -1133,7 +1135,7 @@ Example
 ^^^^^^^^^
 ::
 
-    `curl -X DELETE https://api.ona.io/api/v1/data/28058' -d permanent_delete = 'True' -d instance_ids=101425,108428,1974624`
+    `curl -X DELETE https://api.ona.io/api/v1/data/28058' -d 'permanent_delete=True' -d 'instance_ids=101425,108428,1974624'`
 
 Response
 ^^^^^^^^^

--- a/onadata/apps/api/tests/viewsets/test_data_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_data_viewset.py
@@ -1755,6 +1755,7 @@ class TestDataViewSet(SerializeMixin, TestBase):
         # test that xform submission count is updated
         self.xform.refresh_from_db()
         self.assertEqual(self.xform.num_of_submissions, 3)
+        self.assertEqual(self.xform.instances.count(), 3)
     
         # Test project details updated successfully
         self.assertEqual(
@@ -1783,6 +1784,10 @@ class TestDataViewSet(SerializeMixin, TestBase):
         request = self.factory.get("/", **self.extra)
         response = view(request, pk=formid)
         self.assertEqual(len(response.data), 3)
+
+        # check number of instances and num_of_submissions field
+        self.assertEqual(self.xform.instances.count(), 3)
+        self.assertEqual(self.xform.num_of_submissions, 3)
 
     @override_settings(ENABLE_SUBMISSION_PERMANENT_DELETE=True)
     @patch("onadata.apps.api.viewsets.data_viewset.send_message")
@@ -1824,6 +1829,9 @@ class TestDataViewSet(SerializeMixin, TestBase):
         self.assertEqual(current_count, 2)
         self.assertEqual(self.xform.num_of_submissions, 2)
 
+        # check number of xform instances
+        self.assertEqual(self.xform.instances.count(), 2)
+
     @override_settings(ENABLE_SUBMISSION_PERMANENT_DELETE=True)
     @patch("onadata.apps.api.viewsets.data_viewset.send_message")
     def test_permanent_instance_delete_inactive_form(self, send_message_mock):
@@ -1849,6 +1857,7 @@ class TestDataViewSet(SerializeMixin, TestBase):
         # test that xform submission count is updated
         self.xform.refresh_from_db()
         self.assertEqual(self.xform.num_of_submissions, 3)
+        self.assertEqual(self.xform.instances.count(), 3)
 
         # make form inactive
         self.xform.downloadable = False
@@ -1866,6 +1875,9 @@ class TestDataViewSet(SerializeMixin, TestBase):
         self.assertEqual(self.xform.num_of_submissions, 2)
         self.assertTrue(send_message_mock.called)
 
+        # check number of instances and num_of_submissions field
+        self.assertEqual(self.xform.instances.count(), 2)
+
     @override_settings(ENABLE_SUBMISSION_PERMANENT_DELETE=False)
     def test_failed_permanent_deletion(self):
         """
@@ -1882,9 +1894,8 @@ class TestDataViewSet(SerializeMixin, TestBase):
         )
         response = view(request, pk=formid, dataid=dataid)
         self.assertEqual(response.status_code, 400)
-        self.assertEqual(
-            response.data, {"error": "Permanent Submission deletion not allowed"}
-        )
+        error_msg = "Permanent submission deletion is not enabled for this server."
+        self.assertEqual(response.data, {"error": error_msg})
 
     @patch("onadata.apps.api.viewsets.data_viewset.send_message")
     def test_delete_submission_inactive_form(self, send_message_mock):

--- a/onadata/apps/api/tests/viewsets/test_data_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_data_viewset.py
@@ -1729,6 +1729,143 @@ class TestDataViewSet(SerializeMixin, TestBase):
         self.assertEqual(current_count, 2)
         self.assertEqual(self.xform.num_of_submissions, 2)
 
+    @override_settings(ENABLE_SUBMISSION_PERMANENT_DELETE=True)
+    @patch("onadata.apps.api.viewsets.data_viewset.send_message")
+    def test_submissions_permanent_deletion(self, send_message_mock):
+        """
+        Test that permanent submission deletions work
+        """
+        self._make_submissions()
+        self.xform.refresh_from_db()
+        formid = self.xform.pk
+        dataid = self.xform.instances.all().order_by("id")[0].pk
+        view = DataViewSet.as_view({"delete": "destroy", "get": "list"})
+
+        # initial count = 4 submissions
+        request = self.factory.get("/", **self.extra)
+        response = view(request, pk=formid)
+        self.assertEqual(len(response.data), 4)
+
+        request = self.factory.delete(
+            "/", **self.extra, data={"permanent_delete": True}
+        )
+        response = view(request, pk=formid, dataid=dataid)
+        self.assertEqual(response.status_code, 204)
+
+        # test that xform submission count is updated
+        self.xform.refresh_from_db()
+        self.assertEqual(self.xform.num_of_submissions, 3)
+    
+        # Test project details updated successfully
+        self.assertEqual(
+            self.xform.project.date_modified.strftime("%Y-%m-%d %H:%M:%S"),
+            timezone.now().strftime("%Y-%m-%d %H:%M:%S"),
+        )
+
+        # message sent upon delete
+        self.assertTrue(send_message_mock.called)
+        send_message_mock.assert_called_with(
+            instance_id=dataid,
+            target_id=formid,
+            target_type=XFORM,
+            user=request.user,
+            message_verb=SUBMISSION_DELETED,
+        )
+
+        # second delete of same submission should return 404
+        request = self.factory.delete(
+            "/", **self.extra, data={"permanent_delete": True}
+        )
+        response = view(request, pk=formid, dataid=dataid)
+        self.assertEqual(response.status_code, 404)
+
+        # remaining 3 submissions
+        request = self.factory.get("/", **self.extra)
+        response = view(request, pk=formid)
+        self.assertEqual(len(response.data), 3)
+
+    @override_settings(ENABLE_SUBMISSION_PERMANENT_DELETE=True)
+    @patch("onadata.apps.api.viewsets.data_viewset.send_message")
+    def test_permanent_deletions_bulk_submissions(self, send_message_mock):
+        """
+        Test that permanent bulk submission deletions work
+        """
+        self._make_submissions()
+        self.xform.refresh_from_db()
+
+        formid = self.xform.pk
+        initial_count = self.xform.num_of_submissions
+        view = DataViewSet.as_view({"delete": "destroy"})
+
+        # test with valid instance id's
+        records_to_be_deleted = self.xform.instances.all()[:2]
+        instance_ids = ",".join([str(i.pk) for i in records_to_be_deleted])
+        data = {"instance_ids": instance_ids, "permanent_delete": True}
+
+        request = self.factory.delete("/", data=data, **self.extra)
+        response = view(request, pk=formid)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.data.get("message"),
+            "%d records were deleted" % len(records_to_be_deleted),
+        )
+        self.assertTrue(send_message_mock.called)
+        send_message_mock.called_with(
+            [str(i.pk) for i in records_to_be_deleted],
+            formid,
+            XFORM,
+            request.user,
+            SUBMISSION_DELETED,
+        )
+        self.xform.refresh_from_db()
+        current_count = self.xform.num_of_submissions
+        self.assertNotEqual(current_count, initial_count)
+        self.assertEqual(current_count, 2)
+        self.assertEqual(self.xform.num_of_submissions, 2)
+
+    @override_settings(ENABLE_SUBMISSION_PERMANENT_DELETE=True)
+    @patch("onadata.apps.api.viewsets.data_viewset.send_message")
+    def test_permanent_instance_delete_inactive_form(self, send_message_mock):
+        """
+        Test that permanent submission deletions works on inactive forms
+        """
+        self._make_submissions()
+        formid = self.xform.pk
+        dataid = self.xform.instances.all().order_by("id")[0].pk
+        view = DataViewSet.as_view(
+            {
+                "delete": "destroy",
+            }
+        )
+
+        request = self.factory.delete(
+            "/", **self.extra, data={"permanent_delete": True}
+        )
+        response = view(request, pk=formid, dataid=dataid)
+
+        self.assertEqual(response.status_code, 204)
+
+        # test that xform submission count is updated
+        self.xform.refresh_from_db()
+        self.assertEqual(self.xform.num_of_submissions, 3)
+
+        # make form inactive
+        self.xform.downloadable = False
+        self.xform.save()
+
+        dataid = self.xform.instances.filter(deleted_at=None).order_by("id")[0].pk
+
+        request = self.factory.delete("/", **self.extra, data={"permanent_delete": True})
+        response = view(request, pk=formid, dataid=dataid)
+
+        self.assertEqual(response.status_code, 204)
+
+        # test that xform submission count is updated
+        self.xform.refresh_from_db()
+        self.assertEqual(self.xform.num_of_submissions, 2)
+        self.assertTrue(send_message_mock.called)
+
     @patch("onadata.apps.api.viewsets.data_viewset.send_message")
     def test_delete_submission_inactive_form(self, send_message_mock):
         self._make_submissions()

--- a/onadata/apps/api/viewsets/data_viewset.py
+++ b/onadata/apps/api/viewsets/data_viewset.py
@@ -66,7 +66,7 @@ from onadata.libs.serializers.data_serializer import (
     OSMSerializer,
 )
 from onadata.libs.utils.api_export_tools import custom_response_handler
-from onadata.libs.utils.common_tools import json_stream
+from onadata.libs.utils.common_tools import json_stream, str_to_bool
 from onadata.libs.utils.viewer_tools import get_enketo_urls, get_form_url
 
 SAFE_METHODS = ["GET", "HEAD", "OPTIONS"]
@@ -343,7 +343,7 @@ class DataViewSet(
         instance_ids = request.data.get("instance_ids")
         delete_all_submissions = strtobool(request.data.get("delete_all", "False"))
         # get param to trigger permanent submission deletion
-        permanent_delete = strtobool(request.data.get("permanent_delete", "False"))
+        permanent_delete = str_to_bool(request.data.get("permanent_delete"))
         enable_submission_permanent_delete = getattr(
             settings, "ENABLE_SUBMISSION_PERMANENT_DELETE", False
         )

--- a/onadata/apps/api/viewsets/data_viewset.py
+++ b/onadata/apps/api/viewsets/data_viewset.py
@@ -377,7 +377,9 @@ class DataViewSet(
                         instance.delete()
                     else:
                         error_msg = {
-                            "error": _("Permanent Submission deletion not allowed")
+                            "error": _(
+                                "Permanent submission deletion is not enabled for this server."
+                            )
                         }
                         break
                 else:
@@ -419,7 +421,9 @@ class DataViewSet(
                         self.object.delete()
                     else:
                         error_msg = {
-                            "error": _("Permanent Submission deletion not allowed")
+                            "error": _(
+                                "Permanent submission deletion is not enabled for this server."
+                            )
                         }
                         return Response(error_msg, status=status.HTTP_400_BAD_REQUEST)
                 else:

--- a/onadata/apps/api/viewsets/data_viewset.py
+++ b/onadata/apps/api/viewsets/data_viewset.py
@@ -337,7 +337,7 @@ class DataViewSet(
 
         return Response(data=data)
 
-    # pylint: disable=too-many-branches
+    # pylint: disable=too-many-branches,too-many-locals
     def destroy(self, request, *args, **kwargs):
         """Deletes submissions data."""
         instance_ids = request.data.get("instance_ids")
@@ -346,6 +346,9 @@ class DataViewSet(
         permanent_delete = str_to_bool(request.data.get("permanent_delete"))
         enable_submission_permanent_delete = getattr(
             settings, "ENABLE_SUBMISSION_PERMANENT_DELETE", False
+        )
+        permanent_delete_disabled_msg = _(
+            "Permanent submission deletion is not enabled for this server."
         )
         # pylint: disable=attribute-defined-outside-init
         self.object = self.get_object()
@@ -376,11 +379,7 @@ class DataViewSet(
                     if enable_submission_permanent_delete:
                         instance.delete()
                     else:
-                        error_msg = {
-                            "error": _(
-                                "Permanent submission deletion is not enabled for this server."
-                            )
-                        }
+                        error_msg = {"error": permanent_delete_disabled_msg}
                         break
                 else:
                     # enable soft deletion
@@ -420,11 +419,7 @@ class DataViewSet(
                     if enable_submission_permanent_delete:
                         self.object.delete()
                     else:
-                        error_msg = {
-                            "error": _(
-                                "Permanent submission deletion is not enabled for this server."
-                            )
-                        }
+                        error_msg = {"error": permanent_delete_disabled_msg}
                         return Response(error_msg, status=status.HTTP_400_BAD_REQUEST)
                 else:
                     # enable soft deletion

--- a/onadata/apps/api/viewsets/data_viewset.py
+++ b/onadata/apps/api/viewsets/data_viewset.py
@@ -337,8 +337,9 @@ class DataViewSet(
 
         return Response(data=data)
 
+    # pylint: disable=too-many-branches
     def destroy(self, request, *args, **kwargs):
-        """Soft deletes submissions data."""
+        """Deletes submissions data."""
         instance_ids = request.data.get("instance_ids")
         delete_all_submissions = strtobool(request.data.get("delete_all", "False"))
         # get param to trigger permanent submission deletion
@@ -407,7 +408,7 @@ class DataViewSet(
                 else:
                     # enable soft deletion
                     delete_instance(self.object, request.user)
-                
+
                 # updates the num_of_submissions for the form.
                 self.object.xform.submission_count(force_update=True)
 


### PR DESCRIPTION
### Changes / Features implemented
- Add functionality to permanently delete submissions from db
- Added feature flag `ENABLE_SUBMISSION_PERMANENT_DELETE` to optionally enable/disable the functionality

### Steps taken to verify this change does what is intended
- Tests
### Side effects of implementing this change


**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  - [x] Updated documentation

Closes #2431 
