### PR TITLE
Fix inconsistent XForm num_of_submissions

### DIFF
--- a/onadata/apps/api/tasks.py
+++ b/onadata/apps/api/tasks.py
@@ -36,6 +36,7 @@ logger = logging.getLogger(__name__)
 User = get_user_model()
 
 
+# pylint: disable=too-few-public-methods
 class AutoRetryTask(app.Task):
     """Base task class for retrying exceptions"""
 

--- a/onadata/apps/api/tasks.py
+++ b/onadata/apps/api/tasks.py
@@ -12,7 +12,7 @@ from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.files.storage import default_storage
 from django.core.files.uploadedfile import TemporaryUploadedFile
-from django.db import DatabaseError
+from django.db import DatabaseError, OperationalError
 from django.utils import timezone
 from django.utils.datastructures import MultiValueDict
 
@@ -36,6 +36,13 @@ logger = logging.getLogger(__name__)
 User = get_user_model()
 
 
+class AutoRetryTask(app.Task):
+    """Base task class for retrying exceptions"""
+
+    retry_backoff = 3
+    autoretry_for = (DatabaseError, ConnectionError, OperationalError)
+
+
 def recreate_tmp_file(name, path, mime_type):
     """Creates a TemporaryUploadedFile from a file path with given name"""
     tmp_file = TemporaryUploadedFile(name, mime_type, 0, None)
@@ -45,7 +52,7 @@ def recreate_tmp_file(name, path, mime_type):
     return tmp_file
 
 
-@app.task(bind=True)
+@app.task(bind=True, base=AutoRetryTask)
 def publish_xlsform_async(self, user_id, post_data, owner_id, file_data):
     """Publishes an XLSForm"""
     try:
@@ -79,7 +86,7 @@ def publish_xlsform_async(self, user_id, post_data, owner_id, file_data):
         return {"error": error_message}
 
 
-@app.task()
+@app.task(base=AutoRetryTask)
 def delete_xform_async(xform_id, user_id):
     """Soft delete an XForm asynchrounous task"""
     xform = XForm.objects.get(pk=xform_id)
@@ -87,7 +94,7 @@ def delete_xform_async(xform_id, user_id):
     xform.soft_delete(user)
 
 
