### PR TITLE
Add support for overriding custom encryption

### DIFF
--- a/onadata/apps/viewer/models/data_dictionary.py
+++ b/onadata/apps/viewer/models/data_dictionary.py
@@ -464,7 +464,7 @@ def auto_encrypt_xform(sender, instance, created, **kwargs):
         and is_organization(instance.user.profile)
     ):
         if instance.encrypted and not getattr(
-            settings, "KMS_OVERRIDE_MANUAL_ENCRYPTION", False
+            settings, "KMS_OVERRIDE_CUSTOM_ENCRYPTION", False
         ):
             return
 

--- a/onadata/apps/viewer/tests/test_data_dictionary.py
+++ b/onadata/apps/viewer/tests/test_data_dictionary.py
@@ -469,8 +469,11 @@ class DataDictionaryTestCase(TestBase):
 
             self.assertFalse(xform.encrypted)
 
-        # XForm is not encrypted if already encrypted
-        with override_settings(KMS_AUTO_ENCRYPT_XFORM=True):
+        # XForm is not encrypted if already encrypted and
+        # KMS_OVERRIDE_MANUAL_ENCRYPTION is False
+        with override_settings(
+            KMS_AUTO_ENCRYPT_XFORM=True, KMS_OVERRIDE_MANUAL_ENCRYPTION=False
+        ):
             manual_md = """
             | survey  |
             |         | type        | name           | label      |
@@ -486,6 +489,17 @@ class DataDictionaryTestCase(TestBase):
             self.assertTrue(xform.encrypted)
             self.assertFalse(xform.is_managed)
 
+        # XForm is encrypted if already encrypted and
+        # KMS_OVERRIDE_MANUAL_ENCRYPTION is True
+        with override_settings(
+            KMS_AUTO_ENCRYPT_XFORM=True, KMS_OVERRIDE_MANUAL_ENCRYPTION=True
+        ):
+            xform = self._publish_markdown(manual_md, org.user, id_string="f")
+            xform.refresh_from_db()
+
+            self.assertTrue(xform.encrypted)
+            self.assertTrue(xform.is_managed)
+
         # Initial XForm version is updated when XForm is encrypted
         md = """
         | survey  |
@@ -497,7 +511,7 @@ class DataDictionaryTestCase(TestBase):
         |         | Students    | students       | 202504221539|
         """
         with override_settings(KMS_AUTO_ENCRYPT_XFORM=True):
-            xform = self._publish_markdown(md, org.user, id_string="f")
+            xform = self._publish_markdown(md, org.user, id_string="g")
             xform.refresh_from_db()
 
             self.assertTrue(xform.encrypted)
@@ -508,7 +522,7 @@ class DataDictionaryTestCase(TestBase):
         kms_key.delete()
 
         with override_settings(KMS_AUTO_ENCRYPT_XFORM=True):
-            xform = self._publish_markdown(md, org.user, id_string="g")
+            xform = self._publish_markdown(md, org.user, id_string="h")
             xform.refresh_from_db()
 
             self.assertFalse(xform.encrypted)

--- a/onadata/apps/viewer/tests/test_data_dictionary.py
+++ b/onadata/apps/viewer/tests/test_data_dictionary.py
@@ -470,11 +470,11 @@ class DataDictionaryTestCase(TestBase):
             self.assertFalse(xform.encrypted)
 
         # XForm is not encrypted if already encrypted and
-        # KMS_OVERRIDE_MANUAL_ENCRYPTION is False
+        # KMS_OVERRIDE_CUSTOM_ENCRYPTION is False
         with override_settings(
-            KMS_AUTO_ENCRYPT_XFORM=True, KMS_OVERRIDE_MANUAL_ENCRYPTION=False
+            KMS_AUTO_ENCRYPT_XFORM=True, KMS_OVERRIDE_CUSTOM_ENCRYPTION=False
         ):
-            manual_md = """
+            custom_md = """
             | survey  |
             |         | type        | name           | label      |
             |         | text        | name           | First Name |
@@ -483,18 +483,18 @@ class DataDictionaryTestCase(TestBase):
             |         | form_title  | form_id        | public_key |
             |         | Students    | students       | fake-pub   |
             """
-            xform = self._publish_markdown(manual_md, org.user, id_string="e")
+            xform = self._publish_markdown(custom_md, org.user, id_string="e")
             xform.refresh_from_db()
 
             self.assertTrue(xform.encrypted)
             self.assertFalse(xform.is_managed)
 
         # XForm is encrypted if already encrypted and
-        # KMS_OVERRIDE_MANUAL_ENCRYPTION is True
+        # KMS_OVERRIDE_CUSTOM_ENCRYPTION is True
         with override_settings(
-            KMS_AUTO_ENCRYPT_XFORM=True, KMS_OVERRIDE_MANUAL_ENCRYPTION=True
+            KMS_AUTO_ENCRYPT_XFORM=True, KMS_OVERRIDE_CUSTOM_ENCRYPTION=True
         ):
-            xform = self._publish_markdown(manual_md, org.user, id_string="f")
+            xform = self._publish_markdown(custom_md, org.user, id_string="f")
             xform.refresh_from_db()
 
             self.assertTrue(xform.encrypted)

--- a/onadata/libs/kms/tools.py
+++ b/onadata/libs/kms/tools.py
@@ -301,13 +301,14 @@ def rotate_key(kms_key: KMSKey, rotated_by=None, rotation_reason=None) -> KMSKey
 
 
 @transaction.atomic()
-def encrypt_xform(xform, encrypted_by=None) -> None:
+def encrypt_xform(xform, encrypted_by=None, override_encryption=False) -> None:
     """Encrypt unencrypted XForm
 
     :param xform: Unencrypted XForm
     :param encrypted_by: User encrypting the form
+    :param override_encryption: Whether to override encryption
     """
-    if xform.encrypted:
+    if xform.encrypted and not override_encryption:
         return
 
     if xform.num_of_submissions:

--- a/onadata/libs/tests/kms/test_tools.py
+++ b/onadata/libs/tests/kms/test_tools.py
@@ -623,6 +623,15 @@ class EncryptXFormTestCase(TestBase):
 
         mock_invalidate_xform_list_cache.assert_called_once_with(self.xform)
 
+    def test_override_encryption(self):
+        """Override encryption works."""
+        self.xform.encrypted = True
+        self.xform.save()
+
+        encrypt_xform(self.xform, encrypted_by=self.user, override_encryption=True)
+
+        self.assertEqual(self.xform.versions.count(), 1)
+
 
 @mock_aws
 @override_settings(


### PR DESCRIPTION
### Changes / Features implemented

Add support for overriding custom encryption when a form is published and encrypt the form using managed keys.
