### PR TITLE
Soft delete xform from legacy UI

### DIFF
--- a/onadata/apps/logger/views.py
+++ b/onadata/apps/logger/views.py
@@ -46,7 +46,6 @@ from onadata.libs.utils.logger_tools import (
     PublishXForm,
     inject_instanceid,
     publish_form,
-    remove_xform,
     response_with_mimetype_and_name,
     safe_create_instance,
 )
@@ -504,8 +503,8 @@ def delete_xform(request, username, id_string):
         {"user__username__iexact": username, "id_string__iexact": id_string}
     )
 
-    # delete xform and submissions
-    remove_xform(xform)
+    # Delete xform
+    xform.soft_delete(user=request.user)
 
     audit = {}
     audit_log(

--- a/onadata/libs/utils/logger_tools.py
+++ b/onadata/libs/utils/logger_tools.py
@@ -947,12 +947,6 @@ def inject_instanceid(xml_str, uuid):
     return xml_str
 
 
-def remove_xform(xform):
-    """Deletes an XForm ``xform``."""
-    # delete xform, and all related models
-    xform.delete()
-
-
 class PublishXForm:
     "A class to publish an XML XForm file."
 


### PR DESCRIPTION
Don't call `xform.delete()` method which soft deletes

**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  - [x] Updated documentation

