### PR TITLE
Fix stale data sent to RapidPro when asynchronous processing of submissions is enabled

### DIFF
--- a/onadata/apps/restservice/services/generic_json.py
+++ b/onadata/apps/restservice/services/generic_json.py
@@ -24,8 +24,8 @@ class ServiceDefinition(RestServiceInterface):
     def send(self, url, data=None):
         """Post submisison JSON data to an external service that accepts a JSON post."""
         if data:
-            # We do instance.get_full_dict() instead of instance.json because
-            # when an instance is processed asynchronously, the json may not be upto date
+            # We use Instance.get_full_dict() instead of Instance.json because
+            # when asynchronous processing is enabled, the json may not be upto date
             post_data = json.dumps(data.get_full_dict())
             headers = {"Content-Type": "application/json"}
             try:

--- a/onadata/apps/restservice/services/generic_json.py
+++ b/onadata/apps/restservice/services/generic_json.py
@@ -24,7 +24,9 @@ class ServiceDefinition(RestServiceInterface):
     def send(self, url, data=None):
         """Post submisison JSON data to an external service that accepts a JSON post."""
         if data:
-            post_data = json.dumps(data.json)
+            # We do instance.get_full_dict() instead of instance.json because
+            # when an instance is processed asynchronously, the json may not be upto date
+            post_data = json.dumps(data.get_full_dict())
             headers = {"Content-Type": "application/json"}
             try:
                 requests.post(

--- a/onadata/apps/restservice/services/textit.py
+++ b/onadata/apps/restservice/services/textit.py
@@ -29,9 +29,8 @@ class ServiceDefinition(RestServiceInterface):
         :param data:
         :return:
         """
-        # We do instance.get_full_dict() instead of instance.json because
-        # when an instance is processed asynchronously, the json may not be
-        # upto date
+        # We use Instance.get_full_dict() instead of Instance.json because
+        # when asynchronous processing is enabled, the json may not be upto date
         extra_data = self.clean_keys_of_slashes(data.get_full_dict())
         data_value = MetaData.textit(data.xform)
 

--- a/onadata/apps/restservice/services/textit.py
+++ b/onadata/apps/restservice/services/textit.py
@@ -29,8 +29,10 @@ class ServiceDefinition(RestServiceInterface):
         :param data:
         :return:
         """
-        extra_data = self.clean_keys_of_slashes(data.json)
-
+        # We do instance.get_full_dict() instead of instance.json because
+        # when an instance is processed asynchronously, the json may not be
+        # upto date
+        extra_data = self.clean_keys_of_slashes(data.get_full_dict())
         data_value = MetaData.textit(data.xform)
 
         if data_value:


### PR DESCRIPTION
### Changes / Features implemented

Use `Instance.get_full_dict()` to when sending data to RapidPro instead of `Instance.json`. `Instance.json` may not be upto date when asynchronous processing of submissions is enabled by the time the call to RapidPro is made

### Steps taken to verify this change does what is intended

- [x] QA

### Side effects of implementing this change

No side effects

**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  - [ ] Updated documentation

Closes #2521 
