### PR TITLE
Filter out soft-deleted xforms from project forms endpoint

### DIFF
--- a/onadata/apps/api/tests/viewsets/test_project_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_project_viewset.py
@@ -309,6 +309,25 @@ class TestProjectViewSet(TestAbstractViewSet):
         self.assertEqual(len(response.data.get("forms")), 0)
         self.assertEqual(response.status_code, 200)
 
+    def test_xform_delete_project_forms_endpoint(self):
+        self._publish_xls_form_to_project()
+
+        view = ProjectViewSet.as_view({"get": "forms"})
+        request = self.factory.get("/", **self.extra)
+        response = view(request, pk=self.project.pk)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 1)
+
+        # soft delete form
+        self.xform.soft_delete(user=self.user)
+
+        request = self.factory.get("/", **self.extra)
+        response = view(request, pk=self.project.pk)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 0)
+
     # pylint: disable=invalid-name
     def test_none_empty_forms_and_dataview_properties_in_returned_json(self):
         self._publish_xls_form_to_project()

--- a/onadata/apps/api/viewsets/project_viewset.py
+++ b/onadata/apps/api/viewsets/project_viewset.py
@@ -163,7 +163,7 @@ class ProjectViewSet(
 
             return Response(survey, status=status.HTTP_400_BAD_REQUEST)
 
-        xforms = XForm.objects.filter(project=project)
+        xforms = XForm.objects.filter(project=project, deleted_at__isnull=True)
         serializer = XFormSerializer(xforms, context={"request": request}, many=True)
 
         return Response(serializer.data)


### PR DESCRIPTION
### Changes / Features implemented
- Remove soft-deleted forms from project forms list endpoint

### Steps taken to verify this change does what is intended
- Tests
### Side effects of implementing this change
- The project forms endpoint will only list active forms

**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  - [ ] Updated documentation

Closes #2511 
