### PR TITLE
Fix 0 integer, decimal values parsed as string when saving json

### DIFF
--- a/onadata/apps/logger/models/instance.py
+++ b/onadata/apps/logger/models/instance.py
@@ -421,17 +421,13 @@ class InstanceBaseClass:
             numeric_fields = get_numeric_fields(self.xform)
         for key, value in json_dict.items():
             if isinstance(value, str) and key in numeric_fields:
-                converted_value = numeric_checker(value)
-                if converted_value:
-                    json_dict[key] = converted_value
+                json_dict[key] = numeric_checker(value)
             elif isinstance(value, dict):
                 json_dict[key] = self.numeric_converter(value, numeric_fields)
             elif isinstance(value, list):
                 for k, v in enumerate(value):
                     if isinstance(v, str) and key in numeric_fields:
-                        converted_value = numeric_checker(v)
-                        if converted_value:
-                            json_dict[key] = converted_value
+                        json_dict[key] = numeric_checker(v)
                     elif isinstance(v, dict):
                         value[k] = self.numeric_converter(v, numeric_fields)
         return json_dict

--- a/onadata/apps/logger/tests/models/test_instance.py
+++ b/onadata/apps/logger/tests/models/test_instance.py
@@ -1005,3 +1005,70 @@ class TestInstance(TestBase):
                 "label": "300cm purpleheart",
             },
         )
+
+    def test_parse_numbers(self):
+        """Integers and decimals are parsed correctly"""
+        md = """
+        | survey |
+        |        | type    | name        | label          |
+        |        | integer | num_integer | I am an integer|
+        |        | decimal | num_decimal | I am a decimal |
+        """
+        self._publish_markdown(md, self.user)
+        xform = XForm.objects.order_by("-pk").first()
+        xml = (
+            '<data xmlns:jr="http://openrosa.org/javarosa" xmlns:orx='
+            '"http://openrosa.org/xforms" id="just_numbers" version="202401291157">'
+            "<formhub>"
+            "<uuid>bd4278ad2fd8418fba5e6a822e2623e7</uuid>"
+            "</formhub>"
+            "<num_integer>4</num_integer>"
+            "<num_decimal>5.5</num_decimal>"
+            "<meta>"
+            "<instanceID>uuid:49d75027-405a-4e08-be71-db9a75c70fc2</instanceID>"
+            "</meta>"
+            "</data>"
+        )
+        instance = Instance.objects.create(xml=xml, xform=xform)
+        instance.refresh_from_db()
+
+        self.assertEqual(instance.json["num_integer"], 4)
+        self.assertEqual(instance.json["num_decimal"], 5.5)
+
+        # Test 0
+        xml = (
+            '<data xmlns:jr="http://openrosa.org/javarosa" xmlns:orx='
+            '"http://openrosa.org/xforms" id="just_numbers" version="202401291157">'
+            "<formhub>"
+            "<uuid>bd4278ad2fd8418fba5e6a822e2623e7</uuid>"
+            "</formhub>"
+            "<num_integer>0</num_integer>"
+            "<num_decimal>0.0</num_decimal>"
+            "<meta>"
+            "<instanceID>uuid:59d75027-405a-4e08-be71-db9a75c70fc2</instanceID>"
+            "</meta>"
+            "</data>"
+        )
+        instance = Instance.objects.create(xml=xml, xform=xform)
+        instance.refresh_from_db()
+        self.assertEqual(instance.json["num_integer"], 0)
+        self.assertEqual(instance.json["num_decimal"], 0.0)
+
+        #  Test negatives
+        xml = (
+            '<data xmlns:jr="http://openrosa.org/javarosa" xmlns:orx='
+            '"http://openrosa.org/xforms" id="just_numbers" version="202401291157">'
+            "<formhub>"
+            "<uuid>bd4278ad2fd8418fba5e6a822e2623e7</uuid>"
+            "</formhub>"
+            "<num_integer>-1</num_integer>"
+            "<num_decimal>-1.0</num_decimal>"
+            "<meta>"
+            "<instanceID>uuid:69d75027-405a-4e08-be71-db9a75c70fc2</instanceID>"
+            "</meta>"
+            "</data>"
+        )
+        instance = Instance.objects.create(xml=xml, xform=xform)
+        instance.refresh_from_db()
+        self.assertEqual(instance.json["num_integer"], -1)
+        self.assertEqual(instance.json["num_decimal"], -1.0)


### PR DESCRIPTION
### Changes / Features implemented

Fix 0 integer, decimal values parsed as string when saving submission json

### Steps taken to verify this change does what is intended

- [x] QA

**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  - [ ] Updated documentation

Closes #2619 
