### PR TITLE
tag release v3.14.1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,13 @@ Changelog for Onadata
 
 ``* represents releases that introduce new migrations``
 
+v3.14.1(2023-10-09)
+-------------------
+- Rebuilding to pick the latest google export changes.
+  [@kelvin-muchiri]
+
 v3.14.0(2023-10-02)
+-------------------
 - Ensure sas token is appended to azure blob attachment url
   `PR #2482 <https://github.com/onaio/onadata/pull/2482>`
   [@KipSigei]

--- a/onadata/__init__.py
+++ b/onadata/__init__.py
@@ -6,7 +6,7 @@ visualization.
 """
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "3.14.0"
+__version__ = "3.14.1"
 
 
 # This will make sure the app is always imported when

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = onadata
-version = 3.14.0
+version = 3.14.1
 description = Collect Analyze and Share Data
 long_description = file: README.rst
 long_description_content_type = text/x-rst


### PR DESCRIPTION
### Changes

Bump version to 3.14.1

### Release Notes

**Enhancements**

- Rebuilding to pick the latest google export changes.
  [@kelvin-muchiri]

