### PR TITLE
Allow unapproved submissions when registering export repeats

### DIFF
--- a/onadata/apps/logger/models/instance.py
+++ b/onadata/apps/logger/models/instance.py
@@ -884,9 +884,7 @@ def register_export_repeats(sender, instance, created=False, **kwargs):
     logger_tasks = importlib.import_module("onadata.apps.logger.tasks")
 
     transaction.on_commit(
-        lambda: logger_tasks.register_xform_export_repeats_async.delay(
-            instance.xform.pk
-        )
+        lambda: logger_tasks.register_instance_export_repeats_async.delay(instance.pk)
     )
 
 

--- a/onadata/libs/tests/utils/test_logger_tools.py
+++ b/onadata/libs/tests/utils/test_logger_tools.py
@@ -27,7 +27,6 @@ from onadata.apps.logger.models import (
     EntityList,
     Instance,
     RegistrationForm,
-    SubmissionReview,
     SurveyType,
     XForm,
 )
@@ -1306,30 +1305,6 @@ class RegisterInstanceExportRepeatsTestCase(TestBase):
         register.refresh_from_db()
 
         self.assertEqual(register.extra_data, {})
-
-    def test_submission_review_enabled(self):
-        """When submission review is enabled, only approved Instance is registered"""
-        self.instance.delete()
-        MetaData.submission_review(self.xform, "true")  # Enable submission review
-        self.instance = Instance.objects.create(
-            xml=self.xml, user=self.user, xform=self.xform
-        )
-        register_instance_export_repeats(self.instance)
-
-        self.register.refresh_from_db()
-
-        self.assertEqual(self.register.extra_data, {})
-
-        # Approve submission
-        SubmissionReview.objects.create(
-            instance=self.instance, status=SubmissionReview.APPROVED
-        )
-
-        register_instance_export_repeats(self.instance)
-
-        self.register.refresh_from_db()
-
-        self.assertEqual(self.register.extra_data.get("hospital_repeat"), 2)
 
 
 class RegisterXFormExportRepeatsTestCase(TestBase):

--- a/onadata/libs/utils/logger_tools.py
+++ b/onadata/libs/utils/logger_tools.py
@@ -59,7 +59,6 @@ from onadata.apps.logger.models import (
     Attachment,
     Instance,
     RegistrationForm,
-    SubmissionReview,
     XForm,
     XFormVersion,
 )
@@ -1557,9 +1556,6 @@ def _update_export_repeat_register(instance: Instance, metadata: MetaData) -> No
     :param instance: Instance object
     :param metadata: MetaData object that stores the export repeat register
     """
-    if not _is_submission_approved(instance):
-        return
-
     repeat_max = _get_instance_repeat_max(instance)
 
     for repeat, incoming_max in repeat_max.items():
@@ -1590,30 +1586,6 @@ def _update_export_repeat_register(instance: Instance, metadata: MetaData) -> No
                     metadata.pk,
                 ],
             )
-
-
-def _is_submission_approved(instance: Instance) -> bool:
-    """Check if a submission has been approved
-
-    :param instance: Instance object
-    :return: True if submission is approved, False otherwise
-    """
-    content_type = ContentType.objects.get_for_model(instance.xform)
-    is_review_enabled = MetaData.objects.filter(
-        content_type=content_type,
-        object_id=instance.xform.id,
-        data_type="submission_review",
-        data_value="true",
-    ).exists()
-
-    if not is_review_enabled:
-        return True
-
-    is_submission_approved = SubmissionReview.objects.filter(
-        instance_id=instance.id, status=SubmissionReview.APPROVED
-    ).exists()
-
-    return is_submission_approved
 
 
 @transaction.atomic()


### PR DESCRIPTION
### Changes / Features implemented

This changes allows repeats even from unapproved submissions to be registered as unapproved submissions are usually allowed in exports

### Steps taken to verify this change does what is intended

- [x] QA

### Side effects of implementing this change

Repeats from unapproved submissions are considered during CSV export

**Before submitting this PR for review, please make sure you have:**

  - [ ] Included tests
  - [ ] Updated documentation

Closes #
