### PR TITLE
Bump version to v3.15.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,18 @@ Changelog for Onadata
 
 ``* represents releases that introduce new migrations``
 
+v3.15.0(2023-11-17)
+-------------------
+- Upgrade Django to version 3.2.23
+  `PR #2507 <https://github.com/onaio/onadata/pull/2507>`
+  [@kelvin-muchiri]
+- Custom project invitation template
+  `PR #2506 <https://github.com/onaio/onadata/pull/2506>`
+  [@kelvin-muchiri]
+- Soft delete xform from legacy UI
+  `PR #2506 <https://github.com/onaio/onadata/pull/2503>`
+  [@FrankApiyo]
+
 v3.14.4(2023-11-07)
 -------------------
 - Bump oidc version to v1.0.3

--- a/onadata/__init__.py
+++ b/onadata/__init__.py
@@ -6,7 +6,7 @@ visualization.
 """
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "3.14.4"
+__version__ = "3.15.0"
 
 
 # This will make sure the app is always imported when

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = onadata
-version = 3.14.4
+version = 3.15.0
 description = Collect Analyze and Share Data
 long_description = file: README.rst
 long_description_content_type = text/x-rst


### PR DESCRIPTION
### Changes

Bump version to v3.15.0

### Release Notes

**Enhancements**

- Upgrade Django to version 3.2.23
  https://github.com/onaio/onadata/pull/2507
  [@kelvin-muchiri]
- Custom project invitation template
  https://github.com/onaio/onadata/pull/2506
  [@kelvin-muchiri]
- Soft delete xform from legacy UI
  https://github.com/onaio/onadata/pull/2503
  [@FrankApiyo]


