### PR TITLE
Fix form permissions not updated when project is transferred

### DIFF
--- a/onadata/apps/api/tests/viewsets/test_project_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_project_viewset.py
@@ -1295,9 +1295,11 @@ class TestProjectViewSet(TestAbstractViewSet):
         )
         self.assertEqual(self.project.created_by, alice_profile.user)
         alice_project = self.project
+
         # Publish a form to Alice's project
         self._publish_xls_form_to_project()
         alice_xform = self.xform
+
         # Create organization owned by Bob
         self._login_user_and_profile({"username": bob.username, "email": bob.email})
         self._org_create()
@@ -1314,6 +1316,7 @@ class TestProjectViewSet(TestAbstractViewSet):
 
         owners_team = get_or_create_organization_owners_team(self.organization)
         self.assertIn(alice_profile.user, owners_team.user_set.all())
+
         # Add Jane to Bob's organization with dataentry role
         jane_data = {"username": "jane", "email": "janedoe@example.com"}
         jane_profile = self._create_user_profile(jane_data)
@@ -1323,7 +1326,6 @@ class TestProjectViewSet(TestAbstractViewSet):
             "/", data=json.dumps(data), content_type="application/json", **self.extra
         )
         response = view(request, user=self.organization.user.username)
-
         self.assertEqual(response.status_code, 201)
         self.assertTrue(
             DataEntryRole.user_has_role(jane_profile.user, self.organization)

--- a/onadata/apps/api/tests/viewsets/test_project_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_project_viewset.py
@@ -1295,12 +1295,15 @@ class TestProjectViewSet(TestAbstractViewSet):
         )
         self.assertEqual(self.project.created_by, alice_profile.user)
         alice_project = self.project
-
-        # create org owned by bob then make alice admin
+        # Publish a form to Alice's project
+        self._publish_xls_form_to_project()
+        alice_xform = self.xform
+        # Create organization owned by Bob
         self._login_user_and_profile({"username": bob.username, "email": bob.email})
         self._org_create()
         self.assertEqual(self.organization.created_by, bob)
