### PR TITLE
When an odk token expires is None, deactivate and replace

### DIFF
--- a/onadata/apps/api/viewsets/connect_viewset.py
+++ b/onadata/apps/api/viewsets/connect_viewset.py
@@ -178,7 +178,9 @@ class ConnectViewSet(
                     user=user, status=ODKToken.ACTIVE
                 )
 
-                if not created and timezone.now() > token.expires:
+                if not token.expires or (
+                    not created and timezone.now() > token.expires
+                ):
                     token.status = ODKToken.INACTIVE
                     token.save()
                     token = ODKToken.objects.create(user=user)


### PR DESCRIPTION
### Changes / Features implemented
Fix `NoneType` error
### Steps taken to verify this change does what is intended
Added a test case
### Side effects of implementing this change
`ODKTokens` with `expires` fields set to `None` will be inactivated


**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  - [ ] Updated documentation

Closes https://github.com/onaio/onadata/issues/2584
