### PR TITLE
Enhance performance of open-data endpoint `api/v2/open-data/<uuid>/data`

### DIFF
--- a/onadata/apps/api/tests/viewsets/test_tableau_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_tableau_viewset.py
@@ -362,3 +362,14 @@ class TestTableauViewSet(TestBase):
         response = self.view(request, uuid=uuid)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data, {"count": 2})
+
+    def test_gt_id_query_param(self):
+        """gt_id query param works"""
+        self.view = TableauViewSet.as_view({"get": "data"})
+        _open_data = get_or_create_opendata(self.xform)
+        uuid = _open_data[0].uuid
+        request = self.factory.get("/", data={"gt_id": 500}, **self.extra)
+        response = self.view(request, uuid=uuid)
+        self.assertEqual(response.status_code, 200)
+        row_data = streaming_data(response)
+        self.assertEqual(len(row_data), 0)

--- a/onadata/apps/api/viewsets/v2/tableau_viewset.py
+++ b/onadata/apps/api/viewsets/v2/tableau_viewset.py
@@ -258,10 +258,10 @@ class TableauViewSet(OpenDataViewSet):
                 sql_params = [xform.pk]
 
             if should_paginate:
-                bottom, top = self.paginator.get_offset_limit(
+                offset, limit = self.paginator.get_offset_limit(
                     self.request, self.data_count
                 )
-                sql += f" LIMIT {top} OFFSET {bottom}"
+                sql += f" LIMIT {limit} OFFSET {offset}"
 
             cursor.execute(sql, params=sql_params)
             instances = [

--- a/onadata/apps/api/viewsets/v2/tableau_viewset.py
+++ b/onadata/apps/api/viewsets/v2/tableau_viewset.py
@@ -249,8 +249,8 @@ class TableauViewSet(OpenDataViewSet):
                 offset, limit = self.paginator.get_offset_limit(
                     self.request, self.data_count
                 )
-                sql += f" LIMIT {limit} OFFSET {offset}"
-                instances = Instance.objects.raw(sql, sql_params)
+                sql += " LIMIT %s OFFSET %s"
+                instances = Instance.objects.raw(sql, sql_params + [limit, offset])
                 instances = self.paginate_queryset(instances)
 
             else:

--- a/onadata/apps/api/viewsets/v2/tableau_viewset.py
+++ b/onadata/apps/api/viewsets/v2/tableau_viewset.py
@@ -236,9 +236,7 @@ class TableauViewSet(OpenDataViewSet):
 
             sql = (
                 "SELECT id, json from logger_instance"  # nosec
-                " WHERE xform_id IN %s AND deleted_at IS NULL"
-                + sql_where  # noqa W503
-                + " ORDER BY id ASC"  # noqa W503
+                " WHERE xform_id IN %s AND deleted_at IS NULL" + sql_where  # noqa W503
             )
             xform_pks = [xform.id]
 

--- a/onadata/apps/api/viewsets/v2/tableau_viewset.py
+++ b/onadata/apps/api/viewsets/v2/tableau_viewset.py
@@ -240,21 +240,21 @@ class TableauViewSet(OpenDataViewSet):
 
             if xform.is_merged_dataset:
                 sql = (
-                    "SELECT id, json from logger_instance"
+                    "SELECT id, json from logger_instance"  # nosec
                     " WHERE xform_id IN %s AND deleted_at IS NULL"
                     + sql_where  # noqa W503
                     + " ORDER BY id ASC"  # noqa W503
-                )  # nosec
+                )
                 xform_pks = list(xform.mergedxform.xforms.values_list("pk", flat=True))
                 sql_params = [tuple(xform_pks)]
 
             else:
                 sql = (
-                    "SELECT id, json from logger_instance"
+                    "SELECT id, json from logger_instance"  # nosec
                     " WHERE xform_id = %s AND deleted_at IS NULL"
                     + sql_where  # noqa W503
                     + " ORDER BY id ASC"  # noqa W503
-                )  # nosec
+                )
                 sql_params = [xform.pk]
 
             if should_paginate:

--- a/onadata/apps/api/viewsets/v2/tableau_viewset.py
+++ b/onadata/apps/api/viewsets/v2/tableau_viewset.py
@@ -235,6 +235,9 @@ class TableauViewSet(OpenDataViewSet):
             sql_where = ""
             sql_params = None
 
+            # raw SQL queries were used to improve the performance since
+            # performance was very slow for large querysets
+
             if gt_id:
                 sql_where = f" AND id > {gt_id}"
 

--- a/onadata/libs/pagination.py
+++ b/onadata/libs/pagination.py
@@ -2,6 +2,7 @@
 """
 Pagination classes.
 """
+from typing import Tuple
 from django.conf import settings
 from django.core.paginator import Paginator
 from django.db.models import QuerySet
@@ -137,3 +138,40 @@ class CountOverridablePageNumberPagination(StandardPageNumberPagination):
 
         self.request = request
         return list(self.page)
+
+
+class RawSQLQueryPaginator(CountOverridablePaginator):
+    """Paginator class for raw SQL queries"""
+
+    def page(self, number):
+        """Return page
+
+        self.object_list is NOT sliced because self.object_list should
+        have been paginated via OFFSET and LIMIT before creating a
+        RawPaginator instance
+        """
+        number = self.validate_number(number)
+        return self._get_page(self.object_list, number, self)
+
+
+class RawSQLQueryPageNumberPagination(CountOverridablePageNumberPagination):
+    """PageNumberPagination class for raw SQL queries"""
+
+    django_paginator_class = RawSQLQueryPaginator
+
+    def get_offset_limit(self, request, count) -> Tuple[int, int]:
+        """Returns raw SQL query offset and limit"""
+        page_size = self.get_page_size(request)
+        # pass an empty object_list since we are not handling any pagination
+        # at this point, we are specifically interested in the count
+        paginator = self.django_paginator_class([], page_size, count_override=count)
+        page_number = paginator.validate_number(
+            self.get_page_number(request, paginator)
+        )
+        offset = (page_number - 1) * paginator.per_page
+        limit = offset + paginator.per_page
+
+        if limit + paginator.orphans >= paginator.count:
+            limit = paginator.count
+
+        return (offset, limit)

--- a/onadata/libs/pagination.py
+++ b/onadata/libs/pagination.py
@@ -160,7 +160,7 @@ class RawSQLQueryPageNumberPagination(CountOverridablePageNumberPagination):
     django_paginator_class = RawSQLQueryPaginator
 
     def get_offset_limit(self, request, count) -> Tuple[int, int]:
-        """Returns raw SQL query offset and limit"""
+        """Returns the offset and limit to be used in a raw SQL query"""
         page_size = self.get_page_size(request)
         # pass an empty object_list since we are not handling any pagination
         # at this point, we are specifically interested in the count


### PR DESCRIPTION
### Changes / Features implemented

An improvement to the enhancements implemented [here](https://github.com/onaio/onadata/pull/2435)
 - Use raw SQL queries to improve the performance of endpoint `GET api/v2/open-data/<uuid>/data`
 - Remove ordering of the results by `id` in ascending order since when the number of submissions is large the query is extremely slow. There is also no reason to order the results by default. The consumers of the endpoint can carry out that functionality by themselves

### Steps taken to verify this change does what is intended

- [x] QA

### Side effects of implementing this change

Faster response times for endpoint `GET api/v2/open-data/<uuid>/data`

**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  - [ ] Updated documentation

Closes #
