### PR TITLE
fix: ensure xform GET query parameter  is numeric

### DIFF
--- a/onadata/apps/api/tests/viewsets/test_attachment_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_attachment_viewset.py
@@ -2,6 +2,7 @@
 """
 Test Attachment viewsets.
 """
+
 import os
 
 from django.utils import timezone
@@ -235,11 +236,18 @@ class TestAttachmentViewSet(TestAbstractViewSet):
         response = self.list_view(request)
         self.assertEqual(response.status_code, 404)
 
+        # Authenticated user access
         data["xform"] = "lol"
         request = self.factory.get("/", data, **self.extra)
         response = self.list_view(request)
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.get("Cache-Control"), None)
+
+        # Anonymous user access
+        data["xform"] = "lol"
+        request = self.factory.get("/", data)
+        response = self.list_view(request)
+        self.assertContains(response, "Not Found", status_code=404)
 
     def test_list_view_filter_by_instance(self):
         self._submit_transport_instance_w_attachment()


### PR DESCRIPTION


### Changes / Features implemented

Ensure `xform` GET query parameter is numeric before running DB query to get a record.

### Steps taken to verify this change does what is intended

Updated test.

### Side effects of implementing this change

N/A

**Before submitting this PR for review, please make sure you have:**

  - [X] Included tests
  - [ ] Updated documentation

Closes https://github.com/onaio/onadata/issues/2641