### PR TITLE
Fix async submission count discrepancy

### DIFF
--- a/onadata/apps/logger/models/instance.py
+++ b/onadata/apps/logger/models/instance.py
@@ -829,9 +829,19 @@ def post_save_submission(sender, instance=None, created=False, **kwargs):
         _update_xform_submission_count_delete(instance)
 
     if ASYNC_POST_SUBMISSION_PROCESSING_ENABLED:
-        update_xform_submission_count_async.apply_async(args=[instance.pk, created])
-        save_full_json_async.apply_async(args=[instance.pk, created])
-        update_project_date_modified_async.apply_async(args=[instance.pk, created])
+        transaction.on_commit(
+            lambda: update_xform_submission_count_async.apply_async(
+                args=[instance.pk, created]
+            )
+        )
+        transaction.on_commit(
+            lambda: save_full_json_async.apply_async(args=[instance.pk, created])
+        )
+        transaction.on_commit(
+            lambda: update_project_date_modified_async.apply_async(
+                args=[instance.pk, created]
+            )
+        )
 
     else:
         update_xform_submission_count(instance.pk, created)


### PR DESCRIPTION
### Changes / Features implemented
Use transaction.on_commit() to ensure the post_save signal that updates submission count is executed only when a transaction is completed. More info on this change can be found [here](https://ken-dev.info/django-tricks/2019/10/04/django-signals-in-transaction.html)
### Steps taken to verify this change does what is intended

### Side effects of implementing this change
- [x] QA

**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  - [ ] Updated documentation

Closes #
