### PR TITLE
Tag release v3.11.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,25 @@ Changelog for Onadata
 
 ``* represents releases that introduce new migrations``
 
+v3.11.0(2023-07-28)
+-------------------
+
+- Ensure onadata can work in a multi-domain setup
+  `PR #2450 <https://github.com/onaio/onadata/pull/2450>`
+  [@FrankApiyo]
+- Fix AttributeError: 'ExportBuilder' object has no attribute 'to_google_sheets'
+  `PR #2458 <https://github.com/onaio/onadata/pull/2458>`
+  [@kelvin-muchiri]
+- Enhance performance of open-data endpoint api/v2/open-data/<uuid>/data
+  `PR #2456 <https://github.com/onaio/onadata/pull/2456>`
+  [@kelvin-muchiri]
+- Fix AttributeError: 'NoneType' object has no attribute 'strip' when exporting form data
+  `PR #2453 <https://github.com/onaio/onadata/pull/2453>`
+  [@kelvin-muchiri]
+- Add ability to create, update project invitations
+  `PR #2430 <https://github.com/onaio/onadata/pull/2430>`
+  [@kelvin-muchiri]
+
 v3.10.1(2023-07-20)
 -------------------
 

--- a/onadata/__init__.py
+++ b/onadata/__init__.py
@@ -6,7 +6,7 @@ visualization.
 """
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "3.10.1"
+__version__ = "3.11.0"
 
 
 # This will make sure the app is always imported when

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = onadata
-version = 3.10.1
+version = 3.11.0
 description = Collect Analyze and Share Data
 long_description = file: README.rst
 long_description_content_type = text/x-rst


### PR DESCRIPTION
### Changes

- Bump version to v3.11.0

### Release Notes

#### New features
- Ensure onadata can work in a multi-domain setup
  `PR #2450 <https://github.com/onaio/onadata/pull/2450>`
  [@FrankApiyo]
- Add ability to create, update project invitations
  `PR #2430 <https://github.com/onaio/onadata/pull/2430>`
  [@kelvin-muchiri]

#### Bug fixes
- Fix AttributeError: 'ExportBuilder' object has no attribute 'to_google_sheets'
  `PR #2458 <https://github.com/onaio/onadata/pull/2458>`
  [@kelvin-muchiri]
- Fix AttributeError: 'NoneType' object has no attribute 'strip' when exporting form data
  `PR #2453 <https://github.com/onaio/onadata/pull/2453>`
  [@kelvin-muchiri]

#### Perfomance enhancement
- Enhance performance of open-data endpoint api/v2/open-data/<uuid>/data
  `PR #2456 <https://github.com/onaio/onadata/pull/2456>`
  [@kelvin-muchiri]

