### PR TITLE
Tag release v3.17.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,18 @@ Changelog for Onadata
 
 ``* represents releases that introduce new migrations``
 
+v3.17.0(2023-11-24)
+-------------------
+- Create Composite Index for xform_id and id fields 
+`PR #2519 <https://github.com/onaio/onadata/pull/2519>`
+  [@KipSigei]
+- Filter out soft-deleted xforms from project forms endpoint
+  `PR #2515 <https://github.com/onaio/onadata/pull/2515>`
+  [@KipSigei]
+- Check length of paginated instances in briefcase viewset 
+  `PR #2517 <https://github.com/onaio/onadata/pull/2517>`
+  [@KipSigei]
+
 v3.16.0(2023-11-23)
 -------------------
 - Add custom template tag: settings_value

--- a/onadata/__init__.py
+++ b/onadata/__init__.py
@@ -6,7 +6,7 @@ visualization.
 """
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "3.16.0"
+__version__ = "3.17.0"
 
 
 # This will make sure the app is always imported when

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = onadata
-version = 3.16.0
+version = 3.17.0
 description = Collect Analyze and Share Data
 long_description = file: README.rst
 long_description_content_type = text/x-rst


### PR DESCRIPTION
### Changes

Bump version to v3.17.0

### Release Notes
- Filter out soft-deleted xforms from project forms endpoint
  `PR #2515 <https://github.com/onaio/onadata/pull/2515>`
  [@KipSigei]
- Check length of paginated instances in briefcase viewset 
  `PR #2517 <https://github.com/onaio/onadata/pull/2517>`
  [@KipSigei]