### PR TITLE
 Add support for `OR` operation data filter for date fields

### DIFF
--- a/docs/data.rst
+++ b/docs/data.rst
@@ -676,7 +676,7 @@ Example XIII
 
 Query submissions collected within specific dates and edited within specific dates.
 
-Supported date formats:
+ISO 8601 date formats are supported. Below are examples of common formats:
 
 - ``YYYY-MM-DD`` (e.g., 2024-09-18)
 - ``YYYY-MM-DDThh:mm:ss`` (e.g., 2024-09-18T14:30:00)
@@ -693,7 +693,7 @@ Example XIV
 
 Query submissions collected on specific dates and edited on specifc date
 
-Supported date formats:
+ISO 8601 date formats are supported. Below are examples of common formats:
 
 - ``YYYY-MM-DD`` (e.g., 2024-09-18)
 - ``YYYY-MM-DDThh:mm:ss`` (e.g., 2024-09-18T14:30:00)

--- a/docs/data.rst
+++ b/docs/data.rst
@@ -672,6 +672,14 @@ Query submissions with `NULL` submission review status
 
     curl -X GET https://api.ona.io/api/v1/data/22845?query={"_review_status": null}
 
+Example XIII
+
+Query submissions collected within specific dates and submissions edited within specific dates
+
+::
+
+    curl -X GET https://api.ona.io/api/v1/data/22845?query={"$or": [{"_submission_time":{"$gte": "2020-01-01", "$lte": "2020-08-31"}}, {"_last_edited":{"$gte": "2020-01-01", "$lte": "2020-08-31"}}]}
+
 
 All Filters Options
 

--- a/docs/data.rst
+++ b/docs/data.rst
@@ -571,6 +571,15 @@ Query submitted data of a specific form
 ----------------------------------------
 Use the `query` or `data` parameter to pass in a JSON key/value query.
 
+ISO 8601 date formats are supported. Below are examples of common formats:
+
+- ``YYYY-MM-DD`` (e.g., 2024-09-18)
+- ``YYYY-MM-DDThh:mm:ss`` (e.g., 2024-09-18T14:30:00)
+- ``YYYY-MM-DDThh:mm:ssZ`` (e.g., 2024-09-18T14:30:00Z)
+- ``YYYY-MM-DDThh:mm:ss.ssssssZ`` (e.g., 2024-09-18T14:30:00.169615Z)
+- ``YYYY-MM-DDThh:mm:ss±hh:mm`` (e.g., 2024-09-17T13:39:40+00:00)
+- ``YYYY-MM-DDThh:mm:ss.ssssss±hh:mm`` (e.g., 2024-09-17T13:39:40.169615+00:00)
+
 When quering a date time field whose value is in ISO format such as ``2020-12-18T09:36:19.767455+00:00``, it is important to ensure the ``+`` (plus) is encoded to ``%2b``.
 
 ``+`` without encoding is parsed as whitespace. So ``2020-12-18T09:36:19.767455+00:00`` should be converted to ``2020-12-18T09:36:19.767455%2b00:00``.
@@ -676,15 +685,6 @@ Example XIII
 
 Query submissions collected within specific dates and edited within specific dates.
 
-ISO 8601 date formats are supported. Below are examples of common formats:
-
-- ``YYYY-MM-DD`` (e.g., 2024-09-18)
-- ``YYYY-MM-DDThh:mm:ss`` (e.g., 2024-09-18T14:30:00)
-- ``YYYY-MM-DDThh:mm:ssZ`` (e.g., 2024-09-18T14:30:00Z)
-- ``YYYY-MM-DDThh:mm:ss.ssssssZ`` (e.g., 2024-09-18T14:30:00.169615Z)
-- ``YYYY-MM-DDThh:mm:ss±hh:mm`` (e.g., 2024-09-17T13:39:40+00:00)
-- ``YYYY-MM-DDThh:mm:ss.ssssss±hh:mm`` (e.g., 2024-09-17T13:39:40.169615+00:00)
-
 ::
 
     curl -X GET https://api.ona.io/api/v1/data/22845?query={"$or": [{"_submission_time":{"$gte": "2020-01-01", "$lte": "2020-08-31"}}, {"_last_edited":{"$gte": "2020-01-01", "$lte": "2020-08-31"}}]}
@@ -692,15 +692,6 @@ ISO 8601 date formats are supported. Below are examples of common formats:
 Example XIV
 
 Query submissions collected on specific dates and edited on specifc date
-
-ISO 8601 date formats are supported. Below are examples of common formats:
-
-- ``YYYY-MM-DD`` (e.g., 2024-09-18)
-- ``YYYY-MM-DDThh:mm:ss`` (e.g., 2024-09-18T14:30:00)
-- ``YYYY-MM-DDThh:mm:ssZ`` (e.g., 2024-09-18T14:30:00Z)
-- ``YYYY-MM-DDThh:mm:ss.ssssssZ`` (e.g., 2024-09-18T14:30:00.169615Z)
-- ``YYYY-MM-DDThh:mm:ss±hh:mm`` (e.g., 2024-09-17T13:39:40+00:00)
-- ``YYYY-MM-DDThh:mm:ss.ssssss±hh:mm`` (e.g., 2024-09-17T13:39:40.169615+00:00)
 
 ::
 

--- a/docs/data.rst
+++ b/docs/data.rst
@@ -681,7 +681,9 @@ Supported date formats:
 - ``YYYY-MM-DD`` (e.g., 2024-09-18)
 - ``YYYY-MM-DDThh:mm:ss`` (e.g., 2024-09-18T14:30:00)
 - ``YYYY-MM-DDThh:mm:ssZ`` (e.g., 2024-09-18T14:30:00Z)
+- ``YYYY-MM-DDThh:mm:ss.ssssssZ`` (e.g., 2024-09-18T14:30:00.169615Z)
 - ``YYYY-MM-DDThh:mm:ss±hh:mm`` (e.g., 2024-09-17T13:39:40+00:00)
+- ``YYYY-MM-DDThh:mm:ss.ssssss±hh:mm`` (e.g., 2024-09-17T13:39:40.169615+00:00)
 
 ::
 
@@ -696,7 +698,9 @@ Supported date formats:
 - ``YYYY-MM-DD`` (e.g., 2024-09-18)
 - ``YYYY-MM-DDThh:mm:ss`` (e.g., 2024-09-18T14:30:00)
 - ``YYYY-MM-DDThh:mm:ssZ`` (e.g., 2024-09-18T14:30:00Z)
+- ``YYYY-MM-DDThh:mm:ss.ssssssZ`` (e.g., 2024-09-18T14:30:00.169615Z)
 - ``YYYY-MM-DDThh:mm:ss±hh:mm`` (e.g., 2024-09-17T13:39:40+00:00)
+- ``YYYY-MM-DDThh:mm:ss.ssssss±hh:mm`` (e.g., 2024-09-17T13:39:40.169615+00:00)
 
 ::
 

--- a/docs/data.rst
+++ b/docs/data.rst
@@ -674,11 +674,19 @@ Query submissions with `NULL` submission review status
 
 Example XIII
 
-Query submissions collected within specific dates and submissions edited within specific dates
+Query submissions collected within specific dates and edited within specific dates
 
 ::
 
     curl -X GET https://api.ona.io/api/v1/data/22845?query={"$or": [{"_submission_time":{"$gte": "2020-01-01", "$lte": "2020-08-31"}}, {"_last_edited":{"$gte": "2020-01-01", "$lte": "2020-08-31"}}]}
+
+Example XIV
+
+Query submissions collected on specific dates and edited on specifc date
+
+::
+
+    curl -X GET https://api.ona.io/api/v1/data/22845?query={"$or": [{"_submission_time": "2020-01-01"}, {"_last_edited": "2020-01-01"}]}
 
 
 All Filters Options

