### PR TITLE
Add user to organization asynchronously

### DIFF
--- a/onadata/apps/api/tasks.py
+++ b/onadata/apps/api/tasks.py
@@ -186,7 +186,9 @@ def regenerate_form_instance_json(xform_id: int):
 
 
 @app.task()
-def add_org_user_and_share_projects_async(org_id, user_id, role):
+def add_org_user_and_share_projects_async(
+    org_id, user_id, role
+):  # pylint: invalid-name
     """Add user to organization and share projects asynchronously"""
     organization = OrganizationProfile.objects.get(pk=org_id)
     user = User.objects.get(pk=user_id)

--- a/onadata/apps/api/tasks.py
+++ b/onadata/apps/api/tasks.py
@@ -188,7 +188,7 @@ def regenerate_form_instance_json(xform_id: int):
 @app.task()
 def add_org_user_and_share_projects_async(
     org_id, user_id, role
-):  # pylint: invalid-name
+):  # pylint: disable=invalid-name
     """Add user to organization and share projects asynchronously"""
     organization = OrganizationProfile.objects.get(pk=org_id)
     user = User.objects.get(pk=user_id)

--- a/onadata/apps/api/tasks.py
+++ b/onadata/apps/api/tasks.py
@@ -222,7 +222,10 @@ def add_org_user_and_share_projects_async(
 
         if email_msg and email_subject and user.email:
             send_mail(
-                subject=email_subject, message=email_msg, recipient_list=(user.email,)
+                email_subject,
+                email_msg,
+                settings.DEFAULT_FROM_EMAIL,
+                (user.email,),
             )
 
 

--- a/onadata/apps/api/tasks.py
+++ b/onadata/apps/api/tasks.py
@@ -186,16 +186,16 @@ def regenerate_form_instance_json(xform_id: int):
 
 
 @app.task()
-def add_user_to_org_and_share_projects_async(org_id, user_id, role):
+def add_org_user_and_share_projects_async(org_id, user_id, role):
     """Add user to organization and share projects asynchronously"""
     organization = OrganizationProfile.objects.get(pk=org_id)
     user = User.objects.get(pk=user_id)
 
-    tools.add_user_to_org_and_share_projects(organization, user, role)
+    tools.add_org_user_and_share_projects(organization, user, role)
 
 
 @app.task()
-def remove_user_from_org_async(org_id, user_id):
+def remove_org_user_async(org_id, user_id):
     """Remove user from organization asynchronously"""
     organization = OrganizationProfile.objects.get(pk=org_id)
     user = User.objects.get(pk=user_id)

--- a/onadata/apps/api/tasks.py
+++ b/onadata/apps/api/tasks.py
@@ -16,6 +16,7 @@ from django.utils import timezone
 from django.utils.datastructures import MultiValueDict
 
 from onadata.apps.api import tools
+from onadata.apps.api.models.organization_profile import OrganizationProfile
 from onadata.libs.utils.email import send_generic_email
 from onadata.libs.utils.model_tools import queryset_iterator
 from onadata.libs.utils.cache_tools import (
@@ -182,3 +183,21 @@ def regenerate_form_instance_json(xform_id: int):
             # Clear cache used to store the task id from the AsyncResult
             cache_key = f"{XFORM_REGENERATE_INSTANCE_JSON_TASK}{xform_id}"
             safe_delete(cache_key)
+
+
+@app.task()
+def add_user_to_org_and_share_projects_async(org_id, user_id, role):
+    """Add user to organization and share projects asynchronously"""
+    organization = OrganizationProfile.objects.get(pk=org_id)
+    user = User.objects.get(pk=user_id)
+
+    tools.add_user_to_org_and_share_projects(organization, user, role)
+
+
+@app.task()
+def remove_user_from_org_async(org_id, user_id):
+    """Remove user from organization asynchronously"""
+    organization = OrganizationProfile.objects.get(pk=org_id)
+    user = User.objects.get(pk=user_id)
+
+    tools.remove_user_from_organization(organization, user)

--- a/onadata/apps/api/tests/test_tasks.py
+++ b/onadata/apps/api/tests/test_tasks.py
@@ -271,6 +271,13 @@ class ShareProjectAsyncTestCase(TestBase):
 
         self.assertFalse(ManagerRole.user_has_role(self.alice, self.project))
 
+    @patch("onadata.apps.api.tasks.logger.exception")
+    def test_invalid_project_id(self, mock_log):
+        """Invalid org_id is handled"""
+        share_project_async.delay(sys.maxsize, "alice", "manager")
+        self.assertFalse(ManagerRole.user_has_role(self.alice, self.project))
+        mock_log.assert_called_once()
+
     @patch.object(ShareProject, "save")
     @patch("onadata.apps.api.tasks.share_project_async.retry")
     def test_database_error(self, mock_retry, mock_share):

--- a/onadata/apps/api/tests/test_tasks.py
+++ b/onadata/apps/api/tests/test_tasks.py
@@ -214,7 +214,7 @@ class RemoveOrgUserAsyncTestCase(TestBase):
 
     @patch("onadata.apps.api.tasks.logger.exception")
     def test_invalid_user_id(self, mock_log, mock_remove):
-        """Invalid org_id is handled"""
+        """Invalid user_id is handled"""
         remove_org_user_async.delay(self.org.pk, sys.maxsize)
         mock_remove.assert_not_called()
         mock_log.assert_called_once()
@@ -273,7 +273,7 @@ class ShareProjectAsyncTestCase(TestBase):
 
     @patch("onadata.apps.api.tasks.logger.exception")
     def test_invalid_project_id(self, mock_log):
-        """Invalid org_id is handled"""
+        """Invalid projecct_id is handled"""
         share_project_async.delay(sys.maxsize, "alice", "manager")
         self.assertFalse(ManagerRole.user_has_role(self.alice, self.project))
         mock_log.assert_called_once()

--- a/onadata/apps/api/tests/test_tasks.py
+++ b/onadata/apps/api/tests/test_tasks.py
@@ -1,18 +1,25 @@
 """Tests for module onadata.apps.api.tasks"""
+
 import sys
 
 from unittest.mock import patch
 
 from django.core.cache import cache
+from django.contrib.auth import get_user_model
 
-from onadata.apps.main.tests.test_base import TestBase
 from onadata.apps.api.tasks import (
     send_project_invitation_email_async,
     regenerate_form_instance_json,
+    add_org_user_and_share_projects_async,
+    remove_org_user_async,
 )
+from onadata.apps.api.models.organization_profile import OrganizationProfile
 from onadata.apps.logger.models import ProjectInvitation, Instance
+from onadata.apps.main.tests.test_base import TestBase
 from onadata.libs.utils.user_auth import get_user_default_project
 from onadata.libs.utils.email import ProjectInvitationEmail
+
+User = get_user_model()
 
 
 class SendProjectInivtationEmailAsyncTestCase(TestBase):
@@ -80,7 +87,7 @@ class RegenerateFormInstanceJsonTestCase(TestBase):
         instance.refresh_from_db()
         self.assertFalse("foo" in instance.json)
 
-    @patch("logging.exception")
+    @patch("onadata.apps.api.tasks.logger.exception")
     def test_form_id_invalid(self, mock_log_exception):
         """An invalid xform_id is handled"""
 
@@ -107,3 +114,74 @@ class RegenerateFormInstanceJsonTestCase(TestBase):
         regenerate_form_instance_json.delay(self.xform.pk)
         instance.refresh_from_db()
         self.assertFalse(instance.json)
+
+
+@patch("onadata.apps.api.tasks.tools.add_org_user_and_share_projects")
+class AddOrgUserAndShareProjectsAsyncTestCase(TestBase):
+    """Tests for add_org_user_and_share_projects_async"""
+
+    def setUp(self):
+        super().setUp()
+
+        self.org_user = User.objects.create(username="onaorg")
+        alice = self._create_user("alice", "1234&&")
+        self.org = OrganizationProfile.objects.create(
+            user=self.org_user, name="Ona Org", creator=alice
+        )
+
+    def test_user_added_to_org(self, mock_add):
+        """User is added to organization"""
+        add_org_user_and_share_projects_async(self.org.pk, self.user.pk, "manager")
+        mock_add.assert_called_once_with(self.org, self.user, "manager")
+
+    def test_role_optional(self, mock_add):
+        """role param is optional"""
+        add_org_user_and_share_projects_async(self.org.pk, self.user.pk)
+        mock_add.assert_called_once_with(self.org, self.user, None)
+
+    @patch("onadata.apps.api.tasks.logger.exception")
+    def test_invalid_org_id(self, mock_log, mock_add):
+        """Invalid org_id is handled"""
+        add_org_user_and_share_projects_async(sys.maxsize, self.user.pk)
+        mock_add.assert_not_called()
+        mock_log.assert_called_once()
+
+    @patch("onadata.apps.api.tasks.logger.exception")
+    def test_invalid_user_id(self, mock_log, mock_add):
+        """Invalid org_id is handled"""
+        add_org_user_and_share_projects_async(self.org.pk, sys.maxsize)
+        mock_add.assert_not_called()
+        mock_log.assert_called_once()
+
+
+@patch("onadata.apps.api.tasks.tools.remove_user_from_organization")
+class RemoveOrgUserAsyncTestCase(TestBase):
+    """Tests for remove_org_user_async"""
+
+    def setUp(self):
+        super().setUp()
+
+        self.org_user = User.objects.create(username="onaorg")
+        alice = self._create_user("alice", "1234&&")
+        self.org = OrganizationProfile.objects.create(
+            user=self.org_user, name="Ona Org", creator=alice
+        )
+
+    def test_user_removed_from_org(self, mock_remove):
+        """User is removed from organization"""
+        remove_org_user_async(self.org.pk, self.user.pk)
+        mock_remove.assert_called_once_with(self.org, self.user)
+
+    @patch("onadata.apps.api.tasks.logger.exception")
+    def test_invalid_org_id(self, mock_log, mock_remove):
+        """Invalid org_id is handled"""
+        remove_org_user_async(sys.maxsize, self.user.pk)
+        mock_remove.assert_not_called()
+        mock_log.assert_called_once()
+
+    @patch("onadata.apps.api.tasks.logger.exception")
+    def test_invalid_user_id(self, mock_log, mock_remove):
+        """Invalid org_id is handled"""
+        remove_org_user_async(self.org.pk, sys.maxsize)
+        mock_remove.assert_not_called()
+        mock_log.assert_called_once()

--- a/onadata/apps/api/tests/test_tools.py
+++ b/onadata/apps/api/tests/test_tools.py
@@ -1,0 +1,99 @@
+"""Tests for module onadata.apps.api.tools"""
+
+from django.contrib.auth import get_user_model
+
+from onadata.apps.api.models.organization_profile import (
+    OrganizationProfile,
+    Team,
+    get_organization_members_team,
+)
+from onadata.apps.api.tools import add_org_user_and_share_projects
+from onadata.apps.logger.models.project import Project
+from onadata.apps.main.tests.test_base import TestBase
+from onadata.libs.permissions import DataEntryRole, ManagerRole, OwnerRole
+
+
+User = get_user_model()
+
+
+class AddOrgUserAndShareProjectsTestCase(TestBase):
+    """Tests for method add_org_user_and_share_projects"""
+
+    def setUp(self) -> None:
+        super().setUp()
+
+        self.org_user = User.objects.create(username="onaorg")
+        alice = self._create_user("alice", "1234&&")
+        self.org = OrganizationProfile.objects.create(
+            user=self.org_user, name="Ona Org", creator=alice
+        )
+        self.project = Project.objects.create(
+            name="Demo", organization=self.org_user, created_by=alice
+        )
+
+    def test_add_owner(self):
+        """Owner added to org and projects shared"""
+        add_org_user_and_share_projects(self.org, self.user, "owner")
+
+        self.user.refresh_from_db()
+        owner_team = Team.objects.get(name=f"{self.org_user.username}#Owners")
+        members_team = Team.objects.get(name=f"{self.org_user.username}#members")
+        self.assertTrue(
+            owner_team.user_set.filter(username=self.user.username).exists()
+        )
+        self.assertTrue(
+            members_team.user_set.filter(username=self.user.username).exists()
+        )
+        self.assertTrue(OwnerRole.user_has_role(self.user, self.project))
+        self.assertTrue(OwnerRole.user_has_role(self.user, self.org))
+
+    def test_non_owner(self):
+        """Non-owners add to org and projects shared
+
+        Non-owners should be assigned default project permissions
+        """
+        # Set default permissions for project
+        members_team = get_organization_members_team(self.org)
+        DataEntryRole.add(members_team, self.project)
+
+        add_org_user_and_share_projects(self.org, self.user, "manager")
+
+        self.user.refresh_from_db()
+        owner_team = Team.objects.get(name=f"{self.org_user.username}#Owners")
+        members_team = Team.objects.get(name=f"{self.org_user.username}#members")
+        self.assertFalse(
+            owner_team.user_set.filter(username=self.user.username).exists()
+        )
+        self.assertTrue(
+            members_team.user_set.filter(username=self.user.username).exists()
+        )
+        self.assertTrue(DataEntryRole.user_has_role(self.user, self.project))
+        self.assertTrue(ManagerRole.user_has_role(self.user, self.org))
+
+    def test_project_created_by_manager(self):
+        """A manager is assigned manager role on projects they created"""
+        self.project.created_by = self.user
+        self.project.save()
+
+        add_org_user_and_share_projects(self.org, self.user, "manager")
+
+        self.assertTrue(ManagerRole.user_has_role(self.user, self.project))
+
+    def test_role_none(self):
+        """role param is None or not provided"""
+        # Set default permissions for project
+        members_team = get_organization_members_team(self.org)
+        DataEntryRole.add(members_team, self.project)
+
+        add_org_user_and_share_projects(self.org, self.user)
+
+        self.user.refresh_from_db()
+        owner_team = Team.objects.get(name=f"{self.org_user.username}#Owners")
+        members_team = Team.objects.get(name=f"{self.org_user.username}#members")
+        self.assertFalse(
+            owner_team.user_set.filter(username=self.user.username).exists()
+        )
+        self.assertTrue(
+            members_team.user_set.filter(username=self.user.username).exists()
+        )
+        self.assertTrue(DataEntryRole.user_has_role(self.user, self.project))

--- a/onadata/apps/api/tests/test_tools.py
+++ b/onadata/apps/api/tests/test_tools.py
@@ -7,7 +7,10 @@ from onadata.apps.api.models.organization_profile import (
     Team,
     get_organization_members_team,
 )
-from onadata.apps.api.tools import add_org_user_and_share_projects
+from onadata.apps.api.tools import (
+    add_org_user_and_share_projects,
+    add_user_to_organization,
+)
 from onadata.apps.logger.models.project import Project
 from onadata.apps.main.tests.test_base import TestBase
 from onadata.libs.permissions import DataEntryRole, ManagerRole, OwnerRole
@@ -16,8 +19,78 @@ from onadata.libs.permissions import DataEntryRole, ManagerRole, OwnerRole
 User = get_user_model()
 
 
+class AddUserToOrganizationTestCase(TestBase):
+    """Add tests for add_user_to_organization"""
+
+    def setUp(self) -> None:
+        super().setUp()
+
+        self.org_user = User.objects.create(username="onaorg")
+        alice = self._create_user("alice", "1234&&")
+        self.org = OrganizationProfile.objects.create(
+            user=self.org_user, name="Ona Org", creator=alice
+        )
+
+    def test_add_owner(self):
+        """Owner is added to organization"""
+        add_user_to_organization(self.org, self.user, "owner")
+
+        self.user.refresh_from_db()
+        owner_team = Team.objects.get(name=f"{self.org_user.username}#Owners")
+        members_team = Team.objects.get(name=f"{self.org_user.username}#members")
+        self.assertTrue(
+            owner_team.user_set.filter(username=self.user.username).exists()
+        )
+        self.assertTrue(
+            members_team.user_set.filter(username=self.user.username).exists()
+        )
+        self.assertTrue(OwnerRole.user_has_role(self.user, self.org))
+        self.assertTrue(OwnerRole.user_has_role(self.user, self.org.userprofile_ptr))
+
+        # If role changes, user is removed from owners team
+        add_user_to_organization(self.org, self.user, "editor")
+
+        self.user.refresh_from_db()
+        owner_team.refresh_from_db()
+
+        self.assertFalse(
+            owner_team.user_set.filter(username=self.user.username).exists()
+        )
+        self.assertFalse(OwnerRole.user_has_role(self.user, self.org))
+        self.assertFalse(OwnerRole.user_has_role(self.user, self.org.userprofile_ptr))
+
+    def test_non_owner(self):
+        """Non-owners add to organization"""
+        add_user_to_organization(self.org, self.user, "manager")
+
+        self.user.refresh_from_db()
+        owner_team = Team.objects.get(name=f"{self.org_user.username}#Owners")
+        members_team = Team.objects.get(name=f"{self.org_user.username}#members")
+        self.assertFalse(
+            owner_team.user_set.filter(username=self.user.username).exists()
+        )
+        self.assertTrue(
+            members_team.user_set.filter(username=self.user.username).exists()
+        )
+        self.assertTrue(ManagerRole.user_has_role(self.user, self.org))
+
+    def test_role_none(self):
+        """role param is None or not provided"""
+        add_user_to_organization(self.org, self.user)
+
+        self.user.refresh_from_db()
+        owner_team = Team.objects.get(name=f"{self.org_user.username}#Owners")
+        members_team = Team.objects.get(name=f"{self.org_user.username}#members")
+        self.assertFalse(
+            owner_team.user_set.filter(username=self.user.username).exists()
+        )
+        self.assertTrue(
+            members_team.user_set.filter(username=self.user.username).exists()
+        )
+
+
 class AddOrgUserAndShareProjectsTestCase(TestBase):
-    """Tests for method add_org_user_and_share_projects"""
+    """Tests for add_org_user_and_share_projects"""
 
     def setUp(self) -> None:
         super().setUp()

--- a/onadata/apps/api/tests/viewsets/test_organization_profile_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_organization_profile_viewset.py
@@ -16,6 +16,7 @@ from rest_framework import status
 from onadata.apps.api.models.organization_profile import (
     OrganizationProfile,
     get_organization_members_team,
+    Team,
 )
 from onadata.apps.api.tests.viewsets.test_abstract_viewset import TestAbstractViewSet
 from onadata.apps.api.tools import (
@@ -297,6 +298,8 @@ class TestOrganizationProfileViewSet(TestAbstractViewSet):
         response = view(request, user="denoinc")
         self.assertEqual(response.status_code, 201)
         self.assertEqual(set(response.data), set(["denoinc", "aboy"]))
+        team = Team.objects.get(name=f"{self.organization.user.username}#members")
+        self.assertTrue(team.user_set.filter(username="aboy").exists())
 
     def test_inactive_members_not_listed(self):
         self._org_create()

--- a/onadata/apps/api/tests/viewsets/test_organization_profile_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_organization_profile_viewset.py
@@ -684,7 +684,7 @@ class TestOrganizationProfileViewSet(TestAbstractViewSet):
         response = view(request, user="denoinc")
         self.assertEqual(response.status_code, 400)
 
-    @patch("onadata.libs.serializers.organization_member_serializer.send_mail")
+    @patch("onadata.apps.api.tasks.send_mail")
     def test_add_members_to_org_email(self, mock_email):
         self._org_create()
         view = OrganizationProfileViewSet.as_view({"post": "members"})
@@ -701,14 +701,13 @@ class TestOrganizationProfileViewSet(TestAbstractViewSet):
         self.assertEqual(response.status_code, 201)
         self.assertTrue(mock_email.called)
         mock_email.assert_called_with(
-            "aboy, You have been added to Dennis" " organisation.",
-            "You have been add to denoinc",
-            "noreply@ona.io",
-            ("aboy@org.com",),
+            subject="aboy, You have been added to Dennis" " organisation.",
+            message="You have been add to denoinc",
+            recipient_list=("aboy@org.com",),
         )
         self.assertEqual(set(response.data), set(["denoinc", "aboy"]))
 
-    @patch("onadata.libs.serializers.organization_member_serializer.send_mail")
+    @patch("onadata.apps.api.tasks.send_mail")
     def test_add_members_to_org_email_custom_subj(self, mock_email):
         self._org_create()
         view = OrganizationProfileViewSet.as_view({"post": "members"})
@@ -729,10 +728,9 @@ class TestOrganizationProfileViewSet(TestAbstractViewSet):
         self.assertEqual(response.status_code, 201)
         self.assertTrue(mock_email.called)
         mock_email.assert_called_with(
-            "Your are made",
-            "You have been add to denoinc",
-            "noreply@ona.io",
-            ("aboy@org.com",),
+            subject="Your are made",
+            message="You have been add to denoinc",
+            recipient_list=("aboy@org.com",),
         )
         self.assertEqual(set(response.data), set(["denoinc", "aboy"]))
 

--- a/onadata/apps/api/tests/viewsets/test_organization_profile_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_organization_profile_viewset.py
@@ -684,6 +684,7 @@ class TestOrganizationProfileViewSet(TestAbstractViewSet):
         response = view(request, user="denoinc")
         self.assertEqual(response.status_code, 400)
 
+    @override_settings(DEFAULT_FROM_EMAIL="noreply@ona.io")
     @patch("onadata.apps.api.tasks.send_mail")
     def test_add_members_to_org_email(self, mock_email):
         self._org_create()
@@ -701,12 +702,14 @@ class TestOrganizationProfileViewSet(TestAbstractViewSet):
         self.assertEqual(response.status_code, 201)
         self.assertTrue(mock_email.called)
         mock_email.assert_called_with(
-            subject="aboy, You have been added to Dennis" " organisation.",
-            message="You have been add to denoinc",
-            recipient_list=("aboy@org.com",),
+            "aboy, You have been added to Dennis" " organisation.",
+            "You have been add to denoinc",
+            "noreply@ona.io",
+            ("aboy@org.com",),
         )
         self.assertEqual(set(response.data), set(["denoinc", "aboy"]))
 
+    @override_settings(DEFAULT_FROM_EMAIL="noreply@ona.io")
     @patch("onadata.apps.api.tasks.send_mail")
     def test_add_members_to_org_email_custom_subj(self, mock_email):
         self._org_create()
@@ -728,9 +731,10 @@ class TestOrganizationProfileViewSet(TestAbstractViewSet):
         self.assertEqual(response.status_code, 201)
         self.assertTrue(mock_email.called)
         mock_email.assert_called_with(
-            subject="Your are made",
-            message="You have been add to denoinc",
-            recipient_list=("aboy@org.com",),
+            "Your are made",
+            "You have been add to denoinc",
+            "noreply@ona.io",
+            ("aboy@org.com",),
         )
         self.assertEqual(set(response.data), set(["denoinc", "aboy"]))
 

--- a/onadata/apps/api/tests/viewsets/test_project_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_project_viewset.py
@@ -2488,8 +2488,7 @@ class TestProjectViewSet(TestAbstractViewSet):
             mock_rm_xform_perms,
         ):  # noqa
             mock_rm_xform_perms.side_effect = Exception()
-            with self.assertRaises(Exception):
-                response = view(request, pk=projectid)
+            response = view(request, pk=projectid)
             # permissions have not changed for both xform and project
             self.assertTrue(role_class.user_has_role(alice, self.xform))
             self.assertTrue(role_class.user_has_role(alice, self.project))

--- a/onadata/apps/api/tools.py
+++ b/onadata/apps/api/tools.py
@@ -248,6 +248,7 @@ def add_user_to_organization(organization, user, role=None):
 
         else:
             remove_user_from_team(owners_team, user)
+            OwnerRole.remove_obj_permissions(user, organization.userprofile_ptr)
 
 
 def get_organization_members(organization):

--- a/onadata/apps/api/tools.py
+++ b/onadata/apps/api/tools.py
@@ -832,7 +832,9 @@ def set_enketo_signed_cookies(resp, username=None, json_web_token=None):
     return resp
 
 
-def add_user_to_org_and_share_projects(organization, user, org_role):
+def add_org_user_and_share_projects(
+    organization: OrganizationProfile, user, org_role: str = None
+):
     """Add user to organization and share all projects"""
     add_user_to_organization(organization, user, org_role)
 

--- a/onadata/apps/api/tools.py
+++ b/onadata/apps/api/tools.py
@@ -842,7 +842,7 @@ def add_user_to_org_and_share_projects(organization, user, org_role):
 
     project_qs = organization.user.project_org.all()
 
-    if org_role in [OwnerRole.name]:
+    if org_role == OwnerRole.name:
         # New owners have owner role on all projects
         for project in queryset_iterator(project_qs):
             share(project, org_role)

--- a/onadata/apps/api/viewsets/project_viewset.py
+++ b/onadata/apps/api/viewsets/project_viewset.py
@@ -33,7 +33,6 @@ from onadata.libs.serializers.project_serializer import (
 from onadata.libs.serializers.share_project_serializer import (
     RemoveUserFromProjectSerializer,
     ShareProjectSerializer,
-    propagate_project_permissions_async,
 )
 from onadata.libs.serializers.user_profile_serializer import UserProfileSerializer
 from onadata.libs.serializers.xform_serializer import (
@@ -48,6 +47,7 @@ from onadata.libs.serializers.project_invitation_serializer import (
 from onadata.libs.utils.cache_tools import PROJ_OWNER_CACHE, safe_delete
 from onadata.libs.utils.common_tools import merge_dicts
 from onadata.libs.utils.export_tools import str_to_bool
+from onadata.libs.utils.project_utils import propagate_project_permissions_async
 from onadata.settings.common import DEFAULT_FROM_EMAIL, SHARE_PROJECT_SUBJECT
 
 # pylint: disable=invalid-name
@@ -64,7 +64,6 @@ class ProjectViewSet(
     BaseViewset,
     ModelViewSet,
 ):
-
     """
     List, Retrieve, Update, Create Project and Project Forms.
     """
@@ -182,7 +181,7 @@ class ProjectViewSet(
             remove = strtobool(remove)
 
         if remove:
-            serializer = RemoveUserFromProjectSerializer(data=data)
+            serializer = RemoveUserFromProjectSerializer(data={**data, remove: True})
         else:
             serializer = ShareProjectSerializer(data=data)
         if serializer.is_valid():

--- a/onadata/libs/models/share_project.py
+++ b/onadata/libs/models/share_project.py
@@ -18,6 +18,7 @@ from onadata.libs.utils.cache_tools import (
     PROJ_PERM_CACHE,
     safe_delete,
 )
+from onadata.libs.utils.project_utils import propagate_project_permissions_async
 
 # pylint: disable=invalid-name
 User = get_user_model()
@@ -91,6 +92,8 @@ class ShareProject:
         # clear cache
         safe_delete(f"{PROJ_OWNER_CACHE}{self.project.pk}")
         safe_delete(f"{PROJ_PERM_CACHE}{self.project.pk}")
+        # propagate KPI permissions
+        propagate_project_permissions_async.apply_async(args=[self.project.pk])
 
     @transaction.atomic()
     def __remove_user(self):

--- a/onadata/libs/serializers/organization_member_serializer.py
+++ b/onadata/libs/serializers/organization_member_serializer.py
@@ -13,8 +13,8 @@ from onadata.apps.api.tools import (
     get_organization_members,
 )
 from onadata.apps.api.tasks import (
-    add_user_to_org_and_share_projects_async,
-    remove_user_from_org_async,
+    add_org_user_and_share_projects_async,
+    remove_org_user_async,
 )
 from onadata.apps.main.models.user_profile import UserProfile
 from onadata.libs.permissions import (
@@ -117,10 +117,10 @@ class OrganizationMemberSerializer(serializers.Serializer):
             user = User.objects.get(username=username)
 
             if remove:
-                remove_user_from_org_async.apply_async(args=[organization.pk, user.pk])
+                remove_org_user_async.apply_async(args=[organization.pk, user.pk])
 
             else:
-                add_user_to_org_and_share_projects_async.apply_async(
+                add_org_user_and_share_projects_async.apply_async(
                     args=[organization.pk, user.pk, role]
                 )
 

--- a/onadata/libs/serializers/organization_member_serializer.py
+++ b/onadata/libs/serializers/organization_member_serializer.py
@@ -7,29 +7,22 @@ from django.core.mail import send_mail
 from django.utils.translation import gettext as _
 
 from rest_framework import serializers
-from onadata.apps.api.models.organization_profile import get_organization_members_team
 
 from onadata.apps.api.tools import (
     _get_owners,
-    add_user_to_organization,
-    add_user_to_team,
-    get_or_create_organization_owners_team,
     get_organization_members,
-    remove_user_from_organization,
-    remove_user_from_team,
 )
-from onadata.apps.logger.models.project import Project
+from onadata.apps.api.tasks import (
+    add_user_to_org_and_share_projects_async,
+    remove_user_from_org_async,
+)
 from onadata.apps.main.models.user_profile import UserProfile
 from onadata.libs.permissions import (
     ROLES,
-    ManagerRole,
     OwnerRole,
-    get_team_project_default_permissions,
     is_organization,
 )
 from onadata.libs.serializers.fields.organization_field import OrganizationField
-from onadata.libs.serializers.share_project_serializer import ShareProjectSerializer
-from onadata.libs.utils.project_utils import propagate_project_permissions_async
 from onadata.settings.common import DEFAULT_FROM_EMAIL, SHARE_ORG_SUBJECT
 
 User = get_user_model()
@@ -42,44 +35,6 @@ def _compose_send_email(organization, user, email_msg, email_subject=None):
 
     # send out email message.
     send_mail(email_subject, email_msg, DEFAULT_FROM_EMAIL, (user.email,))
-
-
-def _set_organization_role_to_user(organization, user, role):
-    role_cls = ROLES.get(role)
-    if role_cls:
-        role_cls.add(user, organization)
-
-    owners_team = get_or_create_organization_owners_team(organization)
-    members_team = get_organization_members_team(organization)
-
-    # add user to their respective team
-    if role == OwnerRole.name:
-        # add user to owners team
-        role_cls.add(user, organization.userprofile_ptr)
-        add_user_to_team(owners_team, user)
-        # add user to org projects
-        for project in organization.user.project_org.all():
-            data = {"project": project.pk, "username": user.username, "role": role}
-            serializer = ShareProjectSerializer(data=data)
-            if serializer.is_valid():
-                serializer.save()
-
-    elif role != OwnerRole.name:
-        add_user_to_team(members_team, user)
-        # add user to org projects
-        for project in organization.user.project_org.all():
-            if role != ManagerRole.name:
-                role = get_team_project_default_permissions(members_team, project)
-            else:
-                if project.created_by != user:
-                    role = get_team_project_default_permissions(members_team, project)
-
-            data = {"project": project.pk, "username": user.username, "role": role}
-            serializer = ShareProjectSerializer(data=data)
-            if serializer.is_valid():
-                serializer.save()
-        # remove user from owners team
-        remove_user_from_team(owners_team, user)
 
 
 class OrganizationMemberSerializer(serializers.Serializer):
@@ -161,24 +116,16 @@ class OrganizationMemberSerializer(serializers.Serializer):
         if username:
             user = User.objects.get(username=username)
 
-            add_user_to_organization(organization, user)
-            _set_organization_role_to_user(organization, user, role)
-
-            if email_msg:
-                _compose_send_email(organization, user, email_msg, email_subject)
-
             if remove:
-                remove_user_from_organization(organization, user)
+                remove_user_from_org_async.apply_async(args=[organization.pk, user.pk])
 
-            projects = Project.objects.filter(
-                organization=organization.user, deleted_at__isnull=True
-            )
-            for project in projects.iterator():
-                # Queue permission propagation with a
-                # delay for permissions to be effected
-                propagate_project_permissions_async.apply_async(
-                    args=[project.id], countdown=60
+            else:
+                add_user_to_org_and_share_projects_async.apply_async(
+                    args=[organization.pk, user.pk, role]
                 )
+
+                if email_msg:
+                    _compose_send_email(organization, user, email_msg, email_subject)
 
         return organization
 

--- a/onadata/libs/tests/models/test_share_project.py
+++ b/onadata/libs/tests/models/test_share_project.py
@@ -1,0 +1,66 @@
+"""Tests for module onadata.libs.models.share_project"""
+
+from unittest.mock import patch, call
+
+from onadata.apps.logger.models.data_view import DataView
+from onadata.apps.logger.models.project import Project
+from onadata.apps.logger.models.xform import XForm
+from onadata.apps.main.tests.test_base import TestBase
+from onadata.libs.models.share_project import ShareProject
+from onadata.libs.permissions import ManagerRole
+
+
+@patch(
+    "onadata.libs.models.share_project.propagate_project_permissions_async.apply_async"
+)
+class ShareProjectTestCase(TestBase):
+    """Tests for model ShareProject"""
+
+    def setUp(self):
+        super().setUp()
+
+    @patch("onadata.libs.models.share_project.safe_delete")
+    def test_share(self, mock_safe_delete, mock_propagate):
+        """A project is shared with a user
+
+        Permissions assigned to project, xform and dataview
+        """
+        self._publish_transportation_form()
+        md_xform = """
+        | survey  |
+        |         | type              | name  | label  |
+        |         | text              | name  | Name   |
+        |         | integer           | age   | Age    |
+        |         | select one fruits | fruit | Fruit  |
+        |         |                   |       |        |
+        | choices | list name         | name  | label  |
+        |         | fruits            | 1     | Mango  |
+        |         | fruits            | 2     | Orange |
+        |         | fruits            | 3     | Apple  |
+        """
+        project = Project.objects.create(
+            name="Demo", organization=self.user, created_by=self.user
+        )
+        self._publish_markdown(md_xform, self.user, project)
+        form = XForm.objects.all().order_by("-pk")[0]
+        DataView.objects.create(
+            name="Demo",
+            xform=form,
+            project=self.project,
+            matches_parent=True,
+            columns=[],
+        )
+        alice = self._create_user("alice", "Yuao8(-)")
+        instance = ShareProject(self.project, alice, "manager")
+        instance.save()
+        self.assertTrue(ManagerRole.user_has_role(alice, self.project))
+        self.assertTrue(ManagerRole.user_has_role(alice, self.xform))
+        self.assertTrue(ManagerRole.user_has_role(alice, form))
+        mock_propagate.assert_called_once_with(args=[self.project.pk])
+        # Cache is invalidated
+        mock_safe_delete.assert_has_calls(
+            [
+                call(f"ps-project_owner-{self.project.pk}"),
+                call(f"ps-project_permissions-{self.project.pk}"),
+            ]
+        )


### PR DESCRIPTION
### Changes / Features implemented

[Share a project with user](https://github.com/onaio/onadata/blob/main/docs/projects.rst#share-a-project-with-users) asynchronously
[Add user to an organization](https://github.com/onaio/onadata/blob/main/docs/orgs.rst#add-a-user-to-an-organization) asynchronously
Refactor to remove redundant code

### Steps taken to verify this change does what is intended

- [x] QA

### Side effects of implementing this change

No side effects

**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  - [ ] Updated documentation

Closes #2505
