### PR TITLE
User per-role cache key for the organization_profile_viewset

### DIFF
--- a/onadata/apps/api/tasks.py
+++ b/onadata/apps/api/tasks.py
@@ -12,7 +12,6 @@ from django.conf import settings
 from django.core.files.uploadedfile import TemporaryUploadedFile
 from django.core.files.storage import default_storage
 from django.core.mail import send_mail
-from django.core.cache import cache
 from django.contrib.auth import get_user_model
 from django.db import DatabaseError
 from django.utils import timezone
@@ -261,7 +260,7 @@ def remove_org_user_async(org_id, user_id):
     else:
         tools.remove_user_from_organization(organization, user)
 
-        invalidate_organization_cache(organization.username)
+        invalidate_organization_cache(organization.user.username)
 
 
 @app.task(base=ShareProjectBaseTask)

--- a/onadata/apps/api/tasks.py
+++ b/onadata/apps/api/tasks.py
@@ -38,13 +38,12 @@ logger = logging.getLogger(__name__)
 User = get_user_model()
 
 
-def invalidate_organization_cache(organization_username):
-    """Set organization cache to None for all roles"""
-    role_names = [role.name for role in ROLES_ORDERED]
-    org_roles = [f"{ORG_PROFILE_CACHE}{organization_username}-{user_role}"
-                 for user_role in role_names + ['anon']]
-    for cache_key in org_roles:
-        safe_delete(cache_key)
+def invalidate_organization_cache(org_username):
+    """Set organization cache to none for all roles"""
+    for role in ROLES_ORDERED:
+        key = f"{ORG_PROFILE_CACHE}{org_username}-{role.name}"
+        safe_delete(key)
+    safe_delete(f"{ORG_PROFILE_CACHE}{org_username}-anon")
 
 
 def recreate_tmp_file(name, path, mime_type):

--- a/onadata/apps/api/tasks.py
+++ b/onadata/apps/api/tasks.py
@@ -21,14 +21,13 @@ from onadata.apps.api import tools
 from onadata.apps.api.models.organization_profile import OrganizationProfile
 from onadata.apps.logger.models import Instance, ProjectInvitation, XForm, Project
 from onadata.celeryapp import app
-from onadata.libs.permissions import ROLES_ORDERED
-from onadata.libs.utils.cache_tools import ORG_PROFILE_CACHE
 from onadata.libs.utils.email import send_generic_email
 from onadata.libs.utils.model_tools import queryset_iterator
 from onadata.libs.utils.cache_tools import (
     safe_delete,
     XFORM_REGENERATE_INSTANCE_JSON_TASK,
 )
+from onadata.libs.utils.logger_tools import invalidate_organization_cache
 from onadata.libs.models.share_project import ShareProject
 from onadata.libs.utils.email import ProjectInvitationEmail
 
@@ -36,14 +35,6 @@ logger = logging.getLogger(__name__)
 
 
 User = get_user_model()
-
-
-def invalidate_organization_cache(org_username):
-    """Set organization cache to none for all roles"""
-    for role in ROLES_ORDERED:
-        key = f"{ORG_PROFILE_CACHE}{org_username}-{role.name}"
-        safe_delete(key)
-    safe_delete(f"{ORG_PROFILE_CACHE}{org_username}-anon")
 
 
 def recreate_tmp_file(name, path, mime_type):

--- a/onadata/apps/api/tasks.py
+++ b/onadata/apps/api/tasks.py
@@ -45,7 +45,7 @@ def invalidate_organization_cache(organization_username):
     org_roles = [f"{ORG_PROFILE_CACHE}{organization_username}-{user_role}"
                  for user_role in role_names + ['anon']]
     for cache_key in org_roles:
-        cache.set(cache_key, None)
+        safe_delete(cache_key)
 
 
 def recreate_tmp_file(name, path, mime_type):

--- a/onadata/apps/api/tasks.py
+++ b/onadata/apps/api/tasks.py
@@ -41,8 +41,9 @@ User = get_user_model()
 
 def invalidate_organization_cache(organization_username):
     """Set organization cache to None for all roles"""
+    role_names = [role.name for role in ROLES_ORDERED]
     org_roles = [f"{ORG_PROFILE_CACHE}{organization_username}-{user_role}"
-                 for user_role in ROLES_ORDERED + ['anon']]
+                 for user_role in role_names + ['anon']]
     for cache_key in org_roles:
         cache.set(cache_key, None)
 
