### PR TITLE
Fix  Package 'openjdk-11-jre-headless' has no installation candidate

### DIFF
--- a/docker/onadata-uwsgi/Dockerfile.ubuntu
+++ b/docker/onadata-uwsgi/Dockerfile.ubuntu
@@ -64,29 +64,30 @@ FROM debian:bookworm-20250113 AS runtime
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Install prerequisite packages
-RUN echo "deb http://deb.debian.org/debian bookworm main non-free contrib" >> /etc/apt/sources.list \
+RUN echo "deb http://deb.debian.org/debian bookworm-backports main non-free contrib" > /etc/apt/sources.list.d/bookworm-backports.list \
     && apt-get update -q \
     && apt-get install -y --no-install-recommends locales netcat-traditional \
     && sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen \
-    && dpkg-reconfigure locales
+    && dpkg-reconfigure --frontend=noninteractive locales
 
-ENV LC_ALL=en_US.UTF-8
-ENV LC_CTYPE=en_US.UTF-8
-ENV LANG=en_US.UTF-8
-ENV LANGUAGE=en_US.UTF-8
+# Set locale environment variables
+ENV LC_ALL=en_US.UTF-8 \
+    LC_CTYPE=en_US.UTF-8 \
+    LANG=en_US.UTF-8 \
+    LANGUAGE=en_US.UTF-8
 
-
-# Install OnaData runtime dependencies
-RUN apt-get install -y --no-install-recommends \
+# Install OnaData runtime dependencies (including OpenJDK from backports)
+RUN apt-get update -q && apt-get install -y --no-install-recommends \
     gdal-bin \
     git-core \
-    openjdk-11-jre-headless \
+    -t bookworm-backports openjdk-11-jre-headless \
     libxml2-dev \
     libxslt1-dev \
-    && apt-get autoremove -y \
     && apt-get clean -y \
-    && rm -rf /var/lib/apt/lists/* \
-    && useradd -G tty -m appuser \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create app user and set permissions
+RUN useradd -G tty -m appuser \
     && mkdir -p /srv/onadata \
     && chown -R appuser:appuser /srv/onadata
 

--- a/docker/onadata-uwsgi/Dockerfile.ubuntu
+++ b/docker/onadata-uwsgi/Dockerfile.ubuntu
@@ -58,13 +58,13 @@ USER appuser
 RUN python -m pip install --no-cache-dir -r requirements/docs.pip && \
     make -C docs html
 
+
 FROM debian:bookworm-20250113 AS runtime
 
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Install prerequisite packages
-RUN echo "deb http://deb.debian.org/debian bookworm main non-free contrib" > /etc/apt/sources.list \
-    && echo "deb http://deb.debian.org/debian bookworm-backports main" >> /etc/apt/sources.list \
+RUN echo "deb http://deb.debian.org/debian bookworm main non-free contrib" >> /etc/apt/sources.list \
     && apt-get update -q \
     && apt-get install -y --no-install-recommends locales netcat-traditional \
     && sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen \
@@ -80,7 +80,7 @@ ENV LANGUAGE=en_US.UTF-8
 RUN apt-get install -y --no-install-recommends \
     gdal-bin \
     git-core \
-    openjdk-11-jre-headless \
+    openjdk-17-jre-headless \
     libxml2-dev \
     libxslt1-dev \
     && apt-get autoremove -y \

--- a/docker/onadata-uwsgi/Dockerfile.ubuntu
+++ b/docker/onadata-uwsgi/Dockerfile.ubuntu
@@ -28,8 +28,7 @@ RUN chown -R appuser:appuser /home/appuser/.pyenv
 USER appuser
 
 # hadolint ignore=DL3013
-RUN python -m pip install --upgrade pip && \
-    python -m pip install --no-cache-dir -U pip && \
+RUN python -m pip install --no-cache-dir -U pip && \
     python -m pip install --no-cache-dir -r requirements/base.pip && \
     python -m pip install --no-cache-dir -r requirements/s3.pip && \
     python -m pip install --no-cache-dir -r requirements/ses.pip && \

--- a/docker/onadata-uwsgi/Dockerfile.ubuntu
+++ b/docker/onadata-uwsgi/Dockerfile.ubuntu
@@ -68,7 +68,7 @@ RUN echo "deb http://deb.debian.org/debian bookworm-backports main non-free cont
     && apt-get update -q \
     && apt-get install -y --no-install-recommends locales netcat-traditional \
     && sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen \
-    && dpkg-reconfigure --frontend=noninteractive locales
+    && dpkg-reconfigure locales
 
 # Set locale environment variables
 ENV LC_ALL=en_US.UTF-8 \

--- a/docker/onadata-uwsgi/Dockerfile.ubuntu
+++ b/docker/onadata-uwsgi/Dockerfile.ubuntu
@@ -58,36 +58,35 @@ USER appuser
 RUN python -m pip install --no-cache-dir -r requirements/docs.pip && \
     make -C docs html
 
-
 FROM debian:bookworm-20250113 AS runtime
 
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Install prerequisite packages
-RUN echo "deb http://deb.debian.org/debian bookworm-backports main non-free contrib" > /etc/apt/sources.list.d/bookworm-backports.list \
+RUN echo "deb http://deb.debian.org/debian bookworm main non-free contrib" > /etc/apt/sources.list \
+    && echo "deb http://deb.debian.org/debian bookworm-backports main" >> /etc/apt/sources.list \
     && apt-get update -q \
     && apt-get install -y --no-install-recommends locales netcat-traditional \
     && sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen \
     && dpkg-reconfigure locales
 
-# Set locale environment variables
-ENV LC_ALL=en_US.UTF-8 \
-    LC_CTYPE=en_US.UTF-8 \
-    LANG=en_US.UTF-8 \
-    LANGUAGE=en_US.UTF-8
+ENV LC_ALL=en_US.UTF-8
+ENV LC_CTYPE=en_US.UTF-8
+ENV LANG=en_US.UTF-8
+ENV LANGUAGE=en_US.UTF-8
+
 
 # Install OnaData runtime dependencies
-RUN apt-get update -q && apt-get install -y --no-install-recommends \
+RUN apt-get install -y --no-install-recommends \
     gdal-bin \
     git-core \
-    -t bookworm-backports openjdk-11-jre-headless \
+    openjdk-11-jre-headless \
     libxml2-dev \
     libxslt1-dev \
+    && apt-get autoremove -y \
     && apt-get clean -y \
-    && rm -rf /var/lib/apt/lists/*
-
-# Create app user and set permissions
-RUN useradd -G tty -m appuser \
+    && rm -rf /var/lib/apt/lists/* \
+    && useradd -G tty -m appuser \
     && mkdir -p /srv/onadata \
     && chown -R appuser:appuser /srv/onadata
 

--- a/docker/onadata-uwsgi/Dockerfile.ubuntu
+++ b/docker/onadata-uwsgi/Dockerfile.ubuntu
@@ -76,7 +76,7 @@ ENV LC_ALL=en_US.UTF-8 \
     LANG=en_US.UTF-8 \
     LANGUAGE=en_US.UTF-8
 
-# Install OnaData runtime dependencies (including OpenJDK from backports)
+# Install OnaData runtime dependencies
 RUN apt-get update -q && apt-get install -y --no-install-recommends \
     gdal-bin \
     git-core \


### PR DESCRIPTION
### Changes / Features implemented

Fix Package 'openjdk-11-jre-headless' has no installation candidate when building Docker image

The issue is that openjdk-11-jre-headless is no longer available in Debian Bookworm's main repositories. This change uses openjdk-17-jre-headless