--- a/docs/data.rst
+++ b/docs/data.rst
@@ -682,6 +682,7 @@ Query submissions with `NULL` submission review status
     curl -X GET https://api.ona.io/api/v1/data/22845?query={"_review_status": null}
 
 Example XIII
+^^^^^^^^^^^^
 
 Query submissions collected within specific dates or edited within specific dates.
 
@@ -690,6 +691,7 @@ Query submissions collected within specific dates or edited within specific date
     curl -X GET https://api.ona.io/api/v1/data/22845?query={"$or": [{"_submission_time":{"$gte": "2020-01-01", "$lte": "2020-08-31"}}, {"_last_edited":{"$gte": "2020-01-01", "$lte": "2020-08-31"}}]}
 
 Example XIV
+^^^^^^^^^^^
 
 Query submissions collected on specific dates or edited on specifc date
 

--- a/docs/data.rst
+++ b/docs/data.rst
@@ -674,7 +674,14 @@ Query submissions with `NULL` submission review status
 
 Example XIII
 
-Query submissions collected within specific dates and edited within specific dates
+Query submissions collected within specific dates and edited within specific dates.
+
+Supported date formats:
+
+- ``YYYY-MM-DD`` (e.g., 2024-09-18)
+- ``YYYY-MM-DDThh:mm:ss`` (e.g., 2024-09-18T14:30:00)
+- ``YYYY-MM-DDThh:mm:ssZ`` (e.g., 2024-09-18T14:30:00Z)
+- ``YYYY-MM-DDThh:mm:ss±hh:mm`` (e.g., 2024-09-17T13:39:40+00:00)
 
 ::
 
@@ -683,6 +690,13 @@ Query submissions collected within specific dates and edited within specific dat
 Example XIV
 
 Query submissions collected on specific dates and edited on specifc date
+
+Supported date formats:
+
+- ``YYYY-MM-DD`` (e.g., 2024-09-18)
+- ``YYYY-MM-DDThh:mm:ss`` (e.g., 2024-09-18T14:30:00)
+- ``YYYY-MM-DDThh:mm:ssZ`` (e.g., 2024-09-18T14:30:00Z)
+- ``YYYY-MM-DDThh:mm:ss±hh:mm`` (e.g., 2024-09-17T13:39:40+00:00)
 
 ::
 

--- a/docs/data.rst
+++ b/docs/data.rst
@@ -689,16 +689,7 @@ Query submissions collected within specific dates or edited within specific date
 ::
 
     curl -X GET https://api.ona.io/api/v1/data/22845?query={"$or": [{"_submission_time":{"$gte": "2020-01-01", "$lte": "2020-08-31"}}, {"_last_edited":{"$gte": "2020-01-01", "$lte": "2020-08-31"}}]}
-
-Example XIV
-^^^^^^^^^^^
-
-Query submissions collected on specific dates or edited on specifc date
-
-::
-
-    curl -X GET https://api.ona.io/api/v1/data/22845?query={"$or": [{"_submission_time": "2020-01-01"}, {"_last_edited": "2020-01-01"}]}
-
+    
 
 All Filters Options
 

--- a/docs/data.rst
+++ b/docs/data.rst
@@ -683,7 +683,7 @@ Query submissions with `NULL` submission review status
 
 Example XIII
 
-Query submissions collected within specific dates and edited within specific dates.
+Query submissions collected within specific dates or edited within specific dates.
 
 ::
 
@@ -691,7 +691,7 @@ Query submissions collected within specific dates and edited within specific dat
 
 Example XIV
 
-Query submissions collected on specific dates and edited on specifc date
+Query submissions collected on specific dates or edited on specifc date
 
 ::
 

--- a/onadata/apps/api/tests/viewsets/test_data_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_data_viewset.py
@@ -3514,7 +3514,7 @@ class TestDataViewSet(SerializeMixin, TestBase):
         self.assertEqual(len(response.data), 4)
 
     def test_data_query_or_metadata(self):
-        """$or filter works for meta data"""
+        """OR operation filter works for meta data"""
         view = DataViewSet.as_view({"get": "list"})
         # Mock date_created
         with patch(
@@ -3559,6 +3559,13 @@ class TestDataViewSet(SerializeMixin, TestBase):
         response = view(request, pk=self.xform.pk)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 5)
+        # Invalid dates
+        query_str = (
+            '{"$or": [{"_submission_time": "foo"}, {"_last_edited": "2024-04-01"}]}'
+        )
+        request = self.factory.get("/?query=%s" % query_str, **self.extra)
+        response = view(request, pk=self.xform.pk)
+        self.assertEqual(response.status_code, 400)
 
     def test_data_list_xml_format(self):
         """Test DataViewSet list XML"""

--- a/onadata/apps/api/tests/viewsets/test_data_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_data_viewset.py
@@ -3528,6 +3528,16 @@ class TestDataViewSet(SerializeMixin, TestBase):
             last_edited=datetime.datetime(2024, 4, 1, tzinfo=timezone.utc),
             xml='<data id="b"><fruit>mango</fruit></data>',
         )
+        # Mock date_created
+        with patch(
+            "django.utils.timezone.now",
+            Mock(return_value=datetime.datetime(2023, 4, 1, tzinfo=timezone.utc)),
+        ):
+            Instance.objects.create(
+                xform=self.xform,
+                last_edited=datetime.datetime(2023, 4, 1, tzinfo=timezone.utc),
+                xml='<data id="b"><fruit>mango</fruit></data>',
+            )
         query_str = (
             '{"$or": [{"_submission_time":{"$gte": "2024-09-17", "$lte": "2024-09-17"}}, '
             '{"_last_edited":{"$gte": "2024-04-01", "$lte": "2024-04-01"}}]}'
@@ -3540,6 +3550,11 @@ class TestDataViewSet(SerializeMixin, TestBase):
             '{"$or": [{"_submission_time":{"$gte": "2024-09-17"}}, '
             '{"_last_edited":{"$gte": "2024-04-01"}}]}'
         )
+        request = self.factory.get("/?query=%s" % query_str, **self.extra)
+        response = view(request, pk=self.xform.pk)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 5)
+        query_str = '{"$or": [{"_submission_time": "2024-09-17"}, {"_last_edited": "2024-04-01"}]}'
         request = self.factory.get("/?query=%s" % query_str, **self.extra)
         response = view(request, pk=self.xform.pk)
         self.assertEqual(response.status_code, 200)

--- a/onadata/apps/api/tests/viewsets/test_data_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_data_viewset.py
@@ -3572,6 +3572,18 @@ class TestDataViewSet(SerializeMixin, TestBase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 3)
 
+    def test_query_invalid_date_format(self):
+        """Invalid formatted date filters are handled"""
+        view = DataViewSet.as_view({"get": "list"})
+
+        for json_date_field in ["_submission_time", "_date_modified", "_last_edited"]:
+            query_str = '{"%s": {"$lte": "watermelon"}}' % json_date_field
+            # query_str = '{"_submission_time": {"$lte": "watermelon"}}'
+            request = self.factory.get("/?query=%s" % query_str, **self.extra)
+            response = view(request, pk=self.xform.pk)
+            self.assertEqual(response.status_code, 400)
+            self.assertEqual(f"{response.data['detail']}", "Invalid date format.")
+
     def test_data_list_xml_format(self):
         """Test DataViewSet list XML"""
         # create submission

--- a/onadata/apps/api/tests/viewsets/test_data_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_data_viewset.py
@@ -3581,7 +3581,7 @@ class TestDataViewSet(SerializeMixin, TestBase):
             request = self.factory.get("/?query=%s" % query_str, **self.extra)
             response = view(request, pk=self.xform.pk)
             self.assertEqual(response.status_code, 400)
-            self.assertEqual(f"{response.data['detail']}", "Invalid date format.")
+            self.assertEqual(f"{response.data['detail']}", f"Invalid date {json_date_field}")
 
     def test_data_list_xml_format(self):
         """Test DataViewSet list XML"""

