### PR TITLE
Fix submission marked as duplicate if IntegrityError is thrown

### DIFF
--- a/onadata/apps/api/tests/viewsets/test_data_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_data_viewset.py
@@ -1598,42 +1598,37 @@ class TestDataViewSet(SerializeMixin, TestBase):
         }
         self.assertDictContainsSubset(data, sorted(response.data)[0])
 
-        patch_value = "onadata.libs.utils.logger_tools.get_filtered_instances"
-        with patch(patch_value) as get_filtered_instances:
-            get_filtered_instances.return_value = Instance.objects.filter(
-                uuid="#doesnotexist"
-            )
-            media_file = "1442323232322.jpg"
-            self._make_submission_w_attachment(
-                submission_file.name,
-                os.path.join(
-                    self.this_directory,
-                    "fixtures",
-                    "transportation",
-                    "instances",
-                    self.surveys[0],
-                    media_file,
-                ),
-            )
-            attachment = Attachment.objects.get(name=media_file)
+        media_file = "1442323232322.jpg"
+        self._make_submission_w_attachment(
+            submission_file.name,
+            os.path.join(
+                self.this_directory,
+                "fixtures",
+                "transportation",
+                "instances",
+                self.surveys[0],
+                media_file,
+            ),
+        )
+        attachment = Attachment.objects.get(name=media_file)
 
-            data["_attachments"] = data.get("_attachments") + [
-                {
-                    "download_url": get_attachment_url(attachment),
-                    "small_download_url": get_attachment_url(attachment, "small"),
-                    "medium_download_url": get_attachment_url(attachment, "medium"),
-                    "mimetype": attachment.mimetype,
-                    "instance": attachment.instance.pk,
-                    "filename": attachment.media_file.name,
-                    "name": attachment.name,
-                    "id": attachment.pk,
-                    "xform": xform.id,
-                }
-            ]
-            self.maxDiff = None
-            response = view(request, pk=formid)
-            self.assertDictContainsSubset(sorted([data])[0], sorted(response.data)[0])
-            self.assertEqual(response.status_code, 200)
+        data["_attachments"] = data.get("_attachments") + [
+            {
+                "download_url": get_attachment_url(attachment),
+                "small_download_url": get_attachment_url(attachment, "small"),
+                "medium_download_url": get_attachment_url(attachment, "medium"),
+                "mimetype": attachment.mimetype,
+                "instance": attachment.instance.pk,
+                "filename": attachment.media_file.name,
+                "name": attachment.name,
+                "id": attachment.pk,
+                "xform": xform.id,
+            }
+        ]
+        self.maxDiff = None
+        response = view(request, pk=formid)
+        self.assertDictContainsSubset(sorted([data])[0], sorted(response.data)[0])
+        self.assertEqual(response.status_code, 200)
         submission_file.close()
         os.unlink(submission_file.name)
 

--- a/onadata/apps/api/tests/viewsets/test_xform_submission_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_xform_submission_viewset.py
@@ -1661,3 +1661,41 @@ class TestXFormSubmissionViewSet(TestAbstractViewSet, TransactionTestCase):
             request.META.update(auth(request.META, response))
             response = self.view(request, username=self.user.username)
             self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+    def test_duplicate_submission(self):
+        """Submission is not duplicated if it already exists."""
+        # Existing submission
+        survey = self.surveys[0]
+        submission_path = os.path.join(
+            self.main_directory,
+            "fixtures",
+            "transportation",
+            "instances",
+            survey,
+            survey + ".xml",
+        )
+        self._make_submission(submission_path)
+        # Duplicate submission
+        with open(submission_path, "rb") as sf:
+            data = {"xml_submission_file": sf}
+            request = self.factory.post(f"/{self.user.username}/submission", data)
+            response = self.view(request)
+            self.assertEqual(response.status_code, 401)
+            auth = DigestAuth("bob", "bobbob")
+            request.META.update(auth(request.META, response))
+            response = self.view(request, username=self.user.username)
+
+        self.assertContains(
+            response,
+            "Duplicate submission",
+            status_code=status.HTTP_202_ACCEPTED,
+        )
+        self.assertTrue(response.has_header("X-OpenRosa-Version"))
+        self.assertTrue(response.has_header("X-OpenRosa-Accept-Content-Length"))
+        self.assertTrue(response.has_header("Date"))
+        self.assertEqual(response["Content-Type"], "text/xml; charset=utf-8")
+        self.assertEqual(
+            response["Location"],
+            f"http://testserver/{self.user.username}/submission",
+        )
+        self.assertEqual(Instance.objects.count(), 1)

--- a/onadata/apps/api/tests/viewsets/test_xform_submission_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_xform_submission_viewset.py
@@ -1675,6 +1675,8 @@ class TestXFormSubmissionViewSet(TestAbstractViewSet, TransactionTestCase):
             survey + ".xml",
         )
         self._make_submission(submission_path)
+        self.assertEqual(Instance.objects.count(), 1)
+
         # Duplicate submission
         with open(submission_path, "rb") as sf:
             data = {"xml_submission_file": sf}
