### PR TITLE
Fix extra columns excluded in DataView CSV export

### DIFF
--- a/onadata/apps/api/tests/viewsets/test_dataview_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_dataview_viewset.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 """Test DataViewViewSet"""
+
 import csv
 import json
 import os
 from datetime import datetime, timedelta
 from unittest.mock import patch
-
 
 from django.conf import settings
 from django.core.cache import cache
@@ -13,9 +13,8 @@ from django.core.files.storage import default_storage
 from django.test.utils import override_settings
 from django.utils.timezone import utc
 
-from openpyxl import load_workbook
-
 from flaky import flaky
+from openpyxl import load_workbook
 
 from onadata.apps.api.tests.viewsets.test_abstract_viewset import TestAbstractViewSet
 from onadata.apps.api.viewsets.attachment_viewset import AttachmentViewSet
@@ -1050,7 +1049,11 @@ class TestDataViewViewSet(TestAbstractViewSet):
             "name": "My DataView",
             "xform": f"http://testserver/api/v1/forms/{xform.pk}",
             "project": f"http://testserver/api/v1/projects/{project.pk}",
-            "columns": '["name", "age", "gender", "pizza_type"]',
+            "columns": (
+                '["name", "age", "gender", "pizza_type", "_id", "_uuid", '
+                '"_submission_time", "_index", "_parent_table_name",  "_parent_index", '
+                '"_tags", "_notes", "_version", "_duration","_submitted_by"]'
+            ),
             "query": ('[{"column":"age","filter":"=","value":"28"}]'),
         }
         self._create_dataview(data=data)
@@ -1089,8 +1092,8 @@ class TestDataViewViewSet(TestAbstractViewSet):
         self.assertTrue(export.is_successful)
         workbook = load_workbook(export.full_filepath)
         workbook.iso_dates = True
-        sheet_name = workbook.get_sheet_names()[0]
-        main_sheet = workbook.get_sheet_by_name(sheet_name)
+        sheet_name = workbook.sheetnames[0]
+        main_sheet = workbook[sheet_name]
         sheet_headers = list(main_sheet.values)[0]
         sheet_data = list(main_sheet.values)[1]
         inst = self.xform.instances.get(id=sheet_data[4])

--- a/onadata/libs/tests/utils/test_csv_builder.py
+++ b/onadata/libs/tests/utils/test_csv_builder.py
@@ -2090,7 +2090,10 @@ class TestCSVDataFrameBuilder(TestBase):
         self.assertCountEqual(row, expected_row)
 
     def test_extra_columns_dataview(self):
-        """Extra columns are included in export for dataview"""
+        """Extra columns are included in export for dataview
+
+        Only extra columns in the dataview are included in the export
+        """
         md_xform = """
         | survey  |
         |         | type                   | name  | label  |

--- a/onadata/libs/tests/utils/test_csv_builder.py
+++ b/onadata/libs/tests/utils/test_csv_builder.py
@@ -2115,8 +2115,22 @@ class TestCSVDataFrameBuilder(TestBase):
             include_images=False,
             show_choice_labels=True,
         )
+        extra_cols = [
+            "_id",
+            "_uuid",
+            "_submission_time",
+            "_date_modified",
+            "_tags",
+            "_notes",
+            "_version",
+            "_duration",
+            "_submitted_by",
+            "_total_media",
+            "_media_count",
+            "_media_all_received",
+        ]
 
-        for extra_col in csv_df_builder.extra_columns:
+        for extra_col in extra_cols:
             dataview = DataView.objects.create(
                 xform=xform,
                 name="test",

--- a/onadata/libs/tests/utils/test_csv_builder.py
+++ b/onadata/libs/tests/utils/test_csv_builder.py
@@ -2114,11 +2114,9 @@ class TestCSVDataFrameBuilder(TestBase):
         )
 
         for extra_col in csv_df_builder.extra_columns:
-            dataview = DataView.objects.get_or_create(
-                xform=xform, name="test", project=self.project
+            dataview = DataView.objects.create(
+                xform=xform, name="test", columns=[extra_col], project=self.project
             )
-            dataview.columns = [extra_col]
-            dataview.save()
             temp_file = NamedTemporaryFile(suffix=".csv", delete=False)
             csv_df_builder.export_to(temp_file.name, cursor, dataview=dataview)
             csv_file = open(temp_file.name, "r")

--- a/onadata/libs/tests/utils/test_csv_builder.py
+++ b/onadata/libs/tests/utils/test_csv_builder.py
@@ -2092,7 +2092,7 @@ class TestCSVDataFrameBuilder(TestBase):
     def test_extra_columns_dataview(self):
         """Extra columns are included in export for dataview
 
