### PR TITLE
Add/remove user from organization synchronously

### DIFF
--- a/onadata/apps/api/tests/test_tasks.py
+++ b/onadata/apps/api/tests/test_tasks.py
@@ -7,17 +7,13 @@ from unittest.mock import patch
 from django.core.cache import cache
 from django.contrib.auth import get_user_model
 from django.db import DatabaseError, OperationalError
-from django.test import override_settings
 
 from onadata.apps.api.tasks import (
     send_project_invitation_email_async,
     regenerate_form_instance_json,
-    add_org_user_and_share_projects_async,
-    remove_org_user_async,
     share_project_async,
     ShareProject,
 )
-from onadata.apps.api.models.organization_profile import OrganizationProfile
 from onadata.apps.logger.models import ProjectInvitation, Instance
 from onadata.apps.main.tests.test_base import TestBase
 from onadata.libs.permissions import ManagerRole
@@ -122,179 +118,11 @@ class RegenerateFormInstanceJsonTestCase(TestBase):
         instance.refresh_from_db()
         self.assertFalse(instance.json)
 
+
 def set_cache_for_org(org, request):
     """Utility to set org cache"""
-    org_profile_json = OrganizationSerializer(
-            org, context={"request": request}
-    ).data
+    org_profile_json = OrganizationSerializer(org, context={"request": request}).data
     cache.set(f"{ORG_PROFILE_CACHE}{org.user.username}-owner", org_profile_json)
