### PR TITLE
Set permissions for merged dataset asynchronously

### DIFF
--- a/onadata/apps/logger/models/merged_xform.py
+++ b/onadata/apps/logger/models/merged_xform.py
@@ -2,7 +2,7 @@
 """
 MergedXForm model - stores info on forms to merge.
 """
-from django.db import models
+from django.db import models, transaction
 from django.db.models.signals import post_save
 
 from onadata.apps.logger.models.xform import XForm
@@ -39,10 +39,14 @@ def set_object_permissions(sender, instance=None, created=False, **kwargs):
             OwnerRole.add(instance.created_by, instance)
             OwnerRole.add(instance.created_by, instance.xform_ptr)
 
-        from onadata.libs.utils.project_utils import set_project_perms_to_xform
+        from onadata.libs.utils.project_utils import (
+            set_project_perms_to_xform_async,
+        )
 
-        set_project_perms_to_xform(instance, instance.project)
-        set_project_perms_to_xform(instance.xform_ptr, instance.project)
+        def set_perms():
+            set_project_perms_to_xform_async.delay(instance.pk, instance.project.pk)
+
+        transaction.on_commit(lambda: set_perms())
 
 
 post_save.connect(

--- a/onadata/apps/logger/models/merged_xform.py
+++ b/onadata/apps/logger/models/merged_xform.py
@@ -43,10 +43,11 @@ def set_object_permissions(sender, instance=None, created=False, **kwargs):
             set_project_perms_to_xform_async,
         )
 
-        def set_perms():
-            set_project_perms_to_xform_async.delay(instance.pk, instance.project.pk)
-
-        transaction.on_commit(lambda: set_perms())
+        transaction.on_commit(
+            lambda: set_project_perms_to_xform_async.delay(
+                instance.pk, instance.project.pk
+            )
+        )
 
 
 post_save.connect(

--- a/onadata/apps/logger/models/tests/test_merged_xform.py
+++ b/onadata/apps/logger/models/tests/test_merged_xform.py
@@ -1,0 +1,51 @@
+"""Tests for module onadata.apps.logger.models.merged_xform"""
+
+from pyxform.builder import create_survey_element_from_dict
+from unittest.mock import call, patch
+
+from onadata.apps.main.tests.test_base import TestBase
+from onadata.apps.logger.models.merged_xform import MergedXForm
+from onadata.apps.logger.models.xform import XForm
+
+
+class MergedXFormTestCase(TestBase):
+    @patch("onadata.libs.utils.project_utils.set_project_perms_to_xform_async.delay")
+    def test_perms_applied_async_on_create(self, mock_set_perms):
+        """Permissions are applied asynchronously on create"""
+        md = """
+        | survey  |
+        |         | type              | name  | label   |
+        |         | select one fruits | fruit | Fruit   |
+
+        | choices |
+        |         | list name         | name   | label  |
+        |         | fruits            | orange | Orange |
+        |         | fruits            | mango  | Mango  |
+        """
+        self._publish_markdown(md, self.user, id_string="a")
+        self._publish_markdown(md, self.user, id_string="b")
+        xf1 = XForm.objects.get(id_string="a")
+        xf2 = XForm.objects.get(id_string="b")
+        survey = create_survey_element_from_dict(xf1.json_dict())
+        survey["id_string"] = "c"
+        survey["sms_keyword"] = survey["id_string"]
+        survey["title"] = "Merged XForm"
+        merged_xf = MergedXForm.objects.create(
+            id_string=survey["id_string"],
+            sms_id_string=survey["id_string"],
+            title=survey["title"],
+            user=self.user,
+            created_by=self.user,
+            is_merged_dataset=True,
+            project=self.project,
+            xml=survey.to_xml(),
+            json=survey.to_json(),
+        )
+        merged_xf.xforms.add(xf1)
+        merged_xf.xforms.add(xf2)
+        calls = [
+            call(xf1.pk, self.project.pk),
+            call(xf2.pk, self.project.pk),
+            call(merged_xf.pk, self.project.pk),
+        ]
+        mock_set_perms.assert_has_calls(calls, any_order=True)

--- a/onadata/libs/utils/project_utils.py
+++ b/onadata/libs/utils/project_utils.py
@@ -21,12 +21,18 @@ from onadata.apps.api.models.team import Team
 from onadata.apps.logger.models.project import Project
 from onadata.apps.logger.models.xform import XForm
 from onadata.celeryapp import app
-from onadata.libs.permissions import (ROLES, OwnerRole,
-                                      get_object_users_with_permissions,
-                                      get_role, is_organization)
-from onadata.libs.utils.common_tags import (API_TOKEN,
-                                            ONADATA_KOBOCAT_AUTH_HEADER,
-                                            OWNER_TEAM_NAME)
+from onadata.libs.permissions import (
+    ROLES,
+    OwnerRole,
+    get_object_users_with_permissions,
+    get_role,
+    is_organization,
+)
+from onadata.libs.utils.common_tags import (
+    API_TOKEN,
+    ONADATA_KOBOCAT_AUTH_HEADER,
+    OWNER_TEAM_NAME,
+)
 from onadata.libs.utils.common_tools import report_exception
 
 
@@ -123,6 +129,10 @@ def set_project_perms_to_xform_async(self, xform_id, project_id):
             self.retry(countdown=60 * self.request.retries, exc=e)
         else:
             set_project_perms_to_xform(xform, project)
+
+            # Set MergedXForm permissions if XForm is also a MergedXForm
+            if hasattr(xform, "mergedxform"):
+                set_project_perms_to_xform(xform.mergedxform, project)
 
     try:
         if getattr(settings, "SLAVE_DATABASES", []):


### PR DESCRIPTION
### Changes / Features implemented

Refactor to apply permissions for merged dataset asynchronously

### Steps taken to verify this change does what is intended

- [x] Added tests

### Side effects of implementing this change

**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  - [ ] Updated documentation

Closes #