-        Only extra columns in the dataview are included in the export
+        Extra columns included only if in the dataview
         """
         md_xform = """
         | survey  |
@@ -2118,11 +2118,14 @@ class TestCSVDataFrameBuilder(TestBase):
 
         for extra_col in csv_df_builder.extra_columns:
             dataview = DataView.objects.create(
-                xform=xform, name="test", columns=[extra_col], project=self.project
+                xform=xform,
+                name="test",
+                columns=["age", extra_col],
+                project=self.project,
             )
             temp_file = NamedTemporaryFile(suffix=".csv", delete=False)
             csv_df_builder.export_to(temp_file.name, cursor, dataview=dataview)
             csv_file = open(temp_file.name, "r")
             csv_reader = csv.reader(csv_file)
             header = next(csv_reader)
-            self.assertEqual(header, [extra_col])
+            self.assertEqual(header, ["age", extra_col])

--- a/onadata/libs/tests/utils/test_csv_builder.py
+++ b/onadata/libs/tests/utils/test_csv_builder.py
@@ -2,14 +2,16 @@
 """
 Test CSVDataFrameBuilder
 """
+
 import csv
 import os
+from builtins import chr, open
 from tempfile import NamedTemporaryFile
 
-from builtins import chr, open
 from django.test.utils import override_settings
 from django.utils.dateparse import parse_datetime
 
+from onadata.apps.logger.models import DataView
 from onadata.apps.logger.models.entity_list import EntityList
 from onadata.apps.logger.models.xform import XForm
 from onadata.apps.logger.xform_instance_parser import xform_instance_to_dict
@@ -2086,3 +2088,50 @@ class TestCSVDataFrameBuilder(TestBase):
         ]
         row = next(csv_reader)
         self.assertCountEqual(row, expected_row)
+
+    def test_extra_columns_dataview(self):
+        """Extra columns are included in export for dataview"""
+        md_xform = """
+        | survey  |
+        |         | type                   | name  | label  |
+        |         | text                   | name  | Name   |
+        |         | integer                | age   | Age    |
+        |         | select_multiple fruits | fruit | Fruit  |
+        |         |                        |       |        |
+        | choices | list name              | name  | label  |
+        |         | fruits                 | 1     | Mango  |
+        |         | fruits                 | 2     | Orange |
+        |         | fruits                 | 3     | Apple  |
+        """
+        xform = self._publish_markdown(md_xform, self.user, id_string="b")
+        dataview_cols = [
+            "_id",
+            "_uuid",
+            "_submission_time",
+            "_date_modified",
+            "_tags",
+            "_notes",
+            "_version",
+            "_duration",
+            "_submitted_by",
+            "_total_media",
+            "_media_count",
+            "_media_all_received",
+        ]
+        dataview = DataView.objects.create(
+            xform=xform, columns=dataview_cols, name="test", project=self.project
+        )
+        cursor = [{"name": "Maria", "age": 25, "fruit": "1 2"}]
+        csv_df_builder = CSVDataFrameBuilder(
+            self.user.username,
+            xform.id_string,
+            split_select_multiples=False,
+            include_images=False,
+            show_choice_labels=True,
+        )
+        temp_file = NamedTemporaryFile(suffix=".csv", delete=False)
+        csv_df_builder.export_to(temp_file.name, cursor, dataview=dataview)
+        csv_file = open(temp_file.name, "r")
+        csv_reader = csv.reader(csv_file)
+        header = next(csv_reader)
+        self.assertEqual(header, csv_df_builder.extra_columns)

