### PR TITLE
Solve intermittent bug where form permissions are not applied for new forms

### DIFF
--- a/onadata/apps/api/tests/viewsets/test_organization_profile_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_organization_profile_viewset.py
@@ -7,7 +7,6 @@ from builtins import str as text
 
 from django.contrib.auth.models import User, timezone
 from django.core.cache import cache
-from django.test.utils import override_settings
 
 from guardian.shortcuts import get_perms
 from mock import patch
@@ -801,7 +800,6 @@ class TestOrganizationProfileViewSet(TestAbstractViewSet):
 
         self.assertNotIn(aboy, owner_team.user_set.all())
 
-    @override_settings(CELERY_TASK_ALWAYS_EAGER=True)
     def test_org_members_added_to_projects(self):
         # create org
         self._org_create()

--- a/onadata/apps/viewer/models/data_dictionary.py
+++ b/onadata/apps/viewer/models/data_dictionary.py
@@ -7,12 +7,14 @@ from io import BytesIO, StringIO
 
 from django.core.files.uploadedfile import InMemoryUploadedFile
 from django.db.models.signals import post_save, pre_save
+from django.db import transaction
 from django.utils import timezone
 from django.utils.translation import gettext as _
 
 import openpyxl
 import unicodecsv as csv
 from floip import FloipSurvey
+from kombu.exceptions import OperationalError
 from pyxform.builder import create_survey_element_from_dict
 from pyxform.utils import has_external_choices
 from pyxform.xls2json import parse_file_to_json
@@ -208,9 +210,23 @@ def set_object_permissions(sender, instance=None, created=False, **kwargs):
             OwnerRole.add(instance.created_by, xform)
 
         # pylint: disable=import-outside-toplevel
-        from onadata.libs.utils.project_utils import set_project_perms_to_xform  # noqa
+        from onadata.libs.utils.project_utils import (
+            set_project_perms_to_xform_async,
+        )  # noqa
 
-        set_project_perms_to_xform(xform, instance.project)
+        try:
+            transaction.on_commit(
+                lambda: set_project_perms_to_xform_async.delay(
+                    xform.pk, instance.project.pk
+                )
+            )
+        except OperationalError:
+            # pylint: disable=import-outside-toplevel
+            from onadata.libs.utils.project_utils import (
+                set_project_perms_to_xform,
+            )  # noqa
+
+            set_project_perms_to_xform(xform, instance.project)
 
     if hasattr(instance, "has_external_choices") and instance.has_external_choices:
         instance.xls.seek(0)


### PR DESCRIPTION
### Changes / Features implemented

Django [`post_save` signal is run at the end of of the Model.save() method](https://docs.djangoproject.com/en/4.2/ref/signals/#post-save). It is not guaranteed that the transaction will have commited at this time. This leads to situation where `XForm.DoesNotExist` exception is at times raised when a new form is created which results in users not having the correct permissions for some forms despite having the appropriate roles

[Use transaction.on_commit](https://docs.djangoproject.com/en/3.2/topics/db/transactions/#performing-actions-after-commit) to ensure `set_project_perms_to_xform_async.delay` in the `post_save` signal is only called after the transaction is successful

[Adjust failing tests to accommodate the new change](https://docs.djangoproject.com/en/3.2/topics/db/transactions/#use-in-tests)

### Steps taken to verify this change does what is intended

- [x] QA

### Side effects of implementing this change

No side effects

**Before submitting this PR for review, please make sure you have:**

  - [ ] Included tests
  - [ ] Updated documentation

Closes #
