### PR TITLE
Do not create export register when Instance is saved

### DIFF
--- a/onadata/apps/api/tests/viewsets/test_abstract_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_abstract_viewset.py
@@ -143,14 +143,14 @@ class TestAbstractViewSet(TestBase, TestCase):
         )
 
     def tearDown(self):
-        TestCase.tearDown(self)
-
         # Enable signals
         post_save.connect(
             sender=DataDictionary,
             dispatch_uid="create_export_repeat_register",
             receiver=create_export_repeat_register,
         )
+
+        TestCase.tearDown(self)
 
     def user_profile_data(self):
         """Returns the user profile python object."""

--- a/onadata/apps/api/tests/viewsets/test_abstract_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_abstract_viewset.py
@@ -47,6 +47,7 @@ from onadata.apps.main import tests as main_tests
 from onadata.apps.main.models import MetaData, UserProfile
 from onadata.apps.main.tests.test_base import TestBase
 from onadata.apps.viewer.models import DataDictionary
+from onadata.apps.viewer.models.data_dictionary import create_export_repeat_register
 from onadata.libs.serializers.project_serializer import ProjectSerializer
 from onadata.libs.utils.common_tools import merge_dicts
 
@@ -146,7 +147,9 @@ class TestAbstractViewSet(TestBase, TestCase):
 
         # Enable signals
         post_save.connect(
-            sender=DataDictionary, dispatch_uid="create_export_repeat_register"
+            sender=DataDictionary,
+            dispatch_uid="create_export_repeat_register",
+            receiver=create_export_repeat_register,
         )
 
     def user_profile_data(self):

--- a/onadata/apps/api/tests/viewsets/test_abstract_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_abstract_viewset.py
@@ -141,6 +141,14 @@ class TestAbstractViewSet(TestBase, TestCase):
             sender=DataDictionary, dispatch_uid="create_export_repeat_register"
         )
 
