### PR TITLE
chore: Bump onadata version to 5.0.5

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,21 @@ Changelog for Onadata
 
 ``* represents releases that introduce new migrations``
 
+v5.0.5 (2025-05-19)
+-------------------
+- Refactor: Add module for entities utility functions
+  `PR #2839 <https://github.com/onaio/onadata/pull/2839>`
+  [@kelvin-muchiri]
+- Fix inconsistent XForm num_of_submissions
+  `PR #2848 <https://github.com/onaio/onadata/pull/2848>`
+  [@kelvin-muchiri]
+- Fix cache poisoning vulnerability in UserProfileViewSet
+  `PR #2852 <https://github.com/onaio/onadata/pull/2852>`
+  [@FrankApiyo]
+- chore: Update trivy image ref
+  `PR #2816 <https://github.com/onaio/onadata/pull/2816>`
+  [@FrankApiyo]
+
 v5.0.4 (2025-05-19)
 -------------------
 - PyXForm question may have choices as None 

--- a/onadata/__init__.py
+++ b/onadata/__init__.py
@@ -7,7 +7,7 @@ visualization.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "5.0.4"
+__version__ = "5.0.5"
 
 
 # This will make sure the app is always imported when

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = onadata
-version = 5.0.4
+version = 5.0.5
 description = Collect Analyze and Share Data
 long_description = file: README.rst
 long_description_content_type = text/x-rst


### PR DESCRIPTION
## What's Changed
* Add module for entities utility functions by @kelvin-muchiri in https://github.com/onaio/onadata/pull/2839
* Fix inconsistent XForm num_of_submissions by @kelvin-muchiri in https://github.com/onaio/onadata/pull/2848
* Fix cache poisoning vulnerability in UserProfileViewSet by @FrankApiyo in https://github.com/onaio/onadata/pull/2852
* chore: Update trivy image ref by @FrankApiyo in https://github.com/onaio/onadata/pull/2816
