### PR TITLE
Add missing model index changes

### DIFF
--- a/onadata/apps/logger/models/project.py
+++ b/onadata/apps/logger/models/project.py
@@ -134,6 +134,9 @@ class Project(BaseModel):
             ("view_project_data", "Can view submitted data"),
             ("add_project_entitylist", "Can add entitylist to project"),
         )
+        indexes = [
+            models.Index(fields=["deleted_at"], name="idx_logger_project_deleted_at"),
+        ]
 
     def __str__(self):
         return f"{self.organization}|{self.name}"

--- a/onadata/apps/logger/models/xform.py
+++ b/onadata/apps/logger/models/xform.py
@@ -912,6 +912,12 @@ class XForm(XFormMixin, BaseModel):
             ("can_export_xform_data", _("Can export form data")),
             ("delete_submission", _("Can delete submissions from form")),
         )
+        indexes = [
+            models.Index(
+                fields=["deleted_at"],
+                name="idx_logger_xform_deleted_at",
+            )
+        ]
 
     def file_name(self):
         """Returns the XML filename based on the ``self.id_string``."""


### PR DESCRIPTION
### Changes

Add missing model index changes. 

Running `makemigrations` command adds migrations to remove the indexes added in migration `onadata/apps/logger/migrations/0024_project_idx_logger_project_deleted_at_and_more.py` because the corresponding changes are missing in the models.