### PR TITLE
Fix CSV import error for a form that defines Entities

### DIFF
--- a/onadata/apps/logger/tests/models/test_instance.py
+++ b/onadata/apps/logger/tests/models/test_instance.py
@@ -2,6 +2,7 @@
 """
 Test Instance model.
 """
+
 import os
 from datetime import datetime, timedelta
 from unittest.mock import Mock, patch
@@ -1186,3 +1187,26 @@ class TestInstance(TestBase):
         instance.refresh_from_db()
         self.assertEqual(instance.json["num_integer"], -1)
         self.assertEqual(instance.json["num_decimal"], -1.0)
+
+    def test_xml_entity_node_missing(self):
+        """Entity node missing in submission XML"""
+        self.project = get_user_default_project(self.user)
+        xform = self._publish_registration_form(self.user)
+        xml = (
+            '<?xml version="1.0" encoding="UTF-8"?>'
+            '<data xmlns:jr="http://openrosa.org/javarosa" xmlns:orx='
+            '"http://openrosa.org/xforms" id="trees_registration" version="2022110901">'
+            "<formhub><uuid>d156a2dce4c34751af57f21ef5c4e6cc</uuid></formhub>"
+            "<location>-1.286905 36.772845 0 0</location>"
+            "<species>purpleheart</species>"
+            "<circumference>300</circumference>"
+            "<intake_notes />"
+            "<meta>"
+            "<instanceID>uuid:9d3f042e-cfec-4d2a-8b5b-212e3b04802b</instanceID>"
+            "<instanceName>300cm purpleheart</instanceName>"
+            "</meta>"
+            "</data>"
+        )
+        Instance.objects.create(xml=xml, user=self.user, xform=xform)
+
+        self.assertEqual(Entity.objects.count(), 0)

--- a/onadata/libs/utils/logger_tools.py
+++ b/onadata/libs/utils/logger_tools.py
@@ -1261,11 +1261,11 @@ def create_or_update_entity_from_instance(instance: Instance) -> None:
     registration_form_qs = RegistrationForm.objects.filter(
         xform=instance.xform, is_active=True
     )
+    entity_node = get_meta_from_xml(instance.xml, "entity")
 
-    if not registration_form_qs.exists():
+    if not registration_form_qs.exists() or not entity_node:
         return
 
-    entity_node = get_meta_from_xml(instance.xml, "entity")
     registration_form = registration_form_qs.first()
     mutation_success_checks = ["1", "true"]
     entity_uuid = entity_node.getAttribute("id")


### PR DESCRIPTION
### Changes / Features implemented

fix 'NoneType' object has no attribute 'getAttribute' thrown when import CSV for a form that defines Entities

### Steps taken to verify this change does what is intended

- [x] QA

### Side effects of implementing this change

Resolve CSV import failure for a form that defines Entities

**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  - [ ] Updated documentation

Closes #2753