-@app.task()
+@app.task(base=AutoRetryTask)
 def delete_user_async():
     """Delete inactive user accounts"""
     users = User.objects.filter(
@@ -111,7 +118,7 @@ def get_async_status(job_uuid):
     return result
 
 
-@app.task()
+@app.task(base=AutoRetryTask)
 def send_verification_email(email, message_txt, subject):
     """
     Sends a verification email
@@ -119,13 +126,13 @@ def send_verification_email(email, message_txt, subject):
     send_generic_email(email, message_txt, subject)
 
 
-@app.task()
+@app.task(base=AutoRetryTask)
 def send_account_lockout_email(email, message_txt, subject):
     """Sends account locked email."""
     send_generic_email(email, message_txt, subject)
 
 
-@app.task()
+@app.task(base=AutoRetryTask)
 def delete_inactive_submissions():
     """
     Task to periodically delete soft deleted submissions from db
@@ -143,7 +150,7 @@ def delete_inactive_submissions():
 
 
 # pylint: disable=invalid-name
-@app.task()
+@app.task(base=AutoRetryTask)
 def send_project_invitation_email_async(invitation_id: str, url: str):
     """Sends project invitation email asynchronously"""
     try:
@@ -157,7 +164,7 @@ def send_project_invitation_email_async(invitation_id: str, url: str):
         email.send()
 
 
-@app.task(track_started=True)
+@app.task(track_started=True, base=AutoRetryTask)
 def regenerate_form_instance_json(xform_id: int):
     """Regenerate a form's instances json
 
@@ -189,7 +196,7 @@ def regenerate_form_instance_json(xform_id: int):
             safe_delete(cache_key)
 
 
-@app.task(retry_backoff=3, autoretry_for=(DatabaseError, ConnectionError))
+@app.task(base=AutoRetryTask)
 def share_project_async(project_id, username, role, remove=False):
     """Share project asynchronously"""
     try:
@@ -203,7 +210,7 @@ def share_project_async(project_id, username, role, remove=False):
         share.save()
 
 
-@app.task(retry_backoff=3, autoretry_for=(DatabaseError, ConnectionError))
+@app.task(base=AutoRetryTask)
 def delete_xform_submissions_async(
     xform_id: int,
     deleted_by_id: int,

--- a/onadata/apps/logger/models/instance.py
+++ b/onadata/apps/logger/models/instance.py
@@ -215,6 +215,7 @@ def _update_submission_count_for_today(
 @app.task(
     retry_backoff=3, autoretry_for=(DatabaseError, ConnectionError, OperationalError)
 )
+@use_master
 def update_xform_submission_count_async(self, instance_id, created):
     """
     Celery task to asynchrounously update an XForms Submission count

--- a/onadata/apps/logger/models/instance.py
+++ b/onadata/apps/logger/models/instance.py
@@ -224,7 +224,6 @@ def update_xform_submission_count_async(self, instance_id, created):
     update_xform_submission_count(instance_id, created)
 
 
-@use_master
 def update_xform_submission_count(instance_id, created):
     """Updates the XForm submissions count on a new submission being created."""
     if not created:

--- a/onadata/apps/logger/models/instance.py
+++ b/onadata/apps/logger/models/instance.py
@@ -327,6 +327,7 @@ def _update_xform_submission_count_delete(instance):
         instance.xform.save()
 
 
+# pylint: disable=unused-argument
 def decr_xform_num_of_submissions_on_hard_delete(sender, instance, **kwargs):
     """Decrement XForm `num_of_submissions` counter on Instance hard delete"""
     _update_xform_submission_count_delete(instance)

--- a/onadata/apps/logger/models/instance.py
+++ b/onadata/apps/logger/models/instance.py
@@ -335,8 +335,10 @@ def _is_instance_soft_deleted(sender, instance):
 
 def decr_xform_num_of_submissions_on_soft_delete(sender, instance, **kwargs):
     """Decrement XForm `num_of_submissions` counter on Instance soft delete"""
-    if _is_instance_soft_deleted(sender, instance):
-        _update_xform_submission_count_delete(instance)
+    if not _is_instance_soft_deleted(sender, instance):
+        return
+
+    _update_xform_submission_count_delete(instance)
 
 
 def _update_geopoints(instance):
@@ -903,10 +905,12 @@ def permanently_delete_attachments(sender, instance=None, created=False, **kwarg
 @use_master
 def soft_delete_attachments_on_soft_delete(sender, instance, **kwargs):
     """Soft delete attachments on Instance soft delete"""
-    if _is_instance_soft_deleted(sender, instance):
-        instance.attachments.filter(deleted_at__isnull=True).update(
-            deleted_at=instance.deleted_at, deleted_by=instance.deleted_by
-        )
+    if not _is_instance_soft_deleted(sender, instance):
+        return
+
+    instance.attachments.filter(deleted_at__isnull=True).update(
+        deleted_at=instance.deleted_at, deleted_by=instance.deleted_by
+    )
 
 
 @use_master

--- a/onadata/apps/logger/tasks.py
+++ b/onadata/apps/logger/tasks.py
@@ -1,6 +1,4 @@
-"""
-Asynchronous tasks for the logger app
-"""
+"""Asynchronous tasks for the logger app"""
 
 import logging
 

--- a/onadata/apps/logger/tasks.py
+++ b/onadata/apps/logger/tasks.py
@@ -6,7 +6,7 @@ import logging
 
 from django.contrib.auth import get_user_model
 from django.core.cache import cache
-from django.db import DatabaseError
+from django.db import DatabaseError, OperationalError
 
 from multidb.pinning import use_master
 
@@ -29,24 +29,29 @@ logger = logging.getLogger(__name__)
 User = get_user_model()
 
 
-@app.task(retry_backoff=3, autoretry_for=(DatabaseError, ConnectionError))
+@app.task(
+    retry_backoff=3, autoretry_for=(DatabaseError, ConnectionError, OperationalError)
+)
+@use_master
 def set_entity_list_perms_async(entity_list_id):
     """Set permissions for EntityList asynchronously
 
     :param entity_list_id: Primary key for EntityList
     """
-    with use_master:
-        try:
-            entity_list = EntityList.objects.get(pk=entity_list_id)
+    try:
+        entity_list = EntityList.objects.get(pk=entity_list_id)
 
-        except EntityList.DoesNotExist as err:
-            logger.exception(err)
-            return
+    except EntityList.DoesNotExist as err:
+        logger.exception(err)
+        return
 
-        set_project_perms_to_object(entity_list, entity_list.project)
+    set_project_perms_to_object(entity_list, entity_list.project)
 
 
-@app.task(retry_backoff=3, autoretry_for=(DatabaseError, ConnectionError))
+@app.task(
+    retry_backoff=3, autoretry_for=(DatabaseError, ConnectionError, OperationalError)
+)
+@use_master
 def apply_project_date_modified_async():
     """
     Batch update projects date_modified field periodically
@@ -63,29 +68,34 @@ def apply_project_date_modified_async():
     safe_delete(PROJECT_DATE_MODIFIED_CACHE)
 
 
-@app.task(retry_backoff=3, autoretry_for=(DatabaseError, ConnectionError))
+@app.task(
+    retry_backoff=3, autoretry_for=(DatabaseError, ConnectionError, OperationalError)
+)
+@use_master
 def delete_entities_bulk_async(entity_pks: list[int], username: str | None = None):
     """Delete Entities asynchronously
 
     :param entity_pks: Primary keys of Entities to be deleted
     :param username: Username of the user initiating the delete operation
     """
-    with use_master:
-        entity_qs = Entity.objects.filter(pk__in=entity_pks, deleted_at__isnull=True)
-        deleted_by = None
+    entity_qs = Entity.objects.filter(pk__in=entity_pks, deleted_at__isnull=True)
+    deleted_by = None
 
-        try:
-            if username is not None:
-                deleted_by = User.objects.get(username=username)
+    try:
+        if username is not None:
+            deleted_by = User.objects.get(username=username)
 
-        except User.DoesNotExist as exc:
-            logger.exception(exc)
+    except User.DoesNotExist as exc:
+        logger.exception(exc)
 
-        else:
-            soft_delete_entities_bulk(entity_qs, deleted_by)
+    else:
+        soft_delete_entities_bulk(entity_qs, deleted_by)
 
 
-@app.task(retry_backoff=3, autoretry_for=(DatabaseError, ConnectionError))
+@app.task(
+    retry_backoff=3, autoretry_for=(DatabaseError, ConnectionError, OperationalError)
+)
+@use_master
 def commit_cached_elist_num_entities_async():
     """Commit cached EntityList `num_entities` counter to the database
 
@@ -99,7 +109,10 @@ def commit_cached_elist_num_entities_async():
     commit_cached_elist_num_entities()
 
 
-@app.task(retry_backoff=3, autoretry_for=(DatabaseError, ConnectionError))
+@app.task(
+    retry_backoff=3, autoretry_for=(DatabaseError, ConnectionError, OperationalError)
+)
+@use_master
 def inc_elist_num_entities_async(elist_pk: int):
     """Increment EntityList `num_entities` counter asynchronously
 
@@ -108,7 +121,10 @@ def inc_elist_num_entities_async(elist_pk: int):
     inc_elist_num_entities(elist_pk)
 
 
-@app.task(retry_backoff=3, autoretry_for=(DatabaseError, ConnectionError))
+@app.task(
+    retry_backoff=3, autoretry_for=(DatabaseError, ConnectionError, OperationalError)
+)
+@use_master
 def dec_elist_num_entities_async(elist_pk: int) -> None:
     """Decrement EntityList `num_entities` counter asynchronously
 
@@ -117,7 +133,10 @@ def dec_elist_num_entities_async(elist_pk: int) -> None:
     dec_elist_num_entities(elist_pk)
 
 
-@app.task(retry_backoff=3, autoretry_for=(DatabaseError, ConnectionError))
+@app.task(
+    retry_backoff=3, autoretry_for=(DatabaseError, ConnectionError, OperationalError)
+)
+@use_master
 def register_instance_repeat_columns_async(instance_pk: int) -> None:
     """Register Instance repeat columns asynchronously
 
@@ -133,7 +152,10 @@ def register_instance_repeat_columns_async(instance_pk: int) -> None:
         register_instance_repeat_columns(instance)
 
 
-@app.task(retry_backoff=3, autoretry_for=(DatabaseError, ConnectionError))
+@app.task(
+    retry_backoff=3, autoretry_for=(DatabaseError, ConnectionError, OperationalError)
+)
+@use_master
 def reconstruct_xform_export_register_async(xform_id: int) -> None:
     """Register a XForm's Instances export columns asynchronously
 

--- a/onadata/apps/logger/tasks.py
+++ b/onadata/apps/logger/tasks.py
@@ -30,7 +30,7 @@ User = get_user_model()
 
 
 class AutoRetryTask(app.Task):
-    """Base task class for retrying on database errors"""
+    """Base task class for retrying exceptions"""
 
     retry_backoff = 3
     autoretry_for = (DatabaseError, ConnectionError, OperationalError)

--- a/onadata/apps/logger/tasks.py
+++ b/onadata/apps/logger/tasks.py
@@ -29,6 +29,7 @@ logger = logging.getLogger(__name__)
 User = get_user_model()
 
 
+# pylint: disable=too-few-public-methods
 class AutoRetryTask(app.Task):
     """Base task class for retrying exceptions"""
 

--- a/onadata/apps/logger/tasks.py
+++ b/onadata/apps/logger/tasks.py
@@ -29,9 +29,14 @@ logger = logging.getLogger(__name__)
 User = get_user_model()
 
 
-@app.task(
-    retry_backoff=3, autoretry_for=(DatabaseError, ConnectionError, OperationalError)
-)
+class AutoRetryTask(app.Task):
+    """Base task class for retrying on database errors"""
+
+    retry_backoff = 3
+    autoretry_for = (DatabaseError, ConnectionError, OperationalError)
+
+
+@app.task(base=AutoRetryTask)
 @use_master
 def set_entity_list_perms_async(entity_list_id):
     """Set permissions for EntityList asynchronously
@@ -48,9 +53,7 @@ def set_entity_list_perms_async(entity_list_id):
     set_project_perms_to_object(entity_list, entity_list.project)
 
 
-@app.task(
-    retry_backoff=3, autoretry_for=(DatabaseError, ConnectionError, OperationalError)
-)
+@app.task(base=AutoRetryTask)
 @use_master
 def apply_project_date_modified_async():
     """
@@ -68,9 +71,7 @@ def apply_project_date_modified_async():
     safe_delete(PROJECT_DATE_MODIFIED_CACHE)
 
 
-@app.task(
-    retry_backoff=3, autoretry_for=(DatabaseError, ConnectionError, OperationalError)
-)
+@app.task(base=AutoRetryTask)
 @use_master
 def delete_entities_bulk_async(entity_pks: list[int], username: str | None = None):
     """Delete Entities asynchronously
@@ -92,9 +93,7 @@ def delete_entities_bulk_async(entity_pks: list[int], username: str | None = Non
         soft_delete_entities_bulk(entity_qs, deleted_by)
 
 
-@app.task(
-    retry_backoff=3, autoretry_for=(DatabaseError, ConnectionError, OperationalError)
-)
+@app.task(base=AutoRetryTask)
 @use_master
 def commit_cached_elist_num_entities_async():
     """Commit cached EntityList `num_entities` counter to the database
@@ -109,9 +108,7 @@ def commit_cached_elist_num_entities_async():
     commit_cached_elist_num_entities()
 
 
-@app.task(
-    retry_backoff=3, autoretry_for=(DatabaseError, ConnectionError, OperationalError)
-)
+@app.task(base=AutoRetryTask)
 @use_master
 def inc_elist_num_entities_async(elist_pk: int):
     """Increment EntityList `num_entities` counter asynchronously
@@ -121,9 +118,7 @@ def inc_elist_num_entities_async(elist_pk: int):
     inc_elist_num_entities(elist_pk)
 
 
-@app.task(
-    retry_backoff=3, autoretry_for=(DatabaseError, ConnectionError, OperationalError)
-)
+@app.task(base=AutoRetryTask)
 @use_master
 def dec_elist_num_entities_async(elist_pk: int) -> None:
     """Decrement EntityList `num_entities` counter asynchronously
@@ -133,9 +128,7 @@ def dec_elist_num_entities_async(elist_pk: int) -> None:
     dec_elist_num_entities(elist_pk)
 
 
-@app.task(
-    retry_backoff=3, autoretry_for=(DatabaseError, ConnectionError, OperationalError)
-)
+@app.task(base=AutoRetryTask)
 @use_master
 def register_instance_repeat_columns_async(instance_pk: int) -> None:
     """Register Instance repeat columns asynchronously
@@ -152,9 +145,7 @@ def register_instance_repeat_columns_async(instance_pk: int) -> None:
         register_instance_repeat_columns(instance)
 
 
-@app.task(
-    retry_backoff=3, autoretry_for=(DatabaseError, ConnectionError, OperationalError)
-)
+@app.task(base=AutoRetryTask)
 @use_master
 def reconstruct_xform_export_register_async(xform_id: int) -> None:
     """Register a XForm's Instances export columns asynchronously

--- a/onadata/apps/logger/tests/models/test_instance.py
+++ b/onadata/apps/logger/tests/models/test_instance.py
@@ -15,18 +15,28 @@ from django.test import override_settings
 
 from django_digest.test import DigestAuth
 
-from onadata.apps.logger.models import (Entity, EntityList, Instance,
-                                        RegistrationForm, SubmissionReview,
-                                        XForm)
-from onadata.apps.logger.models.instance import (get_id_string_from_xml_str,
-                                                 numeric_checker)
+from onadata.apps.logger.models import (
+    Entity,
+    EntityList,
+    Instance,
+    RegistrationForm,
+    SubmissionReview,
+    XForm,
+)
+from onadata.apps.logger.models.instance import (
+    get_id_string_from_xml_str,
+    numeric_checker,
+)
 from onadata.apps.main.models.meta_data import MetaData
 from onadata.apps.main.tests.test_base import TestBase
-from onadata.apps.viewer.models.parsed_instance import (ParsedInstance,
-                                                        query_data,
-                                                        query_fields_data)
-from onadata.libs.serializers.submission_review_serializer import \
-    SubmissionReviewSerializer
+from onadata.apps.viewer.models.parsed_instance import (
+    ParsedInstance,
+    query_data,
+    query_fields_data,
+)
+from onadata.libs.serializers.submission_review_serializer import (
+    SubmissionReviewSerializer,
+)
 from onadata.libs.utils.common_tags import MONGO_STRFTIME, SUBMITTED_BY
 from onadata.libs.utils.user_auth import get_user_default_project
 
@@ -384,7 +394,7 @@ class TestInstance(TestBase):
         self.assertEqual(result, "Hello World")
 
     @override_settings(ASYNC_POST_SUBMISSION_PROCESSING_ENABLED=True)
-    @patch("onadata.apps.logger.models.instance.save_full_json_async.apply_async")
+    @patch("onadata.apps.logger.tasks.save_full_json_async.apply_async")
     def test_light_tasks_synchronous(self, mock_json_async):
         """Metadata from light tasks is always processed synchronously"""
         self._publish_transportation_form_and_submit_instance()


### PR DESCRIPTION
### Changes / Features implemented

Exclude non-database operations within `transaction.atomic`. Avoid rolling back the transaction if cache operations that succeed, database operations fail
Retry asynchronous tasks on `django.db.OperationalError`

### Steps taken to verify this change does what is intended

- [ ] QA

### Side effects of implementing this change


**Before submitting this PR for review, please make sure you have:**

  - [ ] Included tests
  - [ ] Updated documentation

Closes #
