### PR TITLE
Explicitly set AWS_S3_ENDPOINT_URL in boto3 configs

### DIFF
--- a/onadata/libs/utils/image_tools.py
+++ b/onadata/libs/utils/image_tools.py
@@ -79,6 +79,7 @@ def generate_aws_media_url(
     """Generate S3 URL."""
     s3_class = get_storage_class("storages.backends.s3boto3.S3Boto3Storage")()
     bucket_name = s3_class.bucket.name
+    aws_endpoint_url = getattr(settings, "AWS_S3_ENDPOINT_URL", "")
     s3_config = Config(
         signature_version=getattr(settings, "AWS_S3_SIGNATURE_VERSION", "s3v4"),
         region_name=getattr(settings, "AWS_S3_REGION_NAME", ""),
@@ -86,6 +87,7 @@ def generate_aws_media_url(
     s3_client = boto3.client(
         "s3",
         config=s3_config,
+        endpoint_url=aws_endpoint_url,
         aws_access_key_id=s3_class.access_key,
         aws_secret_access_key=s3_class.secret_key,
     )


### PR DESCRIPTION
### Changes / Features implemented
- Ensure to explicitly set AWS_S3_ENDPOINT_URL  in boto3 config when defined in settings

### Steps taken to verify this change does what is intended

### Side effects of implementing this change


**Before submitting this PR for review, please make sure you have:**

  - [ ] Included tests
  - [ ] Updated documentation

Closes #
