### PR TITLE
Ignore child questions of grouped sections within repeating sections during CSV export

### DIFF
--- a/onadata/apps/api/tests/viewsets/test_charts_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_charts_viewset.py
@@ -55,53 +55,79 @@ class TestChartsViewSet(TestBase):
         self._publish_xls_file_and_set_xform(
             os.path.join(
                 os.path.dirname(__file__),
-                '..', 'fixtures', 'forms', 'tutorial', 'tutorial.xlsx'))
+                "..",
+                "fixtures",
+                "forms",
+                "tutorial",
+                "tutorial.xlsx",
+            )
+        )
         self.api_client = APIClient()
         self.api_client.login(
-            username=self.login_username, password=self.login_password)
-        self.view = ChartsViewSet.as_view({
-            'get': 'retrieve'
-        })
+            username=self.login_username, password=self.login_password
+        )
+        self.view = ChartsViewSet.as_view({"get": "retrieve"})
         self.factory = APIRequestFactory()
         self._make_submission(
             os.path.join(
-                os.path.dirname(__file__), '..', 'fixtures', 'forms',
-                'tutorial', 'instances', '1.xml'))
+                os.path.dirname(__file__),
+                "..",
+                "fixtures",
+                "forms",
+                "tutorial",
+                "instances",
+                "1.xml",
+            )
+        )
         self._make_submission(
             os.path.join(
-                os.path.dirname(__file__), '..', 'fixtures', 'forms',
-                'tutorial', 'instances', '2.xml'))
+                os.path.dirname(__file__),
+                "..",
+                "fixtures",
+                "forms",
+                "tutorial",
+                "instances",
+                "2.xml",
+            )
+        )
         self._make_submission(
             os.path.join(
-                os.path.dirname(__file__), '..', 'fixtures', 'forms',
-                'tutorial', 'instances', '3.xml'))
+                os.path.dirname(__file__),
+                "..",
+                "fixtures",
+                "forms",
+                "tutorial",
+                "instances",
+                "3.xml",
+            )
+        )
 
     def test_correct_merged_dataset_data_for_charts(self):
         """Return correct data from the charts endpoint"""
-        view = MergedXFormViewSet.as_view({
-            'post': 'create',
-        })
+        view = MergedXFormViewSet.as_view(
+            {
+                "post": "create",
+            }
+        )
         # pylint: disable=attribute-defined-outside-init
         self.project = get_user_default_project(self.user)
