### PR TITLE
Tag release v3.12.1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,16 @@ Changelog for Onadata
 
 ``* represents releases that introduce new migrations``
 
+v3.12.1(2023-08-14)
+-------------------
+
+- Fix pagination on endpoint /api/v2/open-data/<id>/data returning duplicates
+  `PR #2467 <https://github.com/onaio/onadata/pull/2467>`
+  [@kelvin-muchiri]
+- Fix attribute error when uploading xls datasets
+  `PR #2465 <https://github.com/onaio/onadata/pull/2465>`
+  [@FrankApiyo]
+
 v3.12.0(2023-08-07)
 -------------------
 

--- a/onadata/__init__.py
+++ b/onadata/__init__.py
@@ -6,7 +6,7 @@ visualization.
 """
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "3.12.0"
+__version__ = "3.12.1"
 
 
 # This will make sure the app is always imported when

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = onadata
-version = 3.12.0
+version = 3.12.1
 description = Collect Analyze and Share Data
 long_description = file: README.rst
 long_description_content_type = text/x-rst


### PR DESCRIPTION
### Changes

Bump version to v3.12.1

### Release Notes

**Bug Fixes**

- Fix pagination on endpoint /api/v2/open-data/<id>/data returning duplicates
  `PR #2467 <https://github.com/onaio/onadata/pull/2467>`
  [@kelvin-muchiri]
- Fix attribute error when uploading xls datasets
  `PR #2465 <https://github.com/onaio/onadata/pull/2465>`
  [@FrankApiyo]