### PR TITLE
Save xml to json data in pre-save

### DIFF
--- a/onadata/apps/logger/models/instance.py
+++ b/onadata/apps/logger/models/instance.py
@@ -765,6 +765,7 @@ class Instance(models.Model, InstanceBaseClass):
     def save(self, *args, **kwargs):
         force = kwargs.get("force")
         self.date_modified = now()
+        self.json = self.get_dict()  # XML converted to json
 
         if force:
             del kwargs["force"]


### PR DESCRIPTION
### Changes / Features implemented

When asynchronous processing of submissions is enabled, submissions whose json is not yet processed have an empty json on endpoint /api/v1/data/<form_id>. To prevent this from happening, we save the XML to json data during pre-save. The json will later be updated to include the metadata in the post_save signal

### Steps taken to verify this change does what is intended

- [x] QA

### Side effects of implementing this change

Get rid of records with empty json on endpoint `/api/v1/data/<form_id> when processing submissions asynchronously

**Before submitting this PR for review, please make sure you have:**

  - [ ] Included tests
  - [ ] Updated documentation

Closes #
