### PR TITLE
Add user activity logs to messaging endpoint

### DIFF
--- a/onadata/apps/messaging/constants.py
+++ b/onadata/apps/messaging/constants.py
@@ -26,13 +26,20 @@ SUBMISSION_EDITED = "submission_edited"
 SUBMISSION_DELETED = "submission_deleted"
 SUBMISSION_REVIEWED = "submission_reviewed"
 FORM_UPDATED = "form_updated"
+USER_CREATED = "user_created"
+USER_UPDATED = "user_updated"
+USER_PASSWORD_CHANGED = "password_changed"
 MESSAGE_VERBS = [
     MESSAGE, SUBMISSION_REVIEWED, SUBMISSION_CREATED, SUBMISSION_EDITED,
-    SUBMISSION_DELETED, FORM_UPDATED]
+    SUBMISSION_DELETED, FORM_UPDATED, USER_CREATED, USER_UPDATED,
+    USER_PASSWORD_CHANGED]
 VERB_TOPIC_DICT = {
     SUBMISSION_CREATED: "submission/created",
     SUBMISSION_EDITED: "submission/edited",
     SUBMISSION_DELETED: "submission/deleted",
     SUBMISSION_REVIEWED: "submission/reviewed",
-    FORM_UPDATED: "form/updated"
+    FORM_UPDATED: "form/updated",
+    USER_CREATED: "user/created",
+    USER_UPDATED: "user/updated",
+    USER_PASSWORD_CHANGED: "user/password_changed"
 }


### PR DESCRIPTION
### Changes / Features implemented
Adds message notifications for the following actions:
1. user_created
2. user_updated
3. password_changed

### Steps taken to verify this change does what is intended
- Added tests

**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  - [ ] Updated documentation

Closes #
