### PR TITLE
Customized deleted_by serializer field for Dataviews

### DIFF
--- a/onadata/apps/api/tests/viewsets/test_dataview_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_dataview_viewset.py
@@ -454,6 +454,16 @@ class TestDataViewViewSet(TestAbstractViewSet):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 2)
 
+        # delete DataView and check that we don't get it in response
+        dataview = DataView.objects.get(name="My DataView2")
+        deleted_dataview_id = dataview.id
+        dataview.soft_delete(user=self.user)
+        response = view(request)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 1)
+        self.assertNotEqual(response.data[0]["dataviewid"], deleted_dataview_id)
+
         anon_request = request = self.factory.get("/")
         anon_response = view(anon_request)
         self.assertEqual(anon_response.status_code, 401)

--- a/onadata/apps/api/tests/viewsets/test_dataview_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_dataview_viewset.py
@@ -487,6 +487,36 @@ class TestDataViewViewSet(TestAbstractViewSet):
 
         self.assertEqual(response.status_code, 200)
 
+    def test_can_not_get_deleted_dataview(self):
+        data = {
+            "name": "Agriculture Dataview",
+            "xform": f"http://testserver/api/v1/forms/{self.xform.pk}",
+            "project": f"http://testserver/api/v1/projects/{self.project.pk}",
+            "columns": '["name", "age", "gender"]',
+            "query": '[{"column":"age","filter":">","value":"20"},'
+            '{"column":"age","filter":"<","value":"50"}]',
+        }
+
+        self._create_dataview(data=data)
+
+        view = DataViewViewSet.as_view(
+            {
+                "get": "retrieve",
+            }
+        )
+
+        request = self.factory.get("/", **self.extra)
+        response = view(request, pk=self.data_view.pk)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["dataviewid"], self.data_view.pk)
+
+        dataview = DataView.objects.get(id=response.data["dataviewid"])
+        dataview.soft_delete(user=self.user)
+
+        request = self.factory.get("/", **self.extra)
+        response = view(request, pk=self.data_view.pk)
+        self.assertEqual(response.status_code, 404)
+
     # pylint: disable=invalid-name
     def test_dataview_data_filter_integer(self):
         data = {

--- a/onadata/apps/api/viewsets/dataview_viewset.py
+++ b/onadata/apps/api/viewsets/dataview_viewset.py
@@ -159,9 +159,7 @@ class DataViewViewSet(
         """
         Remove deleted DataViews
         """
-        return super().filter_queryset(
-            queryset.filter(deleted_at=None, deleted_by=None)
-        )
+        return super().filter_queryset(queryset.filter(deleted_at=None))
 
     def list(self, request, *args, **kwargs):
         """

--- a/onadata/apps/api/viewsets/dataview_viewset.py
+++ b/onadata/apps/api/viewsets/dataview_viewset.py
@@ -126,7 +126,7 @@ class DataViewViewSet(
     A simple ViewSet for viewing and editing DataViews.
     """
 
-    queryset = DataView.objects.select_related()
+    queryset = DataView.objects.filter(deleted_at__isnull=True).select_related()
     serializer_class = DataViewSerializer
     permission_classes = [DataViewViewsetPermissions]
     lookup_field = "pk"
@@ -154,12 +154,6 @@ class DataViewViewSet(
             serializer_class = self.serializer_class
 
         return serializer_class
-
-    def filter_queryset(self, queryset):
-        """
-        Remove deleted DataViews
-        """
-        return super().filter_queryset(queryset.filter(deleted_at=None))
 
     def list(self, request, *args, **kwargs):
         """

--- a/onadata/apps/api/viewsets/dataview_viewset.py
+++ b/onadata/apps/api/viewsets/dataview_viewset.py
@@ -155,6 +155,14 @@ class DataViewViewSet(
 
         return serializer_class
 
+    def filter_queryset(self, queryset):
+        """
+        Remove deleted DataViews
+        """
+        return super().filter_queryset(
+            queryset.filter(deleted_at=None, deleted_by=None)
+        )
+
     def list(self, request, *args, **kwargs):
         """
         List endpoint for Filtered datasets

--- a/onadata/libs/serializers/dataview_serializer.py
+++ b/onadata/libs/serializers/dataview_serializer.py
@@ -109,11 +109,6 @@ class DataViewSerializer(serializers.HyperlinkedModelSerializer):
     project = serializers.HyperlinkedRelatedField(
         view_name="project-detail", lookup_field="pk", queryset=Project.objects.all()
     )
-    deleted_by = serializers.HyperlinkedRelatedField(
-        view_name="user-detail",
-        lookup_field="username",
-        read_only=True,
-    )
     columns = JsonField()
     query = JsonField(required=False)
     count = serializers.SerializerMethodField()
@@ -124,7 +119,6 @@ class DataViewSerializer(serializers.HyperlinkedModelSerializer):
 
     class Meta:
         model = DataView
-        exclude = ["deleted_by", "deleted_at"]
         fields = (
             "dataviewid",
             "name",

--- a/onadata/libs/serializers/dataview_serializer.py
+++ b/onadata/libs/serializers/dataview_serializer.py
@@ -124,6 +124,7 @@ class DataViewSerializer(serializers.HyperlinkedModelSerializer):
 
     class Meta:
         model = DataView
+        exclude = ["deleted_by", "deleted_at"]
         fields = (
             "dataviewid",
             "name",
@@ -138,8 +139,6 @@ class DataViewSerializer(serializers.HyperlinkedModelSerializer):
             "has_hxl_support",
             "url",
             "date_created",
-            "deleted_at",
-            "deleted_by",
         )
         validators = [
             serializers.UniqueTogetherValidator(

--- a/onadata/libs/serializers/dataview_serializer.py
+++ b/onadata/libs/serializers/dataview_serializer.py
@@ -109,6 +109,11 @@ class DataViewSerializer(serializers.HyperlinkedModelSerializer):
     project = serializers.HyperlinkedRelatedField(
         view_name="project-detail", lookup_field="pk", queryset=Project.objects.all()
     )
+    deleted_by = serializers.HyperlinkedRelatedField(
+        view_name="user-detail",
+        lookup_field="username",
+        read_only=True,
+    )
     columns = JsonField()
     query = JsonField(required=False)
     count = serializers.SerializerMethodField()

--- a/onadata/libs/tests/serializers/test_dataview_serializer.py
+++ b/onadata/libs/tests/serializers/test_dataview_serializer.py
@@ -79,7 +79,7 @@ class TestDataViewSerializer(TestAbstractViewSet):
         serialized_dataview = DataViewSerializer(
             dataview, context={"request": request}
         ).data
-        self.assertEqual(serialized_dataview["deleted_by"], None)
+        self.assertFalse("deleted_by" in serialized_dataview)
         self.assertFalse("deleted_at" in serialized_dataview)
 
     def test_name_and_xform_are_unique(self):

--- a/onadata/libs/tests/serializers/test_dataview_serializer.py
+++ b/onadata/libs/tests/serializers/test_dataview_serializer.py
@@ -46,9 +46,44 @@ class TestDataViewSerializer(TestAbstractViewSet):
 
             return data.get('has_hxl_support')
 
-        self.assertFalse(get_has_hxl_support_value('name_only'))
-        self.assertTrue(get_has_hxl_support_value('age_only'))
-        self.assertTrue(get_has_hxl_support_value('age_and_name'))
+        self.assertFalse(get_has_hxl_support_value("name_only"))
+        self.assertTrue(get_has_hxl_support_value("age_only"))
+        self.assertTrue(get_has_hxl_support_value("age_and_name"))
+
+    def test_no_error_thrown_for_a_dataview_with_deleted_by_set(self):
+        """
+        When `deleted_by` is set, don't throw error when serializing a DataView
+        """
+        self._publish_form_with_hxl_support()
+        request = self.factory.get("/", **self.extra)
+        request.user = self.user
+
+        dataview_name = "My deleted DataView"
+        payload = {
+            "name": dataview_name,
+            "xform": "http://testserver/api/v1/forms/%s" % self.xform.pk,
+            "project": "http://testserver/api/v1/projects/%s" % self.project.pk,
+            "columns": '["name", "age"]',
+            "query": "[]",
+        }
+        serializer = DataViewSerializer(data=payload, context={"request": request})
+        is_valid = serializer.is_valid()
+        self.assertTrue(is_valid)
+
+        serializer.save()
+        self.assertEqual(DataView.objects.count(), 1)
+
+        # delete dataview and check dataviews endpoint
+        dataview = DataView.objects.get(name=dataview_name)
+        dataview.soft_delete(self.user)
+        serialized_dataview = DataViewSerializer(
+            dataview, context={"request": request}
+        ).data
+        self.assertEqual(
+            serialized_dataview["deleted_by"],
+            f"http://testserver/api/v1/users/{self.user.username}",
+        )
+        self.assertTrue("deleted_at" in serialized_dataview)
 
     def test_name_and_xform_are_unique(self):
         """

--- a/onadata/libs/tests/serializers/test_dataview_serializer.py
+++ b/onadata/libs/tests/serializers/test_dataview_serializer.py
@@ -79,11 +79,8 @@ class TestDataViewSerializer(TestAbstractViewSet):
         serialized_dataview = DataViewSerializer(
             dataview, context={"request": request}
         ).data
-        self.assertEqual(
-            serialized_dataview["deleted_by"],
-            f"http://testserver/api/v1/users/{self.user.username}",
-        )
-        self.assertTrue("deleted_at" in serialized_dataview)
+        self.assertEqual(serialized_dataview["deleted_by"], None)
+        self.assertFalse("deleted_at" in serialized_dataview)
 
     def test_name_and_xform_are_unique(self):
         """

--- a/onadata/libs/tests/serializers/test_dataview_serializer.py
+++ b/onadata/libs/tests/serializers/test_dataview_serializer.py
@@ -46,9 +46,9 @@ class TestDataViewSerializer(TestAbstractViewSet):
 
             return data.get('has_hxl_support')
 
-        self.assertFalse(get_has_hxl_support_value("name_only"))
-        self.assertTrue(get_has_hxl_support_value("age_only"))
-        self.assertTrue(get_has_hxl_support_value("age_and_name"))
+        self.assertFalse(get_has_hxl_support_value('name_only'))
+        self.assertTrue(get_has_hxl_support_value('age_only'))
+        self.assertTrue(get_has_hxl_support_value('age_and_name'))
 
     def test_name_and_xform_are_unique(self):
         """

--- a/onadata/libs/tests/serializers/test_dataview_serializer.py
+++ b/onadata/libs/tests/serializers/test_dataview_serializer.py
@@ -50,38 +50,6 @@ class TestDataViewSerializer(TestAbstractViewSet):
         self.assertTrue(get_has_hxl_support_value("age_only"))
         self.assertTrue(get_has_hxl_support_value("age_and_name"))
 
-    def test_no_error_thrown_for_a_dataview_with_deleted_by_set(self):
-        """
-        When `deleted_by` is set, don't throw error when serializing a DataView
-        """
-        self._publish_form_with_hxl_support()
-        request = self.factory.get("/", **self.extra)
-        request.user = self.user
-
-        dataview_name = "My deleted DataView"
-        payload = {
-            "name": dataview_name,
-            "xform": "http://testserver/api/v1/forms/%s" % self.xform.pk,
-            "project": "http://testserver/api/v1/projects/%s" % self.project.pk,
-            "columns": '["name", "age"]',
-            "query": "[]",
-        }
-        serializer = DataViewSerializer(data=payload, context={"request": request})
-        is_valid = serializer.is_valid()
-        self.assertTrue(is_valid)
-
-        serializer.save()
-        self.assertEqual(DataView.objects.count(), 1)
-
-        # delete dataview and check dataviews endpoint
-        dataview = DataView.objects.get(name=dataview_name)
-        dataview.soft_delete(self.user)
-        serialized_dataview = DataViewSerializer(
-            dataview, context={"request": request}
-        ).data
-        self.assertFalse("deleted_by" in serialized_dataview)
-        self.assertFalse("deleted_at" in serialized_dataview)
-
     def test_name_and_xform_are_unique(self):
         """
         Test that we are preventing the creation of exactly the same dataview


### PR DESCRIPTION
### Changes / Features implemented
- Exclude `deleted_by` serializer field
- Filter out dataview that have already been deleted from the dataviews endpoint

### Steps taken to verify this change does what is intended
Ran locally

### Side effects of implementing this change
N/A

**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  - [ ] Updated documentation

Closes https://github.com/onaio/onadata/issues/2720
