### PR TITLE
Tag release v3.14.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,14 @@ Changelog for Onadata
 
 ``* represents releases that introduce new migrations``
 
+v3.14.0(2023-10-02)
+- Ensure geotrace and geoshape in repeats is included in GeoJSON data endpoint
+  `PR #2478 <https://github.com/onaio/onadata/pull/2478>`
+  [@KipSigei]
+- Data endpoint enhancements
+  `PR #2477 <https://github.com/onaio/onadata/pull/2477>`
+  [@kelvin-muchiri]
+
 v3.13.1(2023-09-13)
 -------------------
 - Revert to have data exports default sorting by id

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog for Onadata
 ``* represents releases that introduce new migrations``
 
 v3.14.0(2023-10-02)
+- Ensure sas token is appended to azure blob attachment url
+  `PR #2482 <https://github.com/onaio/onadata/pull/2482>`
+  [@KipSigei]
 - Ensure geotrace and geoshape in repeats is included in GeoJSON data endpoint
   `PR #2478 <https://github.com/onaio/onadata/pull/2478>`
   [@KipSigei]

--- a/onadata/__init__.py
+++ b/onadata/__init__.py
@@ -6,7 +6,7 @@ visualization.
 """
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "3.13.1"
+__version__ = "3.14.0"
 
 
 # This will make sure the app is always imported when

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = onadata
-version = 3.13.1
+version = 3.14.0
 description = Collect Analyze and Share Data
 long_description = file: README.rst
 long_description_content_type = text/x-rst


### PR DESCRIPTION
### Changes

Bump version to v3.14.0

### Release Notes

**Enhancements**
- Ensure sas token is appended to azure blob attachment url
  [PR #2482](https://github.com/onaio/onadata/pull/2482)
  [@KipSigei]
- Data endpoint enhancements
  [PR #2477](https://github.com/onaio/onadata/pull/2477)
  [@kelvin-muchiri]

- Ensure geotrace and geoshape in repeats is included in GeoJSON data endpoint
  [PR #2478](https://github.com/onaio/onadata/pull/2478)
  [@KipSigei]