--- a/onadata/libs/tests/utils/test_csv_builder.py
+++ b/onadata/libs/tests/utils/test_csv_builder.py
@@ -2104,20 +2104,7 @@ class TestCSVDataFrameBuilder(TestBase):
         |         | fruits                 | 3     | Apple  |
         """
         xform = self._publish_markdown(md_xform, self.user, id_string="b")
-        dataview_cols = [
-            "_id",
-            "_uuid",
-            "_submission_time",
-            "_date_modified",
-            "_tags",
-            "_notes",
-            "_version",
-            "_duration",
-            "_submitted_by",
-            "_total_media",
-            "_media_count",
-            "_media_all_received",
-        ]
+        dataview_cols = ["_id"]
         dataview = DataView.objects.create(
             xform=xform, columns=dataview_cols, name="test", project=self.project
         )
@@ -2134,4 +2121,4 @@ class TestCSVDataFrameBuilder(TestBase):
         csv_file = open(temp_file.name, "r")
         csv_reader = csv.reader(csv_file)
         header = next(csv_reader)
-        self.assertEqual(header, csv_df_builder.extra_columns)
+        self.assertEqual(header, ["_id"])

--- a/onadata/libs/tests/utils/test_export_builder.py
+++ b/onadata/libs/tests/utils/test_export_builder.py
@@ -3679,13 +3679,28 @@ class TestExportBuilder(TestBase):
         )
         export_builder = ExportBuilder()
         export_builder.set_survey(self.xform.survey)
-        dataview = DataView.objects.create(
-            xform=self.xform,
-            name="test",
-            columns=["name", "_id"],
-            project=self.project,
-        )
-        fields = export_builder.get_fields(
-            dataview, export_builder.sections[0], "title"
-        )
-        self.assertEqual(fields, ["name", "_id"])
+        extra_cols = [
+            "_id",
+            "_uuid",
+            "_submission_time",
+            "_index",
+            "_parent_table_name",
+            "_parent_index",
+            "_tags",
+            "_notes",
+            "_version",
+            "_duration",
+            "_submitted_by",
+        ]
+
+        for extra_col in extra_cols:
+            dataview = DataView.objects.create(
+                xform=self.xform,
+                name="test",
+                columns=["name", extra_col],
+                project=self.project,
+            )
+            fields = export_builder.get_fields(
+                dataview, export_builder.sections[0], "title"
+            )
+            self.assertEqual(fields, ["name", extra_col])

--- a/onadata/libs/tests/utils/test_export_builder.py
+++ b/onadata/libs/tests/utils/test_export_builder.py
@@ -1740,7 +1740,7 @@ class TestExportBuilder(TestBase):
             workbook = load_workbook(filename)
 
             # check header columns
-            main_sheet = workbook.get_sheet_by_name("childrens_survey")
+            main_sheet = workbook["childrens_survey"]
             expected_column_headers = [
                 "name",
                 "age",
@@ -1819,7 +1819,7 @@ class TestExportBuilder(TestBase):
                 "childrens_survey_with_a_very_l2",
                 "childrens_survey_with_a_very_l3",
             ]
-            self.assertEqual(list(workbook.get_sheet_names()), expected_sheet_names)
+            self.assertEqual(list(workbook.sheetnames), expected_sheet_names)
 
     # pylint: disable=invalid-name
     def test_child_record_parent_table_is_updated_when_sheet_is_renamed(self):
@@ -3674,12 +3674,11 @@ class TestExportBuilder(TestBase):
 
         Only extra columns in the dataview are included in the export
         """
-        survey = self._create_childrens_survey()
         self._publish_xls_file_and_set_xform(
             _logger_fixture_path("childrens_survey.xlsx")
         )
         export_builder = ExportBuilder()
