### PR TITLE
Cache xform list results

### DIFF
--- a/onadata/apps/api/tasks.py
+++ b/onadata/apps/api/tasks.py
@@ -20,6 +20,7 @@ from django.utils.datastructures import MultiValueDict
 from onadata.apps.api import tools
 from onadata.apps.api.models.organization_profile import OrganizationProfile
 from onadata.apps.logger.models import Instance, ProjectInvitation, XForm, Project
+from onadata.apps.api.tools import invalidate_organization_cache
 from onadata.celeryapp import app
 from onadata.libs.utils.email import send_generic_email
 from onadata.libs.utils.model_tools import queryset_iterator
@@ -27,7 +28,6 @@ from onadata.libs.utils.cache_tools import (
     safe_delete,
     XFORM_REGENERATE_INSTANCE_JSON_TASK,
 )
-from onadata.libs.utils.logger_tools import invalidate_organization_cache
 from onadata.libs.models.share_project import ShareProject
 from onadata.libs.utils.email import ProjectInvitationEmail
 

--- a/onadata/apps/api/tests/viewsets/test_xform_list_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_xform_list_viewset.py
@@ -1336,7 +1336,7 @@ class TestXFormListViewSet(TestAbstractViewSet, TransactionTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 3)
 
-    def test_xform_list_set_cache(self):
+    def test_xform_list_cache_set(self):
         """XForm list cache is set if xform_pk or project_pk kwargs present"""
         # `xform_pk` anonymous user
         request = self.factory.get("/")

--- a/onadata/apps/api/tests/viewsets/test_xform_list_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_xform_list_viewset.py
@@ -1416,3 +1416,39 @@ class TestXFormListViewSet(TestAbstractViewSet, TransactionTestCase):
                 }
             ],
         )
+
+    def test_xform_list_cache_hit(self):
+        """Results returned from cache if available"""
+        cache.set(
+            f"xfm-list-{self.xform.pk}-XForm-anon",
+            [
+                {
+                    "formID": "transportation_2011_07_25",
+                    "name": "transportation_2011_07_25",
+                    "version": "2014111",
+                    "hash": self.xform.hash,
+                    "descriptionText": "",
+                    "downloadUrl": f"http://testserver/bob/forms/{self.xform.pk}/form.xml",
+                    "manifestUrl": None,
+                }
+            ],
+        )
+
+        with patch.object(cache, "set") as mock_cache_set:
+            request = self.factory.get("/")
+            response = self.view(request, xform_pk=self.xform.pk)
+            self.assertEqual(response.status_code, 200)
+            # Cache set not called because results were returned from cache
+            mock_cache_set.assert_not_called()
+
+        path = os.path.join(os.path.dirname(__file__), "..", "fixtures", "formList.xml")
+
+        with open(path, encoding="utf-8") as f:
+            form_list_xml = f.read().strip()
+            data = {"hash": self.xform.hash, "pk": self.xform.pk}
+            content = response.render().content.decode("utf-8")
+            self.assertEqual(content, form_list_xml % data)
+            self.assertTrue(response.has_header("X-OpenRosa-Version"))
+            self.assertTrue(response.has_header("X-OpenRosa-Accept-Content-Length"))
+            self.assertTrue(response.has_header("Date"))
+            self.assertEqual(response["Content-Type"], "text/xml; charset=utf-8")

--- a/onadata/apps/api/tests/viewsets/test_xform_list_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_xform_list_viewset.py
@@ -1336,68 +1336,83 @@ class TestXFormListViewSet(TestAbstractViewSet, TransactionTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 3)
 
-    def test_xform_list_cache_set(self):
+    def test_xform_list_set_cache(self):
         """Cache is set if xform_pk or project_pk kwargs is present"""
-        self.view = XFormListViewSet.as_view({"get": "list"})
-        # `xform_pk` present
-        # Anonymous user
+        # `xform_pk` anonymous user
         request = self.factory.get("/")
         response = self.view(request, xform_pk=self.xform.pk)
         self.assertEqual(response.status_code, 200)