-        xform_a = self._publish_markdown(MD, self.user, id_string='a')
-        xform_b = self._publish_markdown(MD2, self.user, id_string='b')
+        xform_a = self._publish_markdown(MD, self.user, id_string="a")
+        xform_b = self._publish_markdown(MD2, self.user, id_string="b")
 
         data = {
-            'xforms': [
+            "xforms": [
                 "http://testserver/api/v1/forms/%s" % xform_a.pk,
                 "http://testserver/api/v1/forms/%s" % xform_b.pk,
             ],
-            'name':
-            'Merged Dataset',
-            'project':
-            f"http://testserver/api/v1/projects/{self.project.pk}",
+            "name": "Merged Dataset",
+            "project": f"http://testserver/api/v1/projects/{self.project.pk}",
         }
         # anonymous user
-        request = self.factory.post('/', data=data)
+        request = self.factory.post("/", data=data)
         response = view(request)
         self.assertEqual(response.status_code, 401)
 
-        request = self.factory.post('/', data=data)
+        request = self.factory.post("/", data=data)
         force_authenticate(request, user=self.user)
         response = view(request)
         self.assertEqual(response.status_code, 201)
@@ -114,19 +140,17 @@ class TestChartsViewSet(TestBase):
         xml = '<data id="b"><fruits>apple cherries</fruits></data>'
         Instance(xform=xform_b, xml=xml).save()
 
-        data = {'field_xpath': 'fruits'}
-        request = self.factory.get('/charts', data=data)
+        data = {"field_xpath": "fruits"}
+        request = self.factory.get("/charts", data=data)
         force_authenticate(request, user=self.user)
-        response = self.view(
-            request,
-            pk=response.data['id']
-        )
+        response = self.view(request, pk=response.data["id"])
         self.assertEqual(response.status_code, 200)
         # check that the data is correct
-        expected_data = [{'fruits': ['Apple', 'Cherries'], 'count': 1},
-                         {'fruits': ['Orange', 'Mango'], 'count': 1}]
-        self.assertEqual(response.data['data'],
-                         expected_data)
+        expected_data = [
+            {"fruits": ["Apple", "Cherries"], "count": 1},
+            {"fruits": ["Orange", "Mango"], "count": 1},
+        ]
+        self.assertEqual(response.data["data"], expected_data)
         # Ensure response is renderable
         response.render()
         cache.clear()
@@ -135,223 +159,191 @@ class TestChartsViewSet(TestBase):
         # the instance below has valid start and end times
         instance = Instance.objects.all()[0]
         _dict = instance.parsed_instance.to_dict_for_mongo()
-        self.assertIn('_duration', list(_dict))
-        self.assertEqual(_dict.get('_duration'), 24.0)
-        self.assertNotEqual(_dict.get('_duration'), None)
+        self.assertIn("_duration", list(_dict))
+        self.assertEqual(_dict.get("_duration"), 24.0)
+        self.assertNotEqual(_dict.get("_duration"), None)
 
         _dict = instance.json
-        duration = calculate_duration(_dict.get('start_time'), 'invalid')
-        self.assertIn('_duration', list(_dict))
-        self.assertEqual(duration, '')
+        duration = calculate_duration(_dict.get("start_time"), "invalid")
+        self.assertIn("_duration", list(_dict))
+        self.assertEqual(duration, "")
         self.assertNotEqual(duration, None)
 
     def test_get_on_categorized_field(self):
-        data = {'field_name': 'gender'}
-        request = self.factory.get('/charts', data)
+        data = {"field_name": "gender"}
+        request = self.factory.get("/charts", data)
         force_authenticate(request, user=self.user)
-        response = self.view(
-            request,
-            pk=self.xform.id,
-            format='html'
-        )
+        response = self.view(request, pk=self.xform.id, format="html")
         self.assertEqual(response.status_code, 200)
-        self.assertNotEqual(response.get('Cache-Control'), None)
-        self.assertEqual(response.data['field_type'], 'select one')
-        self.assertEqual(response.data['field_name'], 'gender')
-        self.assertEqual(response.data['data_type'], 'categorized')
-        self.assertEqual(response.data['data'][0]['gender'], 'Male')
-        self.assertEqual(response.data['data'][1]['gender'], 'Female')
+        self.assertNotEqual(response.get("Cache-Control"), None)
+        self.assertEqual(response.data["field_type"], "select one")
+        self.assertEqual(response.data["field_name"], "gender")
+        self.assertEqual(response.data["data_type"], "categorized")
+        self.assertEqual(response.data["data"][0]["gender"], "Male")
+        self.assertEqual(response.data["data"][1]["gender"], "Female")
 
     def test_get_on_date_field(self):
-        data = {'field_name': 'date'}
-        request = self.factory.get('/charts', data)
+        data = {"field_name": "date"}
+        request = self.factory.get("/charts", data)
         force_authenticate(request, user=self.user)
-        response = self.view(
-            request,
-            pk=self.xform.id)
+        response = self.view(request, pk=self.xform.id)
         self.assertEqual(response.status_code, 200)
-        self.assertNotEqual(response.get('Cache-Control'), None)
-        self.assertEqual(response.data['field_type'], 'date')
-        self.assertEqual(response.data['field_name'], 'date')
-        self.assertEqual(response.data['data_type'], 'time_based')
+        self.assertNotEqual(response.get("Cache-Control"), None)
+        self.assertEqual(response.data["field_type"], "date")
+        self.assertEqual(response.data["field_name"], "date")
+        self.assertEqual(response.data["data_type"], "time_based")
 
-    @mock.patch('onadata.libs.data.query._execute_query',
-                side_effect=raise_data_error)
+    @mock.patch("onadata.libs.data.query._execute_query", side_effect=raise_data_error)
     def test_get_on_date_field_with_invalid_data(self, mock_execute_query):
-        data = {'field_name': 'date'}
-        request = self.factory.get('/charts', data)
+        data = {"field_name": "date"}
+        request = self.factory.get("/charts", data)
         force_authenticate(request, user=self.user)
-        response = self.view(
-            request,
-            pk=self.xform.id)
+        response = self.view(request, pk=self.xform.id)
         self.assertEqual(response.status_code, 400)
 
     def test_get_on_numeric_field(self):
-        data = {'field_name': 'age'}
-        request = self.factory.get('/charts', data)
+        data = {"field_name": "age"}
+        request = self.factory.get("/charts", data)
         force_authenticate(request, user=self.user)
-        response = self.view(
-            request,
-            pk=self.xform.id
-        )
+        response = self.view(request, pk=self.xform.id)
         self.assertEqual(response.status_code, 200)
-        self.assertNotEqual(response.get('Cache-Control'), None)
-        self.assertEqual(response.data['field_type'], 'integer')
-        self.assertEqual(response.data['field_name'], 'age')
-        self.assertEqual(response.data['data_type'], 'numeric')
+        self.assertNotEqual(response.get("Cache-Control"), None)
+        self.assertEqual(response.data["field_type"], "integer")
+        self.assertEqual(response.data["field_name"], "age")
+        self.assertEqual(response.data["data_type"], "numeric")
 
     def test_get_on_select_field(self):
-        data = {'field_name': 'gender'}
-        request = self.factory.get('/charts', data)
+        data = {"field_name": "gender"}
+        request = self.factory.get("/charts", data)
         force_authenticate(request, user=self.user)
-        response = self.view(
-            request,
-            pk=self.xform.id
-        )
+        response = self.view(request, pk=self.xform.id)
         self.assertEqual(response.status_code, 200)
-        self.assertNotEqual(response.get('Cache-Control'), None)
-        self.assertEqual(response.data['field_type'], 'select one')
-        self.assertEqual(response.data['field_name'], 'gender')
-        self.assertEqual(response.data['data_type'], 'categorized')
+        self.assertNotEqual(response.get("Cache-Control"), None)
+        self.assertEqual(response.data["field_type"], "select one")
+        self.assertEqual(response.data["field_name"], "gender")
+        self.assertEqual(response.data["data_type"], "categorized")
 
     def test_get_on_select_field_xpath(self):
-        data = {'field_xpath': 'gender'}
-        request = self.factory.get('/charts', data)
+        data = {"field_xpath": "gender"}
+        request = self.factory.get("/charts", data)
         force_authenticate(request, user=self.user)
-        response = self.view(
-            request,
-            pk=self.xform.id
-        )
+        response = self.view(request, pk=self.xform.id)
 
         self.assertEqual(response.status_code, 200)
-        self.assertNotEqual(response.get('Cache-Control'), None)
-        self.assertEqual(response.data['field_type'], 'select one')
-        self.assertEqual(response.data['field_name'], 'gender')
-        self.assertEqual(response.data['data_type'], 'categorized')
+        self.assertNotEqual(response.get("Cache-Control"), None)
+        self.assertEqual(response.data["field_type"], "select one")
+        self.assertEqual(response.data["field_name"], "gender")
+        self.assertEqual(response.data["data_type"], "categorized")
 
     def test_get_on_select_multi_field(self):
-        field_name = 'favorite_toppings'
-        data = {'field_name': field_name}
-        request = self.factory.get('/charts', data)
+        field_name = "favorite_toppings"
+        data = {"field_name": field_name}
+        request = self.factory.get("/charts", data)
         force_authenticate(request, user=self.user)
-        response = self.view(
-            request,
-            pk=self.xform.id
-        )
+        response = self.view(request, pk=self.xform.id)
         self.assertEqual(response.status_code, 200)
-        self.assertNotEqual(response.get('Cache-Control'), None)
-        self.assertEqual(response.data['field_type'], 'select all that apply')
-        self.assertEqual(response.data['field_name'], field_name)
-        self.assertEqual(response.data['data_type'], 'categorized')
+        self.assertNotEqual(response.get("Cache-Control"), None)
+        self.assertEqual(response.data["field_type"], "select all that apply")
+        self.assertEqual(response.data["field_name"], field_name)
+        self.assertEqual(response.data["data_type"], "categorized")
 
-        options = response.data['data'][0][field_name]
-        self.assertEqual(options, ['Green Peppers', 'Pepperoni'])
+        options = response.data["data"][0][field_name]
+        self.assertEqual(options, ["Green Peppers", "Pepperoni"])
 
     def test_get_on_select_multi_field_html_format(self):
-        field_name = 'favorite_toppings'
-        data = {'field_name': field_name}
-        request = self.factory.get('/charts', data)
+        field_name = "favorite_toppings"
+        data = {"field_name": field_name}
+        request = self.factory.get("/charts", data)
         force_authenticate(request, user=self.user)
-        response = self.view(
-            request,
-            pk=self.xform.id,
-            format='html'
-        )
+        response = self.view(request, pk=self.xform.id, format="html")
         self.assertEqual(response.status_code, 200)
-        self.assertNotEqual(response.get('Cache-Control'), None)
-        self.assertEqual(response.data['field_type'], 'select all that apply')
-        self.assertEqual(response.data['field_name'], field_name)
-        self.assertEqual(response.data['data_type'], 'categorized')
+        self.assertNotEqual(response.get("Cache-Control"), None)
+        self.assertEqual(response.data["field_type"], "select all that apply")
+        self.assertEqual(response.data["field_name"], field_name)
+        self.assertEqual(response.data["data_type"], "categorized")
 
-        options = response.data['data'][0][field_name]
-        self.assertEqual(options, 'Green Peppers, Pepperoni')
+        options = response.data["data"][0][field_name]
+        self.assertEqual(options, "Green Peppers, Pepperoni")
 
     def test_get_all_fields(self):
-        data = {'fields': 'all'}
-        request = self.factory.get('/', data)
+        data = {"fields": "all"}
+        request = self.factory.get("/", data)
         force_authenticate(request, user=self.user)
-        response = self.view(
-            request,
-            pk=self.xform.id
-        )
+        response = self.view(request, pk=self.xform.id)
         self.assertEqual(response.status_code, 200)
-        self.assertNotEqual(response.get('Cache-Control'), None)
-        self.assertIn('age', response.data)
-        self.assertIn('date', response.data)
-        self.assertIn('gender', response.data)
-        self.assertEqual(response.data['age']['field_type'], 'integer')
-        self.assertEqual(response.data['age']['field_name'], 'age')
-        self.assertEqual(response.data['age']['data_type'], 'numeric')
+        self.assertNotEqual(response.get("Cache-Control"), None)
+        self.assertIn("age", response.data)
+        self.assertIn("date", response.data)
+        self.assertIn("gender", response.data)
+        self.assertEqual(response.data["age"]["field_type"], "integer")
+        self.assertEqual(response.data["age"]["field_name"], "age")
+        self.assertEqual(response.data["age"]["data_type"], "numeric")
 
     def test_get_specific_fields(self):
-        data = {'fields': 'date,age'}
-        request = self.factory.get('/', data)
+        data = {"fields": "date,age"}
+        request = self.factory.get("/", data)
         force_authenticate(request, user=self.user)
-        response = self.view(
-            request,
-            pk=self.xform.id
-        )
+        response = self.view(request, pk=self.xform.id)
         self.assertEqual(response.status_code, 200)
-        self.assertNotEqual(response.get('Cache-Control'), None)
+        self.assertNotEqual(response.get("Cache-Control"), None)
 
-        self.assertNotIn('gender', response.data)
+        self.assertNotIn("gender", response.data)
 
-        self.assertIn('age', response.data)
-        data = response.data['age']
-        self.assertEqual(data['field_type'], 'integer')
-        self.assertEqual(data['field_name'], 'age')
-        self.assertEqual(data['data_type'], 'numeric')
+        self.assertIn("age", response.data)
+        data = response.data["age"]
+        self.assertEqual(data["field_type"], "integer")
+        self.assertEqual(data["field_name"], "age")
+        self.assertEqual(data["data_type"], "numeric")
 
-        self.assertIn('date', response.data)
-        data = response.data['date']
-        self.assertEqual(data['field_type'], 'date')
-        self.assertEqual(data['field_name'], 'date')
-        self.assertEqual(data['data_type'], 'time_based')
+        self.assertIn("date", response.data)
+        data = response.data["date"]
+        self.assertEqual(data["field_type"], "date")
+        self.assertEqual(data["field_name"], "date")
+        self.assertEqual(data["data_type"], "time_based")
 
     def test_get_invalid_field_name(self):
-        data = {'fields': 'invalid_field_name'}
-        request = self.factory.get('/', data)
+        data = {"fields": "invalid_field_name"}
+        request = self.factory.get("/", data)
         force_authenticate(request, user=self.user)
-        response = self.view(
-            request,
-            pk=self.xform.id
-        )
+        response = self.view(request, pk=self.xform.id)
         self.assertEqual(response.status_code, 404)
 
     def test_chart_list(self):
-        self.view = ChartsViewSet.as_view({
-            'get': 'list'
-        })
-        request = self.factory.get('/charts')
+        self.view = ChartsViewSet.as_view({"get": "list"})
+        request = self.factory.get("/charts")
         force_authenticate(request, user=self.user)
         response = self.view(request)
-        self.assertNotEqual(response.get('Cache-Control'), None)
+        self.assertNotEqual(response.get("Cache-Control"), None)
         self.assertEqual(response.status_code, 200)
-        data = {'id': self.xform.pk, 'id_string': self.xform.id_string,
-                'url': 'http://testserver/api/v1/charts/%s' % self.xform.pk}
+        data = {
+            "id": self.xform.pk,
+            "id_string": self.xform.id_string,
+            "url": "http://testserver/api/v1/charts/%s" % self.xform.pk,
+        }
         self.assertEqual(response.data, [data])
 
-        request = self.factory.get('/charts')
+        request = self.factory.get("/charts")
         response = self.view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data, [])
 
     def test_chart_list_with_xform_in_delete_async(self):
