### PR TITLE
Pin submission post processing actions to master database

### DIFF
--- a/onadata/apps/logger/models/instance.py
+++ b/onadata/apps/logger/models/instance.py
@@ -228,9 +228,6 @@ def update_xform_submission_count_async(self, instance_id, created):
 def update_xform_submission_count(instance_id, created):
     """Updates the XForm submissions count on a new submission being created."""
     if created:
-        # pylint: disable=import-outside-toplevel
-        from multidb.pinning import use_master
-
         with use_master:
             try:
                 instance = (

--- a/onadata/apps/logger/models/instance.py
+++ b/onadata/apps/logger/models/instance.py
@@ -266,6 +266,7 @@ def update_xform_submission_count(instance_id, created):
                 safe_delete(f"{DATAVIEW_COUNT}{instance.xform_id}")
                 safe_delete(f"{XFORM_COUNT}{instance.xform_id}")
                 # Clear project cache
+                # pylint: disable=import-outside-toplevel
                 from onadata.apps.logger.models.xform import clear_project_cache
 
                 clear_project_cache(instance.xform.project_id)


### PR DESCRIPTION
### Changes

The post processing actions are part of the write flow and should be pinned to master database. This helps the replicas be more available to serve clients
