### PR TITLE
Bump onadata version to v3.18.2

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,14 @@ Changelog for Onadata
 
 ``* represents releases that introduce new migrations``
 
+v3.18.2(2024-02-23)
+-------------------
+- Improve perfomance of /status endpoint
+  `PR #2551 <https://github.com/onaio/onadata/pull/2558>`
+  [@FrankApiyo]
+
 v3.18.1(2024-02-21)
+-------------------
 - Fix bug invalid endpoint when fetching media files
   `PR #2551 <https://github.com/onaio/onadata/pull/2551>`
   [@kelvin-muchiri]

--- a/onadata/__init__.py
+++ b/onadata/__init__.py
@@ -6,7 +6,7 @@ visualization.
 """
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "3.18.1"
+__version__ = "3.18.2"
 
 
 # This will make sure the app is always imported when

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = onadata
-version = 3.18.1
+version = 3.18.2
 description = Collect Analyze and Share Data
 long_description = file: README.rst
 long_description_content_type = text/x-rst


### PR DESCRIPTION
### Changes

Bump version to v3.18.2

### Release notes

**Perfomance improvement**

- Improve perfomance of /status endpoint and add onadata-version to /status endpoint [2558](https://github.com/onaio/onadata/pull/2558)