--- a/onadata/apps/api/tests/viewsets/test_data_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_data_viewset.py
@@ -1109,21 +1109,12 @@ class TestDataViewSet(SerializeMixin, TestBase):
         self.assertEqual(len(response.data), 2)
 
     def test_filter_by_date_modified(self):
-        # Mock date_created
-        with patch(
-            "django.utils.timezone.now",
-            Mock(return_value=datetime.datetime(2024, 1, 1, tzinfo=timezone.utc)),
-        ):
-            self._make_submissions()
-
-        instance = Instance.objects.create(
-            xform=self.xform,
-            xml='<data id="b"><fruit>mango</fruit></data>',
-        )
+        self._make_submissions()
         view = DataViewSet.as_view({"get": "list"})
         request = self.factory.get("/", **self.extra)
         instances = self.xform.instances.all().order_by("pk")
-        self.assertEqual(len(instances), 5)
+        self.assertEqual(len(instances), 4)
+        instance = instances[2]
         date_modified = instance.date_modified.isoformat()
         # greater than or equal to
         query_str = '{"_date_modified": {"$gte": "%s"}}' % date_modified
@@ -1131,16 +1122,17 @@ class TestDataViewSet(SerializeMixin, TestBase):
         request = self.factory.get("/", data=data, **self.extra)
         response = view(request, pk=self.xform.pk)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(response.data), 1)
-        self.assertEqual(response.data[0]["_id"], instance.pk)
+        self.assertEqual(len(response.data), 2)
+        self.assertEqual(response.data[0]["_id"], instances[2].pk)
+        self.assertEqual(response.data[1]["_id"], instances[3].pk)
         # greater than
-        date_modified = instance.date_modified.isoformat()
         query_str = '{"_date_modified": {"$gt": "%s"}}' % date_modified
         data = {"query": query_str}
         request = self.factory.get("/", data=data, **self.extra)
         response = view(request, pk=self.xform.pk)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(response.data), 0)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]["_id"], instances[3].pk)
 
     def test_filter_by_submission_time_and_submitted_by_with_data_arg(self):
         self._make_submissions()

--- a/onadata/apps/api/tests/viewsets/test_data_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_data_viewset.py
@@ -3578,7 +3578,6 @@ class TestDataViewSet(SerializeMixin, TestBase):
 
         for json_date_field in ["_submission_time", "_date_modified", "_last_edited"]:
             query_str = '{"%s": {"$lte": "watermelon"}}' % json_date_field
-            # query_str = '{"_submission_time": {"$lte": "watermelon"}}'
             request = self.factory.get("/?query=%s" % query_str, **self.extra)
             response = view(request, pk=self.xform.pk)
             self.assertEqual(response.status_code, 400)

--- a/onadata/apps/api/tests/viewsets/test_data_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_data_viewset.py
@@ -3513,59 +3513,64 @@ class TestDataViewSet(SerializeMixin, TestBase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 4)
 
-    def test_data_query_or_metadata(self):
-        """OR operation filter works for meta data"""
+    def test_data_query_or_date_fields(self):
+        """OR operation filter works for date fields"""
         view = DataViewSet.as_view({"get": "list"})
-        # Mock date_created
+        # Mock date_created (_submission_time)
         with patch(
             "django.utils.timezone.now",
-            Mock(return_value=datetime.datetime(2024, 9, 17, tzinfo=timezone.utc)),
+            Mock(return_value=datetime.datetime(2024, 9, 16, tzinfo=timezone.utc)),
         ):
-            self._make_submissions()
-
-        Instance.objects.create(
-            xform=self.xform,
-            last_edited=datetime.datetime(2024, 4, 1, tzinfo=timezone.utc),
-            xml='<data id="b"><fruit>mango</fruit></data>',
-        )
-        # Mock date_created
+            Instance.objects.create(
+                xform=self.xform,
+                xml='<data id="b"><fruit>mango</fruit></data>',
+            )
+        # Mock date_created (_submission_time)
         with patch(
             "django.utils.timezone.now",
-            Mock(return_value=datetime.datetime(2023, 4, 1, tzinfo=timezone.utc)),
+            Mock(return_value=datetime.datetime(2024, 9, 18, tzinfo=timezone.utc)),
+        ):
+            Instance.objects.create(
+                xform=self.xform,
+                xml='<data id="b"><fruit>mango</fruit></data>',
+            )
+        # Mock date_created (_submission_time)
+        with patch(
+            "django.utils.timezone.now",
+            Mock(return_value=datetime.datetime(2022, 4, 1, tzinfo=timezone.utc)),
         ):
             Instance.objects.create(
                 xform=self.xform,
                 last_edited=datetime.datetime(2023, 4, 1, tzinfo=timezone.utc),
                 xml='<data id="b"><fruit>mango</fruit></data>',
             )
+        # Mock date_created (_submission_time)
+        with patch(
+            "django.utils.timezone.now",
+            Mock(return_value=datetime.datetime(2022, 4, 1, tzinfo=timezone.utc)),
+        ):
+            Instance.objects.create(
+                xform=self.xform,
+                last_edited=datetime.datetime(2023, 5, 1, tzinfo=timezone.utc),
+                xml='<data id="b"><fruit>mango</fruit></data>',
+            )
+
         query_str = (
-            '{"$or": [{"_submission_time":{"$gte": "2024-09-17", "$lte": "2024-09-17"}}, '
-            '{"_last_edited":{"$gte": "2024-04-01", "$lte": "2024-04-01"}}]}'
+            '{"$or": [{"_submission_time":{"$gte": "2024-09-16", "$lte": "2024-09-18"}}, '
+            '{"_last_edited":{"$gte": "2023-04-01", "$lte": "2023-05-01"}}]}'
         )
         request = self.factory.get("/?query=%s" % query_str, **self.extra)
         response = view(request, pk=self.xform.pk)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(response.data), 5)
+        self.assertEqual(len(response.data), 4)
         query_str = (
-            '{"$or": [{"_submission_time":{"$gte": "2024-09-17"}}, '
-            '{"_last_edited":{"$gte": "2024-04-01"}}]}'
+            '{"$or": [{"_submission_time":{"$gte": "2024-09-16"}}, '
+            '{"_last_edited":{"$gte": "2023-05-01"}}]}'
         )
         request = self.factory.get("/?query=%s" % query_str, **self.extra)
         response = view(request, pk=self.xform.pk)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(response.data), 5)
-        query_str = '{"$or": [{"_submission_time": "2024-09-17"}, {"_last_edited": "2024-04-01"}]}'
-        request = self.factory.get("/?query=%s" % query_str, **self.extra)
-        response = view(request, pk=self.xform.pk)
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(response.data), 5)
-        # Invalid dates
-        query_str = (
-            '{"$or": [{"_submission_time": "foo"}, {"_last_edited": "2024-04-01"}]}'
-        )
-        request = self.factory.get("/?query=%s" % query_str, **self.extra)
-        response = view(request, pk=self.xform.pk)
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(len(response.data), 3)
 
     def test_data_list_xml_format(self):
         """Test DataViewSet list XML"""

--- a/onadata/apps/api/tests/viewsets/test_data_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_data_viewset.py
@@ -3513,7 +3513,7 @@ class TestDataViewSet(SerializeMixin, TestBase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 4)
 
-    def test_data_query_or_date_fields(self):
+    def test_or_with_date_filters(self):
         """OR operation filter works for date fields"""
         view = DataViewSet.as_view({"get": "list"})
         # Mock date_created (_submission_time)
@@ -3572,8 +3572,8 @@ class TestDataViewSet(SerializeMixin, TestBase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 3)
 
