### PR TITLE
Allow unauthenticated HEAD requests in IsAuthenticatedSubmission class

### DIFF
--- a/onadata/apps/api/permissions.py
+++ b/onadata/apps/api/permissions.py
@@ -552,7 +552,10 @@ class IsAuthenticatedSubmission(BasePermission):
                 return False
             profile, _ = UserProfile.objects.get_or_create(user=user)
 
-            if profile.require_auth:
+            if profile.require_auth and not (
+                request.path.endswith(f"{form_pk}/submission")
+                and request.method == "HEAD"
+            ):
                 # raises a permission denied exception,
                 # forces authentication
                 return False

--- a/onadata/apps/api/tests/viewsets/test_xform_submission_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_xform_submission_viewset.py
@@ -962,22 +962,19 @@ class TestXFormSubmissionViewSet(TestAbstractViewSet, TransactionTestCase):
                 s + ".xml",
             )
             with open(submission_path, "rb"):
-                # When require_auth is enabled and
-                # no auth is passed to the request should fail
+                # When require_auth is enabled and HEAD requests to
+                # the /<form-pk>/submission endpoint should succeed
                 request = self.factory.head(f"/enketo/{self.xform.pk}/submission")
-                response = self.view(request)
-                self.assertEqual(response.status_code, 401)
-
-                # When require_auth is enabled & no auth passed is ok
-                request = self.factory.head(f"/enketo/{self.xform.pk}/submission")
-                request.user = self.xform.user
                 response = self.view(request, xform_pk=self.xform.pk)
 
-                self.assertEqual(response.status_code, 401)
+                self.assertEqual(response.status_code, 204)
                 self.assertTrue(response.has_header("X-OpenRosa-Version"))
 
                 # Test Content-Length header is available
-                self.assertTrue(response.has_header("X-OpenRosa-Accept-Content-Length"))
+                self.assertEqual(
+                    response.headers["X-OpenRosa-Accept-Content-Length"],
+                    str(settings.DEFAULT_CONTENT_LENGTH),
+                )
                 self.assertTrue(response.has_header("Date"))
                 self.assertEqual(
                     response["Location"],


### PR DESCRIPTION
### Changes / Features implemented
- Allow unauthenticated HEAD requests to f"{form_pk}/submission" endpoint
### Steps taken to verify this change does what is intended
- Updated tests

**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  - [ ] Updated documentation

Closes https://github.com/onaio/onadata/issues/2568
