### PR TITLE
Delete bulk submissions asynchronously

### DIFF
--- a/onadata/apps/api/tasks.py
+++ b/onadata/apps/api/tasks.py
@@ -214,9 +214,9 @@ def delete_xform_submissions_async(
     """Delete xform submissions asynchronously
 
     :param xform_id: XForm id
+    :param deleted_by_id: User id who deleted the instances
     :param instance_ids: List of instance ids to delete, None to delete all
     :param soft_delete: Soft delete instances if True, otherwise hard delete
-    :param deleted_by_id: User id who deleted the instances
     """
     try:
         xform = XForm.objects.get(pk=xform_id)

--- a/onadata/apps/api/tasks.py
+++ b/onadata/apps/api/tasks.py
@@ -214,7 +214,7 @@ def delete_xform_submissions_async(
     """Delete xform submissions asynchronously
 
     :param xform_id: XForm id
-    :param instance_ids: List of instance ids to delete
+    :param instance_ids: List of instance ids to delete, None to delete all
     :param soft_delete: Soft delete instances if True, otherwise hard delete
     :param deleted_by_id: User id who deleted the instances
     """

--- a/onadata/apps/api/tasks.py
+++ b/onadata/apps/api/tasks.py
@@ -2,31 +2,33 @@
 """
 Celery api.tasks module.
 """
+
+import logging
 import os
 import sys
-import logging
 from datetime import timedelta
 
-from celery.result import AsyncResult
 from django.conf import settings
-from django.core.files.uploadedfile import TemporaryUploadedFile
-from django.core.files.storage import default_storage
 from django.contrib.auth import get_user_model
+from django.core.files.storage import default_storage
+from django.core.files.uploadedfile import TemporaryUploadedFile
 from django.db import DatabaseError
 from django.utils import timezone
 from django.utils.datastructures import MultiValueDict
 
+from celery.result import AsyncResult
+
 from onadata.apps.api import tools
-from onadata.apps.logger.models import Instance, ProjectInvitation, XForm, Project
+from onadata.apps.logger.models import Instance, Project, ProjectInvitation, XForm
 from onadata.celeryapp import app
-from onadata.libs.utils.email import send_generic_email
-from onadata.libs.utils.model_tools import queryset_iterator
-from onadata.libs.utils.cache_tools import (
-    safe_delete,
-    XFORM_REGENERATE_INSTANCE_JSON_TASK,
-)
 from onadata.libs.models.share_project import ShareProject
-from onadata.libs.utils.email import ProjectInvitationEmail
+from onadata.libs.utils.cache_tools import (
+    XFORM_REGENERATE_INSTANCE_JSON_TASK,
+    safe_delete,
+)
+from onadata.libs.utils.email import ProjectInvitationEmail, send_generic_email
+from onadata.libs.utils.logger_tools import delete_xform_submissions
+from onadata.libs.utils.model_tools import queryset_iterator
 
 logger = logging.getLogger(__name__)
 
@@ -200,3 +202,19 @@ def share_project_async(project_id, username, role, remove=False):
     else:
         share = ShareProject(project, username, role, remove)
         share.save()
+
+
+@app.task(retry_backoff=3, autoretry_for=(DatabaseError, ConnectionError))
+def delete_xform_submissions_async(
+    xform_id, instance_ids=None, soft_delete=True, deleted_by_id=None
+):
+    """Delete xform submissions asynchronously"""
+    try:
+        xform = XForm.objects.get(pk=xform_id)
+        deleted_by = User.objects.get(pk=deleted_by_id) if deleted_by_id else None
+
+    except (XForm.DoesNotExist, User.DoesNotExist) as err:
+        logger.exception(err)
+
+    else:
+        delete_xform_submissions(xform, instance_ids, soft_delete, deleted_by)

--- a/onadata/apps/api/tasks.py
+++ b/onadata/apps/api/tasks.py
@@ -206,9 +206,18 @@ def share_project_async(project_id, username, role, remove=False):
 
 @app.task(retry_backoff=3, autoretry_for=(DatabaseError, ConnectionError))
 def delete_xform_submissions_async(
-    xform_id, instance_ids=None, soft_delete=True, deleted_by_id=None
+    xform_id: int,
+    instance_ids: list[int] | None = None,
+    soft_delete: bool = True,
+    deleted_by_id: int | None = None,
 ):
-    """Delete xform submissions asynchronously"""
+    """Delete xform submissions asynchronously
+
+    :param xform_id: XForm id
+    :param instance_ids: List of instance ids to delete
+    :param soft_delete: Soft delete instances if True, otherwise hard delete
+    :param deleted_by_id: User id who deleted the instances
+    """
     try:
         xform = XForm.objects.get(pk=xform_id)
         deleted_by = User.objects.get(pk=deleted_by_id) if deleted_by_id else None

--- a/onadata/apps/api/tasks.py
+++ b/onadata/apps/api/tasks.py
@@ -207,9 +207,9 @@ def share_project_async(project_id, username, role, remove=False):
 @app.task(retry_backoff=3, autoretry_for=(DatabaseError, ConnectionError))
 def delete_xform_submissions_async(
     xform_id: int,
+    deleted_by_id: int,
     instance_ids: list[int] | None = None,
     soft_delete: bool = True,
-    deleted_by_id: int | None = None,
 ):
     """Delete xform submissions asynchronously
 
@@ -220,10 +220,10 @@ def delete_xform_submissions_async(
     """
     try:
         xform = XForm.objects.get(pk=xform_id)
-        deleted_by = User.objects.get(pk=deleted_by_id) if deleted_by_id else None
+        deleted_by = User.objects.get(pk=deleted_by_id)
 
     except (XForm.DoesNotExist, User.DoesNotExist) as err:
         logger.exception(err)
 
     else:
-        delete_xform_submissions(xform, instance_ids, soft_delete, deleted_by)
+        delete_xform_submissions(xform, deleted_by, instance_ids, soft_delete)

--- a/onadata/apps/api/tests/test_tasks.py
+++ b/onadata/apps/api/tests/test_tasks.py
@@ -204,18 +204,16 @@ class DeleteXFormSubmissionsAsyncTestCase(TestBase):
     @patch("onadata.apps.api.tasks.delete_xform_submissions_async.retry")
     def test_database_error(self, mock_retry, mock_delete):
         """We retry calls if DatabaseError is raised"""
-        with patch("onadata.apps.api.tasks.delete_xform_submissions") as mock_delete:
-            mock_delete.side_effect = DatabaseError()
-            delete_xform_submissions_async.delay(self.xform.pk)
-            self.assertTrue(mock_retry.called)
+        mock_delete.side_effect = DatabaseError()
+        delete_xform_submissions_async.delay(self.xform.pk)
+        self.assertTrue(mock_retry.called)
 
     @patch("onadata.apps.api.tasks.delete_xform_submissions_async.retry")
     def test_connection_error(self, mock_retry, mock_delete):
         """We retry calls if ConnectionError is raised"""
-        with patch("onadata.apps.api.tasks.delete_xform_submissions") as mock_delete:
-            mock_delete.side_effect = ConnectionError()
-            delete_xform_submissions_async.delay(self.xform.pk)
-            self.assertTrue(mock_retry.called)
+        mock_delete.side_effect = ConnectionError()
+        delete_xform_submissions_async.delay(self.xform.pk)
+        self.assertTrue(mock_retry.called)
 
     @patch("onadata.apps.api.tasks.logger.exception")
     def test_xform_id_invalid(self, mock_logger, mock_delete):

--- a/onadata/apps/api/tests/test_tasks.py
+++ b/onadata/apps/api/tests/test_tasks.py
@@ -198,33 +198,33 @@ class DeleteXFormSubmissionsAsyncTestCase(TestBase):
 
     def test_delete(self, mock_delete):
         """Submissions are deleted"""
-        delete_xform_submissions_async.delay(self.xform.pk, [1, 2], False, self.user.id)
-        mock_delete.assert_called_once_with(self.xform, [1, 2], False, self.user)
+        delete_xform_submissions_async.delay(self.xform.pk, self.user.pk, [1, 2], False)
+        mock_delete.assert_called_once_with(self.xform, self.user, [1, 2], False)
 
     @patch("onadata.apps.api.tasks.delete_xform_submissions_async.retry")
     def test_database_error(self, mock_retry, mock_delete):
         """We retry calls if DatabaseError is raised"""
         mock_delete.side_effect = DatabaseError()
-        delete_xform_submissions_async.delay(self.xform.pk)
+        delete_xform_submissions_async.delay(self.xform.pk, self.user.pk)
         self.assertTrue(mock_retry.called)
 
     @patch("onadata.apps.api.tasks.delete_xform_submissions_async.retry")
     def test_connection_error(self, mock_retry, mock_delete):
         """We retry calls if ConnectionError is raised"""
         mock_delete.side_effect = ConnectionError()
-        delete_xform_submissions_async.delay(self.xform.pk)
+        delete_xform_submissions_async.delay(self.xform.pk, self.user.pk)
         self.assertTrue(mock_retry.called)
 
     @patch("onadata.apps.api.tasks.logger.exception")
     def test_xform_id_invalid(self, mock_logger, mock_delete):
         """Invalid xform_id is handled"""
-        delete_xform_submissions_async.delay(sys.maxsize)
+        delete_xform_submissions_async.delay(sys.maxsize, self.user.pk)
         self.assertFalse(mock_delete.called)
         mock_logger.assert_called_once()
 
     @patch("onadata.apps.api.tasks.logger.exception")
     def test_user_id_invalid(self, mock_logger, mock_delete):
         """Invalid user_id is handled"""
-        delete_xform_submissions_async.delay(self.xform.pk, deleted_by_id=sys.maxsize)
+        delete_xform_submissions_async.delay(self.xform.pk, sys.maxsize)
         self.assertFalse(mock_delete.called)
         mock_logger.assert_called_once()

--- a/onadata/apps/api/tests/viewsets/test_data_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_data_viewset.py
@@ -1791,6 +1791,10 @@ class TestDataViewSet(SerializeMixin, TestBase):
         response = view(request, pk=formid)
 
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.data.get("message"),
+            "%d records were deleted" % len(records_to_be_deleted),
+        )
         self.xform.refresh_from_db()
         current_count = self.xform.instances.filter(deleted_at=None).count()
         self.assertNotEqual(current_count, initial_count)
@@ -2023,6 +2027,10 @@ class TestDataViewSet(SerializeMixin, TestBase):
         response = view(request, pk=formid)
 
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.data.get("message"),
+            "%d records were deleted" % len(deleted_instances_subset),
+        )
 
         # Test that num of submissions for the form is successfully updated
         self.xform.refresh_from_db()
