### PR TITLE
Bump version to v4.8.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,7 @@ v4.8.0(2024-09-23)
   [@kelvin-muchiri]
 
 v4.7.1(2024-09-16)
+------------------
 - Use chunked queryset when iterating queryset
   `PR #2701 <https://github.com/onaio/onadata/pull/2701>`
   [@kelvin-muchiri]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,15 @@ Changelog for Onadata
 
 ``* represents releases that introduce new migrations``
 
+v4.8.0(2024-09-23)
+------------------
+- Update ona-oidc version to 1.1.1 
+  `PR #2708 <https://github.com/onaio/onadata/pull/2708>`
+  [@FrankApiyo]
+- Add support for OR operation data filter for date fields 
+  `PR #2701 <https://github.com/onaio/onadata/pull/2704>`
+  [@kelvin-muchiri]
+
 v4.7.1(2024-09-16)
 - Use chunked queryset when iterating queryset
   `PR #2701 <https://github.com/onaio/onadata/pull/2701>`

--- a/onadata/__init__.py
+++ b/onadata/__init__.py
@@ -6,7 +6,7 @@ visualization.
 """
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "4.7.1"
+__version__ = "4.8.0"
 
 
 # This will make sure the app is always imported when

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = onadata
-version = 4.7.1
+version = 4.8.0
 description = Collect Analyze and Share Data
 long_description = file: README.rst
 long_description_content_type = text/x-rst


### PR DESCRIPTION
### Changes

Bump version to v4.8.0

**Enhancements**
- https://github.com/onaio/onadata/pull/2708
- https://github.com/onaio/onadata/pull/2704