-        org_url = f"http://testserver/api/v1/users/{self.organization.user.username}"
+
+        # Add Alice as admin to Bob's organization
         view = OrganizationProfileViewSet.as_view({"post": "members"})
         data = {"username": alice_profile.user.username, "role": OwnerRole.name}
         request = self.factory.post(
@@ -1311,6 +1314,20 @@ class TestProjectViewSet(TestAbstractViewSet):
 
         owners_team = get_or_create_organization_owners_team(self.organization)
         self.assertIn(alice_profile.user, owners_team.user_set.all())
+        # Add Jane to Bob's organization with dataentry role
+        jane_data = {"username": "jane", "email": "janedoe@example.com"}
+        jane_profile = self._create_user_profile(jane_data)
+        data = {"username": jane_profile.user.username, "role": DataEntryRole.name}
+        request = self.factory.post("/", data=data, **self.extra)
+        request = self.factory.post(
+            "/", data=json.dumps(data), content_type="application/json", **self.extra
+        )
+        response = view(request, user=self.organization.user.username)
+
+        self.assertEqual(response.status_code, 201)
+        self.assertTrue(
+            DataEntryRole.user_has_role(jane_profile.user, self.organization)
+        )
 
         # Share project to bob as editor
         data = {"username": bob.username, "role": EditorRole.name}
@@ -1322,28 +1339,24 @@ class TestProjectViewSet(TestAbstractViewSet):
         self.assertEqual(response.status_code, 204)
 
         # Transfer project to Bobs Organization
+        org_url = f"http://testserver/api/v1/users/{self.organization.user.username}"
         data = {"owner": org_url, "name": alice_project.name}
         view = ProjectViewSet.as_view({"patch": "partial_update"})
         request = self.factory.patch("/", data=data, **auth_credentials)
         response = view(request, pk=alice_project.pk)
         self.assertEqual(response.status_code, 200)
 
-        # Ensure all Admins have admin privileges to the project
-        # once transferred
-        view = ProjectViewSet.as_view({"get": "retrieve"})
-        request = self.factory.get("/", **self.extra)
-        response = view(request, pk=alice_project.pk)
-        self.assertEqual(response.status_code, 200)
-        project_users = response.data["users"]
+        # Admins have owner privileges to the transferred project
+        # and forms
+        self.assertTrue(OwnerRole.user_has_role(bob, alice_project))
+        self.assertTrue(OwnerRole.user_has_role(bob, alice_xform))
+        self.assertTrue(OwnerRole.user_has_role(alice_profile.user, alice_project))
+        self.assertTrue(OwnerRole.user_has_role(alice_profile.user, alice_xform))
 
-        org_owners = get_or_create_organization_owners_team(
-            self.organization
-        ).user_set.all()
-
-        for user in project_users:
-            owner = org_owners.filter(username=user["user"]).first()
-            if owner:
-                self.assertEqual(user["role"], OwnerRole.name)
+        # Non-admins have readonly privileges to the transferred project
+        # and forms
+        self.assertTrue(ReadOnlyRole.user_has_role(jane_profile.user, alice_project))
+        self.assertTrue(ReadOnlyRole.user_has_role(jane_profile.user, alice_xform))
 
     # pylint: disable=invalid-name
     @override_settings(ALLOW_PUBLIC_DATASETS=False)

--- a/onadata/apps/logger/management/commands/transferproject.py
+++ b/onadata/apps/logger/management/commands/transferproject.py
@@ -10,7 +10,7 @@ from onadata.apps.api.models.organization_profile import (
     get_organization_members_team,
 )
 from onadata.apps.logger.models import MergedXForm, Project, XForm
-from onadata.libs.permissions import OwnerRole, ReadOnlyRole, is_organization
+from onadata.libs.permissions import OwnerRole, ReadOnlyRole
 from onadata.libs.utils.project_utils import set_project_perms_to_xform
 
 
@@ -124,12 +124,6 @@ class Command(BaseCommand):
         to_user = self.get_user(options["new_owner"])
 
         if self.errors:
-            self.stdout.write("".join(self.errors))
-            return
-
-        # You can only transfer projects to an organization account
-        if not is_organization(to_user.profile):
-            self.errors.append("New owner must be an organization")
             self.stdout.write("".join(self.errors))
             return
 

--- a/onadata/apps/logger/management/commands/transferproject.py
+++ b/onadata/apps/logger/management/commands/transferproject.py
@@ -97,7 +97,9 @@ class Command(BaseCommand):
 
         set_project_permissions(Project, project, created=True)
 
-        if hasattr(to_user.profile, "organizationprofile"):
+        if hasattr(to_user, "profile") and hasattr(
+            to_user.profile, "organizationprofile"
+        ):
             # Give readonly permission to members
             organization = to_user.profile.organizationprofile
             owners_team = Team.objects.get(

--- a/onadata/apps/logger/tests/test_transfer_project_command.py
+++ b/onadata/apps/logger/tests/test_transfer_project_command.py
@@ -1,9 +1,10 @@
 """Tests for project transfer command"""
+
 import os
 import sys
 
-from django.contrib.auth import get_user_model
 from django.core.management import call_command
+
 from six import StringIO
 
 from onadata.apps.logger.models import Project, XForm
@@ -11,97 +12,55 @@ from onadata.apps.main.tests.test_base import TestBase
 
 
 class TestMoveProjectToAnewOwner(TestBase):  # pylint: disable=C0111
-    def test_successful_project_transfer(self):  # pylint: disable=C0103
-        """ "Test for a successful project transfer."""
-        user_model = get_user_model()
-        user_1_data = {
-            "username": "user1",
-            "email": "user1@test.com",
-            "password": "test_pass",
-        }
-        user_2_data = {
-            "username": "user2",
-            "email": "user2@test.com",
-            "password": "test_pass",
-        }
-        user1 = user_model.objects.create_user(**user_1_data)
-        user2 = user_model.objects.create_user(**user_2_data)
-        Project.objects.create(
-            name="Test_project_1", organization=user1, created_by=user1
+    def setUp(self):
+        super().setUp()
+
+        self.from_user = self._create_user("bob", "test_pass")
+        self.alice = self._create_user("alice", "test_pass")
+        org = self._create_organization("alice_inc", "Alice Inc", self.alice)
+        self.to_user = org.user
+        Project.objects.bulk_create(
+            [
+                Project(
+                    name=f"Test_project_{i}",
+                    organization=self.from_user,
+                    created_by=self.from_user,
+                )
+                for i in range(1, 6)
+            ]
         )
-        Project.objects.create(
-            name="Test_project_2", organization=user1, created_by=user1
-        )
-        Project.objects.create(
-            name="Test_project_3", organization=user1, created_by=user1
-        )
-        Project.objects.create(
-            name="Test_project_4", organization=user1, created_by=user1
-        )
-        Project.objects.create(
-            name="Test_project_5", organization=user1, created_by=user1
-        )
+
+    def test_transfer_all(self):  # pylint: disable=C0103
+        """Transfer all projects from one user to another."""
         mock_stdout = StringIO()
         sys.stdout = mock_stdout
         call_command(
             "transferproject",
-            current_owner="user1",
-            new_owner="user2",
+            current_owner=self.from_user.username,
+            new_owner=self.to_user.username,
             all_projects=True,
             stdout=mock_stdout,
         )
         expected_output = "Projects transferred successfully"
         self.assertIn(expected_output, mock_stdout.getvalue())
-        self.assertEqual(0, Project.objects.filter(organization=user1).count())
-        self.assertEqual(5, Project.objects.filter(organization=user2).count())
+        self.assertEqual(0, Project.objects.filter(organization=self.from_user).count())
+        self.assertEqual(5, Project.objects.filter(organization=self.to_user).count())
 
-    def test_single_project_transfer(self):
-        """ "Test for a successful project transfer."""
-        user_model = get_user_model()
-        user_1_data = {
-            "username": "user1",
-            "email": "user1@test.com",
-            "password": "test_pass",
-        }
-        user_2_data = {
-            "username": "user2",
-            "email": "user2@test.com",
-            "password": "test_pass",
-        }
-        user1 = user_model.objects.create_user(**user_1_data)
-        user2 = user_model.objects.create_user(**user_2_data)
-        Project.objects.create(
-            name="Test_project_1", organization=user1, created_by=user1
-        )
-        Project.objects.create(
-            name="Test_project_2", organization=user1, created_by=user1
-        )
-        Project.objects.create(
-            name="Test_project_3", organization=user1, created_by=user1
-        )
-        Project.objects.create(
-            name="Test_project_4", organization=user1, created_by=user1
-        )
-
-        test_project = Project.objects.create(
-            name="Test_project_5", organization=user1, created_by=user1
-        )
+    def test_transfer_one(self):
+        """Transfer a single project from one user to another."""
         mock_stdout = StringIO()
         sys.stdout = mock_stdout
-        self.assertIsNotNone(test_project.id)
-
+        target_project = Project.objects.filter(organization=self.from_user).first()
         call_command(
             "transferproject",
-            current_owner="user1",
-            new_owner="user2",
-            project_id=test_project.id,
+            current_owner=self.from_user.username,
+            new_owner=self.to_user.username,
+            project_id=target_project.id,
         )
         expected_output = "Projects transferred successfully"
         self.assertIn(expected_output, mock_stdout.getvalue())
-        self.assertEqual(4, Project.objects.filter(organization=user1).count())
-        self.assertEqual(1, Project.objects.filter(organization=user2).count())
-        test_project_refetched = Project.objects.get(id=test_project.id)
-        self.assertEqual(user2, test_project_refetched.organization)
+        self.assertEqual(4, Project.objects.filter(organization=self.from_user).count())
+        self.assertEqual(1, Project.objects.filter(organization=self.to_user).count())
 
     def test_xforms_are_transferred_as_well(self):  # pylint: disable=C0103
         """Test the transfer of ownership of the XForms."""
@@ -110,34 +69,19 @@ class TestMoveProjectToAnewOwner(TestBase):  # pylint: disable=C0111
             "../fixtures/tutorial/tutorial.xlsx",
         )
         self._publish_xls_file_and_set_xform(xls_file_path)
-        xml_submission_file_path = os.path.join(
-            os.path.dirname(os.path.abspath(__file__)),
-            "../fixtures/tutorial/instances/tutorial_2012-06-27_11-27-53.xml",
-        )
 
-        self._make_submission(xml_submission_file_path)
-        self.assertEqual(self.response.status_code, 201)
-
-        user_model = get_user_model()
-        user_data = {
-            "username": "user",
-            "email": "user@test.com",
-            "password": "test_pass",
-        }
-        new_owner = user_model.objects.create_user(**user_data)
         mock_stdout = StringIO()
         sys.stdout = mock_stdout
         call_command(
             "transferproject",
-            current_owner="bob",
-            new_owner="user",
+            current_owner=self.from_user,
+            new_owner=self.to_user,
             all_projects=True,
             stdout=mock_stdout,
         )
         self.assertIn("Projects transferred successfully\n", mock_stdout.getvalue())
-        bob = user_model.objects.get(username="bob")
-        bobs_forms = XForm.objects.filter(user=bob)
-        new_owner_forms = XForm.objects.filter(user=new_owner)
+        bobs_forms = XForm.objects.filter(user=self.from_user)
+        new_owner_forms = XForm.objects.filter(user=self.to_user)
         self.assertEqual(0, bobs_forms.count())
         self.assertEqual(1, new_owner_forms.count())
 

--- a/onadata/apps/logger/tests/test_transfer_project_command.py
+++ b/onadata/apps/logger/tests/test_transfer_project_command.py
@@ -190,9 +190,13 @@ class TestMoveProjectToAnewOwner(TestBase):  # pylint: disable=C0111
             stdout=mock_stdout,
         )
         expected_output = "Projects transferred successfully"
+        self.xform.refresh_from_db()
+        self.project.refresh_from_db()
         self.assertIn(expected_output, mock_stdout.getvalue())
-        self.assertEqual(0, Project.objects.filter(organization=bob).count())
-        self.assertEqual(1, Project.objects.filter(organization=alice_org.user).count())
+        self.assertEqual(self.project.organization, alice_org.user)
+        self.assertEqual(self.project.organization, alice_org.user)
+        self.assertEqual(self.xform.user, alice_org.user)
+        self.assertEqual(self.xform.created_by, alice_org.user)
         # Admins have owner privileges
         self.assertTrue(OwnerRole.user_has_role(bob, project))
         self.assertTrue(OwnerRole.user_has_role(bob, self.xform))

--- a/onadata/apps/logger/tests/test_transfer_project_command.py
+++ b/onadata/apps/logger/tests/test_transfer_project_command.py
@@ -155,7 +155,7 @@ class TestMoveProjectToAnewOwner(TestBase):  # pylint: disable=C0111
         alice = self._create_user("alice", "test_pass")
         jane = self._create_user("jane", "test_pass")
 
-        # Create Project owned by Bob
+        # Create Project owned by Bob and publish form
         project = Project.objects.create(
             name="Test_project",
             organization=bob,
@@ -174,7 +174,7 @@ class TestMoveProjectToAnewOwner(TestBase):  # pylint: disable=C0111
             name=f"{alice_org.user.username}#members",
             organization=alice_org.user,
         )
-        # Add Bob as admin in Alice's organization
+        # Add Bob as admin to Alice's organization
         bob.groups.add(owners_team)
         bob.groups.add(members_team)
 
@@ -193,13 +193,11 @@ class TestMoveProjectToAnewOwner(TestBase):  # pylint: disable=C0111
         self.assertIn(expected_output, mock_stdout.getvalue())
         self.assertEqual(0, Project.objects.filter(organization=bob).count())
         self.assertEqual(1, Project.objects.filter(organization=alice_org.user).count())
-
         # Admins have owner privileges
         self.assertTrue(OwnerRole.user_has_role(bob, project))
         self.assertTrue(OwnerRole.user_has_role(bob, self.xform))
         self.assertTrue(OwnerRole.user_has_role(alice, project))
         self.assertTrue(OwnerRole.user_has_role(alice, self.xform))
-
         # Non-admins have readonly privileges
         self.assertFalse(OwnerRole.user_has_role(jane, project))
         self.assertTrue(ReadOnlyRole.user_has_role(jane, project))

--- a/onadata/apps/logger/tests/test_transfer_project_command.py
+++ b/onadata/apps/logger/tests/test_transfer_project_command.py
@@ -147,14 +147,10 @@ class TestMoveProjectToAnewOwner(TestBase):  # pylint: disable=C0111
 
     def test_transfer_to_org(self):
         """Transferring to an organization works"""
-        mock_stdout = StringIO()
-        sys.stdout = mock_stdout
-
         # Create users
         bob = self._create_user("bob", "test_pass")
         alice = self._create_user("alice", "test_pass")
         jane = self._create_user("jane", "test_pass")
-
         # Create Project owned by Bob and publish form
         project = Project.objects.create(
             name="Test_project",
@@ -163,7 +159,6 @@ class TestMoveProjectToAnewOwner(TestBase):  # pylint: disable=C0111
         )
         self.project = project
         self._publish_transportation_form()
-
         # Create organization owned by Alice
         alice_org = self._create_organization("alice_inc", "Alice Inc", alice)
         owners_team, _ = Team.objects.get_or_create(
@@ -177,22 +172,17 @@ class TestMoveProjectToAnewOwner(TestBase):  # pylint: disable=C0111
         # Add Bob as admin to Alice's organization
         bob.groups.add(owners_team)
         bob.groups.add(members_team)
-
         # Add Jane as member to Alice's organization
         jane.groups.add(members_team)
-
         # Transfer Bob's project to Alice's organization
         call_command(
             "transferproject",
             current_owner=bob.username,
             new_owner=alice_org.user.username,
             project_id=project.id,
-            stdout=mock_stdout,
         )
-        expected_output = "Projects transferred successfully"
         self.xform.refresh_from_db()
         self.project.refresh_from_db()
-        self.assertIn(expected_output, mock_stdout.getvalue())
         self.assertEqual(self.project.organization, alice_org.user)
         self.assertEqual(self.project.organization, alice_org.user)
         self.assertEqual(self.xform.user, alice_org.user)

--- a/onadata/apps/main/tests/test_base.py
+++ b/onadata/apps/main/tests/test_base.py
@@ -2,6 +2,7 @@
 """
 TestBase - a TestCase base class.
 """
+
 from __future__ import unicode_literals
 
 import base64
@@ -13,8 +14,6 @@ import warnings
 from io import StringIO
 from tempfile import NamedTemporaryFile
 
-from pyxform.builder import create_survey_element_from_dict
-
 from django.conf import settings
 from django.contrib.auth import authenticate, get_user_model
 from django.core.files.uploadedfile import InMemoryUploadedFile
@@ -24,10 +23,12 @@ from django.utils import timezone
 
 from django_digest.test import Client as DigestClient
 from django_digest.test import DigestAuth
+from pyxform.builder import create_survey_element_from_dict
 from rest_framework.test import APIRequestFactory
 from six.moves.urllib.error import URLError
 from six.moves.urllib.request import urlopen
 
+from onadata.apps.api.models import OrganizationProfile
 from onadata.apps.api.viewsets.xform_viewset import XFormViewSet
 from onadata.apps.logger.models import Instance, MergedXForm, XForm, XFormVersion
 from onadata.apps.logger.views import submission
@@ -85,6 +86,13 @@ class TestBase(PyxformMarkdown, TransactionTestCase):
             profile.save()
 
         return user
+
+    def _create_organization(self, username, name, created_by):
+        user = self._create_user(username, "", False)
+        organization, _ = OrganizationProfile.objects.get_or_create(
+            user=user, defaults={"name": name, "creator": created_by}
+        )
+        return organization
 
     # pylint: disable=no-self-use
     def _login(self, username, password):


### PR DESCRIPTION
### Changes / Features implemented

Fix forms permissions not updated when project is transferred. Collaborators who are not part of the recipient organization can still access the project and form.

### Steps taken to verify this change does what is intended

- [ ] QA

### Side effects of implementing this change

**Before submitting this PR for review, please make sure you have:**

  - [X] Included tests
  - [ ] Updated documentation

Closes #
