### PR TITLE
Tag release v3.17.2

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,18 @@ Changelog for Onadata
 
 ``* represents releases that introduce new migrations``
 
+v3.17.2(2023-12-18)
+-------------------
+- Security Updates
+  `PR #2529 <https://github.com/onaio/onadata/pull/2529>`
+  [@KipSigei]
+- Enable Token Authentication on Form List API
+  `PR #2525 <https://github.com/onaio/onadata/pull/2525>`
+  [@KipSigei]
+- Set AWS credentials when generating pre-signed URLS
+  `PR #2527 <https://github.com/onaio/onadata/pull/2527>`
+  [@ukanga]
+
 v3.17.1(2023-12-11)
 -------------------
 - Enable TokenAuthentication on briefcase viewset

--- a/onadata/__init__.py
+++ b/onadata/__init__.py
@@ -6,7 +6,7 @@ visualization.
 """
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "3.17.1"
+__version__ = "3.17.2"
 
 
 # This will make sure the app is always imported when

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = onadata
-version = 3.17.1
+version = 3.17.2
 description = Collect Analyze and Share Data
 long_description = file: README.rst
 long_description_content_type = text/x-rst


### PR DESCRIPTION
### Changes

Bump version to v3.17.2

### Release Notes
- Security Updates
  `PR #2529 <https://github.com/onaio/onadata/pull/2529>`
  [@KipSigei]
- Enable Token Authentication on Form List API
  `PR #2525 <https://github.com/onaio/onadata/pull/2525>`
  [@KipSigei]
- Set AWS credentials when generating pre-signed URLS
  `PR #2527 <https://github.com/onaio/onadata/pull/2527>`
  [@ukanga]
