### PR TITLE
Fix exception thrown when updating organization profile

### DIFF
--- a/onadata/apps/api/tests/viewsets/test_organization_profile_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_organization_profile_viewset.py
@@ -1054,8 +1054,8 @@ class TestOrganizationProfileViewSet(TestAbstractViewSet):
     def test_update_org_name(self):
         self._org_create()
 
-        # update name
-        data = {"name": "Dennis2"}
+        # update name and email
+        data = {"name": "Dennis2", "email": "dennis@mail.com"}
         request = self.factory.patch("/", data=data, **self.extra)
         response = self.view(request, user="denoinc")
         self.assertEqual(response.data["name"], "Dennis2")

--- a/onadata/libs/serializers/organization_serializer.py
+++ b/onadata/libs/serializers/organization_serializer.py
@@ -71,12 +71,11 @@ class OrganizationSerializer(serializers.HyperlinkedModelSerializer):
             first_name, last_name = _get_first_last_names(validated_data.get("name"))
             instance.user.first_name = first_name
             instance.user.last_name = last_name
-            instance.user.save()
 
         if "email" in validated_data:
             instance.user.email = validated_data.pop("email")
-            instance.user.save()
 
+        instance.user.save()
         return super().update(instance, validated_data)
 
     def create(self, validated_data):

--- a/onadata/libs/serializers/organization_serializer.py
+++ b/onadata/libs/serializers/organization_serializer.py
@@ -73,6 +73,10 @@ class OrganizationSerializer(serializers.HyperlinkedModelSerializer):
             instance.user.last_name = last_name
             instance.user.save()
 
+        if "email" in validated_data:
+            instance.user.email = validated_data.pop("email")
+            instance.user.save()
+
         return super().update(instance, validated_data)
 
     def create(self, validated_data):


### PR DESCRIPTION
### Changes / Features implemented
Remove email from `validated_data` before updating the organization profile

### Steps taken to verify this change does what is intended
Updated test cases

**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  - [ ] Updated documentation

Closes https://github.com/onaio/onadata/issues/2676
