### PR TITLE
Ignore EntityList model permissions on API endpoints

### DIFF
--- a/onadata/apps/api/permissions.py
+++ b/onadata/apps/api/permissions.py
@@ -558,3 +558,17 @@ class IsAuthenticatedSubmission(BasePermission):
                 return False
 
         return True
+
+
+class DjangoObjectPermissionsIgnoreModelPerm(DjangoObjectPermissions):
+    """
+    Similar to DjangoModelPermissions, except that model permissions
+    are ignored.
+    """
+
+    def has_permission(self, request, view):
+        """Override `has_permission` method"""
+        if request.user.is_anonymous and request.method not in SAFE_METHODS:
+            return False
+
+        return True

--- a/onadata/apps/api/permissions.py
+++ b/onadata/apps/api/permissions.py
@@ -566,6 +566,7 @@ class DjangoObjectPermissionsIgnoreModelPerm(DjangoObjectPermissions):
     are ignored.
     """
 
+    # pylint: disable=unused-argument
     def has_permission(self, request, view):
         """Override `has_permission` method"""
         if request.user.is_anonymous and request.method not in SAFE_METHODS:

--- a/onadata/apps/api/viewsets/entity_list_viewset.py
+++ b/onadata/apps/api/viewsets/entity_list_viewset.py
@@ -12,7 +12,7 @@ from rest_framework.mixins import (
 )
 
 
-from onadata.apps.api.permissions import DjangoObjectPermissionsAllowAnon
+from onadata.apps.api.permissions import DjangoObjectPermissionsIgnoreModelPerm
 from onadata.apps.api.tools import get_baseviewset_class
 from onadata.apps.logger.models import Entity, EntityList
 from onadata.libs.filters import AnonUserEntityListFilter, EntityListProjectFilter
@@ -53,7 +53,7 @@ class EntityListViewSet(
         )
     )
     serializer_class = EntityListSerializer
-    permission_classes = (DjangoObjectPermissionsAllowAnon,)
+    permission_classes = (DjangoObjectPermissionsIgnoreModelPerm,)
     pagination_class = StandardPageNumberPagination
     filter_backends = (AnonUserEntityListFilter, EntityListProjectFilter)
 

--- a/onadata/libs/utils/user_auth.py
+++ b/onadata/libs/utils/user_auth.py
@@ -17,7 +17,6 @@ from rest_framework.authtoken.models import Token
 
 from onadata.apps.api.models.team import Team
 from onadata.apps.api.models.temp_token import TempToken
-from onadata.apps.logger.models.entity_list import EntityList
 from onadata.apps.logger.models.note import Note
 from onadata.apps.logger.models.project import Project
 from onadata.apps.logger.models.xform import XForm
@@ -223,16 +222,7 @@ def add_cors_headers(response):
 
 def set_api_permissions_for_user(user):
     """Sets the permissions to allow a ``user`` to access the APU."""
-    models = [
-        UserProfile,
-        XForm,
-        MergedXForm,
-        Project,
-        Team,
-        OrganizationProfile,
-        Note,
-        EntityList,
-    ]
+    models = [UserProfile, XForm, MergedXForm, Project, Team, OrganizationProfile, Note]
     for model in models:
         for perm in get_perms_for_model(model):
             assign_perm(f"{perm.content_type.app_label}.{perm.codename}", user)


### PR DESCRIPTION
### Changes / Features implemented

Ignore permissions on API endpoints and avoid manually setting model permissions when a user is created. 
Also avoids having a migration to add the EntityList permissions to existing users so that they can access the API