-        export_builder.set_survey(survey)
+        export_builder.set_survey(self.xform.survey)
         dataview = DataView.objects.create(
             xform=self.xform,
             name="test",

--- a/onadata/libs/tests/utils/test_export_builder.py
+++ b/onadata/libs/tests/utils/test_export_builder.py
@@ -3672,7 +3672,7 @@ class TestExportBuilder(TestBase):
     def test_extra_columns_dataview(self):
         """Extra columns are included in export for dataview
 
-        Only extra columns in the dataview are included in the export
+        Extra columns included only if in the dataview
         """
         self._publish_xls_file_and_set_xform(
             _logger_fixture_path("childrens_survey.xlsx")

--- a/onadata/libs/tests/utils/test_export_builder.py
+++ b/onadata/libs/tests/utils/test_export_builder.py
@@ -2,6 +2,7 @@
 """
 Tests Export Builder Functionality
 """
+
 from __future__ import unicode_literals
 
 import csv
@@ -23,6 +24,7 @@ from pyxform.builder import create_survey_from_xls
 from savReaderWriter import SavHeaderReader, SavReader
 
 from onadata.apps.logger.import_tools import django_file
+from onadata.apps.logger.models import DataView
 from onadata.apps.main.tests.test_base import TestBase
 from onadata.apps.viewer.models.data_dictionary import DataDictionary
 from onadata.apps.viewer.models.parsed_instance import _encode_for_mongo, query_data
@@ -1622,10 +1624,10 @@ class TestExportBuilder(TestBase):
                 "children_cartoons",
                 "children_cartoons_characters",
             ]
-            self.assertEqual(list(workbook.get_sheet_names()), expected_sheet_names)
+            self.assertEqual(list(workbook.sheetnames), expected_sheet_names)
 
             # check header columns
-            main_sheet = workbook.get_sheet_by_name("childrens_survey")
+            main_sheet = workbook["childrens_survey"]
             expected_column_headers = [
                 "name",
                 "age",
@@ -1654,7 +1656,7 @@ class TestExportBuilder(TestBase):
                 sorted(list(column_headers)), sorted(expected_column_headers)
             )
 
-            childrens_sheet = workbook.get_sheet_by_name("children")
+            childrens_sheet = workbook["children"]
             expected_column_headers = [
                 "children/name",
                 "children/age",
@@ -1683,7 +1685,7 @@ class TestExportBuilder(TestBase):
                 sorted(list(column_headers)), sorted(expected_column_headers)
             )
 
-            cartoons_sheet = workbook.get_sheet_by_name("children_cartoons")
+            cartoons_sheet = workbook["children_cartoons"]
             expected_column_headers = [
                 "children/cartoons/name",
                 "children/cartoons/why",
@@ -1704,9 +1706,7 @@ class TestExportBuilder(TestBase):
                 sorted(list(column_headers)), sorted(expected_column_headers)
             )
 
-            characters_sheet = workbook.get_sheet_by_name(
-                "children_cartoons_characters"
-            )
+            characters_sheet = workbook["children_cartoons_characters"]
             expected_column_headers = [
                 "children/cartoons/characters/name",
                 "children/cartoons/characters/good_or_evil",
@@ -3668,3 +3668,25 @@ class TestExportBuilder(TestBase):
             rows[1] = list(map(_str_if_bytes, rows[1]))
             self.assertEqual(expected_data, rows)
         shutil.rmtree(temp_dir)
+
+    def test_extra_columns_dataview(self):
+        """Extra columns are included in export for dataview
+
+        Only extra columns in the dataview are included in the export
+        """
+        survey = self._create_childrens_survey()
+        self._publish_xls_file_and_set_xform(
+            _logger_fixture_path("childrens_survey.xlsx")
+        )
+        export_builder = ExportBuilder()
+        export_builder.set_survey(survey)
+        dataview = DataView.objects.create(
+            xform=self.xform,
+            name="test",
+            columns=["name", "_id"],
+            project=self.project,
+        )
+        fields = export_builder.get_fields(
+            dataview, export_builder.sections[0], "title"
+        )
+        self.assertEqual(fields, ["name", "_id"])

--- a/onadata/libs/utils/csv_builder.py
+++ b/onadata/libs/utils/csv_builder.py
@@ -854,9 +854,7 @@ class CSVDataFrameBuilder(AbstractDataFrameBuilder):
                 )
 
                 # add extra columns
-                for column in filter(
-                    lambda col: col in dataview.columns, self.extra_columns
-                ):
+                for column in filter(lambda col: col not in columns, dataview.columns):
                     if column in self.extra_columns:
                         columns.append(column)
 

--- a/onadata/libs/utils/csv_builder.py
+++ b/onadata/libs/utils/csv_builder.py
@@ -854,9 +854,11 @@ class CSVDataFrameBuilder(AbstractDataFrameBuilder):
                 )
 
                 # add extra columns