-        path = os.path.join(os.path.dirname(__file__), "..", "fixtures", "formList.xml")
+        self.assertEqual(
+            cache.get(f"xfm-list-{self.xform.pk}-XForm-anon"),
+            [
+                {
+                    "formID": "transportation_2011_07_25",
+                    "name": "transportation_2011_07_25",
+                    "version": "2014111",
+                    "hash": self.xform.hash,
+                    "descriptionText": "",
+                    "downloadUrl": f"http://testserver/bob/forms/{self.xform.pk}/form.xml",
+                    "manifestUrl": None,
+                }
+            ],
+        )
 
-        with open(path, encoding="utf-8") as f:
-            form_list_xml = f.read().strip()
-            data = {"hash": self.xform.hash, "pk": self.xform.pk}
-            content = response.render().content.decode("utf-8")
-            self.assertEqual(content, form_list_xml % data)
-            self.assertTrue(response.has_header("X-OpenRosa-Version"))
-            self.assertTrue(response.has_header("X-OpenRosa-Accept-Content-Length"))
-            self.assertTrue(response.has_header("Date"))
-            self.assertEqual(response["Content-Type"], "text/xml; charset=utf-8")
-            self.assertEqual(
-                cache.get(f"xfm-list-{self.xform.pk}-XForm-anon"),
-                [
-                    {
-                        "formID": "transportation_2011_07_25",
-                        "name": "transportation_2011_07_25",
-                        "version": "2014111",
-                        "hash": self.xform.hash,
-                        "descriptionText": "",
-                        "downloadUrl": f"http://testserver/bob/forms/{self.xform.pk}/form.xml",
-                        "manifestUrl": None,
-                    }
-                ],
-            )
+        # `xform_pk` authenticated user
+        cache.clear()
+        request = self.factory.get("/", **self.extra)
+        response = self.view(request, xform_pk=self.xform.pk)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            cache.get(f"xfm-list-{self.xform.pk}-XForm-owner"),
+            [
+                {
+                    "formID": "transportation_2011_07_25",
+                    "name": "transportation_2011_07_25",
+                    "version": "2014111",
+                    "hash": self.xform.hash,
+                    "descriptionText": "",
+                    "downloadUrl": f"http://testserver/bob/forms/{self.xform.pk}/form.xml",
+                    "manifestUrl": None,
+                }
+            ],
+        )
 
-        # `project_pk` present
-        # Anonymous user
+        # `project_pk` anonymous user
         cache.clear()
         request = self.factory.get("/")
         response = self.view(request, project_pk=self.project.pk)
         self.assertEqual(response.status_code, 200)
-        path = os.path.join(os.path.dirname(__file__), "..", "fixtures", "formList.xml")
+        self.assertEqual(
+            cache.get(f"xfm-list-{self.project.pk}-Project-anon"),
+            [
+                {
+                    "formID": "transportation_2011_07_25",
+                    "name": "transportation_2011_07_25",
+                    "version": "2014111",
+                    "hash": self.xform.hash,
+                    "descriptionText": "",
+                    "downloadUrl": f"http://testserver/bob/forms/{self.xform.pk}/form.xml",
+                    "manifestUrl": None,
+                }
+            ],
+        )
 
-        with open(path, encoding="utf-8") as f:
-            form_list_xml = f.read().strip()
-            data = {"hash": self.xform.hash, "pk": self.xform.pk}
-            content = response.render().content.decode("utf-8")
-            self.assertEqual(content, form_list_xml % data)
-            self.assertTrue(response.has_header("X-OpenRosa-Version"))
-            self.assertTrue(response.has_header("X-OpenRosa-Accept-Content-Length"))
-            self.assertTrue(response.has_header("Date"))
-            self.assertEqual(response["Content-Type"], "text/xml; charset=utf-8")
-            self.assertEqual(
-                cache.get(f"xfm-list-{self.project.pk}-Project-anon"),
-                [
-                    {
-                        "formID": "transportation_2011_07_25",
-                        "name": "transportation_2011_07_25",
-                        "version": "2014111",
-                        "hash": self.xform.hash,
-                        "descriptionText": "",
-                        "downloadUrl": f"http://testserver/bob/forms/{self.xform.pk}/form.xml",
-                        "manifestUrl": None,
-                    }
-                ],
-            )
+        # `project_pk` authenticated user
+        cache.clear()
+        request = self.factory.get("/", **self.extra)
+        response = self.view(request, project_pk=self.project.pk)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            cache.get(f"xfm-list-{self.project.pk}-Project-owner"),
+            [
+                {
+                    "formID": "transportation_2011_07_25",
+                    "name": "transportation_2011_07_25",
+                    "version": "2014111",
+                    "hash": self.xform.hash,
+                    "descriptionText": "",
+                    "downloadUrl": f"http://testserver/bob/forms/{self.xform.pk}/form.xml",
+                    "manifestUrl": None,
+                }
+            ],
+        )