-        self.view = ChartsViewSet.as_view({
-            'get': 'list'
-        })
-        request = self.factory.get('/charts')
+        self.view = ChartsViewSet.as_view({"get": "list"})
+        request = self.factory.get("/charts")
         force_authenticate(request, user=self.user)
         response = self.view(request)
-        self.assertNotEqual(response.get('Cache-Control'), None)
+        self.assertNotEqual(response.get("Cache-Control"), None)
         self.assertEqual(response.status_code, 200)
-        data = {'id': self.xform.pk, 'id_string': self.xform.id_string,
-                'url': 'http://testserver/api/v1/charts/%s' % self.xform.pk}
+        data = {
+            "id": self.xform.pk,
+            "id_string": self.xform.id_string,
+            "url": "http://testserver/api/v1/charts/%s" % self.xform.pk,
+        }
         self.assertEqual(response.data, [data])
 
         self.xform.deleted_at = timezone.now()
         self.xform.save()
-        request = self.factory.get('/charts')
+        request = self.factory.get("/charts")
         force_authenticate(request, user=self.user)
         response = self.view(request)
         self.assertEqual(response.status_code, 200)
@@ -362,132 +354,142 @@ class TestChartsViewSet(TestBase):
         self._publish_xls_file_and_set_xform(
             os.path.join(
                 os.path.dirname(__file__),
-                '..', 'fixtures', 'forms', 'cascading', 'cascading.xlsx'))
-
-        self._make_submission(
-            os.path.join(
-                os.path.dirname(__file__), '..', 'fixtures', 'forms',
-                'cascading', 'instances', '1.xml'))
-        self._make_submission(
-            os.path.join(
-                os.path.dirname(__file__), '..', 'fixtures', 'forms',
-                'cascading', 'instances', '2.xml'))
-        self._make_submission(
-            os.path.join(
-                os.path.dirname(__file__), '..', 'fixtures', 'forms',
-                'cascading', 'instances', '3.xml'))
-        self._make_submission(
-            os.path.join(
-                os.path.dirname(__file__), '..', 'fixtures', 'forms',
-                'cascading', 'instances', '4.xml'))
-
-        data = {'field_name': 'cities'}
-        request = self.factory.get('/charts', data)
-        force_authenticate(request, user=self.user)
-        response = self.view(
-            request,
-            pk=self.xform.id,
-            format='json'
+                "..",
+                "fixtures",
+                "forms",
+                "cascading",
+                "cascading.xlsx",
+            )
         )
