### PR TITLE
Tag release v3.17.3

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,12 @@ Changelog for Onadata
 
 ``* represents releases that introduce new migrations``
 
+v3.17.3(2024-01-15)
+-------------------
+- Explicitly set AWS_S3_ENDPOINT_URL in boto3 configs
+  `PR #2540 <https://github.com/onaio/onadata/pull/2540>`
+  [@KipSigei]
+
 v3.17.2(2023-12-18)
 -------------------
 - Security Updates

--- a/onadata/__init__.py
+++ b/onadata/__init__.py
@@ -6,7 +6,7 @@ visualization.
 """
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "3.17.2"
+__version__ = "3.17.3"
 
 
 # This will make sure the app is always imported when

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = onadata
-version = 3.17.2
+version = 3.17.3
 description = Collect Analyze and Share Data
 long_description = file: README.rst
 long_description_content_type = text/x-rst


### PR DESCRIPTION
### Changes

Bump version to v3.17.3

### Release Notes
- Explicitly set AWS_S3_ENDPOINT_URL in boto3 configs
  `PR #2540 <https://github.com/onaio/onadata/pull/2540>`
  [@KipSigei]