### PR TITLE
Tag release v3.12.2

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,15 @@ Changelog for Onadata
 
 ``* represents releases that introduce new migrations``
 
+v3.12.2(2033-08-24)
+-------------------
+- Solve intermittent bug where form permissions are not applied for new forms
+  `PR #2470 <https://github.com/onaio/onadata/pull/2470>`
+  [@kelvin-muchiri]
+- Enhance performance when exporting data on endpoint api/v1/data/<form_id>.<format>
+  `PR #2460 <https://github.com/onaio/onadata/pull/2460>`
+  [@kelvin-muchiri]
+
 v3.12.1(2023-08-14)
 -------------------
 

--- a/onadata/__init__.py
+++ b/onadata/__init__.py
@@ -6,7 +6,7 @@ visualization.
 """
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "3.12.1"
+__version__ = "3.12.2"
 
 
 # This will make sure the app is always imported when

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = onadata
-version = 3.12.1
+version = 3.12.2
 description = Collect Analyze and Share Data
 long_description = file: README.rst
 long_description_content_type = text/x-rst


### PR DESCRIPTION
### Changes

Bump version to v3.12.2

### Release Notes

#### Bug Fixes

- Solve intermittent bug where form permissions are not applied for new forms
  [PR #2470](https://github.com/onaio/onadata/pull/2470>)
  [@kelvin-muchiri]
- Enhance performance when exporting data on endpoint `api/v1/data/<form_id>.<format>`
  [PR #2460 ](https://github.com/onaio/onadata/pull/2460)
  [@kelvin-muchiri]

