### PR TITLE
Bump version to v3.16.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,21 @@ Changelog for Onadata
 
 ``* represents releases that introduce new migrations``
 
+v3.16.0(2023-11-23)
+-------------------
+- Add custom template tag: settings_value
+  `PR #2510 <https://github.com/onaio/onadata/pull/2510>`
+  [@FrankApiyo]
+- Enhancement: Handle Statement Timeout in Briefcase Viewset 
+  `PR #2508 <https://github.com/onaio/onadata/pull/2508>`
+  [@KipSigei]
+- Trigger database call to correctly capture OperationalError
+  `PR #2513 <https://github.com/onaio/onadata/pull/2513>`
+  [@KipSigei]
+- Upgrade Django for omitted requirements files
+  `PR #2512 <https://github.com/onaio/onadata/pull/2512>`
+  [@kelvin-muchiri]
+
 v3.15.0(2023-11-17)
 -------------------
 - Upgrade Django to version 3.2.23

--- a/onadata/__init__.py
+++ b/onadata/__init__.py
@@ -6,7 +6,7 @@ visualization.
 """
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "3.15.0"
+__version__ = "3.16.0"
 
 
 # This will make sure the app is always imported when

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = onadata
-version = 3.15.0
+version = 3.16.0
 description = Collect Analyze and Share Data
 long_description = file: README.rst
 long_description_content_type = text/x-rst


### PR DESCRIPTION
# Release notes: v3.16.0(2023-11-23)

- Add custom template tag: settings_value
  `PR #2510 <https://github.com/onaio/onadata/pull/2510>`
  [@FrankApiyo]
- Enhancement: Handle Statement Timeout in Briefcase Viewset 
  `PR #2508 <https://github.com/onaio/onadata/pull/2508>`
  [@KipSigei]
- Trigger database call to correctly capture OperationalError
  `PR #2513 <https://github.com/onaio/onadata/pull/2513>`
  [@KipSigei]
- Upgrade Django for omitted requirements files
  `PR #2512 <https://github.com/onaio/onadata/pull/2512>`
  [@kelvin-muchiri]