-    def test_query_invalid_date_format(self):
-        """Invalid formatted date filters are handled"""
+    def test_invalid_date_filters(self):
+        """Invalid date filters are handled appropriately"""
         view = DataViewSet.as_view({"get": "list"})
 
         for json_date_field in ["_submission_time", "_date_modified", "_last_edited"]:

--- a/onadata/apps/api/tests/viewsets/test_data_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_data_viewset.py
@@ -3581,7 +3581,10 @@ class TestDataViewSet(SerializeMixin, TestBase):
             request = self.factory.get("/?query=%s" % query_str, **self.extra)
             response = view(request, pk=self.xform.pk)
             self.assertEqual(response.status_code, 400)
-            self.assertEqual(f"{response.data['detail']}", f"Invalid date {json_date_field}")
+            self.assertEqual(
+                f"{response.data['detail']}",
+                f'Invalid date value "watermelon" for the field {json_date_field}.',
+            )
 
     def test_data_list_xml_format(self):
         """Test DataViewSet list XML"""

--- a/onadata/apps/viewer/parsed_instance_tools.py
+++ b/onadata/apps/viewer/parsed_instance_tools.py
@@ -6,13 +6,12 @@ import datetime
 import json
 from builtins import str as text
 from typing import Any, Tuple
+import six
 
 from django.utils.translation import gettext_lazy as _
 
 from onadata.libs.utils.common_tags import KNOWN_DATE_FORMATS
 from onadata.libs.exceptions import InavlidDateFormat
-
-import six
 
 
 KNOWN_DATES = ["_submission_time", "_last_edited", "_date_modified"]

--- a/onadata/apps/viewer/parsed_instance_tools.py
+++ b/onadata/apps/viewer/parsed_instance_tools.py
@@ -11,7 +11,7 @@ import six
 
 from onadata.libs.utils.common_tags import DATE_FORMAT, MONGO_STRFTIME
 