@@ -2037,6 +2045,7 @@ class TestDataViewSet(SerializeMixin, TestBase):
         response = view(request, pk=formid)
 
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data.get("message"), "3 records were deleted")
 
         # Test project details updated successfully
         self.assertEqual(

--- a/onadata/apps/api/tests/viewsets/test_data_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_data_viewset.py
@@ -1887,6 +1887,10 @@ class TestDataViewSet(SerializeMixin, TestBase):
         response = view(request, pk=formid)
 
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.data.get("message"),
+            "%d records were deleted" % len(records_to_be_deleted),
+        )
         self.xform.refresh_from_db()
         current_count = self.xform.num_of_submissions
         self.assertNotEqual(current_count, initial_count)

--- a/onadata/apps/api/tests/viewsets/test_data_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_data_viewset.py
@@ -3810,6 +3810,15 @@ class TestDataViewSet(SerializeMixin, TestBase):
         response = view(request, pk=formid)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 2)
+        # Cached submission ids saved as strings
+        cache.set(
+            f"xfm-submissions-deleting-{self.xform.pk}",
+            [str(instances[0].pk), str(instances[1].pk)],
+        )
+        request = self.factory.get("/", **self.extra)
+        response = view(request, pk=formid)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 2)
 
     @override_settings(ENABLE_SUBMISSION_PERMANENT_DELETE=True)
     @patch(

--- a/onadata/apps/api/tests/viewsets/test_data_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_data_viewset.py
@@ -3852,9 +3852,9 @@ class TestDataViewSet(SerializeMixin, TestBase):
         self.assertEqual(response.status_code, 200)
         mock_del_async.assert_called_once_with(
             self.xform.pk,
+            self.user.pk,
             [str(records_to_be_deleted[0].pk), str(records_to_be_deleted[1].pk)],
             True,
-            self.user.id,
         )
         # Permanent deletion
         mock_del_async.reset_mock()  # Reset mock
@@ -3865,9 +3865,9 @@ class TestDataViewSet(SerializeMixin, TestBase):
         self.assertEqual(response.status_code, 200)
         mock_del_async.assert_called_once_with(
             self.xform.pk,
+            self.user.pk,
             [str(records_to_be_deleted[0].pk), str(records_to_be_deleted[1].pk)],
             False,
-            self.user.id,
         )
 
 

--- a/onadata/apps/api/viewsets/data_viewset.py
+++ b/onadata/apps/api/viewsets/data_viewset.py
@@ -402,11 +402,7 @@ class DataViewSet(
             if request.user.has_perm(CAN_DELETE_SUBMISSION, self.object.xform):
                 instance_id = self.object.pk
                 if permanent_delete:
-                    if enable_submission_permanent_delete:
-                        self.object.delete()
-                    else:
-                        error_msg = {"error": permanent_delete_disabled_msg}
-                        return Response(error_msg, status=status.HTTP_400_BAD_REQUEST)
+                    self.object.delete()
                 else:
                     # enable soft deletion
                     delete_instance(self.object, request.user)

--- a/onadata/apps/api/viewsets/data_viewset.py
+++ b/onadata/apps/api/viewsets/data_viewset.py
@@ -387,9 +387,9 @@ class DataViewSet(
             initial_num_of_submissions = self.object.num_of_submissions
             delete_xform_submissions_async.delay(
                 self.object.id,
+                request.user.id,
                 instance_ids,
                 not permanent_delete,
-                request.user.id,
             )
             safe_cache_set(
                 f"{XFORM_SUBMISSIONS_DELETING}{self.object.id}",

--- a/onadata/apps/api/viewsets/data_viewset.py
+++ b/onadata/apps/api/viewsets/data_viewset.py
@@ -384,6 +384,7 @@ class DataViewSet(
             else:
                 instance_ids = None
 
+            initial_num_of_submissions = self.object.num_of_submissions
             delete_xform_submissions_async.delay(
                 self.object.id,
                 instance_ids,
@@ -395,9 +396,12 @@ class DataViewSet(
                 instance_ids,
                 XFORM_SUBMISSIONS_DELETING_TTL,
             )
+            number_of_records_deleted = (
+                len(instance_ids) if instance_ids else initial_num_of_submissions
+            )
 
             return Response(
-                data={"message": f"{len(instance_ids)} records were deleted"},
+                data={"message": f"{number_of_records_deleted} records were deleted"},
                 status=status.HTTP_200_OK,
             )
 

--- a/onadata/apps/api/viewsets/data_viewset.py
+++ b/onadata/apps/api/viewsets/data_viewset.py
@@ -396,7 +396,10 @@ class DataViewSet(
                 XFORM_SUBMISSIONS_DELETING_TTL,
             )
 
-            return Response(status=status.HTTP_200_OK)
+            return Response(
+                data={"message": f"{len(instance_ids)} records were deleted"},
+                status=status.HTTP_200_OK,
+            )
 
         if isinstance(self.object, Instance):
             if request.user.has_perm(CAN_DELETE_SUBMISSION, self.object.xform):

--- a/onadata/apps/viewer/models/parsed_instance.py
+++ b/onadata/apps/viewer/models/parsed_instance.py
@@ -196,6 +196,7 @@ def exclude_deleting_submissions_clause(xform_id: int) -> tuple[str, list[int]]:
     return (f"id NOT IN ({placeholders})", instance_ids)
 
 
+# pylint: disable=too-many-locals
 def build_sql_where(xform, query, start=None, end=None):
     """Build SQL WHERE clause"""
     known_integers = [

--- a/onadata/apps/viewer/models/parsed_instance.py
+++ b/onadata/apps/viewer/models/parsed_instance.py
@@ -2,6 +2,7 @@
 """
 ParsedInstance model
 """
+
 import datetime
 
 from django.conf import settings
@@ -21,6 +22,7 @@ from onadata.libs.models.sorting import (
     json_order_by_params,
     sort_from_mongo_sort_str,
 )
+from onadata.libs.utils.cache_tools import XFORM_SUBMISSIONS_DELETING, safe_cache_get
 from onadata.libs.utils.common_tags import (
     ATTACHMENTS,
     BAMBOO_DATASET_ID,
@@ -179,6 +181,21 @@ def _get_sort_fields(sort):
     return list(_parse_sort_fields(sort))
 
 
+def exclude_deleting_submissions_clause(xform_id: int) -> tuple[str, list[int]]:
+    """Return SQL clause to exclude submissions whose deletion is in progress
+
+    :param xform_id: XForm ID
+    :return: SQL and list of submission IDs under deletion
+    """
+    instance_ids = safe_cache_get(f"{XFORM_SUBMISSIONS_DELETING}{xform_id}", [])
+
+    if not instance_ids:
+        return ("", [])
+
+    placeholders = ", ".join(["%s"] * len(instance_ids))
+    return (f"id NOT IN ({placeholders})", instance_ids)
+
+
 def build_sql_where(xform, query, start=None, end=None):
     """Build SQL WHERE clause"""
     known_integers = [
@@ -208,6 +225,13 @@ def build_sql_where(xform, query, start=None, end=None):
     if isinstance(end, datetime.datetime):
         sql_where += " AND date_created <= %s"
         where_params += [end.isoformat()]
+
+    exclude_sql, exclude_params = exclude_deleting_submissions_clause(xform.pk)
+
+    if exclude_sql:
+        # Exclude submissions whose deletion is in progress
+        sql_where += f" AND {exclude_sql}"
+        where_params += exclude_params
 
     xform_pks = [xform.pk]
 

--- a/onadata/libs/tests/utils/test_logger_tools.py
+++ b/onadata/libs/tests/utils/test_logger_tools.py
@@ -11,6 +11,7 @@ from unittest.mock import Mock, call, patch
 
 from django.conf import settings
 from django.core.cache import cache
+from django.core.exceptions import PermissionDenied
 from django.core.files.uploadedfile import InMemoryUploadedFile
 from django.http.request import HttpRequest
 from django.test.utils import override_settings
@@ -1054,6 +1055,7 @@ class DeleteXFormSubmissionsTestCase(TestBase):
         self.xform.refresh_from_db()
         self.assertEqual(self.xform.num_of_submissions, 0)
 
+    @override_settings(ENABLE_SUBMISSION_PERMANENT_DELETE=True)
     def test_hard_delete_all(self):
         """All submissions are hard deleted"""
         delete_xform_submissions(self.xform, soft_delete=False)
@@ -1070,6 +1072,7 @@ class DeleteXFormSubmissionsTestCase(TestBase):
         self.xform.refresh_from_db()
         self.assertEqual(self.xform.num_of_submissions, 3)
 
+    @override_settings(ENABLE_SUBMISSION_PERMANENT_DELETE=True)
     def test_hard_delete_subset(self):
         """Subset of submissions are hard deleted"""
         delete_xform_submissions(
@@ -1123,3 +1126,8 @@ class DeleteXFormSubmissionsTestCase(TestBase):
             user=self.user,
             message_verb="submission_deleted",
         )
+
+    def test_hard_delete_enabled(self):
+        """Hard delete should be enabled for hard delete to be successful"""
+        with self.assertRaises(PermissionDenied):
+            delete_xform_submissions(self.xform, soft_delete=False)

--- a/onadata/libs/tests/utils/test_logger_tools.py
+++ b/onadata/libs/tests/utils/test_logger_tools.py
@@ -1142,3 +1142,10 @@ class DeleteXFormSubmissionsTestCase(TestBase):
         """Hard delete should be enabled for hard delete to be successful"""
         with self.assertRaises(PermissionDenied):
             delete_xform_submissions(self.xform, soft_delete=False)
+
+    def test_cache_deleted(self):
+        """Cache tracking submissions being deleted is cleared"""
+        cache.set(f"xfm-submissions-deleting-{self.xform.id}", [self.instances[0].pk])
+        delete_xform_submissions(self.xform)
+
+        self.assertIsNone(cache.get(f"xfm-submissions-deleting-{self.xform.id}"))

--- a/onadata/libs/tests/utils/test_logger_tools.py
+++ b/onadata/libs/tests/utils/test_logger_tools.py
@@ -1084,7 +1084,7 @@ class DeleteXFormSubmissionsTestCase(TestBase):
         self.assertEqual(self.xform.num_of_submissions, 3)
 
     def test_sets_deleted_at(self):
-        """Deleted_at is set to the current time"""
+        """deleted_at is set to the current time"""
         mocked_now = timezone.now()
 
         with patch("django.utils.timezone.now", Mock(return_value=mocked_now)):
@@ -1092,6 +1092,17 @@ class DeleteXFormSubmissionsTestCase(TestBase):
 
         self.assertTrue(
             all(instance.deleted_at == mocked_now for instance in self.instances)
+        )
+
+    def test_sets_date_modified(self):
+        """date_modified is set to the current time"""
+        mocked_now = timezone.now()
+
+        with patch("django.utils.timezone.now", Mock(return_value=mocked_now)):
+            delete_xform_submissions(self.xform)
+
+        self.assertTrue(
+            all(instance.date_modified == mocked_now for instance in self.instances)
         )
 
     def test_sets_deleted_by(self):

--- a/onadata/libs/tests/utils/test_logger_tools.py
+++ b/onadata/libs/tests/utils/test_logger_tools.py
@@ -2,26 +2,27 @@
 """
 Test logger_tools utility functions.
 """
+
 import os
 import re
 from datetime import datetime, timedelta
 from io import BytesIO
-from unittest.mock import patch, call
+from unittest.mock import Mock, call, patch
 
 from django.conf import settings
 from django.core.cache import cache
 from django.core.files.uploadedfile import InMemoryUploadedFile
 from django.http.request import HttpRequest
-from django.utils import timezone
 from django.test.utils import override_settings
+from django.utils import timezone
 
 from defusedxml.ElementTree import ParseError
 
 from onadata.apps.logger.import_tools import django_file
 from onadata.apps.logger.models import (
-    Instance,
     Entity,
     EntityList,
+    Instance,
     RegistrationForm,
     SurveyType,
     XForm,
@@ -35,6 +36,7 @@ from onadata.libs.utils.logger_tools import (
     create_entity_from_instance,
     create_instance,
     dec_elist_num_entities,
+    delete_xform_submissions,
     generate_content_disposition_header,
     get_first_record,
     inc_elist_num_entities,
@@ -1032,3 +1034,92 @@ class CommitCachedEListNumEntitiesTestCase(EntityListNumEntitiesBase):
         self.assertIsNotNone(cache.get(self.ids_key))
         self.assertIsNotNone(cache.get(self.counter_key))
         self.assertIsNotNone(cache.get(self.created_at_key))
+
+
+class DeleteXFormSubmissionsTestCase(TestBase):
+    """Tests for method `delete_xform_submissions`"""
+
+    def setUp(self):
+        super().setUp()
+
+        self._publish_transportation_form()
+        self._make_submissions()
+        self.instances = self.xform.instances.all()
+
+    def test_soft_delete_all(self):
+        """All submissions are soft deleted"""
+        delete_xform_submissions(self.xform)
+
+        self.assertEqual(Instance.objects.filter(deleted_at__isnull=False).count(), 4)
+        self.xform.refresh_from_db()
+        self.assertEqual(self.xform.num_of_submissions, 0)
+
+    def test_hard_delete_all(self):
+        """All submissions are hard deleted"""
+        delete_xform_submissions(self.xform, soft_delete=False)
+
+        self.assertEqual(Instance.objects.count(), 0)
+        self.xform.refresh_from_db()
+        self.assertEqual(self.xform.num_of_submissions, 0)
+
+    def test_soft_delete_subset(self):
+        """Subset of submissions are soft deleted"""
+        delete_xform_submissions(self.xform, instance_ids=[self.instances[0].pk])
+
+        self.assertEqual(Instance.objects.filter(deleted_at__isnull=False).count(), 1)
+        self.xform.refresh_from_db()
+        self.assertEqual(self.xform.num_of_submissions, 3)
+
+    def test_hard_delete_subset(self):
+        """Subset of submissions are hard deleted"""
+        delete_xform_submissions(
+            self.xform, instance_ids=[self.instances[0].pk], soft_delete=False
+        )
+
+        self.assertEqual(Instance.objects.count(), 3)
+        self.xform.refresh_from_db()
+        self.assertEqual(self.xform.num_of_submissions, 3)
+
+    def test_sets_deleted_at(self):
+        """Deleted_at is set to the current time"""
+        mocked_now = timezone.now()
+
+        with patch("django.utils.timezone.now", Mock(return_value=mocked_now)):
+            delete_xform_submissions(self.xform)
+
+        self.assertTrue(
+            all(instance.deleted_at == mocked_now for instance in self.instances)
+        )
+
+    def test_sets_deleted_by(self):
+        """Deleted_by is set to the user who initiated the deletion"""
+        delete_xform_submissions(self.xform, deleted_by=self.user)
+
+        self.assertTrue(
+            all(instance.deleted_by == self.user for instance in self.instances)
+        )
+
+    def test_project_date_modified_updated(self):
+        """Project date_modified is updated to the current time"""
+        mocked_now = timezone.now()
+
+        with patch("django.utils.timezone.now", Mock(return_value=mocked_now)):
+            delete_xform_submissions(self.xform)
+
+        self.project.refresh_from_db()
+        self.assertEqual(self.project.date_modified, mocked_now)
+
+    @patch("onadata.libs.utils.logger_tools.send_message")
+    def test_action_recorded(self, mock_send_message):
+        """Action is recorded in the audit log"""
+        delete_xform_submissions(
+            self.xform, [self.instances[0].pk], deleted_by=self.user
+        )
+
+        mock_send_message.assert_called_once_with(
+            instance_id=[self.instances[0].pk],
+            target_id=self.xform.id,
+            target_type="xform",
+            user=self.user,
+            message_verb="submission_deleted",
+        )

--- a/onadata/libs/utils/cache_tools.py
+++ b/onadata/libs/utils/cache_tools.py
@@ -66,6 +66,8 @@ XFORM_REGENERATE_INSTANCE_JSON_TASK = "xfm-regenerate_instance_json_task-"
 XFORM_MANIFEST_CACHE = "xfm-manifest-"
 XFORM_LIST_CACHE = "xfm-list-"
 XFROM_LIST_CACHE_TTL = 10 * 60  # 10 minutes converted to seconds
+XFORM_SUBMISSIONS_DELETING = "xfm-submissions-deleting-"
+XFORM_SUBMISSIONS_DELETING_TTL = 60 * 60  # 1 hour converted to seconds
 
 # Cache timeouts used in XForm model
 XFORM_REGENERATE_INSTANCE_JSON_TASK_TTL = 24 * 60 * 60  # 24 hrs converted to seconds

--- a/onadata/libs/utils/logger_tools.py
+++ b/onadata/libs/utils/logger_tools.py
@@ -1480,9 +1480,9 @@ def delete_xform_submissions(
     """ "Delete subset or all submissions of an XForm
 
     :param xform: XForm object
+    :param deleted_by: User initiating the delete
     :param instance_ids: List of instance ids to delete, None to delete all
     :param soft_delete: Flag to soft delete or hard delete
-    :param deleted_by: User initiating the delete
     :return: None
     """
     if not soft_delete and not getattr(

--- a/onadata/libs/utils/logger_tools.py
+++ b/onadata/libs/utils/logger_tools.py
@@ -1479,7 +1479,7 @@ def delete_xform_submissions(
     """ "Delete subset or all submissions of an XForm
 
     :param xform: XForm object
-    :param instance_ids: List of instance ids to delete, if None, all submissions
+    :param instance_ids: List of instance ids to delete, None to delete all
     :param soft_delete: Flag to soft delete or hard delete
     :param deleted_by: User initiating the delete
     :return: None

--- a/onadata/libs/utils/logger_tools.py
+++ b/onadata/libs/utils/logger_tools.py
@@ -1482,6 +1482,7 @@ def delete_xform_submissions(
     :param instance_ids: List of instance ids to delete
     :param soft_delete: Flag to soft delete or hard delete
     :param deleted_by: User initiating the delete
+    :return: None
     """
     if instance_ids:
         instances = xform.instances.filter(id__in=instance_ids, deleted_at__isnull=True)

--- a/onadata/libs/utils/logger_tools.py
+++ b/onadata/libs/utils/logger_tools.py
@@ -1495,7 +1495,8 @@ def delete_xform_submissions(
         instances = xform.instances.filter(deleted_at__isnull=True)
 
     if soft_delete:
-        instances.update(deleted_at=timezone.now(), deleted_by=deleted_by)
+        now = timezone.now()
+        instances.update(deleted_at=now, date_modified=now, deleted_by=deleted_by)
     else:
         # Hard delete
         instances.delete()

--- a/onadata/libs/utils/logger_tools.py
+++ b/onadata/libs/utils/logger_tools.py
@@ -1490,17 +1490,17 @@ def delete_xform_submissions(
     ):
         raise PermissionDenied("Hard delete is not enabled")
 
+    instance_qs = xform.instances.filter(deleted_at__isnull=True)
+
     if instance_ids:
-        instances = xform.instances.filter(id__in=instance_ids, deleted_at__isnull=True)
-    else:
-        instances = xform.instances.filter(deleted_at__isnull=True)
+        instance_qs = instance_qs.filter(id__in=instance_ids)
 
     if soft_delete:
         now = timezone.now()
-        instances.update(deleted_at=now, date_modified=now, deleted_by=deleted_by)
+        instance_qs.update(deleted_at=now, date_modified=now, deleted_by=deleted_by)
     else:
         # Hard delete
-        instances.delete()
+        instance_qs.delete()
 
     if instance_ids is None:
         # Every submission has been deleted

--- a/onadata/libs/utils/logger_tools.py
+++ b/onadata/libs/utils/logger_tools.py
@@ -1479,7 +1479,7 @@ def delete_xform_submissions(
     """ "Delete subset or all submissions of an XForm
 
     :param xform: XForm object
-    :param instance_ids: List of instance ids to delete
+    :param instance_ids: List of instance ids to delete, if None, all submissions
     :param soft_delete: Flag to soft delete or hard delete
     :param deleted_by: User initiating the delete
     :return: None

--- a/onadata/libs/utils/logger_tools.py
+++ b/onadata/libs/utils/logger_tools.py
@@ -1473,9 +1473,9 @@ def _exec_cached_elist_counter_commit_failover() -> None:
 
 def delete_xform_submissions(
     xform: XForm,
+    deleted_by: User,
     instance_ids: list[int] | None = None,
     soft_delete: bool = True,
-    deleted_by: User | None = None,
 ) -> None:
     """ "Delete subset or all submissions of an XForm
 

--- a/onadata/libs/utils/logger_tools.py
+++ b/onadata/libs/utils/logger_tools.py
@@ -1484,6 +1484,11 @@ def delete_xform_submissions(
     :param deleted_by: User initiating the delete
     :return: None
     """
+    if not soft_delete and not getattr(
+        settings, "ENABLE_SUBMISSION_PERMANENT_DELETE", False
+    ):
+        raise PermissionDenied("Hard delete is not enabled")
+
     if instance_ids:
         instances = xform.instances.filter(id__in=instance_ids, deleted_at__isnull=True)
     else:

--- a/onadata/libs/utils/logger_tools.py
+++ b/onadata/libs/utils/logger_tools.py
@@ -103,6 +103,7 @@ from onadata.libs.utils.cache_tools import (
     ELIST_NUM_ENTITIES_CREATED_AT,
     ELIST_NUM_ENTITIES_IDS,
     ELIST_NUM_ENTITIES_LOCK,
+    XFORM_SUBMISSIONS_DELETING,
     safe_delete,
     set_cache_with_lock,
 )
@@ -1511,7 +1512,7 @@ def delete_xform_submissions(
 
     xform.project.date_modified = timezone.now()
     xform.project.save(update_fields=["date_modified"])
-
+    safe_delete(f"{XFORM_SUBMISSIONS_DELETING}{xform.pk}")
     send_message(
         instance_id=instance_ids,
         target_id=xform.id,

--- a/onadata/libs/utils/logger_tools.py
+++ b/onadata/libs/utils/logger_tools.py
@@ -3,6 +3,7 @@
 """
 logger_tools - Logger app utility functions.
 """
+
 import json
 import logging
 import os
@@ -13,12 +14,10 @@ from builtins import str as text
 from datetime import datetime, timedelta
 from hashlib import sha256
 from http.client import BadStatusLine
-from typing import NoReturn, Any
+from typing import Any, NoReturn
 from wsgiref.util import FileWrapper
 from xml.dom import Node
 from xml.parsers.expat import ExpatError
-import boto3
-from botocore.client import Config
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
@@ -30,12 +29,12 @@ from django.core.exceptions import (
 )
 from django.core.files.storage import get_storage_class
 from django.db import DataError, IntegrityError, transaction
-from django.db.models import Q, F
+from django.db.models import F, Q
 from django.db.models.query import QuerySet
 from django.http import (
     HttpResponse,
-    HttpResponseRedirect,
     HttpResponseNotFound,
+    HttpResponseRedirect,
     StreamingHttpResponse,
     UnreadablePostError,
 )
@@ -44,7 +43,8 @@ from django.utils import timezone
 from django.utils.encoding import DjangoUnicodeDecodeError
 from django.utils.translation import gettext as _
 
-
+import boto3
+from botocore.client import Config
 from defusedxml.ElementTree import ParseError, fromstring
 from dict2xml import dict2xml
 from modilabs.utils.subprocess_timeout import ProcessTimedOut
@@ -81,13 +81,14 @@ from onadata.apps.logger.xform_instance_parser import (
     NonUniqueFormIdError,
     clean_and_parse_xml,
     get_deprecated_uuid_from_xml,
-    get_submission_date_from_xml,
-    get_uuid_from_xml,
     get_entity_uuid_from_xml,
     get_meta_from_xml,
+    get_submission_date_from_xml,
+    get_uuid_from_xml,
 )
 from onadata.apps.messaging.constants import (
     SUBMISSION_CREATED,
+    SUBMISSION_DELETED,
     SUBMISSION_EDITED,
     XFORM,
 )
@@ -97,19 +98,18 @@ from onadata.apps.viewer.models.parsed_instance import ParsedInstance
 from onadata.apps.viewer.signals import process_submission
 from onadata.libs.utils.analytics import TrackObjectEvent
 from onadata.libs.utils.cache_tools import (
+    ELIST_FAILOVER_REPORT_SENT,
     ELIST_NUM_ENTITIES,
+    ELIST_NUM_ENTITIES_CREATED_AT,
     ELIST_NUM_ENTITIES_IDS,
     ELIST_NUM_ENTITIES_LOCK,
-    ELIST_NUM_ENTITIES_CREATED_AT,
-    ELIST_FAILOVER_REPORT_SENT,
     safe_delete,
     set_cache_with_lock,
 )
 from onadata.libs.utils.common_tags import METADATA_FIELDS
 from onadata.libs.utils.common_tools import get_uuid, report_exception
-from onadata.libs.utils.model_tools import set_uuid, queryset_iterator
+from onadata.libs.utils.model_tools import queryset_iterator, set_uuid
 from onadata.libs.utils.user_auth import get_user_default_project
-
 
 OPEN_ROSA_VERSION_HEADER = "X-OpenRosa-Version"
 HTTP_OPEN_ROSA_VERSION_HEADER = "HTTP_X_OPENROSA_VERSION"
@@ -1468,3 +1468,47 @@ def _exec_cached_elist_counter_commit_failover() -> None:
             )
             report_exception(subject, msg)
             cache.set(ELIST_FAILOVER_REPORT_SENT, "sent", 86400)
+
+
+def delete_xform_submissions(
+    xform: XForm,
+    instance_ids: list[int] | None = None,
+    soft_delete: bool = True,
+    deleted_by: User | None = None,
+) -> None:
+    """ "Delete subset or all submissions of an XForm
+
+    :param xform: XForm object
+    :param instance_ids: List of instance ids to delete
+    :param soft_delete: Flag to soft delete or hard delete
+    :param deleted_by: User initiating the delete
+    """
+    if instance_ids:
+        instances = xform.instances.filter(id__in=instance_ids, deleted_at__isnull=True)
+    else:
+        instances = xform.instances.filter(deleted_at__isnull=True)
+
+    if soft_delete:
+        instances.update(deleted_at=timezone.now(), deleted_by=deleted_by)
+    else:
+        # Hard delete
+        instances.delete()
+
+    if instance_ids is None:
+        # Every submission has been deleted
+        xform.num_of_submissions = 0
+        xform.save(update_fields=["num_of_submissions"])
+
+    else:
+        xform.submission_count(force_update=True)
+
+    xform.project.date_modified = timezone.now()
+    xform.project.save(update_fields=["date_modified"])
+
+    send_message(
+        instance_id=instance_ids,
+        target_id=xform.id,
+        target_type=XFORM,
+        user=deleted_by,
+        message_verb=SUBMISSION_DELETED,
+    )


### PR DESCRIPTION
### Changes / Features Implemented

Delete submissions asynchronously
Track submissions being deleted in cache and exclude them when returning data

### Steps taken to verify this change does what is intended

- [x] QA

### Side effects of implementing this change

Eliminate timeouts when deleting many submissions

**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  - [ ] Updated documentation

Closes #2462 
