### PR TITLE
Fix AttributeError: 'ExportBuilder' object has no attribute 'to_google_sheets'

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 [flake8]
 max-line-length = 88
 select = C,E,F,W,B,B950
-extend-ignore = E203,E501
+extend-ignore = E203,E501,W503
 per-file-ignores = __init__.py:F401

--- a/onadata/apps/api/tests/viewsets/test_xform_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_xform_viewset.py
@@ -5088,6 +5088,22 @@ nhMo+jI88L3qfm4/rtWKuQ9/a268phlNj34uQeoDDHuRViQo00L5meE/pFptm
 class ExportAsyncTestCase(XFormViewSetBaseTestCase):
     """Tests for exporting form data asynchronously"""
 
+    def _google_credentials_mock(self):
+        """Returns a mock of a Google Credentials instance"""
+
+        class GoogleCredentialsMock:
+            def to_json(self):
+                return {
+                    "refresh_token": "refresh-token",
+                    "token_uri": "https://oauth2.googleapis.com/token",
+                    "client_id": "client-id",
+                    "client_secret": "client-secret",
+                    "scopes": ["https://www.googleapis.com/auth/drive.file"],
+                    "expiry": datetime(2016, 8, 18, 12, 43, 30, 316792),
+                }
+
+        return GoogleCredentialsMock()
+
     def setUp(self):
         super().setUp()
 
@@ -5550,18 +5566,8 @@ class ExportAsyncTestCase(XFormViewSetBaseTestCase):
     @override_settings(GOOGLE_EXPORT=False)
     @patch("onadata.libs.utils.api_export_tools._get_google_credential")
     def test_google_exports_setting_false(self, mock_google_creds):
-        class CredentialsMock:
-            def to_json(self):
-                return {
-                    "refresh_token": "refresh-token",
-                    "token_uri": "https://oauth2.googleapis.com/token",
-                    "client_id": "client-id",
-                    "client_secret": "client-secret",
-                    "scopes": ["https://www.googleapis.com/auth/drive.file"],
-                    "expiry": datetime(2016, 8, 18, 12, 43, 30, 316792),
-                }
-
-        mock_google_creds.return_value = CredentialsMock()
+        """Google sheet export not allowed if setting.GOOGLE_EXPORT is false"""
+        mock_google_creds.return_value = self._google_credentials_mock()
         self._publish_xls_form_to_project()
         data = {"format": "gsheets"}
         request = self.factory.get("/", data=data, **self.extra)
@@ -5572,18 +5578,8 @@ class ExportAsyncTestCase(XFormViewSetBaseTestCase):
 
     @patch("onadata.libs.utils.api_export_tools._get_google_credential")
     def test_google_exports_setting_missing(self, mock_google_creds):
-        class CredentialsMock:
-            def to_json(self):
-                return {
-                    "refresh_token": "refresh-token",
-                    "token_uri": "https://oauth2.googleapis.com/token",
-                    "client_id": "client-id",
-                    "client_secret": "client-secret",
-                    "scopes": ["https://www.googleapis.com/auth/drive.file"],
-                    "expiry": datetime(2016, 8, 18, 12, 43, 30, 316792),
-                }
-
-        mock_google_creds.return_value = CredentialsMock()
+        """Google sheet export not allowed if setting.GOOGLE_EXPORT is missing"""
+        mock_google_creds.return_value = self._google_credentials_mock()
         self._publish_xls_form_to_project()
         data = {"format": "gsheets"}
         request = self.factory.get("/", data=data, **self.extra)

--- a/onadata/apps/api/tests/viewsets/test_xform_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_xform_viewset.py
@@ -4680,6 +4680,7 @@ nhMo+jI88L3qfm4/rtWKuQ9/a268phlNj34uQeoDDHuRViQo00L5meE/pFptm
             with self.assertRaises(KeyError):
                 self._validate_csv_export(response, None, key, expected_data)
 