-
-@patch("onadata.apps.api.tasks.tools.add_org_user_and_share_projects")
-class AddOrgUserAndShareProjectsAsyncTestCase(TestBase):
-    """Tests for add_org_user_and_share_projects_async"""
-
-    def setUp(self):
-        super().setUp()
-
-        self.org_user = User.objects.create(username="onaorg")
-        alice = self._create_user("alice", "1234&&")
-        self.org = OrganizationProfile.objects.create(
-            user=self.org_user, name="Ona Org", creator=alice
-        )
-        self.extra = {"HTTP_AUTHORIZATION": f"Token {self.user.auth_token}"}
-
-    def test_user_added_to_org(self, mock_add):
-        """User is added to organization"""
-        request = self.factory.get("/", **self.extra)
-        request.user = self.user
-        set_cache_for_org(self.org, request)
-        cache_key = f"{ORG_PROFILE_CACHE}{self.org.user.username}-owner"
-        self.assertIsNotNone(cache.get(cache_key))
-        add_org_user_and_share_projects_async.delay(
-            self.org.pk, self.user.pk, "manager"
-        )
-        mock_add.assert_called_once_with(self.org, self.user, "manager")
-        self.assertEqual(cache.get(cache_key), None)
-
-    def test_role_optional(self, mock_add):
-        """role param is optional"""
-        add_org_user_and_share_projects_async.delay(self.org.pk, self.user.pk)
-        mock_add.assert_called_once_with(self.org, self.user, None)
-
-    @patch("onadata.apps.api.tasks.logger.exception")
-    def test_invalid_org_id(self, mock_log, mock_add):
-        """Invalid org_id is handled"""
-        add_org_user_and_share_projects_async.delay(sys.maxsize, self.user.pk)
-        mock_add.assert_not_called()
-        mock_log.assert_called_once()
-
-    @patch("onadata.apps.api.tasks.logger.exception")
-    def test_invalid_user_id(self, mock_log, mock_add):
-        """Invalid org_id is handled"""
-        add_org_user_and_share_projects_async.delay(self.org.pk, sys.maxsize)
-        mock_add.assert_not_called()
-        mock_log.assert_called_once()
-
-    @patch("onadata.apps.api.tasks.add_org_user_and_share_projects_async.retry")
-    def test_database_error(self, mock_retry, mock_add):
-        """We retry calls if DatabaseError is raised"""
-        mock_add.side_effect = DatabaseError()
-        add_org_user_and_share_projects_async.delay(self.org.pk, self.user.pk)
-        self.assertTrue(mock_retry.called)
-        _, kwargs = mock_retry.call_args_list[0]
-        self.assertTrue(isinstance(kwargs["exc"], DatabaseError))
-
-    @patch("onadata.apps.api.tasks.add_org_user_and_share_projects_async.retry")
-    def test_connection_error(self, mock_retry, mock_add):
-        """We retry calls if ConnectionError is raised"""
-        mock_add.side_effect = ConnectionError()
-        add_org_user_and_share_projects_async.delay(self.org.pk, self.user.pk)
-        self.assertTrue(mock_retry.called)
-        _, kwargs = mock_retry.call_args_list[0]
-        self.assertTrue(isinstance(kwargs["exc"], ConnectionError))
-
-    @patch("onadata.apps.api.tasks.add_org_user_and_share_projects_async.retry")
-    def test_operation_error(self, mock_retry, mock_add):
-        """We retry calls if OperationError is raised"""
-        mock_add.side_effect = OperationalError()
-        add_org_user_and_share_projects_async.delay(self.org.pk, self.user.pk)
-        self.assertTrue(mock_retry.called)
-        _, kwargs = mock_retry.call_args_list[0]
-        self.assertTrue(isinstance(kwargs["exc"], OperationalError))
-
-    @override_settings(DEFAULT_FROM_EMAIL="noreply@ona.io")
-    @patch("onadata.apps.api.tasks.send_mail")
-    def test_send_mail(self, mock_email, mock_add):
-        """Send mail works"""
-        self.user.email = "bob@example.com"
-        self.user.save()
-        add_org_user_and_share_projects_async.delay(
-            self.org.pk, self.user.pk, "manager", "Subject", "Body"
-        )
-        mock_email.assert_called_with(
-            "Subject",
-            "Body",
-            "noreply@ona.io",
-            ("bob@example.com",),
-        )
-        mock_add.assert_called_once_with(self.org, self.user, "manager")
-
-    @override_settings(DEFAULT_FROM_EMAIL="noreply@ona.io")
-    @patch("onadata.apps.api.tasks.send_mail")
-    def test_user_email_none(self, mock_email, mock_add):
-        """Email not sent if user email is None"""
-        add_org_user_and_share_projects_async.delay(
-            self.org.pk, self.user.pk, "manager", "Subject", "Body"
-        )
-        mock_email.assert_not_called()
-        mock_add.assert_called_once_with(self.org, self.user, "manager")
-
-
-@patch("onadata.apps.api.tasks.tools.remove_user_from_organization")
-class RemoveOrgUserAsyncTestCase(TestBase):
-    """Tests for remove_org_user_async"""
-
-    def setUp(self):
-        super().setUp()
-
-        self.org_user = User.objects.create(username="onaorg")
-        alice = self._create_user("alice", "1234&&")
-        self.org = OrganizationProfile.objects.create(
-            user=self.org_user, name="Ona Org", creator=alice
-        )
-        self.extra = {"HTTP_AUTHORIZATION": f"Token {self.user.auth_token}"}
-
-    def test_user_removed_from_org(self, mock_remove):
-        """User is removed from organization"""
-        request = self.factory.get("/", **self.extra)
-        request.user = self.user
-        set_cache_for_org(self.org, request)
-        cache_key = f"{ORG_PROFILE_CACHE}{self.org.user.username}-owner"
-        self.assertIsNotNone(cache.get(cache_key))
-        remove_org_user_async.delay(self.org.pk, self.user.pk)
-        mock_remove.assert_called_once_with(self.org, self.user)
-        self.assertEqual(cache.get(cache_key), None)
-
-    @patch("onadata.apps.api.tasks.logger.exception")
-    def test_invalid_org_id(self, mock_log, mock_remove):
-        """Invalid org_id is handled"""
-        remove_org_user_async.delay(sys.maxsize, self.user.pk)
-        mock_remove.assert_not_called()
-        mock_log.assert_called_once()
-
-    @patch("onadata.apps.api.tasks.logger.exception")
-    def test_invalid_user_id(self, mock_log, mock_remove):
-        """Invalid user_id is handled"""
-        remove_org_user_async.delay(self.org.pk, sys.maxsize)
-        mock_remove.assert_not_called()
-        mock_log.assert_called_once()
-
-    @patch("onadata.apps.api.tasks.remove_org_user_async.retry")
-    def test_database_error(self, mock_retry, mock_remove):
-        """We retry calls if DatabaseError is raised"""
-        mock_remove.side_effect = DatabaseError()
-        remove_org_user_async.delay(self.org.pk, self.user.pk)
-        self.assertTrue(mock_retry.called)
-        _, kwargs = mock_retry.call_args_list[0]
-        self.assertTrue(isinstance(kwargs["exc"], DatabaseError))
-
-    @patch("onadata.apps.api.tasks.remove_org_user_async.retry")
-    def test_connection_error(self, mock_retry, mock_remove):
-        """We retry calls if ConnectionError is raised"""
-        mock_remove.side_effect = ConnectionError()
-        remove_org_user_async.delay(self.org.pk, self.user.pk)
-        self.assertTrue(mock_retry.called)
-        _, kwargs = mock_retry.call_args_list[0]
-        self.assertTrue(isinstance(kwargs["exc"], ConnectionError))
-
-    @patch("onadata.apps.api.tasks.remove_org_user_async.retry")
-    def test_operation_error(self, mock_retry, mock_remove):
-        """We retry calls if OperationError is raised"""
-        mock_remove.side_effect = OperationalError()
-        remove_org_user_async.delay(self.org.pk, self.user.pk)
-        self.assertTrue(mock_retry.called)
-        _, kwargs = mock_retry.call_args_list[0]
-        self.assertTrue(isinstance(kwargs["exc"], OperationalError))
 
 
 class ShareProjectAsyncTestCase(TestBase):

