### PR TITLE
Fix stale data sent to rest services after editing submission

### DIFF
--- a/onadata/apps/api/tests/viewsets/test_data_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_data_viewset.py
@@ -3782,7 +3782,10 @@ class TestOSM(TestAbstractViewSet):
         self._publish_xls_form_to_project(xlsform_path=xlsform_path)
         submission_path = os.path.join(osm_fixtures_dir, "instance_a.xml")
         files = [open(path, "rb") for path in paths]
-        self._make_submission(submission_path, media_file=files)
+
+        with self.captureOnCommitCallbacks(execute=True):
+            # Ensure on commit callbacks are executed
+            self._make_submission(submission_path, media_file=files)
         self.assertTrue(hasattr(self, "instance"))
         self.assertEqual(self.instance.attachments.all().count(), len(files))
 

--- a/onadata/apps/api/tests/viewsets/test_osm_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_osm_viewset.py
@@ -65,9 +65,15 @@ class TestOSMViewSet(TestAbstractViewSet):
         count = Attachment.objects.filter(extension="osm").count()
         count_osm = OsmData.objects.count()
         _submission_time = parse_datetime("2013-02-18 15:54:01Z")
-        self._make_submission(
-            submission_path, media_file=files, forced_submission_time=_submission_time
-        )
+
+        with self.captureOnCommitCallbacks(execute=True):
+            # Ensure on commit callbacks are executed
+            self._make_submission(
+                submission_path,
+                media_file=files,
+                forced_submission_time=_submission_time,
+            )
+
         self.assertTrue(Attachment.objects.filter(extension="osm").count() > count)
         self.assertEqual(OsmData.objects.count(), count_osm + 2)
 

--- a/onadata/apps/api/tests/viewsets/test_project_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_project_viewset.py
@@ -876,7 +876,6 @@ class TestProjectViewSet(TestAbstractViewSet):
         self.assertTrue(ReadOnlyRole.user_has_role(alice_profile.user, self.project))
 
         with self.captureOnCommitCallbacks(execute=True):
-            # Ensure on commit callbacks are executed
             self._publish_xls_form_to_project()
 
         alice_profile.refresh_from_db()

--- a/onadata/apps/api/tests/viewsets/test_project_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_project_viewset.py
@@ -876,6 +876,7 @@ class TestProjectViewSet(TestAbstractViewSet):
         self.assertTrue(ReadOnlyRole.user_has_role(alice_profile.user, self.project))
 
         with self.captureOnCommitCallbacks(execute=True):
+            # Ensure on commit callbacks are executed
             self._publish_xls_form_to_project()
 
         alice_profile.refresh_from_db()

--- a/onadata/apps/api/tests/viewsets/test_xform_submission_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_xform_submission_viewset.py
@@ -1266,12 +1266,16 @@ class TestXFormSubmissionViewSet(TestAbstractViewSet, TransactionTestCase):
 
             with open(submission_path, "rb") as sf:
                 data = {"xml_submission_file": sf, "media_file": f}
-                request = self.factory.post("/submission", data)
-                response = self.view(request)
-                self.assertEqual(response.status_code, 401)
-                auth = DigestAuth("bob", "bobbob")
-                request.META.update(auth(request.META, response))
-                response = self.view(request, username=self.user.username)
+
+                with self.captureOnCommitCallbacks(execute=True):
+                    # Ensure on commit callbacks are executed
+                    request = self.factory.post("/submission", data)
+                    response = self.view(request)
+                    self.assertEqual(response.status_code, 401)
+                    auth = DigestAuth("bob", "bobbob")
+                    request.META.update(auth(request.META, response))
+                    response = self.view(request, username=self.user.username)
+
                 self.assertContains(response, "Successful submission", status_code=201)
                 instance = Instance.objects.all().order_by("-pk")[0]
                 mock_send.assert_called_once_with(rest_service.service_url, instance)
@@ -1310,12 +1314,16 @@ class TestXFormSubmissionViewSet(TestAbstractViewSet, TransactionTestCase):
 
             with open(submission_path, "rb") as sf:
                 data = {"xml_submission_file": sf, "media_file": f}