+    @override_settings(GOOGLE_EXPORT=True)
     def test_xform_gsheet_exports_disabled_sync_mode(self):
         xlsform_path = os.path.join(
             settings.PROJECT_ROOT, "libs", "tests", "utils", "fixtures", "tutorial.xlsx"

--- a/onadata/apps/api/tests/viewsets/test_xform_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_xform_viewset.py
@@ -3597,6 +3597,17 @@ nhMo+jI88L3qfm4/rtWKuQ9/a268phlNj34uQeoDDHuRViQo00L5meE/pFptm
             response = view(request, pk=formid)
             self.assertEqual(response.status_code, 200)
 
+    def test_check_async_publish_empty_uuid(self):
+        view = XFormViewSet.as_view({"get": "create_async"})
+
+        # set an empty uuid
+        get_data = {"job_uuid": ""}
+        request = self.factory.get("/", data=get_data, **self.extra)
+        response = view(request)
+
+        self.assertEqual(response.status_code, 202)
+        self.assertEqual(response.data, {"error": "Empty job uuid"})
+
     def test_always_new_report_with_data_id(self):
         with HTTMock(enketo_mock):
             self._publish_xls_form_to_project()
@@ -5305,17 +5316,6 @@ class ExportAsyncTestCase(XFormViewSetBaseTestCase):
             response = view(request, pk=formid, format="xlsx")
             self.assertTrue(async_result.called)
             self.assertEqual(response.status_code, 202)
-
-    def test_check_async_publish_empty_uuid(self):
-        view = XFormViewSet.as_view({"get": "create_async"})
-
-        # set an empty uuid
-        get_data = {"job_uuid": ""}
-        request = self.factory.get("/", data=get_data, **self.extra)
-        response = view(request)
-
-        self.assertEqual(response.status_code, 202)
-        self.assertEqual(response.data, {"error": "Empty job uuid"})
 
     @override_settings(CELERY_TASK_ALWAYS_EAGER=True)
     @patch("onadata.libs.utils.api_export_tools.AsyncResult")

--- a/onadata/apps/api/viewsets/xform_viewset.py
+++ b/onadata/apps/api/viewsets/xform_viewset.py
@@ -80,6 +80,7 @@ from onadata.libs.utils.api_export_tools import (
     get_existing_file_format,
     process_async_export,
     response_for_format,
+    _get_export_type,
 )
 from onadata.libs.utils.cache_tools import PROJ_OWNER_CACHE, safe_delete
 from onadata.libs.utils.common_tools import json_stream
@@ -863,28 +864,23 @@ class XFormViewSet(
     @action(methods=["GET"], detail=True)
     def export_async(self, request, *args, **kwargs):
         """Returns the status of an async export."""
-        job_uuid = request.query_params.get("job_uuid")
-        export_type = request.query_params.get("format")
-        query = request.query_params.get("query")
         xform = self.get_object()
+        export_type = request.query_params.get("format")
 
-        token = request.query_params.get("token")
-        meta = request.query_params.get("meta")
-        data_id = request.query_params.get("data_id")
-        options = parse_request_export_options(request.query_params)
-        options["host"] = request.get_host()
+        try:
+            _get_export_type(export_type)
 
-        options.update(
-            {
-                "meta": meta,
-                "token": token,
-                "data_id": data_id,
-            }
-        )
-        if query:
-            options.update({"query": query})
+        except ParseError:
+            payload = {"details": _("Export format not supported")}
+            return Response(
+                data=payload,
+                status=status.HTTP_403_FORBIDDEN,
+                content_type="application/json",
+            )
 
-        if request.query_params.get("format") in ["csvzip", "savzip"]:
+        job_uuid = request.query_params.get("job_uuid")
+
+        if export_type in ["csvzip", "savzip"]:
             # Overide renderer and mediatype because all response are
             # suppose to be in json
             # TODO: Avoid overiding the format query param for export type
@@ -903,6 +899,23 @@ class XFormViewSet(
                 except NameError:
                     resp = get_async_response(job_uuid, request, xform)
         else:
+            query = request.query_params.get("query")
+            token = request.query_params.get("token")
+            meta = request.query_params.get("meta")
+            data_id = request.query_params.get("data_id")
+            options = parse_request_export_options(request.query_params)
+            options["host"] = request.get_host()
+            options.update(
+                {
+                    "meta": meta,
+                    "token": token,
+                    "data_id": data_id,
+                }
+            )
+
+            if query:
+                options.update({"query": query})
+
             resp = process_async_export(request, xform, export_type, options)
 
             if isinstance(resp, HttpResponseRedirect):
@@ -917,7 +930,9 @@ class XFormViewSet(
         self.etag_data = f"{timezone.now()}"
 
         return Response(
-            data=resp, status=status.HTTP_202_ACCEPTED, content_type="application/json"
+            data=resp,
+            status=status.HTTP_202_ACCEPTED,
+            content_type="application/json",
         )
 
     def _get_streaming_response(self):

--- a/onadata/apps/api/viewsets/xform_viewset.py
+++ b/onadata/apps/api/viewsets/xform_viewset.py
@@ -867,16 +867,17 @@ class XFormViewSet(
         xform = self.get_object()
         export_type = request.query_params.get("format")
 
-        try:
-            _get_export_type(export_type)
+        if export_type:
+            try:
+                _get_export_type(export_type)
 
-        except ParseError:
-            payload = {"details": _("Export format not supported")}
-            return Response(
-                data=payload,
-                status=status.HTTP_403_FORBIDDEN,
-                content_type="application/json",
-            )
+            except exceptions.ParseError:
+                payload = {"details": _("Export format not supported")}
+                return Response(
+                    data=payload,
+                    status=status.HTTP_403_FORBIDDEN,
+                    content_type="application/json",
+                )
 
         job_uuid = request.query_params.get("job_uuid")
 

--- a/onadata/libs/tests/utils/test_export_tools.py
+++ b/onadata/libs/tests/utils/test_export_tools.py
@@ -455,6 +455,27 @@ class TestExportTools(TestBase, TestAbstractViewSet):
         self.assertEqual(options["remove_group_name"], True)
         self.assertEqual(options["include_images"], True)
 
+    def test_export_not_found(self):
+        export_type = "csv"
+        options = {
+            "group_delimiter": "/",
+            "remove_group_name": False,
+            "split_select_multiples": True,
+        }
+
+        self._publish_transportation_form_and_submit_instance()
+        self._create_old_export(self.xform, export_type, options)
+        export = Export(xform=self.xform, export_type=export_type, options=options)
+        export.save()
+        export_id = export.pk
+
+        export.delete()
+        export = generate_export(export_type, self.xform, export_id, options)
+
+        self.assertIsNotNone(export)
+        self.assertTrue(export.is_successful)
+        self.assertNotEqual(export_id, export.pk)
+
     def test_kml_export_data(self):
         """
         Test kml_export_data(id_string, user, xform=None).
@@ -979,35 +1000,3 @@ class TestExportTools(TestBase, TestAbstractViewSet):
         for a in Attachment.objects.all():
             self.assertTrue(os.path.exists(os.path.join(temp_dir, a.media_file.name)))
         shutil.rmtree(temp_dir)
-
-
-class GenerateExportTestCase(TestBase):
-    """Tests for method generate_export"""
-
-    def _create_old_export(self, xform, export_type, options):
-        Export(xform=xform, export_type=export_type, options=options).save()
-        self.export = Export.objects.filter(xform=xform, export_type=export_type)
-
-    def test_export_not_found(self):
-        export_type = "csv"
-        options = {
-            "group_delimiter": "/",
-            "remove_group_name": False,
-            "split_select_multiples": True,
-        }
-
-        self._publish_transportation_form_and_submit_instance()
-        self._create_old_export(self.xform, export_type, options)
-        export = Export(xform=self.xform, export_type=export_type, options=options)
-        export.save()
-        export_id = export.pk
-
-        export.delete()
-        export = generate_export(export_type, self.xform, export_id, options)
-
-        self.assertIsNotNone(export)
-        self.assertTrue(export.is_successful)
-        self.assertNotEqual(export_id, export.pk)
-
-    def test_missing_google_exports(self):
-        """"""

--- a/onadata/libs/tests/utils/test_export_tools.py
+++ b/onadata/libs/tests/utils/test_export_tools.py
@@ -455,27 +455,6 @@ class TestExportTools(TestBase, TestAbstractViewSet):
         self.assertEqual(options["remove_group_name"], True)
         self.assertEqual(options["include_images"], True)
 
-    def test_export_not_found(self):
-        export_type = "csv"
-        options = {
-            "group_delimiter": "/",
-            "remove_group_name": False,
-            "split_select_multiples": True,
-        }
-
-        self._publish_transportation_form_and_submit_instance()
-        self._create_old_export(self.xform, export_type, options)
-        export = Export(xform=self.xform, export_type=export_type, options=options)
-        export.save()
-        export_id = export.pk
-
-        export.delete()
-        export = generate_export(export_type, self.xform, export_id, options)
-
-        self.assertIsNotNone(export)
-        self.assertTrue(export.is_successful)
-        self.assertNotEqual(export_id, export.pk)
-
     def test_kml_export_data(self):
         """
         Test kml_export_data(id_string, user, xform=None).
@@ -1000,3 +979,35 @@ class TestExportTools(TestBase, TestAbstractViewSet):
         for a in Attachment.objects.all():
             self.assertTrue(os.path.exists(os.path.join(temp_dir, a.media_file.name)))
         shutil.rmtree(temp_dir)
+
+
+class GenerateExportTestCase(TestBase):
+    """Tests for method generate_export"""
+
+    def _create_old_export(self, xform, export_type, options):
+        Export(xform=xform, export_type=export_type, options=options).save()
+        self.export = Export.objects.filter(xform=xform, export_type=export_type)
+
+    def test_export_not_found(self):
+        export_type = "csv"
+        options = {
+            "group_delimiter": "/",
+            "remove_group_name": False,
+            "split_select_multiples": True,
+        }
+
+        self._publish_transportation_form_and_submit_instance()
+        self._create_old_export(self.xform, export_type, options)
+        export = Export(xform=self.xform, export_type=export_type, options=options)
+        export.save()
+        export_id = export.pk
+
+        export.delete()
+        export = generate_export(export_type, self.xform, export_id, options)
+
+        self.assertIsNotNone(export)
+        self.assertTrue(export.is_successful)
+        self.assertNotEqual(export_id, export.pk)
+
+    def test_missing_google_exports(self):
+        """"""

--- a/onadata/libs/utils/api_export_tools.py
+++ b/onadata/libs/utils/api_export_tools.py
@@ -114,14 +114,15 @@ def include_hxl_row(dv_columns, hxl_columns):
 
 
 def _get_export_type(export_type):
-    if export_type in list(EXPORT_EXT):
-        export_type = EXPORT_EXT[export_type]
-    else:
+    if export_type not in EXPORT_EXT or (
+        export_type == Export.GOOGLE_SHEETS_EXPORT
+        and not getattr(settings, "GOOGLE_EXPORT", False)
+    ):
         raise exceptions.ParseError(
             _(f"'{export_type}' format not known or not implemented!")
         )
 
-    return export_type
+    return EXPORT_EXT[export_type]
 
 
 # pylint: disable=too-many-arguments, too-many-locals, too-many-branches
@@ -181,7 +182,6 @@ def custom_response_handler(  # noqa: C0901
         export = get_object_or_404(Export, id=export_id, xform=xform)
     else:
         if export_type == Export.GOOGLE_SHEETS_EXPORT:
-
             return Response(
                 data=json.dumps(
                     {"details": _("Sheets export only supported in async mode")}


### PR DESCRIPTION
### Changes / Features implemented

- Fix **AttributeError: 'ExportBuilder' object has no attribute 'to_google_sheets'** raised when google export is not enabled by performing validation during data export. Raise `403` HTTP status if validation fails
- Ignore Flake 8 rule [Line break occurred before a binary operator](https://www.flake8rules.com/rules/W503.html)

### Steps taken to verify this change does what is intended

- [x] QA

### Side effects of implementing this change

No side effects

**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  - [ ] Updated documentation

Closes #
