### PR TITLE
Tag release v3.13.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,16 @@ Changelog for Onadata
 
 ``* represents releases that introduce new migrations``
 
-v3.12.2(2033-08-24)
+v3.13.0(2023-09-04)
+-------------------
+- Add project and form level odk submission-list and download endpoints
+  `PR #2451 <https://github.com/onaio/onadata/pull/2451>`
+  [@KipSigei]
+- Fix async submission count discrepancy
+  `PR #2469 <https://github.com/onaio/onadata/pull/2469>`
+  [@KipSigei]
+
+v3.12.2(2023-08-24)
 -------------------
 - Solve intermittent bug where form permissions are not applied for new forms
   `PR #2470 <https://github.com/onaio/onadata/pull/2470>`

--- a/onadata/__init__.py
+++ b/onadata/__init__.py
@@ -6,7 +6,7 @@ visualization.
 """
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "3.12.2"
+__version__ = "3.13.0"
 
 
 # This will make sure the app is always imported when

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = onadata
-version = 3.12.2
+version = 3.13.0
 description = Collect Analyze and Share Data
 long_description = file: README.rst
 long_description_content_type = text/x-rst


### PR DESCRIPTION
### Changes

Bump version to v3.13.0

### Release Notes

#### Bug Fixes

- Fix async submission count discrepancy
  [PR #2469](https://github.com/onaio/onadata/pull/2469>)
  [@KipSigei ]

#### New Features
- Add project and form level odk submission-list and download endpoints
  [PR #2451](https://github.com/onaio/onadata/pull/2451)
  [@KipSigei ]
