### PR TITLE
Fix bug invalid endpoint when fetching media files

### DIFF
--- a/onadata/libs/utils/image_tools.py
+++ b/onadata/libs/utils/image_tools.py
@@ -82,7 +82,7 @@ def generate_aws_media_url(
     aws_endpoint_url = getattr(settings, "AWS_S3_ENDPOINT_URL", None)
     s3_config = Config(
         signature_version=getattr(settings, "AWS_S3_SIGNATURE_VERSION", "s3v4"),
-        region_name=getattr(settings, "AWS_S3_REGION_NAME", ""),
+        region_name=getattr(settings, "AWS_S3_REGION_NAME", None),
     )
     s3_client = boto3.client(
         "s3",

--- a/onadata/libs/utils/image_tools.py
+++ b/onadata/libs/utils/image_tools.py
@@ -90,7 +90,6 @@ def generate_aws_media_url(
         endpoint_url=aws_endpoint_url,
         aws_access_key_id=s3_class.access_key,
         aws_secret_access_key=s3_class.secret_key,
-        region_name=s3_class.region_name,
     )
 
     # Generate a presigned URL for the S3 object

--- a/onadata/libs/utils/image_tools.py
+++ b/onadata/libs/utils/image_tools.py
@@ -79,6 +79,7 @@ def generate_aws_media_url(
     """Generate S3 URL."""
     s3_class = get_storage_class("storages.backends.s3boto3.S3Boto3Storage")()
     bucket_name = s3_class.bucket.name
+    aws_endpoint_url = getattr(settings, "AWS_S3_ENDPOINT_URL", None)
     s3_config = Config(
         signature_version=getattr(settings, "AWS_S3_SIGNATURE_VERSION", "s3v4"),
         region_name=getattr(settings, "AWS_S3_REGION_NAME", ""),
@@ -86,6 +87,7 @@ def generate_aws_media_url(
     s3_client = boto3.client(
         "s3",
         config=s3_config,
+        endpoint_url=aws_endpoint_url,
         aws_access_key_id=s3_class.access_key,
         aws_secret_access_key=s3_class.secret_key,
         region_name=s3_class.region_name,

--- a/onadata/libs/utils/image_tools.py
+++ b/onadata/libs/utils/image_tools.py
@@ -90,6 +90,7 @@ def generate_aws_media_url(
         endpoint_url=aws_endpoint_url,
         aws_access_key_id=s3_class.access_key,
         aws_secret_access_key=s3_class.secret_key,
+        region_name=s3_class.region_name,
     )
 
     # Generate a presigned URL for the S3 object

--- a/onadata/libs/utils/image_tools.py
+++ b/onadata/libs/utils/image_tools.py
@@ -79,7 +79,6 @@ def generate_aws_media_url(
     """Generate S3 URL."""
     s3_class = get_storage_class("storages.backends.s3boto3.S3Boto3Storage")()
     bucket_name = s3_class.bucket.name
-    aws_endpoint_url = getattr(settings, "AWS_S3_ENDPOINT_URL", "")
     s3_config = Config(
         signature_version=getattr(settings, "AWS_S3_SIGNATURE_VERSION", "s3v4"),
         region_name=getattr(settings, "AWS_S3_REGION_NAME", ""),
@@ -87,7 +86,6 @@ def generate_aws_media_url(
     s3_client = boto3.client(
         "s3",
         config=s3_config,
-        endpoint_url=aws_endpoint_url,
         aws_access_key_id=s3_class.access_key,
         aws_secret_access_key=s3_class.secret_key,
         region_name=s3_class.region_name,


### PR DESCRIPTION
### Changes / Features implemented

Fix error `Invalid endpoint` when fetching media files by setting boto3 `AWS_S3_ENDPOINT_URL` to default to `None` instead of an empty string. When an empty string is passed as the value, it is considered a valid value by the package's implementation

### Steps taken to verify this change does what is intended

- [ ] QA

### Side effects of implementing this change


**Before submitting this PR for review, please make sure you have:**

  - [ ] Included tests
  - [ ] Updated documentation

Closes #