+
+        self._make_submission(
+            os.path.join(
+                os.path.dirname(__file__),
+                "..",
+                "fixtures",
+                "forms",
+                "cascading",
+                "instances",
+                "1.xml",
+            )
+        )
+        self._make_submission(
+            os.path.join(
+                os.path.dirname(__file__),
+                "..",
+                "fixtures",
+                "forms",
+                "cascading",
+                "instances",
+                "2.xml",
+            )
+        )
+        self._make_submission(
+            os.path.join(
+                os.path.dirname(__file__),
+                "..",
+                "fixtures",
+                "forms",
+                "cascading",
+                "instances",
+                "3.xml",
+            )
+        )
+        self._make_submission(
+            os.path.join(
+                os.path.dirname(__file__),
+                "..",
+                "fixtures",
+                "forms",
+                "cascading",
+                "instances",
+                "4.xml",
+            )
+        )
+
+        data = {"field_name": "cities"}
+        request = self.factory.get("/charts", data)
+        force_authenticate(request, user=self.user)
+        response = self.view(request, pk=self.xform.id, format="json")
 
         self.assertEqual(response.status_code, 200)
         self.assertTrue(response.data)
         expected = [
-            {'cities': [u'Nice'], 'count': 1},
-            {'cities': [u'Seoul'], 'count': 1},
-            {'cities': [u'Cape Town'], 'count': 2}
+            {"cities": ["Nice"], "count": 1},
+            {"cities": ["Seoul"], "count": 1},
+            {"cities": ["Cape Town"], "count": 2},
         ]
