### PR TITLE
Bump version to v3.18.1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,11 @@ Changelog for Onadata
 
 ``* represents releases that introduce new migrations``
 
+v3.18.1(2024-02-21)
+- Fix bug invalid endpoint when fetching media files
+  `PR #2551 <https://github.com/onaio/onadata/pull/2551>`
+  [@kelvin-muchiri]
+
 v3.18.0(2024-02-05)
 -------------------
 - Fix SQL syntax error when grouping by select one

--- a/onadata/__init__.py
+++ b/onadata/__init__.py
@@ -6,7 +6,7 @@ visualization.
 """
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "3.18.0"
+__version__ = "3.18.1"
 
 
 # This will make sure the app is always imported when

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = onadata
-version = 3.18.0
+version = 3.18.1
 description = Collect Analyze and Share Data
 long_description = file: README.rst
 long_description_content_type = text/x-rst


### PR DESCRIPTION
### Changes

Bump version to v3.18.1

### Release notes

**Bug fixes**

- https://github.com/onaio/onadata/pull/2551