-                request = self.factory.post("/submission", data)
-                response = self.view(request)
-                self.assertEqual(response.status_code, 401)
-                auth = DigestAuth("bob", "bobbob")
-                request.META.update(auth(request.META, response))
-                response = self.view(request, username=self.user.username)
+
+                with self.captureOnCommitCallbacks(execute=True):
+                    # Ensure on commit callbacks are executed
+                    request = self.factory.post("/submission", data)
+                    response = self.view(request)
+                    self.assertEqual(response.status_code, 401)
+                    auth = DigestAuth("bob", "bobbob")
+                    request.META.update(auth(request.META, response))
+                    response = self.view(request, username=self.user.username)
+
                 self.assertContains(response, "Successful submission", status_code=201)
                 new_uuid = "6b2cc313-fc09-437e-8139-fcd32f695d41"
                 instance = Instance.objects.get(uuid=new_uuid)

--- a/onadata/apps/restservice/services/generic_json.py
+++ b/onadata/apps/restservice/services/generic_json.py
@@ -24,9 +24,7 @@ class ServiceDefinition(RestServiceInterface):  # pylint: disable=too-few-public
     def send(self, url, data=None):
         """Post submisison JSON data to an external service that accepts a JSON post."""
         if data:
-            # We use Instance.get_full_dict() instead of Instance.json because
-            # when asynchronous processing is enabled, the json may not be upto date
-            post_data = json.dumps(data.get_full_dict())
+            post_data = json.dumps(data.json)
             headers = {"Content-Type": "application/json"}
             try:
                 requests.post(

--- a/onadata/apps/restservice/services/textit.py
+++ b/onadata/apps/restservice/services/textit.py
@@ -33,9 +33,7 @@ class ServiceDefinition(RestServiceInterface):
         :param data:
         :return:
         """
-        # We use Instance.get_full_dict() instead of Instance.json because
-        # when asynchronous processing is enabled, the json may not be upto date
-        extra_data = self.clean_keys_of_slashes(data.get_full_dict())
+        extra_data = self.clean_keys_of_slashes(data.json)
         data_value = MetaData.textit(data.xform)
 
         if data_value:

--- a/onadata/apps/restservice/signals.py
+++ b/onadata/apps/restservice/signals.py
@@ -17,9 +17,7 @@ def call_webhooks(sender, **kwargs):  # pylint: disable=unused-argument
     """
     instance = kwargs["instance"]
 
-    call_service_async.apply_async(
-        args=[instance.pk, instance.get_full_dict()], countdown=1
-    )
+    call_service_async.apply_async(args=[instance.pk], countdown=1)
 
 
 trigger_webhook.connect(call_webhooks, dispatch_uid="call_webhooks")

--- a/onadata/apps/restservice/signals.py
+++ b/onadata/apps/restservice/signals.py
@@ -3,16 +3,9 @@
 RestService signals module
 """
 import django.dispatch
-from django.conf import settings
-from multidb.pinning import use_master
 
 from onadata.apps.restservice.tasks import call_service_async
-from onadata.apps.restservice.utils import call_service
-from onadata.apps.logger.models.instance import Instance
 
-ASYNC_POST_SUBMISSION_PROCESSING_ENABLED = getattr(
-    settings, "ASYNC_POST_SUBMISSION_PROCESSING_ENABLED", False
-)
 
 # pylint: disable=invalid-name
 trigger_webhook = django.dispatch.Signal()
@@ -22,19 +15,11 @@ def call_webhooks(sender, **kwargs):  # pylint: disable=unused-argument
     """
     Call webhooks signal.
     """
-    instance_id = kwargs["instance"].pk
-    if ASYNC_POST_SUBMISSION_PROCESSING_ENABLED:
-        call_service_async.apply_async(args=[instance_id], countdown=1)
-    else:
-        with use_master:
-            try:
-                instance = Instance.objects.get(pk=instance_id)
-            except Instance.DoesNotExist:
-                # if the instance has already been removed we do not send it to the
-                # service
-                pass
-            else:
-                call_service(instance)
+    instance = kwargs["instance"]
+
+    call_service_async.apply_async(
+        args=[instance.pk, instance.get_full_dict()], countdown=1
+    )
 
 
 trigger_webhook.connect(call_webhooks, dispatch_uid="call_webhooks")

--- a/onadata/apps/restservice/tasks.py
+++ b/onadata/apps/restservice/tasks.py
@@ -12,8 +12,8 @@ from onadata.celeryapp import app
 @app.task()
 def call_service_async(instance_pk, latest_json=None):
     """Async function that calls call_service()."""
-    # load the parsed instance
-
+    # Pin to master just incase the Instance was created and is not available
+    # the replicas
     with use_master:
         try:
             instance = Instance.objects.get(pk=instance_pk)

--- a/onadata/apps/restservice/tasks.py
+++ b/onadata/apps/restservice/tasks.py
@@ -13,7 +13,7 @@ from onadata.celeryapp import app
 def call_service_async(instance_pk, latest_json=None):
     """Async function that calls call_service()."""
     # Pin to master just incase the Instance was created and is not available
-    # the replicas
+    # in the replicas
     with use_master:
         try:
             instance = Instance.objects.get(pk=instance_pk)

--- a/onadata/apps/restservice/tasks.py
+++ b/onadata/apps/restservice/tasks.py
@@ -12,8 +12,7 @@ from onadata.celeryapp import app
 @app.task()
 def call_service_async(instance_pk):
     """Async function that calls call_service()."""
-    # Pin to master just incase the Instance was created and is not available
-    # in the replicas
+    # Use master database
     with use_master:
         try:
             instance = Instance.objects.get(pk=instance_pk)
@@ -22,4 +21,4 @@ def call_service_async(instance_pk):
             # service
             return
 
-    call_service(instance)
+        call_service(instance)

--- a/onadata/apps/restservice/tasks.py
+++ b/onadata/apps/restservice/tasks.py
@@ -10,7 +10,7 @@ from onadata.celeryapp import app
 
 
 @app.task()
-def call_service_async(instance_pk, latest_json=None):
+def call_service_async(instance_pk):
     """Async function that calls call_service()."""
     # Pin to master just incase the Instance was created and is not available
     # in the replicas
@@ -21,11 +21,5 @@ def call_service_async(instance_pk, latest_json=None):
             # if the instance has already been removed we do not send it to the
             # service
             return
-
-    if latest_json is None:
-        instance.json = instance.get_full_dict()
-
-    else:
-        instance.json = latest_json
 
     call_service(instance)

--- a/onadata/apps/restservice/tasks.py
+++ b/onadata/apps/restservice/tasks.py
@@ -8,7 +8,7 @@ from onadata.celeryapp import app
 
 
 @app.task()
-def call_service_async(instance_pk):
+def call_service_async(instance_pk, latest_json=None):
     """Async function that calls call_service()."""
     # load the parsed instance
 
@@ -19,4 +19,10 @@ def call_service_async(instance_pk):
         # service
         pass
     else:
+        if latest_json is None:
+            instance.json = instance.get_full_dict()
+
+        else:
+            instance.json = latest_json
+
         call_service(instance)

--- a/onadata/apps/restservice/tests/viewsets/test_restservicesviewset.py
+++ b/onadata/apps/restservice/tests/viewsets/test_restservicesviewset.py
@@ -305,6 +305,7 @@ class TestRestServicesViewSet(TestAbstractViewSet):
         self.assertFalse(mock_http.called)
 
         with self.captureOnCommitCallbacks(execute=True):
+            # Ensure on commit callbacks are executed
             self._make_submissions()
 
         self.assertTrue(mock_http.called)

--- a/onadata/apps/restservice/tests/viewsets/test_restservicesviewset.py
+++ b/onadata/apps/restservice/tests/viewsets/test_restservicesviewset.py
@@ -303,7 +303,9 @@ class TestRestServicesViewSet(TestAbstractViewSet):
         )
 
         self.assertFalse(mock_http.called)
-        self._make_submissions()
+
+        with self.captureOnCommitCallbacks(execute=True):
+            self._make_submissions()
 
         self.assertTrue(mock_http.called)
         self.assertEqual(mock_http.call_count, 4)

--- a/onadata/libs/tests/utils/test_export_tools.py
+++ b/onadata/libs/tests/utils/test_export_tools.py
@@ -102,7 +102,10 @@ class TestExportTools(TestAbstractViewSet):
         self._publish_xls_file_and_set_xform(xlsform_path)
         submission_path = os.path.join(osm_fixtures_dir, "instance_a.xml")
         count = Attachment.objects.filter(extension="osm").count()
-        self._make_submission_w_attachment(submission_path, paths)
+
+        with self.captureOnCommitCallbacks(execute=True):
+            # Ensure on commit callbacks are executed
+            self._make_submission_w_attachment(submission_path, paths)
         self.assertTrue(Attachment.objects.filter(extension="osm").count() > count)
 
         options = {"extension": Attachment.OSM}


### PR DESCRIPTION
### Changes / Features implemented

The data sent to rest services can be stale if the instance is not yet saved to the database when a submission is edited.

We wait until until the transaction completes successfully by using `transaction.on_commit`

### Steps taken to verify this change does what is intended

- [x] QA

Closes #2668