-        self.assertEqual(expected, response.data['data'])
+        self.assertEqual(expected, response.data["data"])
 
     @override_settings(XFORM_CHARTS_CACHE_TIME=0)
     def test_deleted_submission_not_in_chart_endpoint(self):
-        data = {'field_name': 'gender'}
-        request = self.factory.get('/charts', data)
+        data = {"field_name": "gender"}
+        request = self.factory.get("/charts", data)
         force_authenticate(request, user=self.user)
-        response = self.view(
-            request,
-            pk=self.xform.id,
-            format='html'
-        )
+        response = self.view(request, pk=self.xform.id, format="html")
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(sum([i['count'] for i in response.data['data']]), 3)
+        self.assertEqual(sum([i["count"] for i in response.data["data"]]), 3)
 
         # soft delete one instance
 
         inst = self.xform.instances.all()[0]
         inst.set_deleted(timezone.now())
 
-        response = self.view(
-            request,
-            pk=self.xform.id,
-            format='html'
-        )
+        response = self.view(request, pk=self.xform.id, format="html")
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(sum([i['count'] for i in response.data['data']]), 2)
+        self.assertEqual(sum([i["count"] for i in response.data["data"]]), 2)
 
     def test_nan_not_json_response(self):
         self._make_submission(
             os.path.join(
-                os.path.dirname(__file__), '..', 'fixtures', 'forms',
-                'tutorial', 'instances', 'nan_net_worth.xml'))
-
-        data = {'field_name': 'networth_calc',
-                'group_by': 'pizza_fan'}
-        request = self.factory.get('/charts', data)
-        force_authenticate(request, user=self.user)
-        response = self.view(
-            request,
-            pk=self.xform.id,
-            format='json'
+                os.path.dirname(__file__),
+                "..",
+                "fixtures",
+                "forms",
+                "tutorial",
+                "instances",
+                "nan_net_worth.xml",
+            )
         )