--- a/onadata/apps/api/tests/test_tools.py
+++ b/onadata/apps/api/tests/test_tools.py
@@ -7,90 +7,16 @@ from onadata.apps.api.models.organization_profile import (
     Team,
     get_organization_members_team,
 )
-from onadata.apps.api.tools import (
-    add_org_user_and_share_projects,
-    add_user_to_organization,
-)
+from onadata.apps.api.tools import add_user_to_organization
 from onadata.apps.logger.models.project import Project
 from onadata.apps.main.tests.test_base import TestBase
 from onadata.libs.permissions import DataEntryRole, ManagerRole, OwnerRole
-
 
 User = get_user_model()
 
 
 class AddUserToOrganizationTestCase(TestBase):
-    """Add tests for add_user_to_organization"""
-
-    def setUp(self) -> None:
-        super().setUp()
-
-        self.org_user = User.objects.create(username="onaorg")
-        alice = self._create_user("alice", "1234&&")
-        self.org = OrganizationProfile.objects.create(
-            user=self.org_user, name="Ona Org", creator=alice
-        )
-
-    def test_add_owner(self):
-        """Owner is added to organization"""
-        add_user_to_organization(self.org, self.user, "owner")
-
-        self.user.refresh_from_db()
-        owner_team = Team.objects.get(name=f"{self.org_user.username}#Owners")
-        members_team = Team.objects.get(name=f"{self.org_user.username}#members")
-        self.assertTrue(
-            owner_team.user_set.filter(username=self.user.username).exists()
-        )
-        self.assertTrue(
-            members_team.user_set.filter(username=self.user.username).exists()
-        )
-        self.assertTrue(OwnerRole.user_has_role(self.user, self.org))
-        self.assertTrue(OwnerRole.user_has_role(self.user, self.org.userprofile_ptr))
-
-        # If role changes, user is removed from owners team
-        add_user_to_organization(self.org, self.user, "editor")
-
-        self.user.refresh_from_db()
-        owner_team.refresh_from_db()
-
-        self.assertFalse(
-            owner_team.user_set.filter(username=self.user.username).exists()
-        )
-        self.assertFalse(OwnerRole.user_has_role(self.user, self.org))
-        self.assertFalse(OwnerRole.user_has_role(self.user, self.org.userprofile_ptr))
-
-    def test_non_owner(self):
-        """Non-owners add to organization"""
-        add_user_to_organization(self.org, self.user, "manager")
-
-        self.user.refresh_from_db()
-        owner_team = Team.objects.get(name=f"{self.org_user.username}#Owners")
-        members_team = Team.objects.get(name=f"{self.org_user.username}#members")
-        self.assertFalse(
-            owner_team.user_set.filter(username=self.user.username).exists()
-        )
-        self.assertTrue(
-            members_team.user_set.filter(username=self.user.username).exists()
-        )
-        self.assertTrue(ManagerRole.user_has_role(self.user, self.org))
-
-    def test_role_none(self):
-        """role param is None or not provided"""
-        add_user_to_organization(self.org, self.user)
-
-        self.user.refresh_from_db()
-        owner_team = Team.objects.get(name=f"{self.org_user.username}#Owners")
-        members_team = Team.objects.get(name=f"{self.org_user.username}#members")
-        self.assertFalse(
-            owner_team.user_set.filter(username=self.user.username).exists()
-        )
-        self.assertTrue(
-            members_team.user_set.filter(username=self.user.username).exists()
-        )
-
-
-class AddOrgUserAndShareProjectsTestCase(TestBase):
-    """Tests for add_org_user_and_share_projects"""
+    """Tests for add_user_to_organization"""
 
     def setUp(self) -> None:
         super().setUp()
@@ -106,7 +32,7 @@ class AddOrgUserAndShareProjectsTestCase(TestBase):
 
     def test_add_owner(self):
         """Owner added to org and projects shared"""
-        add_org_user_and_share_projects(self.org, self.user, "owner")
+        add_user_to_organization(self.org, self.user, "owner")
 
         self.user.refresh_from_db()
         owner_team = Team.objects.get(name=f"{self.org_user.username}#Owners")
@@ -129,7 +55,7 @@ class AddOrgUserAndShareProjectsTestCase(TestBase):
         members_team = get_organization_members_team(self.org)
         DataEntryRole.add(members_team, self.project)
 
-        add_org_user_and_share_projects(self.org, self.user, "manager")
+        add_user_to_organization(self.org, self.user, "manager")
 
         self.user.refresh_from_db()
         owner_team = Team.objects.get(name=f"{self.org_user.username}#Owners")
