### PR TITLE
Disable sending of activation email when creating organization

### DIFF
--- a/onadata/apps/api/tools.py
+++ b/onadata/apps/api/tools.py
@@ -177,16 +177,9 @@ def create_organization_object(org_name, creator, attrs=None):
     )
     new_user.save()
     try:
-        registration_profile = RegistrationProfile.objects.create_profile(new_user)
+        RegistrationProfile.objects.create_profile(new_user)
     except IntegrityError as e:
         raise ValidationError(_(f"{org_name} already exists")) from e
-    if email:
-        site = (
-            attrs["host"]
-            if "host" in attrs
-            else Site.objects.get(pk=settings.SITE_ID).domain
-        )
-        registration_profile.send_activation_email(site)
     profile = OrganizationProfile(
         user=new_user,
         name=name,


### PR DESCRIPTION
### Changes / Features implemented

Disable sending of activation email when creating organization

### Steps taken to verify this change does what is intended

- [x] QA

### Side effects of implementing this change

No activation email will be sent when creating an organization.

**Before submitting this PR for review, please make sure you have:**

  - [ ] Included tests
  - [ ] Updated documentation

Closes #2669
