### PR TITLE
Fix ValueError for User instance primary key in password validation

### DIFF
--- a/onadata/libs/tests/utils/test_password_validator.py
+++ b/onadata/libs/tests/utils/test_password_validator.py
@@ -1,0 +1,57 @@
+from django.test import TestCase
+from django.contrib.auth.models import User
+from django.core.exceptions import ValidationError
+
+from onadata.apps.main.models.password_history import PasswordHistory
+from onadata.libs.utils.validators import PreviousPasswordValidator
+
+class PreviousPasswordValidatorTestCase(TestCase):
+    def test_validator_does_not_raise_valueerror_missing_pk(self):
+        # Create a validator instance
+        validator = PreviousPasswordValidator()
+
+        # Create a user instance without saving it to the database
+        user = User(username='testuser')
+
+        # Call the validate method and ensure it does not raise a ValueError
+        try:
+            validator.validate('somepassword', user=user)
+        except ValueError:
+            self.fail("PreviousPasswordValidator raised ValueError unexpectedly!")
+
+    def test_validator_raises_validationerror_for_reused_password(self):
+        # Create and save a user to the database
+        user = User.objects.create(username='testuser')
+        user.set_password('oldpassword')
+        user.save()
+
+        # Add the old password to password history
+        PasswordHistory.objects.create(user=user, hashed_password=user.password)
+
+        # Create a validator instance
+        validator = PreviousPasswordValidator()
+
+        # Try using an old password
+        with self.assertRaises(ValidationError) as cm:
+            validator.validate('oldpassword', user=user)
+
+        self.assertEqual(
+            str(cm.exception.message), "You cannot use a previously used password.")
+
+    def test_validator_allows_new_password(self):
+        # Create and save a user to the database
+        user = User.objects.create(username='testuser')
+        user.set_password('oldpassword')
+        user.save()
+
+        # Add the old password to password history
+        PasswordHistory.objects.create(user=user, hashed_password=user.password)
+
+        # Create a validator instance
+        validator = PreviousPasswordValidator()
+
+        # Try using a new password
+        try:
+            validator.validate('newpassword@123', user=user)
+        except ValidationError:
+            self.fail("PreviousPasswordValidator raised ValidationError unexpectedly!")

--- a/onadata/libs/tests/utils/test_password_validator.py
+++ b/onadata/libs/tests/utils/test_password_validator.py
@@ -5,24 +5,32 @@ from django.core.exceptions import ValidationError
 from onadata.apps.main.models.password_history import PasswordHistory
 from onadata.libs.utils.validators import PreviousPasswordValidator
 
+
 class PreviousPasswordValidatorTestCase(TestCase):
-    def test_validator_does_not_raise_valueerror_missing_pk(self):
+    """
+    Test case for the PreviousPasswordValidator class.
+    Ensures correct behavior of password validation.
+    """
+
+    def test_missing_pk(self):
+        """Validator does not raise ValueError for missing pk"""
         # Create a validator instance
         validator = PreviousPasswordValidator()
 
         # Create a user instance without saving it to the database
-        user = User(username='testuser')
+        user = User(username="testuser")
 
         # Call the validate method and ensure it does not raise a ValueError
         try:
-            validator.validate('somepassword', user=user)
+            validator.validate("somepassword", user=user)
         except ValueError:
             self.fail("PreviousPasswordValidator raised ValueError unexpectedly!")
 
-    def test_validator_raises_validationerror_for_reused_password(self):
+    def test_reused_password(self):
+        """Test ValidationError exception thrown on reused password"""
         # Create and save a user to the database
-        user = User.objects.create(username='testuser')
-        user.set_password('oldpassword')
+        user = User.objects.create(username="testuser")
+        user.set_password("oldpassword")
         user.save()
 
         # Add the old password to password history
@@ -33,15 +41,17 @@ class PreviousPasswordValidatorTestCase(TestCase):
 
         # Try using an old password
         with self.assertRaises(ValidationError) as cm:
-            validator.validate('oldpassword', user=user)
+            validator.validate("oldpassword", user=user)
 
         self.assertEqual(
-            str(cm.exception.message), "You cannot use a previously used password.")
+            str(cm.exception.message), "You cannot use a previously used password."
+        )
 
-    def test_validator_allows_new_password(self):
+    def test_allows_new_password(self):
+        """Test validator allows new password not used before"""
         # Create and save a user to the database
-        user = User.objects.create(username='testuser')
-        user.set_password('oldpassword')
+        user = User.objects.create(username="testuser")
+        user.set_password("oldpassword")
         user.save()
 
         # Add the old password to password history
@@ -52,6 +62,6 @@ class PreviousPasswordValidatorTestCase(TestCase):
 
         # Try using a new password
         try:
-            validator.validate('newpassword@123', user=user)
+            validator.validate("newpassword@123", user=user)
         except ValidationError:
             self.fail("PreviousPasswordValidator raised ValidationError unexpectedly!")

--- a/onadata/libs/utils/validators.py
+++ b/onadata/libs/utils/validators.py
@@ -12,7 +12,7 @@ class PreviousPasswordValidator:
         self.history_limit = history_limt
 
     def validate(self, password, user=None):
-        if user and user.is_active:
+        if user and user.pk and user.is_active:
             if user.check_password(password):
                 raise ValidationError(self.message)
 


### PR DESCRIPTION
### Changes / Features implemented
- Fix ValueError exception thrown during password validation which happens when the created user instance hasn't been fully committed to database, closes #2603 
### Steps taken to verify this change does what is intended

### Side effects of implementing this change


**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  - [ ] Updated documentation

Closes #