+
+        data = {"field_name": "networth_calc", "group_by": "pizza_fan"}
+        request = self.factory.get("/charts", data)
+        force_authenticate(request, user=self.user)
+        response = self.view(request, pk=self.xform.id, format="json")
         renderer = DecimalJSONRenderer()
-        res = json.loads(renderer.render(response.data).decode('utf-8'))
+        res = json.loads(renderer.render(response.data).decode("utf-8"))
 
         expected = {
             "field_type": "calculate",
             "data_type": "numeric",
             "field_xpath": "networth_calc",
             "data": [
-                {
-                    "count": 2,
-                    "sum": 150000.0,
-                    "pizza_fan": ["No"],
-                    "mean": 75000.0
-                },
-                {
-                    "count": 2,
-                    "sum": None,
-                    "pizza_fan": ["Yes"],
-                    "mean": None
-                }
+                {"count": 2, "sum": 150000.0, "pizza_fan": ["No"], "mean": 75000.0},
+                {"count": 2, "sum": None, "pizza_fan": ["Yes"], "mean": None},
             ],
             "grouped_by": "pizza_fan",
             "field_label": "Networth Calc",
             "field_name": "networth_calc",
-            "xform": self.xform.pk
+            "xform": self.xform.pk,
         }
         self.assertEqual(expected, res)
 
     def test_on_charts_with_content_type(self):
-        request = self.factory.get('/charts', content_type="application/json")
+        request = self.factory.get("/charts", content_type="application/json")
         force_authenticate(request, user=self.user)
-        response = self.view(
-            request,
-            pk=self.xform.pk,
-            id_string=self.xform.id_string
-            )
+        response = self.view(request, pk=self.xform.pk, id_string=self.xform.id_string)
         expected = {
-            'id': self.xform.pk,
-            'id_string': self.xform.id_string,
-            'url': 'http://testserver/api/v1/charts/{}'.format(self.xform.pk)
+            "id": self.xform.pk,
+            "id_string": self.xform.id_string,
+            "url": "http://testserver/api/v1/charts/{}".format(self.xform.pk),
         }
         self.assertEqual(200, response.status_code)
         self.assertDictContainsSubset(expected, response.data)
 
         # If content-type is not returned; Assume that the desired
         # response is JSON
-        request = self.factory.get('/')
+        request = self.factory.get("/")
         force_authenticate(request, user=self.user)
         response = self.view(request, pk=self.xform.pk)
         self.assertEqual(200, response.status_code)
@@ -497,31 +499,23 @@ class TestChartsViewSet(TestBase):
         """
         Test that the chart endpoints caching works as expected
         """
-        data = {'field_name': 'gender'}
-        request = self.factory.get('/charts', data)
+        data = {"field_name": "gender"}
+        request = self.factory.get("/charts", data)
         force_authenticate(request, user=self.user)
         cache_key = f"{XFORM_CHARTS}{self.xform.id}NonegenderNonehtml"
         initial_data = {"some_data": "some_value"}
         cache.set(cache_key, initial_data)
 
-        response = self.view(
-            request,
-            pk=self.xform.id,
-            format='html'
-        )
+        response = self.view(request, pk=self.xform.id, format="html")
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data, initial_data)
 
         # Ensure that the initially cached data is refreshed
         # when `refresh` query param is true
