### PR TITLE
Tag release v3.18.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,15 @@ Changelog for Onadata
 
 ``* represents releases that introduce new migrations``
 
+v3.17.4(2024-02-05)
+-------------------
+- Fix SQL syntax error when grouping by select one
+  `PR #2549 <https://github.com/onaio/onadata/pull/2549>`
+  [@KipSigei]
+- Process Instance metadata from light tasks synchronously
+  `PR #2547 <https://github.com/onaio/onadata/pull/2547>`
+  [@kelvin-muchiri]
+
 v3.17.3(2024-01-15)
 -------------------
 - Explicitly set AWS_S3_ENDPOINT_URL in boto3 configs

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,7 @@ Changelog for Onadata
 
 ``* represents releases that introduce new migrations``
 
-v3.17.4(2024-02-05)
+v3.18.0(2024-02-05)
 -------------------
 - Fix SQL syntax error when grouping by select one
   `PR #2549 <https://github.com/onaio/onadata/pull/2549>`

--- a/onadata/__init__.py
+++ b/onadata/__init__.py
@@ -6,7 +6,7 @@ visualization.
 """
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "3.17.3"
+__version__ = "3.17.4"
 
 
 # This will make sure the app is always imported when

--- a/onadata/__init__.py
+++ b/onadata/__init__.py
@@ -6,7 +6,7 @@ visualization.
 """
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "3.17.4"
+__version__ = "3.18.0"
 
 
 # This will make sure the app is always imported when

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = onadata
-version = 3.17.4
+version = 3.18.0
 description = Collect Analyze and Share Data
 long_description = file: README.rst
 long_description_content_type = text/x-rst

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = onadata
-version = 3.17.3
+version = 3.17.4
 description = Collect Analyze and Share Data
 long_description = file: README.rst
 long_description_content_type = text/x-rst


### PR DESCRIPTION
### Changes

Bump version to 3.18.0

### Release Notes

- https://github.com/onaio/onadata/pull/2549
  [@KipSigei]

- https://github.com/onaio/onadata/pull/2547
[@kelvin-muchiri]
