### PR TITLE
Make user active status configurable

### DIFF
--- a/onadata/libs/serializers/user_profile_serializer.py
+++ b/onadata/libs/serializers/user_profile_serializer.py
@@ -299,7 +299,7 @@ class UserProfileSerializer(serializers.HyperlinkedModelSerializer):
                 new_user.delete()
             raise serializers.ValidationError({"password": e.messages})
 
-        new_user.is_active = True
+        new_user.is_active = settings.USER_ACTIVE_BY_DEFAULT
         new_user.first_name = params.get("first_name")
         new_user.last_name = params.get("last_name")
         new_user.save()

--- a/onadata/settings/common.py
+++ b/onadata/settings/common.py
@@ -719,3 +719,5 @@ CSP_STYLE_SRC = [
     "'sha256-52i34Zg+qg4/kTYjnNHEmW8jhzGRxjt77FX9aveiXqw='",
 ]
 CSP_INCLUDE_NONCE_IN = ["script-src", "style-src"]
+
+USER_ACTIVE_BY_DEFAULT = True


### PR DESCRIPTION
Make user active status configurable #2679

Changes made:
Added USER_DEFAULT_IS_ACTIVE setting in settings/common.py to control the default active status of newly created users.
Modified the user creation logic to use the USER_DEFAULT_IS_ACTIVE setting.


