### PR TITLE
Tag release v3.14.4

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,18 @@ Changelog for Onadata
 
 ``* represents releases that introduce new migrations``
 
+v3.14.4(2023-11-07)
+-------------------
+- Bump oidc version to v1.0.3
+  `PR #2501 <https://github.com/onaio/onadata/pull/2501>`
+  [@kelvin-muchiri]
+- Improve performance for attachments xform meta permissions check
+  `PR #2499 <https://github.com/onaio/onadata/pull/2499>`
+  [@KipSigei]
+- Create user auth token if doesn't exist upon retrieval
+  `PR #2496 <https://github.com/onaio/onadata/pull/2496>`
+  [@ciremusyoka]
+
 v3.14.3(2023-10-30)
 -------------------
 - Stream response on endpoint /<username>/xformsManifest/<form_id>

--- a/onadata/__init__.py
+++ b/onadata/__init__.py
@@ -6,7 +6,7 @@ visualization.
 """
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "3.14.3"
+__version__ = "3.14.4"
 
 
 # This will make sure the app is always imported when

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = onadata
-version = 3.14.3
+version = 3.14.4
 description = Collect Analyze and Share Data
 long_description = file: README.rst
 long_description_content_type = text/x-rst


### PR DESCRIPTION
### Changes

Bump version to 3.14.4

### Release Notes

**Enhancements**
- Bump oidc version to v1.0.3
  PR #2501
  [@kelvin-muchiri]
- Improve performance for attachments xform meta permissions check
  PR #2499
  [@KipSigei]
- Create user auth token if doesn't exist upon retrieval
  PR #2496
  [@ciremusyoka]
