### PR TITLE
Fix SQL syntax error when grouping by select one

### DIFF
--- a/onadata/apps/api/tests/viewsets/test_charts_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_charts_viewset.py
@@ -524,3 +524,35 @@ class TestChartsViewSet(TestBase):
         )
         self.assertEqual(response.status_code, 200)
         self.assertNotEqual(response.data, initial_data)
+
+    def test_charts_group_by_select_one(self):
+        """
+        Test that the chart endpoint works correctly
+        when grouping with select one field
+        """
+        data = {"field_name": "gender", "group_by": "pizza_fan"}
+        request = self.factory.get("/charts", data)
+        force_authenticate(request, user=self.user)
+        initial_data = {
+            "data": [
+                {"gender": ["Male"], "items": [{"pizza_fan": ["No"], "count": 1}]},
+                {
+                    "gender": ["Female"],
+                    "items": [
+                        {"pizza_fan": ["No"], "count": 1},
+                        {"pizza_fan": ["Yes"], "count": 1},
+                    ],
+                },
+            ],
+            "data_type": "categorized",
+            "field_label": "Gender",
+            "field_xpath": "gender",
+            "field_name": "gender",
+            "field_type": "select one",
+            "grouped_by": "pizza_fan",
+            "xform": self.xform.pk,
+        }
+
+        response = self.view(request, pk=self.xform.id)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data, initial_data)

--- a/onadata/libs/data/query.py
+++ b/onadata/libs/data/query.py
@@ -80,7 +80,7 @@ def _postgres_count_group_field_n_group_by(field, name, xform, group_by, data_vi
         "count(*) as count "
         "FROM %(table)s WHERE "
         + restricted_string
-        + "AND deleted_at IS NULL "
+        + " AND deleted_at IS NULL "
         + additional_filters
         + " GROUP BY %(json)s, %(group_by)s"
         + " ORDER BY %(json)s, %(group_by)s"


### PR DESCRIPTION
### Changes / Features implemented
- Fix SQL syntax error when grouping by select one on charts endpoint

### Steps taken to verify this change does what is intended
- Tests
### Side effects of implementing this change

**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  - [ ] Updated documentation

Closes #2543 