@@ -1699,3 +1701,70 @@ class TestXFormSubmissionViewSet(TestAbstractViewSet, TransactionTestCase):
             f"http://testserver/{self.user.username}/submission",
         )
         self.assertEqual(Instance.objects.count(), 1)
+
+    def test_duplicate_submission_extra_attachments(self):
+        """Extra attachments from duplicate submission are saved."""
+        # Existing submission
+        survey = self.surveys[0]
+        submission_path = os.path.join(
+            self.main_directory,
+            "fixtures",
+            "transportation",
+            "instances",
+            survey,
+            survey + ".xml",
+        )
+        media_path = os.path.join(
+            self.main_directory,
+            "fixtures",
+            "transportation",
+            "instances",
+            survey,
+            "1335783522563.jpg",
+        )
+        self._make_submission_w_attachment(submission_path, media_path)
+        self.assertEqual(Instance.objects.count(), 1)
+        self.assertEqual(Attachment.objects.count(), 1)
+
+        # Duplicate submission
+        # Extra attachment
+        media_path_2 = os.path.join(
+            self.main_directory,
+            "fixtures",
+            "transportation",
+            "instances",
+            survey,
+            "1335783522564.JPG",
+        )
+        with open(submission_path, "rb") as sf, open(media_path, "rb") as mf, open(
+            media_path_2, "rb"
+        ) as mf2:
+            data = {
+                "xml_submission_file": sf,
+                "media_file": mf,
+                "media_file_2": mf2,
+            }
+            request = self.factory.post(f"/{self.user.username}/submission", data)
+            response = self.view(request)
+            self.assertEqual(response.status_code, 401)
+            auth = DigestAuth("bob", "bobbob")
+            request.META.update(auth(request.META, response))
+            response = self.view(request, username=self.user.username)
+
+        self.assertContains(
+            response,
+            "Duplicate submission",
+            status_code=status.HTTP_202_ACCEPTED,
+        )
+        self.assertTrue(response.has_header("X-OpenRosa-Version"))
+        self.assertTrue(response.has_header("X-OpenRosa-Accept-Content-Length"))
+        self.assertTrue(response.has_header("Date"))
+        self.assertEqual(response["Content-Type"], "text/xml; charset=utf-8")
+        self.assertEqual(
+            response["Location"],
+            f"http://testserver/{self.user.username}/submission",
+        )
+        self.assertEqual(Instance.objects.count(), 1)
+        self.assertEqual(Attachment.objects.count(), 2)
+        self.assertTrue(Attachment.objects.filter(name="1335783522563.jpg").exists())
+        self.assertTrue(Attachment.objects.filter(name="1335783522564.JPG").exists())

--- a/onadata/libs/utils/logger_tools.py
+++ b/onadata/libs/utils/logger_tools.py
@@ -594,36 +594,21 @@ def create_instance(
 
         return DuplicateInstance()
 
-    try:
-        with transaction.atomic():
-            if isinstance(xml, bytes):
-                xml = xml.decode("utf-8")
-            instance = save_submission(
-                xform,
-                xml,
-                media_files,
-                new_uuid,
-                submitted_by,
-                status,
-                date_created_override,
-                checksum,
-                request,
-            )
-    except IntegrityError:
-        instance = get_first_record(
-            Instance.objects.filter(uuid=new_uuid, xform_id=xform.pk)
+    with transaction.atomic():
+        if isinstance(xml, bytes):
+            xml = xml.decode("utf-8")
+        instance = save_submission(
+            xform,
+            xml,
+            media_files,
+            new_uuid,
+            submitted_by,
+            status,
+            date_created_override,
+            checksum,
+            request,
         )
 
-        if instance:
-            attachment_names = [
-                a.media_file.name.split("/")[-1]
-                for a in Attachment.objects.filter(instance=instance)
-            ]
-            media_files = [f for f in media_files if f.name not in attachment_names]
-            save_attachments(xform, instance, media_files)
-            instance.save()
-
-        instance = DuplicateInstance()
     return instance
 
 

--- a/onadata/libs/utils/logger_tools.py
+++ b/onadata/libs/utils/logger_tools.py
@@ -444,11 +444,11 @@ def save_attachments(xform, instance, media_files, remove_deleted_media=False):
             Attachment.objects.get_or_create(
                 xform=xform,
                 instance=instance,
-                media_file=f,
                 mimetype=content_type,
                 name=filename,
                 extension=extension,
                 user=instance.user,
+                defaults={"media_file": f},
             )
     if remove_deleted_media:
         instance.soft_delete_attachments()


### PR DESCRIPTION
### Changes / Features implemented

Fix submission marked as duplicate if `django.db.IntegrityError` is thrown when saving the submission. The 

### Steps taken to verify this change does what is intended

- [ ] QA

### Side effects of implementing this change

`django.db.IntegrityError` will have a HTTP response code of `500` and not `202`

**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  - [ ] Updated documentation

Closes #