+    def tearDown(self):
+        TestCase.tearDown(self)
+
+        # Enable signals
+        post_save.connect(
+            sender=DataDictionary, dispatch_uid="create_export_repeat_register"
+        )
+
     def user_profile_data(self):
         """Returns the user profile python object."""
         return {

--- a/onadata/apps/api/tests/viewsets/test_abstract_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_abstract_viewset.py
@@ -2,6 +2,7 @@
 """
 Test base class for API viewset tests.
 """
+
 import json
 import os
 import re
@@ -11,6 +12,7 @@ from tempfile import NamedTemporaryFile
 from django.conf import settings
 from django.contrib.auth import authenticate, get_user_model
 from django.contrib.auth.models import Permission
+from django.db.models.signals import post_save
 from django.test import TestCase
 
 import requests
@@ -42,8 +44,9 @@ from onadata.apps.logger.models.widget import Widget
 from onadata.apps.logger.views import submission
 from onadata.apps.logger.xform_instance_parser import clean_and_parse_xml
 from onadata.apps.main import tests as main_tests
-from onadata.apps.main.tests.test_base import TestBase
 from onadata.apps.main.models import MetaData, UserProfile
+from onadata.apps.main.tests.test_base import TestBase
+from onadata.apps.viewer.models import DataDictionary
 from onadata.libs.serializers.project_serializer import ProjectSerializer
 from onadata.libs.utils.common_tools import merge_dicts
 
@@ -133,6 +136,10 @@ class TestAbstractViewSet(TestBase, TestCase):
         self.factory = APIRequestFactory()
         self._login_user_and_profile()
         self.maxDiff = None
+        # Disable signals
+        post_save.disconnect(
+            sender=DataDictionary, dispatch_uid="create_export_repeat_register"
+        )
 
     def user_profile_data(self):
         """Returns the user profile python object."""

--- a/onadata/apps/logger/tests/models/test_instance.py
+++ b/onadata/apps/logger/tests/models/test_instance.py
@@ -7,6 +7,7 @@ import os
 from datetime import datetime, timedelta
 from unittest.mock import Mock, patch
 
+from django.contrib.contenttypes.models import ContentType
 from django.http.request import HttpRequest
 from django.test import override_settings
 from django.utils.timezone import utc
@@ -1230,6 +1231,12 @@ class TestInstance(TestBase):
         """
         self._publish_markdown(md, self.user, project)
         xform = XForm.objects.all().order_by("-pk").first()
+        metadata = MetaData.objects.create(
+            content_type=ContentType.objects.get_for_model(xform),
+            object_id=xform.id,
+            data_type="export_repeat_register",
+            data_value="",
+        )
         xml = (
             '<?xml version="1.0" encoding="UTF-8"?>'
             '<data xmlns:jr="http://openrosa.org/javarosa" xmlns:orx='

--- a/onadata/apps/logger/tests/models/test_instance.py
+++ b/onadata/apps/logger/tests/models/test_instance.py
@@ -7,7 +7,6 @@ import os
 from datetime import datetime, timedelta
 from unittest.mock import Mock, patch
 
-from django.contrib.contenttypes.models import ContentType
 from django.http.request import HttpRequest
 from django.test import override_settings
 from django.utils.timezone import utc
@@ -1231,12 +1230,6 @@ class TestInstance(TestBase):
         """
         self._publish_markdown(md, self.user, project)
         xform = XForm.objects.all().order_by("-pk").first()
-        metadata = MetaData.objects.create(
-            content_type=ContentType.objects.get_for_model(xform),
-            object_id=xform.id,
-            data_type="export_repeat_register",
-            data_value="",
-        )
         xml = (
             '<?xml version="1.0" encoding="UTF-8"?>'
             '<data xmlns:jr="http://openrosa.org/javarosa" xmlns:orx='

--- a/onadata/apps/logger/tests/models/test_instance.py
+++ b/onadata/apps/logger/tests/models/test_instance.py
@@ -1228,8 +1228,7 @@ class TestInstance(TestBase):
         |         | form_title  | form_id         |                     |
         |         | Births      | births          |                     |
         """
-        self._publish_markdown(md, self.user, project)
-        xform = XForm.objects.all().order_by("-pk").first()
+        xform = self._publish_markdown(md, self.user, project)
         xml = (
             '<?xml version="1.0" encoding="UTF-8"?>'
             '<data xmlns:jr="http://openrosa.org/javarosa" xmlns:orx='

--- a/onadata/apps/main/tests/test_csv_export.py
+++ b/onadata/apps/main/tests/test_csv_export.py
@@ -2,17 +2,19 @@
 """
 Test CSV Exports
 """
+
 import csv
 import os
 
 from django.core.files.storage import get_storage_class
+from django.db.models.signals import post_save
 from django.utils.dateparse import parse_datetime
 
-from onadata.apps.viewer.models.data_dictionary import DataDictionary
-from onadata.apps.viewer.models.export import Export
 from onadata.apps.logger.models import XForm
-from onadata.libs.utils.export_tools import generate_export
 from onadata.apps.main.tests.test_base import TestBase
+from onadata.apps.viewer.models import DataDictionary, Export
+from onadata.apps.viewer.models.data_dictionary import create_export_repeat_register
+from onadata.libs.utils.export_tools import generate_export
 
 
 class TestCsvExport(TestBase):
@@ -23,150 +25,161 @@ class TestCsvExport(TestBase):
     def setUp(self):
         self._create_user_and_login()
 
-        self.fixture_dir = os.path.join(
-            self.this_directory, 'fixtures', 'csv_export')
-        self._submission_time = parse_datetime('2013-02-18 15:54:01Z')
+        self.fixture_dir = os.path.join(self.this_directory, "fixtures", "csv_export")
+        self._submission_time = parse_datetime("2013-02-18 15:54:01Z")
         self.options = {"extension": "csv"}
         self.xform = None
+        # Disable signals
+        post_save.disconnect(
+            sender=DataDictionary, dispatch_uid="create_export_repeat_register"
+        )
+
+    def tearDown(self):
+        # Reconnect signals
+        post_save.connect(
+            sender=DataDictionary,
+            dispatch_uid="create_export_repeat_register",
+            receiver=create_export_repeat_register,
+        )
+
+        super().tearDown()
 
     def test_csv_export_output(self):
         """
         Test CSV export output
         """
-        path = os.path.join(self.fixture_dir, 'tutorial_w_repeats.xlsx')
+        path = os.path.join(self.fixture_dir, "tutorial_w_repeats.xlsx")
         self._publish_xls_file_and_set_xform(path)
-        path = os.path.join(self.fixture_dir, 'tutorial_w_repeats.xml')
-        self._make_submission(
-            path, forced_submission_time=self._submission_time)
+        path = os.path.join(self.fixture_dir, "tutorial_w_repeats.xml")
+        self._make_submission(path, forced_submission_time=self._submission_time)
         # test csv
 
-        export = generate_export(
-            Export.CSV_EXPORT,
-            self.xform,
-            None,
-            self.options)
+        export = generate_export(Export.CSV_EXPORT, self.xform, None, self.options)
         storage = get_storage_class()()
         self.assertTrue(storage.exists(export.filepath))
         path, ext = os.path.splitext(export.filename)
-        self.assertEqual(ext, '.csv')
-        test_file_path = os.path.join(
-            self.fixture_dir, 'tutorial_w_repeats.csv')
-        with storage.open(export.filepath, 'r') as csv_file:
+        self.assertEqual(ext, ".csv")
+        test_file_path = os.path.join(self.fixture_dir, "tutorial_w_repeats.csv")
+        with storage.open(export.filepath, "r") as csv_file:
             self._test_csv_files(csv_file, test_file_path)
 
     def test_csv_nested_repeat_output(self):
         """
         Test CSV export with nested repeats
         """
-        path = os.path.join(self.fixture_dir, 'double_repeat.xlsx')
+        path = os.path.join(self.fixture_dir, "double_repeat.xlsx")
         self._publish_xls_file(path)
-        self.xform = XForm.objects.get(id_string='double_repeat')
-        path = os.path.join(self.fixture_dir, 'instance.xml')
-        self._make_submission(
-            path, forced_submission_time=self._submission_time)
+        self.xform = XForm.objects.get(id_string="double_repeat")
+        path = os.path.join(self.fixture_dir, "instance.xml")
+        self._make_submission(path, forced_submission_time=self._submission_time)
         self.maxDiff = None
         data_dictionary = DataDictionary.objects.all()[0]
         xpaths = [
-            u'/data/bed_net[1]/member[1]/name',
-            u'/data/bed_net[1]/member[2]/name',
-            u'/data/bed_net[2]/member[1]/name',
-            u'/data/bed_net[2]/member[2]/name',
-            u'/data/meta/instanceID'
+            "/data/bed_net[1]/member[1]/name",
+            "/data/bed_net[1]/member[2]/name",
+            "/data/bed_net[2]/member[1]/name",
+            "/data/bed_net[2]/member[2]/name",
+            "/data/meta/instanceID",
         ]
         self.assertEqual(data_dictionary.xpaths(repeat_iterations=2), xpaths)
         # test csv
-        export = generate_export(
-            Export.CSV_EXPORT,
-            self.xform,
-            None,
-            self.options)
+        export = generate_export(Export.CSV_EXPORT, self.xform, None, self.options)
         storage = get_storage_class()()
         self.assertTrue(storage.exists(export.filepath))
         path, ext = os.path.splitext(export.filename)
-        self.assertEqual(ext, '.csv')
-        test_file_path = os.path.join(self.fixture_dir, 'export.csv')
-        with storage.open(export.filepath, 'r') as csv_file:
+        self.assertEqual(ext, ".csv")
+        test_file_path = os.path.join(self.fixture_dir, "export.csv")
+        with storage.open(export.filepath, "r") as csv_file:
             self._test_csv_files(csv_file, test_file_path)
 
     def test_dotted_fields_csv_export(self):
         """
         Test CSV export with dotted field names
         """
-        path = os.path.join(os.path.dirname(__file__), 'fixtures', 'userone',
-                            'userone_with_dot_name_fields.xlsx')
+        path = os.path.join(
+            os.path.dirname(__file__),
+            "fixtures",
+            "userone",
+            "userone_with_dot_name_fields.xlsx",
+        )
         self._publish_xls_file_and_set_xform(path)
-        path = os.path.join(os.path.dirname(__file__), 'fixtures', 'userone',
-                            'userone_with_dot_name_fields.xml')
-        self._make_submission(
-            path, forced_submission_time=self._submission_time)
+        path = os.path.join(
+            os.path.dirname(__file__),
+            "fixtures",
+            "userone",
+            "userone_with_dot_name_fields.xml",
+        )
+        self._make_submission(path, forced_submission_time=self._submission_time)
         # test csv
-        self.options['id_string'] = 'userone'
-        export = generate_export(
-            Export.CSV_EXPORT,
-            self.xform,
-            None,
-            self.options)
+        self.options["id_string"] = "userone"
+        export = generate_export(Export.CSV_EXPORT, self.xform, None, self.options)
         storage = get_storage_class()()
         self.assertTrue(storage.exists(export.filepath))
         path, ext = os.path.splitext(export.filename)
-        self.assertEqual(ext, '.csv')
+        self.assertEqual(ext, ".csv")
         test_file_path = os.path.join(
-            os.path.dirname(__file__), 'fixtures', 'userone',
-            'userone_with_dot_name_fields.csv')
-        with storage.open(export.filepath, 'r') as csv_file:
+            os.path.dirname(__file__),
+            "fixtures",
+            "userone",
+            "userone_with_dot_name_fields.csv",
+        )
+        with storage.open(export.filepath, "r") as csv_file:
             self._test_csv_files(csv_file, test_file_path)
 
     def test_csv_truncated_titles(self):
         """
         Test CSV export with removed_group_name = True
         """
-        path = os.path.join(self.fixture_dir, 'tutorial_w_repeats.xlsx')
+        path = os.path.join(self.fixture_dir, "tutorial_w_repeats.xlsx")
         self._publish_xls_file_and_set_xform(path)
-        path = os.path.join(self.fixture_dir, 'tutorial_w_repeats.xml')
-        self._make_submission(
-            path, forced_submission_time=self._submission_time)
+        path = os.path.join(self.fixture_dir, "tutorial_w_repeats.xml")
+        self._make_submission(path, forced_submission_time=self._submission_time)
         # test csv
-        self.options['remove_group_name'] = True
-        export = generate_export(
-            Export.CSV_EXPORT,
-            self.xform,
-            None,
-            self.options)
+        self.options["remove_group_name"] = True
+        export = generate_export(Export.CSV_EXPORT, self.xform, None, self.options)
         storage = get_storage_class()()
         self.assertTrue(storage.exists(export.filepath))
         path, ext = os.path.splitext(export.filename)
-        self.assertEqual(ext, '.csv')
+        self.assertEqual(ext, ".csv")
         test_file_path = os.path.join(
-            self.fixture_dir, 'tutorial_w_repeats_truncate_titles.csv')
-        with storage.open(export.filepath, 'r') as csv_file:
+            self.fixture_dir, "tutorial_w_repeats_truncate_titles.csv"
+        )
+        with storage.open(export.filepath, "r") as csv_file:
             self._test_csv_files(csv_file, test_file_path)
 
     def test_csv_repeat_with_note(self):
         """
         Test that note field in repeat is not in csv export
         """
-        path = os.path.join(self.fixture_dir, 'repeat_w_note.xlsx')
+        path = os.path.join(self.fixture_dir, "repeat_w_note.xlsx")
         self._publish_xls_file_and_set_xform(path)
-        path = os.path.join(self.fixture_dir, 'repeat_w_note.xml')
-        self._make_submission(
-            path, forced_submission_time=self._submission_time)
-        export = generate_export(
-            Export.CSV_EXPORT,
-            self.xform,
-            None,
-            self.options)
+        path = os.path.join(self.fixture_dir, "repeat_w_note.xml")
+        self._make_submission(path, forced_submission_time=self._submission_time)
+        export = generate_export(Export.CSV_EXPORT, self.xform, None, self.options)
         storage = get_storage_class()()
         self.assertTrue(storage.exists(export.filepath))
         path, ext = os.path.splitext(export.filename)
-        self.assertEqual(ext, '.csv')
-        with storage.open(export.filepath, 'r') as csv_file:
+        self.assertEqual(ext, ".csv")
+        with storage.open(export.filepath, "r") as csv_file:
             reader = csv.reader(csv_file)
             rows = [row for row in reader]
             actual_headers = [h for h in rows[0]]
             expected_headers = [
-                'chnum', 'chrepeat[1]/chname', 'chrepeat[2]/chname',
-                'meta/instanceID', '_id', '_uuid', '_submission_time',
-                '_date_modified', '_tags', '_notes', '_version',
-                '_duration', '_submitted_by', '_total_media',
-                '_media_count', '_media_all_received']
+                "chnum",
+                "chrepeat[1]/chname",
+                "chrepeat[2]/chname",
+                "meta/instanceID",
+                "_id",
+                "_uuid",
+                "_submission_time",
+                "_date_modified",
+                "_tags",
+                "_notes",
+                "_version",
+                "_duration",
+                "_submitted_by",
+                "_total_media",
+                "_media_count",
+                "_media_all_received",
+            ]
             self.assertEqual(sorted(expected_headers), sorted(actual_headers))

--- a/onadata/apps/viewer/models/data_dictionary.py
+++ b/onadata/apps/viewer/models/data_dictionary.py
@@ -35,6 +35,7 @@ from onadata.libs.utils.cache_tools import (
     PROJ_FORMS_CACHE,
     safe_delete,
 )
+from onadata.libs.utils.common_tags import EXPORT_REPEAT_REGISTER
 from onadata.libs.utils.model_tools import get_columns_with_hxl, set_uuid
 
 
@@ -437,4 +438,22 @@ post_save.connect(
     invalidate_caches,
     sender=DataDictionary,
     dispatch_uid="xform_invalidate_caches",
+)
+
+
+def create_export_repeat_register(sender, instance=None, created=False, **kwargs):
+    """Create export repeat register for the form"""
+    if created:
+        MetaData.objects.create(
+            content_type=ContentType.objects.get_for_model(instance),
+            object_id=instance.pk,
+            data_type=EXPORT_REPEAT_REGISTER,
+            data_value="",
+        )
+
+
+post_save.connect(
+    create_export_repeat_register,
+    sender=DataDictionary,
+    dispatch_uid="create_export_repeat_register",
 )

--- a/onadata/apps/viewer/models/tests/test_data_dictionary.py
+++ b/onadata/apps/viewer/models/tests/test_data_dictionary.py
@@ -2,6 +2,7 @@
 
 import json
 
+from django.contrib.contenttypes.models import ContentType
 from django.core.cache import cache
 
 from onadata.apps.logger.models.entity_list import EntityList
@@ -307,3 +308,16 @@ class DataDictionaryTestCase(TestBase):
 
         for key in cache_keys:
             self.assertIsNone(cache.get(key))
+
+    def test_export_repeat_register_created(self):
+        """Export repeat register is created when form is published"""
+        self._publish_markdown(self.registration_form, self.user)
+        xform = XForm.objects.all().order_by("-pk").first()
+        content_type = ContentType.objects.get_for_model(xform)
+        exists = MetaData.objects.filter(
+            data_type="export_repeat_register",
+            object_id=xform.pk,
+            content_type=content_type,
+        ).exists()
+
+        self.assertTrue(exists)

--- a/onadata/apps/viewer/models/tests/test_data_dictionary.py
+++ b/onadata/apps/viewer/models/tests/test_data_dictionary.py
@@ -311,8 +311,7 @@ class DataDictionaryTestCase(TestBase):
 
     def test_export_repeat_register_created(self):
         """Export repeat register is created when form is published"""
-        self._publish_markdown(self.registration_form, self.user)
-        xform = XForm.objects.all().order_by("-pk").first()
+        xform = self._publish_markdown(self.registration_form, self.user)
         content_type = ContentType.objects.get_for_model(xform)
         exists = MetaData.objects.filter(
             data_type="export_repeat_register",

--- a/onadata/libs/tests/utils/test_csv_builder.py
+++ b/onadata/libs/tests/utils/test_csv_builder.py
@@ -72,14 +72,14 @@ class TestCSVDataFrameBuilder(TestBase):
         )
 
     def tearDown(self):
-        super().tearDown()
-
         # Enable signals
         post_save.connect(
             sender=DataDictionary,
             dispatch_uid="create_export_repeat_register",
             receiver=create_export_repeat_register,
         )
+
+        super().tearDown()
 
     def _publish_xls_fixture_set_xform(self, fixture):
         """

--- a/onadata/libs/tests/utils/test_csv_builder.py
+++ b/onadata/libs/tests/utils/test_csv_builder.py
@@ -21,6 +21,7 @@ from onadata.apps.logger.xform_instance_parser import xform_instance_to_dict
 from onadata.apps.main.models.meta_data import MetaData
 from onadata.apps.main.tests.test_base import TestBase
 from onadata.apps.viewer.models import DataDictionary
+from onadata.apps.viewer.models.data_dictionary import create_export_repeat_register
 from onadata.libs.utils.common_tags import NA_REP
 from onadata.libs.utils.csv_builder import (
     AbstractDataFrameBuilder,
@@ -68,6 +69,16 @@ class TestCSVDataFrameBuilder(TestBase):
         # Disable signals
         post_save.disconnect(
             sender=DataDictionary, dispatch_uid="create_export_repeat_register"
+        )
+
+    def tearDown(self):
+        super().tearDown()
+
+        # Enable signals
+        post_save.connect(
+            sender=DataDictionary,
+            dispatch_uid="create_export_repeat_register",
+            receiver=create_export_repeat_register,
         )
 
     def _publish_xls_fixture_set_xform(self, fixture):

--- a/onadata/libs/tests/utils/test_logger_tools.py
+++ b/onadata/libs/tests/utils/test_logger_tools.py
@@ -1183,8 +1183,7 @@ class RegisterInstanceExportRepeatsTestCase(TestBase):
         |         | form_title  | form_id         |                     |
         |         | Births      | births          |                     |
         """
-        self._publish_markdown(md, self.user, self.project)
-        self.xform = XForm.objects.all().order_by("-pk").first()
+        self.xform = self._publish_markdown(md, self.user, self.project)
         self.xml = (
             '<?xml version="1.0" encoding="UTF-8"?>'
             '<data xmlns:jr="http://openrosa.org/javarosa" xmlns:orx='
@@ -1349,8 +1348,7 @@ class RegisterXFormExportRepeatsTestCase(TestBase):
         |         | form_title  | form_id         |                     |
         |         | Births      | births          |                     |
         """
-        self._publish_markdown(md, self.user, self.project)
-        self.xform = XForm.objects.all().order_by("-pk").first()
+        self.xform = self._publish_markdown(md, self.user, self.project)
         xml = (
             '<?xml version="1.0" encoding="UTF-8"?>'
             '<data xmlns:jr="http://openrosa.org/javarosa" xmlns:orx='

--- a/onadata/libs/tests/utils/test_logger_tools.py
+++ b/onadata/libs/tests/utils/test_logger_tools.py
@@ -1168,6 +1168,7 @@ class RegisterInstanceExportRepeatsTestCase(TestBase):
 
         # Disable signals
         post_save.disconnect(sender=Instance, dispatch_uid="register_export_repeats")
+
         self.project = get_user_default_project(self.user)
         md = """
         | survey |
@@ -1215,11 +1216,10 @@ class RegisterInstanceExportRepeatsTestCase(TestBase):
         self.instance = Instance.objects.create(
             xml=self.xml, user=self.user, xform=self.xform
         )
-        self.register, _ = MetaData.objects.get_or_create(
+        self.register = MetaData.objects.get(
             data_type="export_repeat_register",
             object_id=self.xform.pk,
             content_type=ContentType.objects.get_for_model(self.xform),
-            defaults={"data_value": ""},
         )
 
     def test_repeat_register_not_found(self):
@@ -1340,6 +1340,7 @@ class RegisterXFormExportRepeatsTestCase(TestBase):
 
         # Disable signals
         post_save.disconnect(sender=Instance, dispatch_uid="register_export_repeats")
+
         self.project = get_user_default_project(self.user)
         md = """
         | survey |
@@ -1387,11 +1388,10 @@ class RegisterXFormExportRepeatsTestCase(TestBase):
         self.instance = Instance.objects.create(
             xml=xml, user=self.user, xform=self.xform
         )
-        self.register, _ = MetaData.objects.get_or_create(
+        self.register = MetaData.objects.get(
             data_type="export_repeat_register",
             object_id=self.xform.pk,
             content_type=ContentType.objects.get_for_model(self.xform),
-            defaults={"data_value": ""},
         )
 
     def test_register(self):

--- a/onadata/libs/tests/utils/test_logger_tools.py
+++ b/onadata/libs/tests/utils/test_logger_tools.py
@@ -1217,13 +1217,12 @@ class RegisterInstanceExportRepeatsTestCase(TestBase):
             xml=self.xml, user=self.user, xform=self.xform
         )
 
-    def test_repeat_count_create(self):
-        """MetaData of type export_repeat_register is created"""
+    def test_repeat_register_not_found(self):
+        """Nothing happens if export repeat register is not found"""
         register_instance_export_repeats(self.instance)
 
-        metadata = MetaData.objects.get(data_type="export_repeat_register")
-        self.assertEqual(metadata.extra_data.get("hospital_repeat"), 2)
-        self.assertEqual(metadata.extra_data.get("child_repeat"), 2)
+        exists = MetaData.objects.filter(data_type="export_repeat_register").exists()
+        self.assertFalse(exists)
 
     def test_incoming_repeat_max_greater(self):
         """Repeat count is incremented if incoming repeat count is greater"""
@@ -1282,7 +1281,7 @@ class RegisterInstanceExportRepeatsTestCase(TestBase):
         self.assertEqual(metadata.extra_data.get("child_repeat"), 2)
 
     def test_no_repeats(self):
-        """Instance has no repeats"""
+        """No change in register if no repeats are found in the instance"""
         md = """
         | survey |
         |        | type         | name            | label               |
@@ -1306,61 +1305,17 @@ class RegisterInstanceExportRepeatsTestCase(TestBase):
             "</data>"
         )
         instance = Instance.objects.create(xml=xml, user=self.user, xform=xform)
+        metadata = MetaData.objects.create(
+            content_type=ContentType.objects.get_for_model(self.xform),
+            object_id=self.xform.id,
+            data_type="export_repeat_register",
+            data_value="",
+        )
 
         register_instance_export_repeats(instance)
+        metadata.refresh_from_db()
 
-        exists = MetaData.objects.filter(data_type="export_repeat_register").exists()
-        self.assertTrue(exists)
-        metadata = MetaData.objects.get(data_type="export_repeat_register")
         self.assertEqual(metadata.extra_data, {})
-
-    def test_create_register_previous_candidates(self):
-        """Previous submissions are considered when creating repeat register"""
-        # Existing submission with a higher repeat count for hospital_repeat
-        xml = (
-            '<?xml version="1.0" encoding="UTF-8"?>'
-            '<data xmlns:jr="http://openrosa.org/javarosa" xmlns:orx='
-            '"http://openrosa.org/xforms" id="trees_update" version="2024050801">'
-            f"<formhub><uuid>{self.xform.uuid}</uuid></formhub>"
-            "<hospital_repeat>"
-            "<hospital>Aga Khan</hospital>"
-            "<child_repeat>"
-            "<name>Zakayo</name>"
-            "<birthweight>3.3</birthweight>"
-            "</child_repeat>"
-            "<child_repeat>"
-            "<name>Melania</name>"
-            "<birthweight>3.5</birthweight>"
-            "</child_repeat>"
-            "</hospital_repeat>"
-            "<hospital_repeat>"
-            "<hospital>Mama Lucy</hospital>"
-            "<child_repeat>"
-            "<name>Winnie</name>"
-            "<birthweight>3.1</birthweight>"
-            "</child_repeat>"
-            "</hospital_repeat>"
-            "<hospital_repeat>"
-            "<hospital>Nairobi West</hospital>"
-            "<child_repeat>"
-            "<name>Tom</name>"
-            "<birthweight>3.1</birthweight>"
-            "</child_repeat>"
-            "</hospital_repeat>"
-            "<meta>"
-            "<instanceID>uuid:cb5eb8fe-a046-4e75-9c7f-72183b871698</instanceID>"
-            "</meta>"
-            "</data>"
-        )
-        Instance.objects.create(xml=xml, user=self.user, xform=self.xform)
-
-        register_instance_export_repeats(self.instance)
-
-        metadata = MetaData.objects.get(data_type="export_repeat_register")
-        # The previous submission should be considered since it has the most repeats
-        # for hospital_repeat
-        self.assertEqual(metadata.extra_data.get("hospital_repeat"), 3)
-        self.assertEqual(metadata.extra_data.get("child_repeat"), 2)
 
     def test_submission_review_enabled(self):
         """When submission review is enabled, only approved Instance is registered"""
@@ -1369,9 +1324,15 @@ class RegisterInstanceExportRepeatsTestCase(TestBase):
         self.instance = Instance.objects.create(
             xml=self.xml, user=self.user, xform=self.xform
         )
+        metadata = MetaData.objects.create(
+            content_type=ContentType.objects.get_for_model(self.xform),
+            object_id=self.xform.id,
+            data_type="export_repeat_register",
+            data_value="",
+        )
         register_instance_export_repeats(self.instance)
 
-        metadata = MetaData.objects.get(data_type="export_repeat_register")
+        metadata.refresh_from_db()
 
         self.assertEqual(metadata.extra_data, {})
 

--- a/onadata/libs/tests/utils/test_logger_tools.py
+++ b/onadata/libs/tests/utils/test_logger_tools.py
@@ -34,6 +34,7 @@ from onadata.apps.logger.models import (
 from onadata.apps.logger.xform_instance_parser import AttachmentNameError
 from onadata.apps.main.models.meta_data import MetaData
 from onadata.apps.main.tests.test_base import TestBase
+from onadata.apps.viewer.models import DataDictionary
 from onadata.libs.test_utils.pyxform_test_case import PyxformTestCase
 from onadata.libs.utils.common_tags import MEDIA_ALL_RECEIVED, MEDIA_COUNT, TOTAL_MEDIA
 from onadata.libs.utils.logger_tools import (
@@ -1166,6 +1167,11 @@ class RegisterInstanceExportRepeatsTestCase(TestBase):
     def setUp(self):
         super().setUp()
 
+        # Disable signals
+        post_save.disconnect(sender=Instance, dispatch_uid="register_export_repeats")
+        post_save.disconnect(
+            sender=DataDictionary, dispatch_uid="create_export_repeat_register"
+        )
         self.project = get_user_default_project(self.user)
         md = """
         | survey |
@@ -1211,8 +1217,6 @@ class RegisterInstanceExportRepeatsTestCase(TestBase):
             "</meta>"
             "</data>"
         )
-        # Disable signals to avoid creating MetaData
-        post_save.disconnect(sender=Instance, dispatch_uid="register_export_repeats")
         self.instance = Instance.objects.create(
             xml=self.xml, user=self.user, xform=self.xform
         )


### PR DESCRIPTION
### Changes / Features implemented

Creating a register if it does not exist when an Instance is saved resulted in a bloated queue and load on the database from traversing all submissions for a XForm.

Instances under which we should create the register:

1. When a new form is published
2. When a CSV export is triggered and the register does not exist.

### Steps taken to verify this change does what is intended

- [x] QA

### Side effects of implementing this change

Prevents the queue and database from becoming bloated with requests to traverse all submissions for a form to build the export register when a Instance is saved.

**Before submitting this PR for review, please make sure you have:**

  - [X] Included tests
  - [ ] Updated documentation

Closes #