--- a/onadata/apps/api/tests/viewsets/test_xform_list_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_xform_list_viewset.py
@@ -1337,7 +1337,7 @@ class TestXFormListViewSet(TestAbstractViewSet, TransactionTestCase):
         self.assertEqual(len(response.data), 3)
 
     def test_xform_list_set_cache(self):
-        """Cache is set if xform_pk or project_pk kwargs is present"""
+        """XForm list cache is set if xform_pk or project_pk kwargs present"""
         # `xform_pk` anonymous user
         request = self.factory.get("/")
         response = self.view(request, xform_pk=self.xform.pk)
@@ -1418,7 +1418,7 @@ class TestXFormListViewSet(TestAbstractViewSet, TransactionTestCase):
         )
 
     def test_xform_list_cache_hit(self):
-        """Results returned from cache if available"""
+        """XForm list results returned from cache if available"""
         cache.set(
             f"xfm-list-{self.xform.pk}-XForm-anon",
             [

--- a/onadata/apps/api/tests/viewsets/test_xform_list_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_xform_list_viewset.py
@@ -1338,6 +1338,7 @@ class TestXFormListViewSet(TestAbstractViewSet, TransactionTestCase):
 
     def test_xform_list_cache_set(self):
         """Cache is set if xform_pk or project_pk kwargs is present"""
+        # `xform_pk` present
         request = self.factory.get("/")
         response = self.view(request, xform_pk=self.xform.pk)
         self.assertEqual(response.status_code, 401)

--- a/onadata/apps/api/tests/viewsets/test_xform_list_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_xform_list_viewset.py
@@ -1338,12 +1338,10 @@ class TestXFormListViewSet(TestAbstractViewSet, TransactionTestCase):
 
     def test_xform_list_cache_set(self):
         """Cache is set if xform_pk or project_pk kwargs is present"""
+        self.view = XFormListViewSet.as_view({"get": "list"})
         # `xform_pk` present
+        # Anonymous user
         request = self.factory.get("/")
-        response = self.view(request, xform_pk=self.xform.pk)
-        self.assertEqual(response.status_code, 401)
-        auth = DigestAuth("bob", "bobbob")
-        request.META.update(auth(request.META, response))
         response = self.view(request, xform_pk=self.xform.pk)
         self.assertEqual(response.status_code, 200)
         path = os.path.join(os.path.dirname(__file__), "..", "fixtures", "formList.xml")
@@ -1358,5 +1356,48 @@ class TestXFormListViewSet(TestAbstractViewSet, TransactionTestCase):
             self.assertTrue(response.has_header("Date"))
             self.assertEqual(response["Content-Type"], "text/xml; charset=utf-8")
             self.assertEqual(
-                cache.get(f"xfm-list-{self.xform.pk}-XForm-anon"), form_list_xml % data
+                cache.get(f"xfm-list-{self.xform.pk}-XForm-anon"),
+                [
+                    {
+                        "formID": "transportation_2011_07_25",
+                        "name": "transportation_2011_07_25",
+                        "version": "2014111",
+                        "hash": self.xform.hash,
+                        "descriptionText": "",
+                        "downloadUrl": f"http://testserver/bob/forms/{self.xform.pk}/form.xml",
+                        "manifestUrl": None,
+                    }
+                ],
+            )
+
+        # `project_pk` present
+        # Anonymous user
+        cache.clear()
+        request = self.factory.get("/")
+        response = self.view(request, project_pk=self.project.pk)
+        self.assertEqual(response.status_code, 200)
+        path = os.path.join(os.path.dirname(__file__), "..", "fixtures", "formList.xml")
+
+        with open(path, encoding="utf-8") as f:
+            form_list_xml = f.read().strip()
+            data = {"hash": self.xform.hash, "pk": self.xform.pk}
+            content = response.render().content.decode("utf-8")
+            self.assertEqual(content, form_list_xml % data)
+            self.assertTrue(response.has_header("X-OpenRosa-Version"))
+            self.assertTrue(response.has_header("X-OpenRosa-Accept-Content-Length"))
+            self.assertTrue(response.has_header("Date"))
+            self.assertEqual(response["Content-Type"], "text/xml; charset=utf-8")
+            self.assertEqual(
+                cache.get(f"xfm-list-{self.project.pk}-Project-anon"),
+                [
+                    {
+                        "formID": "transportation_2011_07_25",
+                        "name": "transportation_2011_07_25",
+                        "version": "2014111",
+                        "hash": self.xform.hash,
+                        "descriptionText": "",
+                        "downloadUrl": f"http://testserver/bob/forms/{self.xform.pk}/form.xml",
+                        "manifestUrl": None,
+                    }
+                ],
             )

--- a/onadata/apps/api/tests/viewsets/test_xform_list_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_xform_list_viewset.py
@@ -1335,3 +1335,27 @@ class TestXFormListViewSet(TestAbstractViewSet, TransactionTestCase):
         response = self.view(request, project_pk=self.project.pk)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 3)
+
+    def test_xform_list_cache_set(self):
+        """Cache is set if xform_pk or project_pk kwargs is present"""
+        request = self.factory.get("/")
+        response = self.view(request, xform_pk=self.xform.pk)
+        self.assertEqual(response.status_code, 401)
+        auth = DigestAuth("bob", "bobbob")
+        request.META.update(auth(request.META, response))
+        response = self.view(request, xform_pk=self.xform.pk)
+        self.assertEqual(response.status_code, 200)
+        path = os.path.join(os.path.dirname(__file__), "..", "fixtures", "formList.xml")
+
+        with open(path, encoding="utf-8") as f:
+            form_list_xml = f.read().strip()
+            data = {"hash": self.xform.hash, "pk": self.xform.pk}
+            content = response.render().content.decode("utf-8")
+            self.assertEqual(content, form_list_xml % data)
+            self.assertTrue(response.has_header("X-OpenRosa-Version"))
+            self.assertTrue(response.has_header("X-OpenRosa-Accept-Content-Length"))
+            self.assertTrue(response.has_header("Date"))
+            self.assertEqual(response["Content-Type"], "text/xml; charset=utf-8")
+            self.assertEqual(
+                cache.get(f"xfm-list-{self.xform.pk}-XForm-anon"), form_list_xml % data
+            )

--- a/onadata/apps/api/tools.py
+++ b/onadata/apps/api/tools.py
@@ -918,7 +918,7 @@ def invalidate_organization_cache(org_username):
     safe_delete(f"{ORG_PROFILE_CACHE}{org_username}-anon")
 
 
-def get_xform_list_cache_key_by_role(user, xform_or_project):
+def get_xform_list_cache_key(user, xform_or_project):
     """Get the cache key for the XForm list by user role"""
     object_type = type(xform_or_project).__name__
     cache_key_prefix = f"{XFORM_LIST_CACHE}{xform_or_project.id}-{object_type}"

--- a/onadata/apps/api/tools.py
+++ b/onadata/apps/api/tools.py
@@ -51,6 +51,7 @@ from onadata.libs.baseviewset import DefaultBaseViewset
 from onadata.libs.models.share_project import ShareProject
 from onadata.libs.permissions import (
     ROLES,
+    ROLES_ORDERED,
     DataEntryMinorRole,
     DataEntryOnlyRole,
     DataEntryRole,
@@ -75,8 +76,11 @@ from onadata.libs.utils.cache_tools import (
     PROJ_NUM_DATASET_CACHE,
     PROJ_OWNER_CACHE,
     PROJ_SUB_DATE_CACHE,
-    reset_project_cache,
+    ORG_PROFILE_CACHE,
+    XFORM_LIST_CACHE,
+    project_cache_prefixes,
     safe_delete,
+    safe_cache_set,
 )
 from onadata.libs.utils.common_tags import MEMBERS, XFORM_META_PERMS
 from onadata.libs.utils.logger_tools import (
@@ -92,6 +96,7 @@ from onadata.libs.utils.user_auth import (
     check_and_set_form_by_id,
     check_and_set_form_by_id_string,
 )
+
 
 DECIMAL_PRECISION = 2
 
@@ -366,6 +371,23 @@ def do_publish_xlsform(user, post, files, owner, id_string=None, project=None):
         return form.publish(owner, id_string=id_string, created_by=user)
 
     return publish_form(set_form)
+
+
+def reset_project_cache(project, request, project_serializer_class):
+    """
+    Clears and sets project cache
+    """
+
+    # Clear all project cache entries
+    for prefix in project_cache_prefixes:
+        safe_delete(f"{prefix}{project.pk}")
+
+    # Reserialize project and cache value
+    # Note: The ProjectSerializer sets all the other cache entries
+    project_cache_data = project_serializer_class(
+        project, context={"request": request}
+    ).data
+    safe_cache_set(f"{PROJ_OWNER_CACHE}{project.pk}", project_cache_data)
 
 
 def publish_project_xform(request, project):
@@ -873,3 +895,42 @@ def add_org_user_and_share_projects(
             else:
                 project_role = get_team_project_default_permissions(team, project)
                 share(project, project_role)
+
+
+def get_org_profile_cache_key(user, organization):
+    """Return cache key given user and organization profile"""
+    org_username = organization.user.username
+
+    if user.is_anonymous:
+        return f"{ORG_PROFILE_CACHE}{org_username}-anon"
+
+    user_role = get_role_in_org(user, organization)
+
+    return f"{ORG_PROFILE_CACHE}{org_username}-{user_role}"
+
+
+def invalidate_organization_cache(org_username):
+    """Set organization cache to none for all roles"""
+    for role in ROLES_ORDERED:
+        key = f"{ORG_PROFILE_CACHE}{org_username}-{role.name}"
+        safe_delete(key)
+
+    safe_delete(f"{ORG_PROFILE_CACHE}{org_username}-anon")
+
+
+def get_xform_list_cache_key_by_role(user, xform_or_project):
+    """Get the cache key for the XForm list by user role"""
+    object_type = type(xform_or_project).__name__
+    cache_key_prefix = f"{XFORM_LIST_CACHE}{xform_or_project.id}-{object_type}"
+    anonymous_user_key = f"{cache_key_prefix}-anon"
+
+    if user.is_anonymous:
+        return anonymous_user_key
+
+    perms = get_perms(user, xform_or_project)
+    user_role = get_role(perms, xform_or_project)
+
+    if user_role is None:
+        return anonymous_user_key
+
+    return f"{cache_key_prefix}-{user_role}"

--- a/onadata/apps/api/tools.py
+++ b/onadata/apps/api/tools.py
@@ -901,7 +901,15 @@ def invalidate_organization_cache(org_username):
 
 
 def get_xform_list_cache_key(user, xform_or_project):
-    """Get the cache key for the XForm list by user role"""
+    """Get the cache key for the XForm list by user's role
+
+    Args:
+        user: User making request
+        xform_or_project: XForm or Project being accessed
+
+    Returns:
+        str: cache key based on role assigned to form/project
+    """
     object_type = type(xform_or_project).__name__
     cache_key_prefix = f"{XFORM_LIST_CACHE}{xform_or_project.id}-{object_type}"
     anonymous_user_key = f"{cache_key_prefix}-anon"

--- a/onadata/apps/api/tools.py
+++ b/onadata/apps/api/tools.py
@@ -78,9 +78,8 @@ from onadata.libs.utils.cache_tools import (
     PROJ_SUB_DATE_CACHE,
     ORG_PROFILE_CACHE,
     XFORM_LIST_CACHE,
-    project_cache_prefixes,
+    reset_project_cache,
     safe_delete,
-    safe_cache_set,
 )
 from onadata.libs.utils.common_tags import MEMBERS, XFORM_META_PERMS
 from onadata.libs.utils.logger_tools import (
@@ -371,23 +370,6 @@ def do_publish_xlsform(user, post, files, owner, id_string=None, project=None):
         return form.publish(owner, id_string=id_string, created_by=user)
 
     return publish_form(set_form)
-
-
-def reset_project_cache(project, request, project_serializer_class):
-    """
-    Clears and sets project cache
-    """
-
-    # Clear all project cache entries
-    for prefix in project_cache_prefixes:
-        safe_delete(f"{prefix}{project.pk}")
-
-    # Reserialize project and cache value
-    # Note: The ProjectSerializer sets all the other cache entries
-    project_cache_data = project_serializer_class(
-        project, context={"request": request}
-    ).data
-    safe_cache_set(f"{PROJ_OWNER_CACHE}{project.pk}", project_cache_data)
 
 
 def publish_project_xform(request, project):

--- a/onadata/apps/api/viewsets/organization_profile_viewset.py
+++ b/onadata/apps/api/viewsets/organization_profile_viewset.py
@@ -17,7 +17,7 @@ from rest_framework.viewsets import ModelViewSet
 
 from onadata.apps.api import permissions
 from onadata.apps.api.models.organization_profile import OrganizationProfile
-from onadata.apps.api.tools import get_baseviewset_class
+from onadata.apps.api.tools import get_baseviewset_class, get_org_profile_cache_key
 from onadata.libs.filters import (
     OrganizationPermissionFilter,
     OrganizationsSharedWithUserFilter,
@@ -32,7 +32,6 @@ from onadata.libs.serializers.organization_member_serializer import (
 from onadata.libs.serializers.organization_serializer import OrganizationSerializer
 from onadata.libs.utils.cache_tools import safe_delete
 from onadata.libs.utils.common_tools import merge_dicts
-from onadata.libs.utils.logger_tools import get_org_profile_cache_key
 
 BaseViewset = get_baseviewset_class()
 
@@ -121,14 +120,11 @@ class OrganizationProfileViewSet(
 
         serializer.save()
 
-        data = self.serializer_class(
-            organization, context={"request": request}
-        ).data
+        data = self.serializer_class(organization, context={"request": request}).data
         # pylint: disable=attribute-defined-outside-init
         self.etag_data = json.dumps(data)
         resp_status = (
-            status.HTTP_201_CREATED if request.method == "POST"
-            else status.HTTP_200_OK
+            status.HTTP_201_CREATED if request.method == "POST" else status.HTTP_200_OK
         )
 
         return Response(status=resp_status, data=serializer.data)

--- a/onadata/apps/api/viewsets/xform_list_viewset.py
+++ b/onadata/apps/api/viewsets/xform_list_viewset.py
@@ -16,7 +16,7 @@ from rest_framework.response import Response
 from onadata.apps.api.tools import (
     get_baseviewset_class,
     get_media_file_response,
-    get_xform_list_cache_key_by_role,
+    get_xform_list_cache_key,
 )
 from onadata.apps.logger.models.project import Project
 from onadata.apps.logger.models.xform import XForm, get_forms_shared_with_user
@@ -170,11 +170,11 @@ class XFormListViewSet(ETagsMixin, BaseViewset, viewsets.ReadOnlyModelViewSet):
 
         if xform_pk:
             xform = get_object_or_404(XForm, pk=xform_pk)
-            cache_key = get_xform_list_cache_key_by_role(self.request.user, xform)
+            cache_key = get_xform_list_cache_key(self.request.user, xform)
 
         elif project_pk:
             project = get_object_or_404(Project, pk=project_pk)
-            cache_key = get_xform_list_cache_key_by_role(self.request.user, project)
+            cache_key = get_xform_list_cache_key(self.request.user, project)
 
         return cache_key
 

--- a/onadata/apps/api/viewsets/xform_list_viewset.py
+++ b/onadata/apps/api/viewsets/xform_list_viewset.py
@@ -185,9 +185,6 @@ class XFormListViewSet(ETagsMixin, BaseViewset, viewsets.ReadOnlyModelViewSet):
             return Response("", headers=headers, status=204)
 
         cache_key = self._get_xform_list_cache_key()
-        import ipdb
-
-        ipdb.set_trace()
 
         if cache_key is not None:
             cached_result = safe_cache_get(cache_key)

--- a/onadata/apps/api/viewsets/xform_list_viewset.py
+++ b/onadata/apps/api/viewsets/xform_list_viewset.py
@@ -13,7 +13,12 @@ from rest_framework.authentication import TokenAuthentication
 from rest_framework.decorators import action
 from rest_framework.response import Response
 
-from onadata.apps.api.tools import get_baseviewset_class, get_media_file_response
+from onadata.apps.api.tools import (
+    get_baseviewset_class,
+    get_media_file_response,
+    get_xform_list_cache_key_by_role,
+)
+from onadata.apps.logger.models.project import Project
 from onadata.apps.logger.models.xform import XForm, get_forms_shared_with_user
 from onadata.apps.main.models.meta_data import MetaData
 from onadata.apps.main.models.user_profile import UserProfile
@@ -30,7 +35,12 @@ from onadata.libs.serializers.xform_serializer import (
     XFormListSerializer,
     XFormManifestSerializer,
 )
-from onadata.libs.utils.cache_tools import XFORM_MANIFEST_CACHE
+from onadata.libs.utils.cache_tools import (
+    XFORM_MANIFEST_CACHE,
+    XFROM_LIST_CACHE_TTL,
+    safe_cache_get,
+    safe_cache_set,
+)
 from onadata.libs.utils.common_tags import GROUP_DELIMETER_TAG, REPEAT_INDEX_TAGS
 from onadata.libs.utils.export_builder import ExportBuilder
 
@@ -153,14 +163,44 @@ class XFormListViewSet(ETagsMixin, BaseViewset, viewsets.ReadOnlyModelViewSet):
 
         return queryset
 
-    def list(self, request, *args, **kwargs):
-        # pylint: disable=attribute-defined-outside-init
-        self.object_list = self.filter_queryset(self.get_queryset())
+    def _get_xform_list_cache_key(self):
+        xform_pk = self.kwargs.get("xform_pk")
+        project_pk = self.kwargs.get("project_pk")
+        cache_key = None
 
+        if xform_pk:
+            xform = get_object_or_404(XForm, pk=xform_pk)
+            cache_key = get_xform_list_cache_key_by_role(self.request.user, xform)
+
+        elif project_pk:
+            project = get_object_or_404(Project, pk=project_pk)
+            cache_key = get_xform_list_cache_key_by_role(self.request.user, project)
+
+        return cache_key
+
+    def list(self, request, *args, **kwargs):
         headers = get_openrosa_headers(request, location=False)
-        serializer = self.get_serializer(self.object_list, many=True)
+
         if request.method in ["HEAD"]:
             return Response("", headers=headers, status=204)
+
+        cache_key = self._get_xform_list_cache_key()
+        import ipdb
+
+        ipdb.set_trace()
+
+        if cache_key is not None:
+            cached_result = safe_cache_get(cache_key)
+
+            if cached_result is not None:
+                return Response(cached_result, headers=headers)
+
+        # pylint: disable=attribute-defined-outside-init
+        self.object_list = self.filter_queryset(self.get_queryset())
+        serializer = self.get_serializer(self.object_list, many=True)
+
+        if cache_key is not None:
+            safe_cache_set(cache_key, serializer.data, XFROM_LIST_CACHE_TTL)
 
         return Response(serializer.data, headers=headers)
 

--- a/onadata/libs/utils/cache_tools.py
+++ b/onadata/libs/utils/cache_tools.py
@@ -87,8 +87,7 @@ def safe_cache_set(key, value, timeout=None):
     """
     Safely set a value in the cache.
 
-    If the cache is not reachable, the operation silently
-    fails.
+    If the cache is not reachable, the operation silently fails.
 
     Args:
         key (str): The cache key to set.
@@ -113,8 +112,7 @@ def safe_cache_get(key, default=None):
     """
     Safely get a value from the cache.
 
-    If the cache is not reachable, the operation silently
-    fails.
+    If the cache is not reachable, the operation silently fails.
 
     Args:
         key (str): The cache key to retrieve.

--- a/onadata/libs/utils/cache_tools.py
+++ b/onadata/libs/utils/cache_tools.py
@@ -62,7 +62,7 @@ XFORM_CHARTS = "xfm-get_form_charts-"
 XFORM_REGENERATE_INSTANCE_JSON_TASK = "xfm-regenerate_instance_json_task-"
 XFORM_MANIFEST_CACHE = "xfm-manifest-"
 XFORM_LIST_CACHE = "xfm-list-"
-XFROM_LIST_CACHE_TTL = 10 * 60
+XFROM_LIST_CACHE_TTL = 10 * 60  # 10 minutes converted to seconds
 
 # Cache timeouts used in XForm model
 XFORM_REGENERATE_INSTANCE_JSON_TASK_TTL = 24 * 60 * 60  # 24 hrs converted to seconds

--- a/onadata/libs/utils/cache_tools.py
+++ b/onadata/libs/utils/cache_tools.py
@@ -97,7 +97,7 @@ def reset_project_cache(project, request, project_serializer_class):
     project_cache_data = project_serializer_class(
         project, context={"request": request}
     ).data
-    safe_cache_set(f"{PROJ_OWNER_CACHE}{project.pk}", project_cache_data)
+    cache.set(f"{PROJ_OWNER_CACHE}{project.pk}", project_cache_data)
 
 
 def safe_cache_set(key, value, timeout=None):

--- a/onadata/libs/utils/cache_tools.py
+++ b/onadata/libs/utils/cache_tools.py
@@ -83,6 +83,23 @@ def safe_key(key):
     return hashlib.sha256(force_bytes(key)).hexdigest()
 
 
+def reset_project_cache(project, request, project_serializer_class):
+    """
+    Clears and sets project cache
+    """
+
+    # Clear all project cache entries
+    for prefix in project_cache_prefixes:
+        safe_delete(f"{prefix}{project.pk}")
+
+    # Reserialize project and cache value
+    # Note: The ProjectSerializer sets all the other cache entries
+    project_cache_data = project_serializer_class(
+        project, context={"request": request}
+    ).data
+    safe_cache_set(f"{PROJ_OWNER_CACHE}{project.pk}", project_cache_data)
+
+
 def safe_cache_set(key, value, timeout=None):
     """
     Safely set a value in the cache.

--- a/onadata/libs/utils/logger_tools.py
+++ b/onadata/libs/utils/logger_tools.py
@@ -90,30 +90,11 @@ from onadata.apps.messaging.serializers import send_message
 from onadata.apps.viewer.models.data_dictionary import DataDictionary
 from onadata.apps.viewer.models.parsed_instance import ParsedInstance
 from onadata.apps.viewer.signals import process_submission
-from onadata.libs.permissions import ROLES_ORDERED, get_role_in_org
-from onadata.libs.utils.cache_tools import ORG_PROFILE_CACHE, safe_delete
 from onadata.libs.utils.analytics import TrackObjectEvent
 from onadata.libs.utils.common_tags import METADATA_FIELDS
 from onadata.libs.utils.common_tools import get_uuid, report_exception
 from onadata.libs.utils.model_tools import set_uuid, queryset_iterator
 from onadata.libs.utils.user_auth import get_user_default_project
-
-
-def get_org_profile_cache_key(user, organization):
-    """Return cache key given user and organization profile"""
-    if user.is_anonymous:
-        return f"{ORG_PROFILE_CACHE}{organization.user.username}-anon"
-    user_role = get_role_in_org(user, organization)
-    org_username = organization.user.username
-    return f"{ORG_PROFILE_CACHE}{org_username}-{user_role}"
-
-
-def invalidate_organization_cache(org_username):
-    """Set organization cache to none for all roles"""
-    for role in ROLES_ORDERED:
-        key = f"{ORG_PROFILE_CACHE}{org_username}-{role.name}"
-        safe_delete(key)
-    safe_delete(f"{ORG_PROFILE_CACHE}{org_username}-anon")
 
 
 OPEN_ROSA_VERSION_HEADER = "X-OpenRosa-Version"


### PR DESCRIPTION
### Changes / Features implemented

Cache xform list results by users role. 
Move methods to resolve cyclic dependency errors.

**Limitations**

The cache is only invalidated at expiry time. The expiry time is set at 10 minutes. Cache invalidation when a form is deleted/added will be added in future.

### Steps taken to verify this change does what is intended

- [x] Added tests

### Side effects of implementing this change


**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  