-                for col in dataview.columns:
-                    if col in self.extra_columns:
-                        columns.append(col)
+                for column in filter(
+                    lambda col: col in dataview.columns, self.extra_columns
+                ):
+                    if column in self.extra_columns:
+                        columns.append(column)
 
             else:
                 columns = list(

--- a/onadata/libs/utils/csv_builder.py
+++ b/onadata/libs/utils/csv_builder.py
@@ -854,7 +854,10 @@ class CSVDataFrameBuilder(AbstractDataFrameBuilder):
                 )
 
                 # add extra columns
-                columns += list(self.extra_columns)
+                for col in dataview.columns:
+                    if col in self.extra_columns:
+                        columns.append(col)
+
             else:
                 columns = list(
                     chain.from_iterable(

--- a/onadata/libs/utils/csv_builder.py
+++ b/onadata/libs/utils/csv_builder.py
@@ -2,6 +2,7 @@
 """
 CSV export utility functions.
 """
+
 from collections import OrderedDict
 from itertools import chain, tee
 
@@ -10,11 +11,10 @@ from django.utils.translation import gettext as _
 
 import unicodecsv as csv
 from pyxform.question import Question
-from pyxform.section import RepeatingSection, Section, GroupedSection
+from pyxform.section import GroupedSection, RepeatingSection, Section
 from six import iteritems
 
-from onadata.apps.logger.models import EntityList
-from onadata.apps.logger.models import OsmData
+from onadata.apps.logger.models import EntityList, OsmData
 from onadata.apps.logger.models.xform import XForm, question_types_to_exclude
 from onadata.apps.viewer.models.data_dictionary import DataDictionary
 from onadata.libs.utils.common_tags import (
@@ -852,6 +852,9 @@ class CSVDataFrameBuilder(AbstractDataFrameBuilder):
                         ]
                     )
                 )
+
+                # add extra columns
+                columns += list(self.extra_columns)
             else:
                 columns = list(
                     chain.from_iterable(

--- a/onadata/libs/utils/export_builder.py
+++ b/onadata/libs/utils/export_builder.py
@@ -1496,6 +1496,8 @@ class ExportBuilder:
                 if column in self.extra_columns:
                     columns.append(column)
 
+            return columns
+
         return [
             (
                 element.get("_label_xpath") or element[key]

--- a/onadata/libs/utils/export_builder.py
+++ b/onadata/libs/utils/export_builder.py
@@ -3,6 +3,7 @@
 """
 ExportBuilder
 """
+
 from __future__ import unicode_literals
 
 import csv
@@ -1480,7 +1481,7 @@ class ExportBuilder:
         Return list of element value with the key in section['elements'].
         """
         if dataview:
-            return [
+            columns = [
                 (
                     element.get("_label_xpath") or element[key]
                     if self.SHOW_CHOICE_LABELS
@@ -1488,7 +1489,12 @@ class ExportBuilder:
                 )
                 for element in section["elements"]
                 if element["title"] in dataview.columns
-            ] + self.extra_columns
+            ]
+
+            # add extra columns
+            for column in filter(lambda col: col not in columns, dataview.columns):
+                if column in self.extra_columns:
+                    columns.append(column)
 
         return [
             (


### PR DESCRIPTION
### Changes / Features implemented

Fix extra columns e.g `_id` excluded in DataView CSV export
Fix extra columns not included in DataView columns present in other export formats
Fix `openpyxl` deprecated syntax

### Steps taken to verify this change does what is intended

- [x] QA

### Side effects of implementing this change

Extra columns in DataView will be included DataView CSV exports
Only extra columns in Data View will be included on other export formats


**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  - [ ] Updated documentation

Closes #
