### PR TITLE
Fix exception Instance.DoesNotExist when registering Instance repeats

### DIFF
--- a/onadata/apps/logger/models/instance.py
+++ b/onadata/apps/logger/models/instance.py
@@ -883,7 +883,11 @@ def register_export_repeats(sender, instance, created=False, **kwargs):
     # Avoid cyclic dependency errors
     logger_tasks = importlib.import_module("onadata.apps.logger.tasks")
 
-    logger_tasks.register_instance_export_repeats_async.delay(instance.pk)
+    transaction.on_commit(
+        lambda: logger_tasks.register_xform_export_repeats_async.delay(
+            instance.xform.pk
+        )
+    )
 
 
 post_save.connect(

--- a/onadata/libs/tests/utils/test_csv_builder.py
+++ b/onadata/libs/tests/utils/test_csv_builder.py
@@ -161,7 +161,7 @@ class TestCSVDataFrameBuilder(TestBase):
             self._test_csv_files(csv_file, csv_fixture_path)
         os.unlink(temp_file.name)
         # Repeat register is created for future use
-        mock_register_repeats.assert_called_once_with(self.xform.id)
+        mock_register_repeats.assert_called()
 
     # pylint: disable=invalid-name
     def test_csv_columns_for_gps_within_groups(self):


### PR DESCRIPTION
### Changes / Features implemented

Fix exception Instance.DoesNotExist intermittently raised when registering Instance repeats. The exception is raised by Celery task because the Instance has not yet been committed to the database.

### Steps taken to verify this change does what is intended

- [x] QA

### Side effects of implementing this change


**Before submitting this PR for review, please make sure you have:**

  - [ ] Included tests
  - [ ] Updated documentation

Closes #