@@ -148,7 +74,7 @@ class AddOrgUserAndShareProjectsTestCase(TestBase):
         self.project.created_by = self.user
         self.project.save()
 
-        add_org_user_and_share_projects(self.org, self.user, "manager")
+        add_user_to_organization(self.org, self.user, "manager")
 
         self.assertTrue(ManagerRole.user_has_role(self.user, self.project))
 
@@ -158,7 +84,7 @@ class AddOrgUserAndShareProjectsTestCase(TestBase):
         members_team = get_organization_members_team(self.org)
         DataEntryRole.add(members_team, self.project)
 
-        add_org_user_and_share_projects(self.org, self.user)
+        add_user_to_organization(self.org, self.user)
 
         self.user.refresh_from_db()
         owner_team = Team.objects.get(name=f"{self.org_user.username}#Owners")

--- a/onadata/apps/api/tests/viewsets/test_organization_profile_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_organization_profile_viewset.py
@@ -809,8 +809,12 @@ class TestOrganizationProfileViewSet(TestAbstractViewSet):
         request = self.factory.get("/", **self.extra)
         response = view(request, user="denoinc")
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.data["users"][2]["user"], "aboy")
-        self.assertEqual(response.data["users"][2]["role"], "editor")
+        self.assertTrue(
+            any(
+                item["user"] == "aboy" and item["role"] == "editor"
+                for item in response.data["users"]
+            )
+        )
 
     def test_add_members_to_owner_role(self):
         self._org_create()

--- a/onadata/apps/api/tests/viewsets/test_organization_profile_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_organization_profile_viewset.py
@@ -734,7 +734,7 @@ class TestOrganizationProfileViewSet(TestAbstractViewSet):
         self.assertEqual(response.status_code, 400)
 
     @override_settings(DEFAULT_FROM_EMAIL="noreply@ona.io")
-    @patch("onadata.apps.api.tasks.send_mail")
+    @patch("onadata.libs.serializers.organization_member_serializer.send_mail")
     def test_add_members_to_org_email(self, mock_email):
         self._org_create()
         view = OrganizationProfileViewSet.as_view({"post": "members"})
@@ -759,7 +759,7 @@ class TestOrganizationProfileViewSet(TestAbstractViewSet):
         self.assertEqual(set(response.data), set(["denoinc", "aboy"]))
 
     @override_settings(DEFAULT_FROM_EMAIL="noreply@ona.io")
-    @patch("onadata.apps.api.tasks.send_mail")
+    @patch("onadata.libs.serializers.organization_member_serializer.send_mail")
     def test_add_members_to_org_email_custom_subj(self, mock_email):
         self._org_create()
         view = OrganizationProfileViewSet.as_view({"post": "members"})

--- a/onadata/apps/api/tests/viewsets/test_organization_profile_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_organization_profile_viewset.py
@@ -809,6 +809,7 @@ class TestOrganizationProfileViewSet(TestAbstractViewSet):
         request = self.factory.get("/", **self.extra)
         response = view(request, user="denoinc")
         self.assertEqual(response.status_code, 200)
+        # items can be in any order
         self.assertTrue(
             any(
                 item["user"] == "aboy" and item["role"] == "editor"

--- a/onadata/apps/api/tools.py
+++ b/onadata/apps/api/tools.py
@@ -195,7 +195,14 @@ def create_organization_object(org_name, creator, attrs=None):
 
 
 def remove_user_from_organization(organization, user):
-    """Remove a user from an organization"""
+    """Remove a user from an organization
+
+    Remove user from organization and all projects in the organization
+
+    :param organization: OrganizationProfile instance
+    :param user: User instance
+    :return: None
+    """
     team = get_organization_members_team(organization)
     remove_user_from_team(team, user)
     owners_team = get_or_create_organization_owners_team(organization)
@@ -244,7 +251,15 @@ def remove_user_from_team(team, user):
 
 
 def add_user_to_organization(organization, user, role=None):
-    """Add a user to an organization"""
+    """Add a user to an organization
+
+    Add user to organization and all projects in the organization
+
+    :param organization: OrganizationProfile instance
+    :param user: User instance
+    :param role: Role name
+    :return: None
+    """
 
     team = get_organization_members_team(organization)
     add_user_to_team(team, user)


### PR DESCRIPTION
### Changes / Features implemented

Since an organization is a Group, adding/removing user from an organization does not take long and can be done synchronously. Sharing organization projects will take longer and remains asynchronous.

### Steps taken to verify this change does what is intended

- [x] QA

### Side effects of implementing this change

No delay in a user being added to an organization. Clients are able to get the updated members list immediately

**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  - [ ] Updated documentation

Closes #