-        data['refresh'] = 'true'
-        request = self.factory.get('/charts', data)
+        data["refresh"] = "true"
+        request = self.factory.get("/charts", data)
         force_authenticate(request, user=self.user)
-        response = self.view(
-            request,
-            pk=self.xform.id,
-            format='html'
-        )
+        response = self.view(request, pk=self.xform.id, format="html")
         self.assertEqual(response.status_code, 200)
         self.assertNotEqual(response.data, initial_data)
 
@@ -535,7 +529,12 @@ class TestChartsViewSet(TestBase):
         force_authenticate(request, user=self.user)
         initial_data = {
             "data": [
-                {"gender": ["Male"], "items": [{"pizza_fan": ["No"], "count": 1}]},
+                {
+                    "gender": ["Male"],
+                    "items": [
+                        {"pizza_fan": ["No"], "count": 1},
+                    ],
+                },
                 {
                     "gender": ["Female"],
                     "items": [
@@ -555,4 +554,6 @@ class TestChartsViewSet(TestBase):
 
         response = self.view(request, pk=self.xform.id)
         self.assertEqual(response.status_code, 200)
+        # response.data['data'] items can be in any order
+        self.assertCountEqual(response.data.pop("data"), initial_data.pop("data"))
         self.assertEqual(response.data, initial_data)

--- a/onadata/libs/tests/utils/test_csv_builder.py
+++ b/onadata/libs/tests/utils/test_csv_builder.py
@@ -1806,8 +1806,8 @@ class TestCSVDataFrameBuilder(TestBase):
         )
         self.assertEqual(cursor[0], result)
 
-    def test_split_select_multiples_within_repeat_group(self):
-        """Select multiple choices nested within groups and repeats are split"""
+    def test_select_multiples_grouped_repeating_w_split(self):
+        """Select multiple choices within group within repeat with split"""
         md_xform = """
         | survey  |                          |              |                   |
         |         | type                     | name         | label             |
@@ -1922,8 +1922,8 @@ class TestCSVDataFrameBuilder(TestBase):
 
         csv_file.close()
 
-    def test_select_multiples_within_repeat_group(self):
-        """Select multiple choices nested within groups and repeats w/o split"""
+    def test_select_multiples_grouped_repeating_wo_split(self):
+        """Select multiple choices within group within repeat without split"""
         md_xform = """
         | survey  |                          |              |                   |
         |         | type                     | name         | label             |

--- a/onadata/libs/tests/utils/test_csv_builder.py
+++ b/onadata/libs/tests/utils/test_csv_builder.py
@@ -1806,8 +1806,8 @@ class TestCSVDataFrameBuilder(TestBase):
         )
         self.assertEqual(cursor[0], result)
 
-    def test_repeat_in_groups_multiples_split(self):
-        """Repeat in nested groups multiple choices w/split works"""
+    def test_split_select_multiples_within_repeat_group(self):
+        """Select multiple choices nested within groups and repeats are split"""
         md_xform = """
         | survey  |                          |              |                   |
         |         | type                     | name         | label             |
@@ -1922,8 +1922,8 @@ class TestCSVDataFrameBuilder(TestBase):
 
         csv_file.close()
 
-    def test_repeat_in_groups_multiples_no_split(self):
-        """Repeat in nested groups multiple choices w/o split works"""
+    def test_select_multiples_within_repeat_group(self):
+        """Select multiple choices nested within groups and repeats w/o split"""
         md_xform = """
         | survey  |                          |              |                   |
         |         | type                     | name         | label             |

--- a/onadata/libs/utils/csv_builder.py
+++ b/onadata/libs/utils/csv_builder.py
@@ -708,12 +708,13 @@ class CSVDataFrameBuilder(AbstractDataFrameBuilder):
             if isinstance(child, Section):
                 child_is_repeating = False
 
-                if isinstance(child, GroupedSection) and is_repeating_section:
+                if isinstance(child, RepeatingSection) or (
+                    isinstance(child, GroupedSection) and is_repeating_section
+                ):
                     child_is_repeating = True
 
-                elif isinstance(child, RepeatingSection):
+                if isinstance(child, RepeatingSection):
                     ordered_columns[child.get_abbreviated_xpath()] = []
-                    child_is_repeating = True
 
                 cls._build_ordered_columns(child, ordered_columns, child_is_repeating)
             elif (

--- a/onadata/libs/utils/csv_builder.py
+++ b/onadata/libs/utils/csv_builder.py
@@ -600,7 +600,6 @@ class CSVDataFrameBuilder(AbstractDataFrameBuilder):
                     # order repeat according to xform order
                     _item = get_ordered_repeat_value(key, item)
                     if key in _item and _item[key] == "n/a":
-                        # See https://github.com/onaio/zebra/issues/6830
                         # handles the case of a repeat construct in the data but the
                         # form has no repeat construct defined using begin repeat for
                         # example when you have a hidden value that has a repeat_count

--- a/onadata/libs/utils/csv_builder.py
+++ b/onadata/libs/utils/csv_builder.py
@@ -10,7 +10,7 @@ from django.utils.translation import gettext as _
 
 import unicodecsv as csv
 from pyxform.question import Question
-from pyxform.section import RepeatingSection, Section
+from pyxform.section import RepeatingSection, Section, GroupedSection
 from six import iteritems
 
 from onadata.apps.logger.models import OsmData
@@ -704,15 +704,17 @@ class CSVDataFrameBuilder(AbstractDataFrameBuilder):
         is_repeating_section ensures that child questions of repeating sections
         are not considered columns
         """
-        if is_repeating_section:
-            return
-
         for child in survey_element.children:
             if isinstance(child, Section):
                 child_is_repeating = False
-                if isinstance(child, RepeatingSection):
+
+                if isinstance(child, GroupedSection) and is_repeating_section:
+                    child_is_repeating = True
+
+                elif isinstance(child, RepeatingSection):
                     ordered_columns[child.get_abbreviated_xpath()] = []
                     child_is_repeating = True
+
                 cls._build_ordered_columns(child, ordered_columns, child_is_repeating)
             elif (
                 isinstance(child, Question)

--- a/onadata/libs/utils/csv_builder.py
+++ b/onadata/libs/utils/csv_builder.py
@@ -385,15 +385,19 @@ class AbstractDataFrameBuilder:
                 if value_select_multiples:
                     record.update(
                         {
-                            choice.replace("/" + name, "/" + label)
-                            if show_choice_labels
-                            else choice: (
-                                label
+                            (
+                                choice.replace("/" + name, "/" + label)
                                 if show_choice_labels
-                                else record[key].split()[selections.index(choice)]
+                                else choice
+                            ): (
+                                (
+                                    label
+                                    if show_choice_labels
+                                    else record[key].split()[selections.index(choice)]
+                                )
+                                if choice in selections
+                                else None
                             )
-                            if choice in selections
-                            else None
                             for choice, name, label in choices
                         }
                     )
@@ -402,20 +406,23 @@ class AbstractDataFrameBuilder:
                     # False and set to True for items in selections
                     record.update(
                         {
-                            choice.replace("/" + name, "/" + label)
-                            if show_choice_labels
-                            else choice: choice in selections
+                            (
+                                choice.replace("/" + name, "/" + label)
+                                if show_choice_labels
+                                else choice
+                            ): choice
+                            in selections
                             for choice, name, label in choices
                         }
                     )
                 else:
                     record.update(
                         {
-                            choice.replace("/" + name, "/" + label)
-                            if show_choice_labels
-                            else choice: YES
-                            if choice in selections
-                            else NO
+                            (
+                                choice.replace("/" + name, "/" + label)
+                                if show_choice_labels
+                                else choice
+                            ): (YES if choice in selections else NO)
                             for choice, name, label in choices
                         }
                     )
@@ -698,6 +705,9 @@ class CSVDataFrameBuilder(AbstractDataFrameBuilder):
         is_repeating_section ensures that child questions of repeating sections
         are not considered columns
         """
+        if is_repeating_section:
+            return
+
         for child in survey_element.children:
             if isinstance(child, Section):
                 child_is_repeating = False
@@ -729,9 +739,11 @@ class CSVDataFrameBuilder(AbstractDataFrameBuilder):
                 if key in self.ordered_columns.keys():
                     self.ordered_columns[key] = remove_dups_from_list_maintain_order(
                         [
-                            choice.replace("/" + name, "/" + label)
-                            if self.show_choice_labels
-                            else choice
+                            (
+                                choice.replace("/" + name, "/" + label)
+                                if self.show_choice_labels
+                                else choice
+                            )
                             for choice, name, label in choices
                         ]
                     )


### PR DESCRIPTION
### Changes / Features implemented

- Fix bug where child questions of grouped sections that are children of repeating sections are not ignored during CSV export therefore appearing as extra column headers
- Fix flaky test `onadata.apps.api.tests.viewsets.test_charts_viewset.TestChartsViewSet.test_charts_group_by_select_one`

### Steps taken to verify this change does what is intended

- [x] QA
- [x] Tests

### Side effects of implementing this change

No side effects

**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  - [ ] Updated documentation

Closes #2562 