@@ -233,7 +234,7 @@ def add_org_user_and_share_projects_async(
     else:
         tools.add_org_user_and_share_projects(organization, user, role)
 
-        invalidate_organization_cache(organization.username)
+        invalidate_organization_cache(organization.user.username)
 
         if email_msg and email_subject and user.email:
             send_mail(

--- a/onadata/apps/api/tasks.py
+++ b/onadata/apps/api/tasks.py
@@ -40,8 +40,9 @@ User = get_user_model()
 
 
 def invalidate_organization_cache(organization_username):
+    """Set organization cache to None for all roles"""
     org_roles = [f"{ORG_PROFILE_CACHE}{organization_username}-{user_role}"
-                 for user_role in [ROLES_ORDERED]]
+                 for user_role in ROLES_ORDERED + ['anon']]
     for cache_key in org_roles:
         cache.set(cache_key, None)
 

--- a/onadata/apps/api/tests/test_tasks.py
+++ b/onadata/apps/api/tests/test_tasks.py
@@ -123,6 +123,7 @@ class RegenerateFormInstanceJsonTestCase(TestBase):
         self.assertFalse(instance.json)
 
 def set_cache_for_org(org, request):
+    """Utility to set org cache"""
     org_profile_json = OrganizationSerializer(
             org, context={"request": request}
     ).data
@@ -140,7 +141,7 @@ class AddOrgUserAndShareProjectsAsyncTestCase(TestBase):
         self.org = OrganizationProfile.objects.create(
             user=self.org_user, name="Ona Org", creator=alice
         )
-        self.extra = {"HTTP_AUTHORIZATION": "Token %s" % self.user.auth_token}
+        self.extra = {"HTTP_AUTHORIZATION": f"Token {self.user.auth_token}"}
 
     def test_user_added_to_org(self, mock_add):
         """User is added to organization"""
@@ -241,7 +242,7 @@ class RemoveOrgUserAsyncTestCase(TestBase):
         self.org = OrganizationProfile.objects.create(
             user=self.org_user, name="Ona Org", creator=alice
         )
-        self.extra = {"HTTP_AUTHORIZATION": "Token %s" % self.user.auth_token}
+        self.extra = {"HTTP_AUTHORIZATION": f"Token {self.user.auth_token}"}
 
     def test_user_removed_from_org(self, mock_remove):
         """User is removed from organization"""

--- a/onadata/apps/api/tests/test_tasks.py
+++ b/onadata/apps/api/tests/test_tasks.py
@@ -21,8 +21,10 @@ from onadata.apps.api.models.organization_profile import OrganizationProfile
 from onadata.apps.logger.models import ProjectInvitation, Instance
 from onadata.apps.main.tests.test_base import TestBase
 from onadata.libs.permissions import ManagerRole
+from onadata.libs.serializers.organization_serializer import OrganizationSerializer
 from onadata.libs.utils.user_auth import get_user_default_project
 from onadata.libs.utils.email import ProjectInvitationEmail
+from onadata.libs.utils.cache_tools import ORG_PROFILE_CACHE
 
 User = get_user_model()
 
@@ -120,6 +122,11 @@ class RegenerateFormInstanceJsonTestCase(TestBase):
         instance.refresh_from_db()
         self.assertFalse(instance.json)
 
+def set_cache_for_org(org, request):
+    org_profile_json = OrganizationSerializer(
+            org, context={"request": request}
+    ).data
+    cache.set(f"{ORG_PROFILE_CACHE}{org.user.username}-owner", org_profile_json)
 
 @patch("onadata.apps.api.tasks.tools.add_org_user_and_share_projects")
 class AddOrgUserAndShareProjectsAsyncTestCase(TestBase):
@@ -136,10 +143,17 @@ class AddOrgUserAndShareProjectsAsyncTestCase(TestBase):
 
     def test_user_added_to_org(self, mock_add):
         """User is added to organization"""
+        self.extra = {"HTTP_AUTHORIZATION": "Token %s" % self.user.auth_token}
+        request = self.factory.get("/", **self.extra)
+        request.user = self.user
+        set_cache_for_org(self.org, request)
+        cache_key = f"{ORG_PROFILE_CACHE}{self.org.user.username}-owner"
+        self.assertIsNotNone(cache.get(cache_key))
         add_org_user_and_share_projects_async.delay(
             self.org.pk, self.user.pk, "manager"
         )
         mock_add.assert_called_once_with(self.org, self.user, "manager")
+        self.assertEqual(cache.get(cache_key), None)
 
     def test_role_optional(self, mock_add):
         """role param is optional"""
@@ -230,8 +244,15 @@ class RemoveOrgUserAsyncTestCase(TestBase):
 
     def test_user_removed_from_org(self, mock_remove):
         """User is removed from organization"""
+        self.extra = {"HTTP_AUTHORIZATION": "Token %s" % self.user.auth_token}
+        request = self.factory.get("/", **self.extra)
+        request.user = self.user
+        set_cache_for_org(self.org, request)
+        cache_key = f"{ORG_PROFILE_CACHE}{self.org.user.username}-owner"
+        self.assertIsNotNone(cache.get(cache_key))
         remove_org_user_async.delay(self.org.pk, self.user.pk)
         mock_remove.assert_called_once_with(self.org, self.user)
+        self.assertEqual(cache.get(cache_key), None)
 
     @patch("onadata.apps.api.tasks.logger.exception")
     def test_invalid_org_id(self, mock_log, mock_remove):

--- a/onadata/apps/api/tests/test_tasks.py
+++ b/onadata/apps/api/tests/test_tasks.py
@@ -140,10 +140,10 @@ class AddOrgUserAndShareProjectsAsyncTestCase(TestBase):
         self.org = OrganizationProfile.objects.create(
             user=self.org_user, name="Ona Org", creator=alice
         )
+        self.extra = {"HTTP_AUTHORIZATION": "Token %s" % self.user.auth_token}
 
     def test_user_added_to_org(self, mock_add):
         """User is added to organization"""
-        self.extra = {"HTTP_AUTHORIZATION": "Token %s" % self.user.auth_token}
         request = self.factory.get("/", **self.extra)
         request.user = self.user
         set_cache_for_org(self.org, request)
@@ -241,10 +241,10 @@ class RemoveOrgUserAsyncTestCase(TestBase):
         self.org = OrganizationProfile.objects.create(
             user=self.org_user, name="Ona Org", creator=alice
         )
+        self.extra = {"HTTP_AUTHORIZATION": "Token %s" % self.user.auth_token}
 
     def test_user_removed_from_org(self, mock_remove):
         """User is removed from organization"""
-        self.extra = {"HTTP_AUTHORIZATION": "Token %s" % self.user.auth_token}
         request = self.factory.get("/", **self.extra)
         request.user = self.user
         set_cache_for_org(self.org, request)

--- a/onadata/apps/api/viewsets/organization_profile_viewset.py
+++ b/onadata/apps/api/viewsets/organization_profile_viewset.py
@@ -38,6 +38,7 @@ BaseViewset = get_baseviewset_class()
 
 
 def get_cache_key(user, organization):
+    """Return cache key given user and organization profile"""
     if user.is_anonymous:
         return f"{ORG_PROFILE_CACHE}{organization.user.username}-anon"
     user_role = get_role_in_org(user, organization)
@@ -129,6 +130,9 @@ class OrganizationProfileViewSet(
 
         serializer.save()
 
+        data = OrganizationSerializer(
+            organization, context={"request": request}
+        ).data
         # pylint: disable=attribute-defined-outside-init
         self.etag_data = json.dumps(data)
         resp_status = (

--- a/onadata/apps/api/viewsets/organization_profile_viewset.py
+++ b/onadata/apps/api/viewsets/organization_profile_viewset.py
@@ -130,7 +130,7 @@ class OrganizationProfileViewSet(
 
         serializer.save()
 
-        data = OrganizationSerializer(
+        data = self.serializer_class(
             organization, context={"request": request}
         ).data
         # pylint: disable=attribute-defined-outside-init


### PR DESCRIPTION
### Changes / Features implemented
- Invalidate cache when organization permissions are updated
- User per-role cache key for the organization_profile_viewset

### Steps taken to verify this change does what is intended
- Updated tests
### Side effects of implementing this change
N/A

**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  - [ ] Updated documentation

Closes https://github.com/onaio/onadata/issues/2672
