### PR TITLE
Tag release v3.17.1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,15 @@ Changelog for Onadata
 
 ``* represents releases that introduce new migrations``
 
+v3.17.1(2023-12-11)
+-------------------
+- Enable TokenAuthentication on briefcase viewset
+  `PR #2523 <https://github.com/onaio/onadata/pull/2523>`
+  [@KipSigei]
+- Fix stale data sent to RapidPro when asynchronous processing of submissions is enabled
+  `PR #2522 <https://github.com/onaio/onadata/pull/2522>`
+  [@kelvin-muchiri]
+
 v3.17.0(2023-11-24)
 -------------------
 - Create Composite Index for xform_id and id fields 

--- a/onadata/__init__.py
+++ b/onadata/__init__.py
@@ -6,7 +6,7 @@ visualization.
 """
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "3.17.0"
+__version__ = "3.17.1"
 
 
 # This will make sure the app is always imported when

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = onadata
-version = 3.17.0
+version = 3.17.1
 description = Collect Analyze and Share Data
 long_description = file: README.rst
 long_description_content_type = text/x-rst


### PR DESCRIPTION
### Changes

Bump version to v3.17.1

### Release Notes
- Enable TokenAuthentication on briefcase viewset
  `PR #2523 <https://github.com/onaio/onadata/pull/2523>`
  [@KipSigei]
- Fix stale data sent to RapidPro when asynchronous processing of submissions is enabled
  `PR #2522 <https://github.com/onaio/onadata/pull/2522>`
  [@kelvin-muchiri]