### PR TITLE
Bump version to v4.6.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,13 @@ Changelog for Onadata
 
 ``* represents releases that introduce new migrations``
 
-v4.5.1(2024-08-30)
+v4.6.0(2024-09-02)
+------------------
+- Cache xform list results
+  `PR #2692 <https://github.com/onaio/onadata/pull/2692>`
+  [@kelvin-muchiri]
+
+v4.5.2(2024-08-30)
 ------------------
 - Add CustomScopedRateThrolle throttling class
   `PR #2685 <https://github.com/onaio/onadata/pull/2689>`

--- a/onadata/__init__.py
+++ b/onadata/__init__.py
@@ -6,7 +6,7 @@ visualization.
 """
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "4.5.2"
+__version__ = "4.6.0"
 
 
 # This will make sure the app is always imported when

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = onadata
-version = 4.5.2
+version = 4.6.0
 description = Collect Analyze and Share Data
 long_description = file: README.rst
 long_description_content_type = text/x-rst


### PR DESCRIPTION
### Changes

Bump version to v4.6.0

**Enhancements**

- https://github.com/onaio/onadata/pull/2692