-KNOWN_DATES = ["_submission_time", "_last_edited", "_date_modified"]
+KNOWN_DATES = ["_submission_time"]
 NONE_JSON_FIELDS = {
     "_submission_time": "date_created",
     "_date_modified": "date_modified",

--- a/onadata/apps/viewer/parsed_instance_tools.py
+++ b/onadata/apps/viewer/parsed_instance_tools.py
@@ -9,9 +9,9 @@ from typing import Any, Tuple
 
 import six
 
-from onadata.libs.utils.common_tags import DATE_FORMAT, MONGO_STRFTIME
+from onadata.libs.utils.common_tags import KNOWN_DATE_FORMATS
 
-KNOWN_DATES = ["_submission_time"]
+KNOWN_DATES = ["_submission_time", "_last_edited", "_date_modified"]
 NONE_JSON_FIELDS = {
     "_submission_time": "date_created",
     "_date_modified": "date_modified",
@@ -62,11 +62,14 @@ def _parse_where(query, known_integers, known_decimals, or_where, or_params):
                 _v = value
                 if field_key in KNOWN_DATES:
                     raw_date = value
-                    for date_format in (MONGO_STRFTIME, DATE_FORMAT):
+                    for date_format in KNOWN_DATE_FORMATS:
                         try:
-                            _v = datetime.datetime.strptime(raw_date[:19], date_format)
+                            _v = datetime.datetime.strptime(raw_date, date_format)
                         except ValueError:
                             pass
+                        else:
+                            break
+
                 if field_key in NONE_JSON_FIELDS:
                     where_params.extend([text(_v)])
                 else:

--- a/onadata/apps/viewer/parsed_instance_tools.py
+++ b/onadata/apps/viewer/parsed_instance_tools.py
@@ -75,8 +75,8 @@ def _parse_where(query, known_integers, known_decimals, or_where, or_params):
                             is_date_valid = True
                             break
 
-                if not is_date_valid:
-                    raise InavlidDateFormat(_(f"Invalid date {field_key}"))
+                    if not is_date_valid:
+                        raise InavlidDateFormat(_(f"Invalid date {field_key}"))
 
                 if field_key in NONE_JSON_FIELDS:
                     where_params.extend([text(_v)])

--- a/onadata/apps/viewer/parsed_instance_tools.py
+++ b/onadata/apps/viewer/parsed_instance_tools.py
@@ -2,14 +2,11 @@
 """
 ParsedInstance model utility functions
 """
-import datetime
 import json
 from builtins import str as text
 from typing import Any, Tuple
 
 import six
-
-from onadata.libs.utils.common_tags import KNOWN_DATE_FORMATS
 
 KNOWN_DATES = ["_submission_time", "_last_edited", "_date_modified"]
 NONE_JSON_FIELDS = {
@@ -60,15 +57,6 @@ def _parse_where(query, known_integers, known_decimals, or_where, or_params):
                 if key in OPERANDS:
                     where.append(" ".join([json_str, OPERANDS.get(key), "%s"]))
                 _v = value
-                if field_key in KNOWN_DATES:
-                    raw_date = value
-                    for date_format in KNOWN_DATE_FORMATS:
-                        try:
-                            _v = datetime.datetime.strptime(raw_date, date_format)
-                        except ValueError:
-                            pass
-                        else:
-                            break
 
                 if field_key in NONE_JSON_FIELDS:
                     where_params.extend([text(_v)])

--- a/onadata/apps/viewer/parsed_instance_tools.py
+++ b/onadata/apps/viewer/parsed_instance_tools.py
@@ -4,7 +4,6 @@ ParsedInstance model utility functions
 """
 import datetime
 import json
-import six
 from builtins import str as text
 from typing import Any, Tuple
 
@@ -12,6 +11,8 @@ from django.utils.translation import gettext_lazy as _
 
 from onadata.libs.utils.common_tags import KNOWN_DATE_FORMATS
 from onadata.libs.exceptions import InavlidDateFormat
+
+import six
 
 
 KNOWN_DATES = ["_submission_time", "_last_edited", "_date_modified"]

--- a/onadata/apps/viewer/parsed_instance_tools.py
+++ b/onadata/apps/viewer/parsed_instance_tools.py
@@ -8,6 +8,8 @@ import six
 from builtins import str as text
 from typing import Any, Tuple
 
+from django.utils.translation import gettext_lazy as _
+
 from onadata.libs.utils.common_tags import KNOWN_DATE_FORMATS
 from onadata.libs.exceptions import InavlidDateFormat
 
@@ -74,7 +76,7 @@ def _parse_where(query, known_integers, known_decimals, or_where, or_params):
                             break
 
                 if not is_date_valid:
-                    raise InavlidDateFormat()
+                    raise InavlidDateFormat(_(f"Invalid date {field_key}"))
 
                 if field_key in NONE_JSON_FIELDS:
                     where_params.extend([text(_v)])

--- a/onadata/apps/viewer/parsed_instance_tools.py
+++ b/onadata/apps/viewer/parsed_instance_tools.py
@@ -76,7 +76,11 @@ def _parse_where(query, known_integers, known_decimals, or_where, or_params):
                             break
 
                     if not is_date_valid:
-                        raise InavlidDateFormat(_(f"Invalid date {field_key}"))
+                        raise InavlidDateFormat(
+                            _(
+                                f'Invalid date value "{value}" for the field {field_key}.'
+                            )
+                        )
 
                 if field_key in NONE_JSON_FIELDS:
                     where_params.extend([text(_v)])

--- a/onadata/apps/viewer/parsed_instance_tools.py
+++ b/onadata/apps/viewer/parsed_instance_tools.py
@@ -11,7 +11,7 @@ import six
 
 from onadata.libs.utils.common_tags import DATE_FORMAT, MONGO_STRFTIME
 
-KNOWN_DATES = ["_submission_time", "_last_edited", "__date_modified"]
+KNOWN_DATES = ["_submission_time", "_last_edited", "_date_modified"]
 NONE_JSON_FIELDS = {
     "_submission_time": "date_created",
     "_date_modified": "date_modified",

--- a/onadata/apps/viewer/parsed_instance_tools.py
+++ b/onadata/apps/viewer/parsed_instance_tools.py
@@ -2,11 +2,15 @@
 """
 ParsedInstance model utility functions
 """
+import datetime
 import json
+import six
 from builtins import str as text
 from typing import Any, Tuple
 
-import six
+from onadata.libs.utils.common_tags import KNOWN_DATE_FORMATS
+from onadata.libs.exceptions import InavlidDateFormat
+
 
 KNOWN_DATES = ["_submission_time", "_last_edited", "_date_modified"]
 NONE_JSON_FIELDS = {
@@ -57,6 +61,20 @@ def _parse_where(query, known_integers, known_decimals, or_where, or_params):
                 if key in OPERANDS:
                     where.append(" ".join([json_str, OPERANDS.get(key), "%s"]))
                 _v = value
+                if field_key in KNOWN_DATES:
+                    raw_date = value
+                    is_date_valid = False
+                    for date_format in KNOWN_DATE_FORMATS:
+                        try:
+                            _v = datetime.datetime.strptime(raw_date, date_format)
+                        except ValueError:
+                            is_date_valid = False
+                        else:
+                            is_date_valid = True
+                            break
+
+                if not is_date_valid:
+                    raise InavlidDateFormat()
 
                 if field_key in NONE_JSON_FIELDS:
                     where_params.extend([text(_v)])

--- a/onadata/apps/viewer/parsed_instance_tools.py
+++ b/onadata/apps/viewer/parsed_instance_tools.py
@@ -11,7 +11,7 @@ import six
 
 from onadata.libs.utils.common_tags import DATE_FORMAT, MONGO_STRFTIME
 
-KNOWN_DATES = ["_submission_time"]
+KNOWN_DATES = ["_submission_time", "_last_edited", "__date_modified"]
 NONE_JSON_FIELDS = {
     "_submission_time": "date_created",
     "_date_modified": "date_modified",
@@ -131,6 +131,20 @@ def get_where_clause(query, form_integer_fields=None, form_decimal_fields=None):
 
                 for or_query in or_dict:
                     for key, value in or_query.items():
+                        if key in NONE_JSON_FIELDS:
+                            and_query_where, and_query_where_params = _parse_where(
+                                or_query,
+                                known_integers,
+                                known_decimals,
+                                [],
+                                [],
+                            )
+                            or_where.extend(
+                                ["".join(["(", " AND ".join(and_query_where), ")"])]
+                            )
+                            or_params.extend(and_query_where_params)
+                            continue
+
                         if value is None:
                             or_where.extend([f"json->>'{key}' IS NULL"])
                         elif isinstance(value, list):

--- a/onadata/apps/viewer/parsed_instance_tools.py
+++ b/onadata/apps/viewer/parsed_instance_tools.py
@@ -76,11 +76,11 @@ def _parse_where(query, known_integers, known_decimals, or_where, or_params):
                             break
 
                     if not is_date_valid:
-                        raise InavlidDateFormat(
-                            _(
-                                f'Invalid date value "{value}" for the field {field_key}.'
-                            )
+                        err_msg = _(
+                            f'Invalid date value "{value}" '
+                            f"for the field {field_key}."
                         )
+                        raise InavlidDateFormat(err_msg)
 
                 if field_key in NONE_JSON_FIELDS:
                     where_params.extend([text(_v)])

--- a/onadata/apps/viewer/tests/test_parsed_instance.py
+++ b/onadata/apps/viewer/tests/test_parsed_instance.py
@@ -90,9 +90,8 @@ class TestParsedInstance(TestBase):
         self.assertEqual(where, ["json::text ~* cast(%s as text)"])
         self.assertEqual(where_params, [11])
 
-    def test_get_where_clause_w_metadata(self):
-        """get_where_clause with meta data fields"""
-        # Date and Time with Time Zone Offset
+    def test_get_where_clause_or_date_range(self):
+        """OR operation get_where_clause with date range"""
         query = (
             '{"$or": [{"_submission_time":{"$gte": "2024-09-17T13:39:40.001694+00:00", '
             '"$lte": "2024-09-17T13:39:40.001694+00:00"}}, '
@@ -112,65 +111,15 @@ class TestParsedInstance(TestBase):
         self.assertEqual(
             where_params,
             [
-                "2024-09-17 13:39:40.001694+00:00",
-                "2024-09-17 13:39:40.001694+00:00",
-                "2024-04-01 13:39:40.001694+00:00",
-                "2024-04-01 13:39:40.001694+00:00",
+                "2024-09-17T13:39:40.001694+00:00",
+                "2024-09-17T13:39:40.001694+00:00",
+                "2024-04-01T13:39:40.001694+00:00",
+                "2024-04-01T13:39:40.001694+00:00",
             ],
         )
-        # Date and Time with UTC Designation ("Z")
-        query = (
-            '{"$or": [{"_submission_time":{"$gte": "2024-09-17T13:39:40.001694Z", '
-            '"$lte": "2024-09-17T13:39:40.001694Z"}}, '
-            '{"_last_edited":{"$gte": "2024-04-01T13:39:40.001694Z", '
-            '"$lte": "2024-04-01T13:39:40.001694Z"}}]}'
-        )
-        where, where_params = get_where_clause(query)
-        self.assertEqual(
-            where,
-            [
-                (
-                    "((date_created >= %s AND date_created <= %s) OR "
-                    "(last_edited >= %s AND last_edited <= %s))"
-                )
-            ],
-        )
-        self.assertEqual(
-            where_params,
-            [
-                "2024-09-17 13:39:40.001694+00:00",
-                "2024-09-17 13:39:40.001694+00:00",
-                "2024-04-01 13:39:40.001694+00:00",
-                "2024-04-01 13:39:40.001694+00:00",
-            ],
-        )
-        # Extended Format (YYYY-MM-DD)
-        query = (
-            '{"$or": [{"_submission_time":{"$gte": "2024-09-17T13:39:40", '
-            '"$lte": "2024-09-17T13:39:40"}}, '
-            '{"_last_edited":{"$gte": "2024-04-01T13:39:40", '
-            '"$lte": "2024-04-01T13:39:40"}}]}'
-        )
-        where, where_params = get_where_clause(query)
-        self.assertEqual(
-            where,
-            [
-                (
-                    "((date_created >= %s AND date_created <= %s) OR "
-                    "(last_edited >= %s AND last_edited <= %s))"
-                )
-            ],
-        )
-        self.assertEqual(
-            where_params,
-            [
-                "2024-09-17 13:39:40",
-                "2024-09-17 13:39:40",
-                "2024-04-01 13:39:40",
-                "2024-04-01 13:39:40",
-            ],
-        )
-        # Exact date match
+
+    def test_get_where_clause_or_exact_date(self):
+        """OR operation get_where_clause with exact dates"""
         query = (
             '{"$or": [{"_submission_time": "2024-09-17T10:32:52"}, '
             '{"_last_edited": "2024-04-01T10:32:52"}]}'
@@ -181,14 +130,6 @@ class TestParsedInstance(TestBase):
             where_params,
             ["2024-09-17T10:32:52", "2024-04-01T10:32:52"],
         )
-        # No range
-        query = (
-            '{"$or": [{"_submission_time":{"$lte": "2024-09-17T10:32:52"}}, '
-            '{"_last_edited":{"$gte": "2024-04-01T10:32:52"}}]}'
-        )
-        where, where_params = get_where_clause(query)
-        self.assertEqual(where, ["((date_created <= %s) OR (last_edited >= %s))"])
-        self.assertEqual(where_params, ["2024-09-17 10:32:52", "2024-04-01 10:32:52"])
 
     def test_retrieve_records_based_on_form_verion(self):
         self._create_user_and_login()

--- a/onadata/apps/viewer/tests/test_parsed_instance.py
+++ b/onadata/apps/viewer/tests/test_parsed_instance.py
@@ -120,14 +120,15 @@ class TestParsedInstance(TestBase):
             '{"_last_edited": "2024-04-01"}]}'
         )
         where, where_params = get_where_clause(query)
-        self.assertEqual(
-            where,
-            ["((date_created = %s) OR (last_edited = %s))"],
+        self.assertEqual(where, ["((date_created = %s) OR (last_edited = %s))"])
+        self.assertEqual(where_params, ["2024-09-17", "2024-04-01"])
+        query = (
+            '{"$or": [{"_submission_time":{"$lte": "2024-09-17"}}, '
+            '{"_last_edited":{"$gte": "2024-04-01"}}]}'
         )
-        self.assertEqual(
-            where_params,
-            ["2024-09-17", "2024-04-01"],
-        )
+        where, where_params = get_where_clause(query)
+        self.assertEqual(where, ["((date_created <= %s) OR (last_edited >= %s))"])
+        self.assertEqual(where_params, ["2024-09-17 00:00:00", "2024-04-01 00:00:00"])
 
     def test_retrieve_records_based_on_form_verion(self):
         self._create_user_and_login()

--- a/onadata/apps/viewer/tests/test_parsed_instance.py
+++ b/onadata/apps/viewer/tests/test_parsed_instance.py
@@ -92,12 +92,37 @@ class TestParsedInstance(TestBase):
 
     def test_get_where_clause_w_metadata(self):
         """get_where_clause with meta data fields"""
-        # Date in ISO format
+        # UTC date format
         query = (
             '{"$or": [{"_submission_time":{"$gte": "2024-09-17T13:39:40.001694+00:00", '
             '"$lte": "2024-09-17T13:39:40.001694+00:00"}}, '
             '{"_last_edited":{"$gte": "2024-04-01T13:39:40.001694+00:00", '
             '"$lte": "2024-04-01T13:39:40.001694+00:00"}}]}'
+        )
+        where, where_params = get_where_clause(query)
+        self.assertEqual(
+            where,
+            [
+                (
+                    "((date_created >= %s AND date_created <= %s) OR "
+                    "(last_edited >= %s AND last_edited <= %s))"
+                )
+            ],
+        )
+        self.assertEqual(
+            where_params,
+            [
+                "2024-09-17 13:39:40.001694+00:00",
+                "2024-09-17 13:39:40.001694+00:00",
+                "2024-04-01 13:39:40.001694+00:00",
+                "2024-04-01 13:39:40.001694+00:00",
+            ],
+        )
+        query = (
+            '{"$or": [{"_submission_time":{"$gte": "2024-09-17T13:39:40.001694Z", '
+            '"$lte": "2024-09-17T13:39:40.001694Z"}}, '
+            '{"_last_edited":{"$gte": "2024-04-01T13:39:40.001694Z", '
+            '"$lte": "2024-04-01T13:39:40.001694Z"}}]}'
         )
         where, where_params = get_where_clause(query)
         self.assertEqual(

--- a/onadata/apps/viewer/tests/test_parsed_instance.py
+++ b/onadata/apps/viewer/tests/test_parsed_instance.py
@@ -118,19 +118,6 @@ class TestParsedInstance(TestBase):
             ],
         )
 
-    def test_get_where_clause_or_exact_date(self):
-        """OR operation get_where_clause with exact dates"""
-        query = (
-            '{"$or": [{"_submission_time": "2024-09-17T10:32:52"}, '
-            '{"_last_edited": "2024-04-01T10:32:52"}]}'
-        )
-        where, where_params = get_where_clause(query)
-        self.assertEqual(where, ["((date_created = %s) OR (last_edited = %s))"])
-        self.assertEqual(
-            where_params,
-            ["2024-09-17T10:32:52", "2024-04-01T10:32:52"],
-        )
-
     def test_retrieve_records_based_on_form_verion(self):
         self._create_user_and_login()
         self._publish_transportation_form()

--- a/onadata/apps/viewer/tests/test_parsed_instance.py
+++ b/onadata/apps/viewer/tests/test_parsed_instance.py
@@ -92,11 +92,12 @@ class TestParsedInstance(TestBase):
 
     def test_get_where_clause_w_metadata(self):
         """get_where_clause with meta data fields"""
+        # Date in ISO format
         query = (
-            '{"$or": [{"_submission_time":{"$gte": "2024-09-17T10:32:52", '
-            '"$lte": "2024-09-17T10:32:52"}}, '
-            '{"_last_edited":{"$gte": "2024-04-01T10:32:52", '
-            '"$lte": "2024-04-01T10:32:52"}}]}'
+            '{"$or": [{"_submission_time":{"$gte": "2024-09-17T13:39:40.001694+00:00", '
+            '"$lte": "2024-09-17T13:39:40.001694+00:00"}}, '
+            '{"_last_edited":{"$gte": "2024-04-01T13:39:40.001694+00:00", '
+            '"$lte": "2024-04-01T13:39:40.001694+00:00"}}]}'
         )
         where, where_params = get_where_clause(query)
         self.assertEqual(
@@ -111,10 +112,36 @@ class TestParsedInstance(TestBase):
         self.assertEqual(
             where_params,
             [
-                "2024-09-17 10:32:52",
-                "2024-09-17 10:32:52",
-                "2024-04-01T10:32:52",
-                "2024-04-01T10:32:52",
+                "2024-09-17 13:39:40.001694+00:00",
+                "2024-09-17 13:39:40.001694+00:00",
+                "2024-04-01 13:39:40.001694+00:00",
+                "2024-04-01 13:39:40.001694+00:00",
+            ],
+        )
+        # Date with time
+        query = (
+            '{"$or": [{"_submission_time":{"$gte": "2024-09-17T13:39:40", '
+            '"$lte": "2024-09-17T13:39:40"}}, '
+            '{"_last_edited":{"$gte": "2024-04-01T13:39:40", '
+            '"$lte": "2024-04-01T13:39:40"}}]}'
+        )
+        where, where_params = get_where_clause(query)
+        self.assertEqual(
+            where,
+            [
+                (
+                    "((date_created >= %s AND date_created <= %s) OR "
+                    "(last_edited >= %s AND last_edited <= %s))"
+                )
+            ],
+        )
+        self.assertEqual(
+            where_params,
+            [
+                "2024-09-17 13:39:40",
+                "2024-09-17 13:39:40",
+                "2024-04-01 13:39:40",
+                "2024-04-01 13:39:40",
             ],
         )
         query = (
@@ -133,7 +160,7 @@ class TestParsedInstance(TestBase):
         )
         where, where_params = get_where_clause(query)
         self.assertEqual(where, ["((date_created <= %s) OR (last_edited >= %s))"])
-        self.assertEqual(where_params, ["2024-09-17 10:32:52", "2024-04-01T10:32:52"])
+        self.assertEqual(where_params, ["2024-09-17 10:32:52", "2024-04-01 10:32:52"])
 
     def test_retrieve_records_based_on_form_verion(self):
         self._create_user_and_login()

--- a/onadata/apps/viewer/tests/test_parsed_instance.py
+++ b/onadata/apps/viewer/tests/test_parsed_instance.py
@@ -92,7 +92,7 @@ class TestParsedInstance(TestBase):
 
     def test_get_where_clause_w_metadata(self):
         """get_where_clause with meta data fields"""
-        # UTC date format
+        # Date and Time with Time Zone Offset
         query = (
             '{"$or": [{"_submission_time":{"$gte": "2024-09-17T13:39:40.001694+00:00", '
             '"$lte": "2024-09-17T13:39:40.001694+00:00"}}, '
@@ -118,6 +118,7 @@ class TestParsedInstance(TestBase):
                 "2024-04-01 13:39:40.001694+00:00",
             ],
         )
+        # Date and Time with UTC Designation ("Z")
         query = (
             '{"$or": [{"_submission_time":{"$gte": "2024-09-17T13:39:40.001694Z", '
             '"$lte": "2024-09-17T13:39:40.001694Z"}}, '
@@ -143,7 +144,7 @@ class TestParsedInstance(TestBase):
                 "2024-04-01 13:39:40.001694+00:00",
             ],
         )
-        # Date with time
+        # Extended Format (YYYY-MM-DD)
         query = (
             '{"$or": [{"_submission_time":{"$gte": "2024-09-17T13:39:40", '
             '"$lte": "2024-09-17T13:39:40"}}, '
@@ -169,6 +170,7 @@ class TestParsedInstance(TestBase):
                 "2024-04-01 13:39:40",
             ],
         )
+        # Exact date match
         query = (
             '{"$or": [{"_submission_time": "2024-09-17T10:32:52"}, '
             '{"_last_edited": "2024-04-01T10:32:52"}]}'
@@ -179,6 +181,7 @@ class TestParsedInstance(TestBase):
             where_params,
             ["2024-09-17T10:32:52", "2024-04-01T10:32:52"],
         )
+        # No range
         query = (
             '{"$or": [{"_submission_time":{"$lte": "2024-09-17T10:32:52"}}, '
             '{"_last_edited":{"$gte": "2024-04-01T10:32:52"}}]}'

--- a/onadata/apps/viewer/tests/test_parsed_instance.py
+++ b/onadata/apps/viewer/tests/test_parsed_instance.py
@@ -1,6 +1,8 @@
 import os
-
 from datetime import datetime
+
+from rest_framework.exceptions import ParseError
+
 from onadata.apps.logger.models.instance import Instance
 from onadata.apps.main.models.user_profile import UserProfile
 from onadata.apps.main.tests.test_base import TestBase
@@ -96,6 +98,8 @@ class TestParsedInstance(TestBase):
             '{"$or": [{"_submission_time":{"$gte": "2024-09-17T13:39:40.001694+00:00", '
             '"$lte": "2024-09-17T13:39:40.001694+00:00"}}, '
             '{"_last_edited":{"$gte": "2024-04-01T13:39:40.001694+00:00", '
+            '"$lte": "2024-04-01T13:39:40.001694+00:00"}}, '
+            '{"_date_modified":{"$gte": "2024-04-01T13:39:40.001694+00:00", '
             '"$lte": "2024-04-01T13:39:40.001694+00:00"}}]}'
         )
         where, where_params = get_where_clause(query)
@@ -104,19 +108,30 @@ class TestParsedInstance(TestBase):
             [
                 (
                     "((date_created >= %s AND date_created <= %s) OR "
-                    "(last_edited >= %s AND last_edited <= %s))"
+                    "(last_edited >= %s AND last_edited <= %s) OR "
+                    "(date_modified >= %s AND date_modified <= %s))"
                 )
             ],
         )
         self.assertEqual(
             where_params,
             [
-                "2024-09-17T13:39:40.001694+00:00",
-                "2024-09-17T13:39:40.001694+00:00",
-                "2024-04-01T13:39:40.001694+00:00",
-                "2024-04-01T13:39:40.001694+00:00",
+                "2024-09-17 13:39:40.001694+00:00",
+                "2024-09-17 13:39:40.001694+00:00",
+                "2024-04-01 13:39:40.001694+00:00",
+                "2024-04-01 13:39:40.001694+00:00",
+                "2024-04-01 13:39:40.001694+00:00",
+                "2024-04-01 13:39:40.001694+00:00",
             ],
         )
+
+    def test_invalid_date_format(self):
+        """Inavlid date format is handled"""
+        for json_date_field in ["_submission_time", "_date_modified", "_last_edited"]:
+            query = {json_date_field: {"$lte": "watermelon"}}
+
+            with self.assertRaises(ParseError):
+                get_where_clause(query)
 
     def test_retrieve_records_based_on_form_verion(self):
         self._create_user_and_login()

--- a/onadata/apps/viewer/tests/test_parsed_instance.py
+++ b/onadata/apps/viewer/tests/test_parsed_instance.py
@@ -93,8 +93,10 @@ class TestParsedInstance(TestBase):
     def test_get_where_clause_w_metadata(self):
         """get_where_clause with meta data fields"""
         query = (
-            '{"$or": [{"_submission_time":{"$gte": "2024-09-17", "$lte": "2024-09-17"}}, '
-            '{"_last_edited":{"$gte": "2024-04-01", "$lte": "2024-04-01"}}]}'
+            '{"$or": [{"_submission_time":{"$gte": "2024-09-17T10:32:52", '
+            '"$lte": "2024-09-17T10:32:52"}}, '
+            '{"_last_edited":{"$gte": "2024-04-01T10:32:52", '
+            '"$lte": "2024-04-01T10:32:52"}}]}'
         )
         where, where_params = get_where_clause(query)
         self.assertEqual(
@@ -109,26 +111,29 @@ class TestParsedInstance(TestBase):
         self.assertEqual(
             where_params,
             [
-                "2024-09-17 00:00:00",
-                "2024-09-17 00:00:00",
-                "2024-04-01 00:00:00",
-                "2024-04-01 00:00:00",
+                "2024-09-17 10:32:52",
+                "2024-09-17 10:32:52",
+                "2024-04-01T10:32:52",
+                "2024-04-01T10:32:52",
             ],
         )
         query = (
-            '{"$or": [{"_submission_time": "2024-09-17"}, '
-            '{"_last_edited": "2024-04-01"}]}'
+            '{"$or": [{"_submission_time": "2024-09-17T10:32:52"}, '
+            '{"_last_edited": "2024-04-01T10:32:52"}]}'
         )
         where, where_params = get_where_clause(query)
         self.assertEqual(where, ["((date_created = %s) OR (last_edited = %s))"])
-        self.assertEqual(where_params, ["2024-09-17", "2024-04-01"])
+        self.assertEqual(
+            where_params,
+            ["2024-09-17T10:32:52", "2024-04-01T10:32:52"],
+        )
         query = (
-            '{"$or": [{"_submission_time":{"$lte": "2024-09-17"}}, '
-            '{"_last_edited":{"$gte": "2024-04-01"}}]}'
+            '{"$or": [{"_submission_time":{"$lte": "2024-09-17T10:32:52"}}, '
+            '{"_last_edited":{"$gte": "2024-04-01T10:32:52"}}]}'
         )
         where, where_params = get_where_clause(query)
         self.assertEqual(where, ["((date_created <= %s) OR (last_edited >= %s))"])
-        self.assertEqual(where_params, ["2024-09-17 00:00:00", "2024-04-01 00:00:00"])
+        self.assertEqual(where_params, ["2024-09-17 10:32:52", "2024-04-01T10:32:52"])
 
     def test_retrieve_records_based_on_form_verion(self):
         self._create_user_and_login()

--- a/onadata/libs/exceptions.py
+++ b/onadata/libs/exceptions.py
@@ -38,6 +38,6 @@ class ServiceUnavailable(APIException):
 
 
 class InavlidDateFormat(ParseError):
-    """Raise when request query has invalid date field"""
+    """Raise when request query has invalid date."""
 
     default_detail = _("Invalid date format.")

--- a/onadata/libs/exceptions.py
+++ b/onadata/libs/exceptions.py
@@ -2,7 +2,7 @@
 """Custom Expecting classes."""
 from django.utils.translation import gettext_lazy as _
 
-from rest_framework.exceptions import APIException
+from rest_framework.exceptions import APIException, ParseError
 
 
 class EnketoError(Exception):
@@ -35,3 +35,9 @@ class ServiceUnavailable(APIException):
 
     status_code = 503
     default_detail = "Service temporarily unavailable, try again later."
+
+
+class InavlidDateFormat(ParseError):
+    """Raise when request query has invalid date field"""
+
+    default_detail = _("Invalid date format.")

--- a/onadata/libs/utils/common_tags.py
+++ b/onadata/libs/utils/common_tags.py
@@ -71,6 +71,12 @@ LAST_EDITED = "_last_edited"
 # datetime format that we store in mongo
 MONGO_STRFTIME = "%Y-%m-%dT%H:%M:%S"
 DATE_FORMAT = "%Y-%m-%d"
+KNOWN_DATE_FORMATS = [
+    DATE_FORMAT,
+    MONGO_STRFTIME,
+    "%Y-%m-%dT%H:%M:%S%z",
+    "%Y-%m-%dT%H:%M:%S.%f%z",
+]
 
 # how to represent N/A in exports
 NA_REP = "n/a"

--- a/onadata/libs/utils/common_tags.py
+++ b/onadata/libs/utils/common_tags.py
@@ -71,12 +71,6 @@ LAST_EDITED = "_last_edited"
 # datetime format that we store in mongo
 MONGO_STRFTIME = "%Y-%m-%dT%H:%M:%S"
 DATE_FORMAT = "%Y-%m-%d"
-KNOWN_DATE_FORMATS = [
-    DATE_FORMAT,
-    MONGO_STRFTIME,
-    "%Y-%m-%dT%H:%M:%S%z",
-    "%Y-%m-%dT%H:%M:%S.%f%z",
-]
 
 # how to represent N/A in exports
 NA_REP = "n/a"

--- a/onadata/libs/utils/common_tags.py
+++ b/onadata/libs/utils/common_tags.py
@@ -71,7 +71,8 @@ LAST_EDITED = "_last_edited"
 # datetime format that we store in mongo
 MONGO_STRFTIME = "%Y-%m-%dT%H:%M:%S"
 DATE_FORMAT = "%Y-%m-%d"
-KNOWN_DATE_FORMATS = [MONGO_STRFTIME, DATE_FORMAT, "%Y-%m-%dT%H:%M:%S.%f%z"]
+ISO_FORMAT = "%Y-%m-%dT%H:%M:%S.%f%z"
+KNOWN_DATE_FORMATS = [MONGO_STRFTIME, DATE_FORMAT, ISO_FORMAT]
 
 # how to represent N/A in exports
 NA_REP = "n/a"

--- a/onadata/libs/utils/common_tags.py
+++ b/onadata/libs/utils/common_tags.py
@@ -71,6 +71,7 @@ LAST_EDITED = "_last_edited"
 # datetime format that we store in mongo
 MONGO_STRFTIME = "%Y-%m-%dT%H:%M:%S"
 DATE_FORMAT = "%Y-%m-%d"
+KNOWN_DATE_FORMATS = [MONGO_STRFTIME, DATE_FORMAT, "%Y-%m-%dT%H:%M:%S.%f%z"]
 
 # how to represent N/A in exports
 NA_REP = "n/a"

--- a/onadata/libs/utils/common_tags.py
+++ b/onadata/libs/utils/common_tags.py
@@ -71,8 +71,8 @@ LAST_EDITED = "_last_edited"
 # datetime format that we store in mongo
 MONGO_STRFTIME = "%Y-%m-%dT%H:%M:%S"
 DATE_FORMAT = "%Y-%m-%d"
-ISO_FORMAT = "%Y-%m-%dT%H:%M:%S.%f%z"
-KNOWN_DATE_FORMATS = [MONGO_STRFTIME, DATE_FORMAT, ISO_FORMAT]
+DATE_WITH_TIMEZONE_FORMAT = "%Y-%m-%dT%H:%M:%S.%f%z"
+KNOWN_DATE_FORMATS = [MONGO_STRFTIME, DATE_FORMAT, DATE_WITH_TIMEZONE_FORMAT]
 
 # how to represent N/A in exports
 NA_REP = "n/a"

--- a/onadata/libs/utils/common_tags.py
+++ b/onadata/libs/utils/common_tags.py
@@ -71,8 +71,8 @@ LAST_EDITED = "_last_edited"
 # datetime format that we store in mongo
 MONGO_STRFTIME = "%Y-%m-%dT%H:%M:%S"
 DATE_FORMAT = "%Y-%m-%d"
-DATE_WITH_TIMEZONE_FORMAT = "%Y-%m-%dT%H:%M:%S.%f%z"
-KNOWN_DATE_FORMATS = [MONGO_STRFTIME, DATE_FORMAT, DATE_WITH_TIMEZONE_FORMAT]
+UTC_DATE_FORMAT = "%Y-%m-%dT%H:%M:%S.%f%z"
+KNOWN_DATE_FORMATS = [MONGO_STRFTIME, DATE_FORMAT, UTC_DATE_FORMAT]
 
 # how to represent N/A in exports
 NA_REP = "n/a"

--- a/onadata/libs/utils/common_tags.py
+++ b/onadata/libs/utils/common_tags.py
@@ -71,8 +71,12 @@ LAST_EDITED = "_last_edited"
 # datetime format that we store in mongo
 MONGO_STRFTIME = "%Y-%m-%dT%H:%M:%S"
 DATE_FORMAT = "%Y-%m-%d"
-UTC_DATE_FORMAT = "%Y-%m-%dT%H:%M:%S.%f%z"
-KNOWN_DATE_FORMATS = [MONGO_STRFTIME, DATE_FORMAT, UTC_DATE_FORMAT]
+KNOWN_DATE_FORMATS = [
+    DATE_FORMAT,
+    MONGO_STRFTIME,
+    "%Y-%m-%dT%H:%M:%S%z",
+    "%Y-%m-%dT%H:%M:%S.%f%z",
+]
 
 # how to represent N/A in exports
 NA_REP = "n/a"

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -7,5 +7,5 @@ git+https://github.com/onaio/django-digest.git@6bf61ec08502fd3545d4f2c0838b6cb15
 git+https://github.com/onaio/django-multidb-router.git@f711368180d58eef87eda54fadfd5f8355623d52#egg=django-multidb-router
 git+https://github.com/onaio/floip-py.git@3c980eb184069ae7c3c9136b18441978237cd41d#egg=pyfloip
 git+https://github.com/onaio/python-json2xlsclient.git@62b4645f7b4f2684421a13ce98da0331a9dd66a0#egg=python-json2xlsclient
-git+https://github.com/onaio/ona-oidc.git@pytz-deprecated#egg=ona-oidc
+git+https://github.com/onaio/ona-oidc.git@v1.0.4#egg=ona-oidc
 -e git+https://github.com/onaio/savreaderwriter.git@fix-pep-440-issues#egg=savreaderwriter

--- a/requirements/base.pip
+++ b/requirements/base.pip
@@ -235,7 +235,7 @@ oauthlib==3.2.2
     # via
     #   django-oauth-toolkit
     #   requests-oauthlib
-ona-oidc @ git+https://github.com/onaio/ona-oidc.git@pytz-deprecated
+ona-oidc @ git+https://github.com/onaio/ona-oidc.git@v1.0.4
     # via -r requirements/base.in
 openpyxl==3.1.2
     # via

--- a/requirements/dev.pip
+++ b/requirements/dev.pip
@@ -303,7 +303,7 @@ oauthlib==3.2.2
     # via
     #   django-oauth-toolkit
     #   requests-oauthlib
-ona-oidc @ git+https://github.com/onaio/ona-oidc.git@pytz-deprecated
+ona-oidc @ git+https://github.com/onaio/ona-oidc.git@v1.0.4
     # via -r requirements/base.in
 openpyxl==3.1.2
     # via


### PR DESCRIPTION
### Changes / Features implemented

Add support for OR operation with date fields when filter on endpoint `/api/v1/data`

### Steps taken to verify this change does what is intended

- [x] QA


**Before submitting this PR for review, please make sure you have:**

  - [X] Included tests
  - [X] Updated documentation

Closes #2698 
