### PR TITLE
Use safe cache operations

### DIFF
--- a/onadata/apps/api/models/organization_profile.py
+++ b/onadata/apps/api/models/organization_profile.py
@@ -19,7 +19,7 @@ from multidb.pinning import use_master
 
 from onadata.apps.api.models.team import Team
 from onadata.apps.main.models.user_profile import UserProfile
-from onadata.libs.utils.cache_tools import IS_ORG, safe_delete
+from onadata.libs.utils.cache_tools import IS_ORG, safe_cache_delete
 from onadata.libs.utils.common_tags import MEMBERS
 
 User = get_user_model()
@@ -32,7 +32,7 @@ def org_profile_post_delete_callback(sender, instance, **kwargs):
     """
     # delete the org_user too
     instance.user.delete()
-    safe_delete(f"{IS_ORG}{instance.pk}")
+    safe_cache_delete(f"{IS_ORG}{instance.pk}")
 
 
 def create_owner_team_and_assign_permissions(org):

--- a/onadata/apps/api/models/organization_profile.py
+++ b/onadata/apps/api/models/organization_profile.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-"""
-OrganizationProfile module.
-"""
+"""OrganizationProfile module."""
 
 import importlib
 

--- a/onadata/apps/api/tasks.py
+++ b/onadata/apps/api/tasks.py
@@ -24,7 +24,7 @@ from onadata.celeryapp import app
 from onadata.libs.models.share_project import ShareProject
 from onadata.libs.utils.cache_tools import (
     XFORM_REGENERATE_INSTANCE_JSON_TASK,
-    safe_delete,
+    safe_cache_delete,
 )
 from onadata.libs.utils.email import ProjectInvitationEmail, send_generic_email
 from onadata.libs.utils.logger_tools import delete_xform_submissions
@@ -195,7 +195,7 @@ def regenerate_form_instance_json(xform_id: int):
             xform.save()
             # Clear cache used to store the task id from the AsyncResult
             cache_key = f"{XFORM_REGENERATE_INSTANCE_JSON_TASK}{xform_id}"
-            safe_delete(cache_key)
+            safe_cache_delete(cache_key)
 
 
 @app.task(base=AutoRetryTask)

--- a/onadata/apps/api/tests/models/test_organization_profile.py
+++ b/onadata/apps/api/tests/models/test_organization_profile.py
@@ -11,7 +11,7 @@ from onadata.apps.api.models.team import Team
 from onadata.apps.logger.models import KMSKey
 from onadata.apps.main.tests.test_base import TestBase
 from onadata.libs.permissions import OwnerRole
-from onadata.libs.utils.cache_tools import IS_ORG, safe_delete
+from onadata.libs.utils.cache_tools import IS_ORG, safe_cache_delete
 
 
 class TestOrganizationProfile(TestBase):
@@ -56,7 +56,7 @@ class TestOrganizationProfile(TestBase):
         cache.set(f"{IS_ORG}{profile_id}", True)
 
         profile.delete()
-        safe_delete(f"{IS_ORG}{profile_id}")
+        safe_cache_delete(f"{IS_ORG}{profile_id}")
         self.assertIsNone(cache.get(f"{IS_ORG}{profile_id}"))
         self.assertEqual(count - 1, OrganizationProfile.objects.all().count())
 

--- a/onadata/apps/api/tests/viewsets/test_project_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_project_viewset.py
@@ -58,11 +58,11 @@ from onadata.libs.permissions import (
     ReadOnlyRole,
     ReadOnlyRoleNoDownload,
 )
+from onadata.libs.serializers.metadata_serializer import MetaDataSerializer
 from onadata.libs.serializers.project_serializer import (
     BaseProjectSerializer,
     ProjectSerializer,
 )
-from onadata.libs.serializers.metadata_serializer import MetaDataSerializer
 from onadata.libs.utils.cache_tools import PROJ_OWNER_CACHE, safe_key
 from onadata.libs.utils.user_auth import get_user_default_project
 
@@ -1720,7 +1720,7 @@ class TestProjectViewSet(TestAbstractViewSet):
         self.assertEqual(project.metadata, json_metadata)
 
     # pylint: disable=invalid-name
-    def test_cache_updated_on_project_update(self):
+    def test_cache_invalidation_on_project_update(self):
         view = ProjectViewSet.as_view({"get": "retrieve", "patch": "partial_update"})
         self._project_create()
         request = self.factory.get("/", **self.extra)
@@ -1737,14 +1737,7 @@ class TestProjectViewSet(TestAbstractViewSet):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(True, response.data.get("public"))
         cached_project = cache.get(f"{PROJ_OWNER_CACHE}{self.project.pk}")
-        self.assertEqual(cached_project, response.data)
-
-        request = self.factory.get("/", **self.extra)
-        response = view(request, pk=self.project.pk)
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(True, response.data.get("public"))
-        cached_project = cache.get(f"{PROJ_OWNER_CACHE}{self.project.pk}")
-        self.assertEqual(cached_project, response.data)
+        self.assertIsNone(cached_project)
 
     def test_project_put_updates(self):
         self._project_create()

--- a/onadata/apps/api/tests/viewsets/test_project_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_project_viewset.py
@@ -1720,24 +1720,20 @@ class TestProjectViewSet(TestAbstractViewSet):
         self.assertEqual(project.metadata, json_metadata)
 
     # pylint: disable=invalid-name
-    def test_cache_invalidation_on_project_update(self):
-        view = ProjectViewSet.as_view({"get": "retrieve", "patch": "partial_update"})
+    def test_cache_invalidated_on_project_update(self):
+        """Cache is invalidated on project update"""
+        view = ProjectViewSet.as_view({"patch": "partial_update"})
         self._project_create()
-        request = self.factory.get("/", **self.extra)
-        response = view(request, pk=self.project.pk)
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(False, response.data.get("public"))
-        cached_project = cache.get(f"{PROJ_OWNER_CACHE}{self.project.pk}")
-        self.assertEqual(cached_project, response.data)
 
-        projectid = self.project.pk
+        cache_key = f"{PROJ_OWNER_CACHE}{self.project.pk}"
+        self.assertIsNotNone(cache.get(cache_key))
+
         data = {"public": True}
         request = self.factory.patch("/", data=data, **self.extra)
-        response = view(request, pk=projectid)
+        response = view(request, pk=self.project.pk)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(True, response.data.get("public"))
-        cached_project = cache.get(f"{PROJ_OWNER_CACHE}{self.project.pk}")
-        self.assertIsNone(cached_project)
+        self.assertIsNone(cache.get(cache_key))
 
     def test_project_put_updates(self):
         self._project_create()

--- a/onadata/apps/api/tests/viewsets/test_xform_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_xform_viewset.py
@@ -77,18 +77,18 @@ from onadata.libs.permissions import (
     ReadOnlyRole,
     ReadOnlyRoleNoDownload,
 )
+from onadata.libs.serializers.metadata_serializer import create_xform_meta_permissions
 from onadata.libs.serializers.xform_serializer import (
     XFormBaseSerializer,
     XFormSerializer,
 )
-from onadata.libs.serializers.metadata_serializer import create_xform_meta_permissions
 from onadata.libs.utils.api_export_tools import get_existing_file_format
 from onadata.libs.utils.cache_tools import (
     ENKETO_URL_CACHE,
     PROJ_FORMS_CACHE,
     XFORM_DATA_VERSIONS,
     XFORM_PERMISSIONS_CACHE,
-    safe_delete,
+    safe_cache_delete,
 )
 from onadata.libs.utils.common_tags import GROUPNAME_REMOVED_FLAG, MONGO_STRFTIME
 from onadata.libs.utils.common_tools import (
@@ -1188,7 +1188,7 @@ class TestXFormViewSet(XFormViewSetBaseTestCase):
 
             ReadOnlyRole.add(self.user, self.xform)
             view = XFormViewSet.as_view({"get": "retrieve"})
-            safe_delete("{}{}".format(XFORM_PERMISSIONS_CACHE, self.xform.pk))
+            safe_cache_delete("{}{}".format(XFORM_PERMISSIONS_CACHE, self.xform.pk))
             request = self.factory.get("/", **self.extra)
             response = view(request, pk=self.xform.pk)
             bobs_form_data = response.data
@@ -4552,7 +4552,7 @@ nhMo+jI88L3qfm4/rtWKuQ9/a268phlNj34uQeoDDHuRViQo00L5meE/pFptm
             self.assertEqual(2, count)
 
             # delete cache
-            safe_delete(f"{ENKETO_URL_CACHE}{self.xform.pk}")
+            safe_cache_delete(f"{ENKETO_URL_CACHE}{self.xform.pk}")
 
             view = XFormViewSet.as_view(
                 {
@@ -4953,7 +4953,7 @@ nhMo+jI88L3qfm4/rtWKuQ9/a268phlNj34uQeoDDHuRViQo00L5meE/pFptm
         instance.set_deleted()
 
         # delete cache
-        safe_delete(f"{XFORM_DATA_VERSIONS}{self.xform.pk}")
+        safe_cache_delete(f"{XFORM_DATA_VERSIONS}{self.xform.pk}")
 
         request = self.factory.get("/", **self.extra)
         response = view(request, pk=self.xform.pk)

--- a/onadata/apps/api/viewsets/data_viewset.py
+++ b/onadata/apps/api/viewsets/data_viewset.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-"""
-The /data API endpoint.
-"""
+"""The /data API endpoint."""
 
 import json
 import math

--- a/onadata/apps/api/viewsets/dataview_viewset.py
+++ b/onadata/apps/api/viewsets/dataview_viewset.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-"""
-The /dataview API endpoint implementation.
-"""
+"""The /dataview API endpoint implementation."""
 
 from django.db.models.signals import post_delete, post_save
 from django.http import Http404, HttpResponseBadRequest

--- a/onadata/apps/api/viewsets/organization_profile_viewset.py
+++ b/onadata/apps/api/viewsets/organization_profile_viewset.py
@@ -8,7 +8,6 @@ List, Retrieve, Update, Create/Register Organizations.
 import json
 
 from django.conf import settings
-from django.core.cache import cache
 from django.utils.module_loading import import_string
 
 from rest_framework import status
@@ -38,7 +37,7 @@ from onadata.libs.serializers.organization_serializer import (
     OrganizationSerializer,
     RotateOrganizationKeySerializer,
 )
-from onadata.libs.utils.cache_tools import safe_delete
+from onadata.libs.utils.cache_tools import safe_cache_get, safe_cache_set, safe_delete
 from onadata.libs.utils.common_tools import merge_dicts
 
 BaseViewset = get_baseviewset_class()
@@ -82,13 +81,13 @@ class OrganizationProfileViewSet(
         """Get organization from cache or db"""
         organization = self.get_object()
         cache_key = get_org_profile_cache_key(request.user, organization)
-        cached_org = cache.get(cache_key)
+        cached_org = safe_cache_get(cache_key)
 
         if cached_org:
             return Response(cached_org)
 
         response = super().retrieve(request, *args, **kwargs)
-        cache.set(cache_key, response.data)
+        safe_cache_set(cache_key, response.data)
         return response
 
     def create(self, request, *args, **kwargs):
@@ -98,7 +97,7 @@ class OrganizationProfileViewSet(
         username = organization.get("org")
         organization_profile = OrganizationProfile.objects.get(user__username=username)
         cache_key = get_org_profile_cache_key(request.user, organization_profile)
-        cache.set(cache_key, organization)
+        safe_cache_set(cache_key, organization)
         return response
 
     def destroy(self, request, *args, **kwargs):
@@ -111,7 +110,7 @@ class OrganizationProfileViewSet(
         """Update org in cache and db"""
         response = super().update(request, *args, **kwargs)
         cache_key = get_org_profile_cache_key(request.user, self.get_object())
-        cache.set(cache_key, response.data)
+        safe_cache_set(cache_key, response.data)
         return response
 
     @action(methods=["DELETE", "GET", "POST", "PUT"], detail=True)

--- a/onadata/apps/api/viewsets/organization_profile_viewset.py
+++ b/onadata/apps/api/viewsets/organization_profile_viewset.py
@@ -37,7 +37,11 @@ from onadata.libs.serializers.organization_serializer import (
     OrganizationSerializer,
     RotateOrganizationKeySerializer,
 )
-from onadata.libs.utils.cache_tools import safe_cache_get, safe_cache_set, safe_delete
+from onadata.libs.utils.cache_tools import (
+    safe_cache_delete,
+    safe_cache_get,
+    safe_cache_set,
+)
 from onadata.libs.utils.common_tools import merge_dicts
 
 BaseViewset = get_baseviewset_class()
@@ -103,7 +107,7 @@ class OrganizationProfileViewSet(
     def destroy(self, request, *args, **kwargs):
         """Clear cache and destroy organization"""
         cache_key = get_org_profile_cache_key(request.user, self.get_object())
-        safe_delete(cache_key)
+        safe_cache_delete(cache_key)
         return super().destroy(request, *args, **kwargs)
 
     def update(self, request, *args, **kwargs):

--- a/onadata/apps/api/viewsets/project_viewset.py
+++ b/onadata/apps/api/viewsets/project_viewset.py
@@ -79,10 +79,9 @@ class ProjectViewSet(
 
     # pylint: disable=no-member
     queryset = (
-        Project.objects.filter(deleted_at__isnull=True, organization__is_active=True)
+        Project.objects.filter(deleted_at__isnull=True)
         .order_by("-date_created")
         .select_related()
-        .prefetch_related("xform_set")
     )
     serializer_class = ProjectSerializer
     lookup_field = "pk"
@@ -107,25 +106,42 @@ class ProjectViewSet(
 
         return super().get_serializer_class()
 
+    def get_queryset(self):
+        """Use 'prepared' prefetched queryset for GET requests."""
+        if self.request.method.upper() in ["GET", "OPTIONS"]:
+            self.queryset = Project.prefetched.filter(
+                deleted_at__isnull=True, organization__is_active=True
+            ).order_by("-date_created")
+
+        return super().get_queryset()
+
     def update(self, request, *args, **kwargs):
         """Updates project properties and set's cache with the updated records."""
         project_id = kwargs.get("pk")
         response = super().update(request, *args, **kwargs)
-        # Invalidate cached project
-        safe_delete(f"{PROJ_OWNER_CACHE}{project_id}")
+        safe_cache_set(f"{PROJ_OWNER_CACHE}{project_id}", response.data)
         return response
 
     def retrieve(self, request, *args, **kwargs):
         """Retrieve single project"""
-        project = self.get_object()
-        cache_key = f"{PROJ_OWNER_CACHE}{project.pk}"
-        cached_project = safe_cache_get(cache_key)
+        project_id = kwargs.get("pk")
+        project = safe_cache_get(f"{PROJ_OWNER_CACHE}{project_id}")
+        if project:
+            return Response(project)
+        # pylint: disable=attribute-defined-outside-init
+        self.object = self.get_object()
+        serializer = ProjectSerializer(self.object, context={"request": request})
+        return Response(serializer.data)
 
-        if cached_project:
-            return Response(cached_project)
+    def list(self, request, *args, **kwargs):
+        """Returns a list of projects"""
+        queryset = self.filter_queryset(self.get_queryset())
+        page = self.paginate_queryset(queryset)
+        if page:
+            serializer = self.get_serializer(page, many=True)
+        else:
+            serializer = self.get_serializer(queryset, many=True)
 
-        serializer = ProjectSerializer(project, context={"request": request})
-        safe_cache_set(cache_key, serializer.data)
         return Response(serializer.data)
 
     @action(methods=["POST", "GET"], detail=True)

--- a/onadata/apps/api/viewsets/project_viewset.py
+++ b/onadata/apps/api/viewsets/project_viewset.py
@@ -48,9 +48,9 @@ from onadata.libs.serializers.xform_serializer import (
 )
 from onadata.libs.utils.cache_tools import (
     PROJ_OWNER_CACHE,
+    safe_cache_delete,
     safe_cache_get,
     safe_cache_set,
-    safe_delete,
 )
 from onadata.libs.utils.common_tools import merge_dicts, report_exception
 from onadata.libs.utils.export_tools import str_to_bool
@@ -230,7 +230,7 @@ class ProjectViewSet(
             return Response(data=serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
         # clear cache
-        safe_delete(f"{PROJ_OWNER_CACHE}{self.object.pk}")
+        safe_cache_delete(f"{PROJ_OWNER_CACHE}{self.object.pk}")
 
         return Response(status=status.HTTP_204_NO_CONTENT)
 

--- a/onadata/apps/api/viewsets/project_viewset.py
+++ b/onadata/apps/api/viewsets/project_viewset.py
@@ -5,7 +5,6 @@ The /projects API endpoint implementation.
 
 import logging
 
-from django.core.cache import cache
 from django.core.mail import send_mail
 from django.shortcuts import get_object_or_404
 from django.utils.translation import gettext as _
@@ -47,7 +46,12 @@ from onadata.libs.serializers.xform_serializer import (
     XFormCreateSerializer,
     XFormSerializer,
 )
-from onadata.libs.utils.cache_tools import PROJ_OWNER_CACHE, safe_delete
+from onadata.libs.utils.cache_tools import (
+    PROJ_OWNER_CACHE,
+    safe_cache_get,
+    safe_cache_set,
+    safe_delete,
+)
 from onadata.libs.utils.common_tools import merge_dicts, report_exception
 from onadata.libs.utils.export_tools import str_to_bool
 from onadata.libs.utils.project_utils import propagate_project_permissions_async
@@ -115,13 +119,13 @@ class ProjectViewSet(
         """Updates project properties and set's cache with the updated records."""
         project_id = kwargs.get("pk")
         response = super().update(request, *args, **kwargs)
-        cache.set(f"{PROJ_OWNER_CACHE}{project_id}", response.data)
+        safe_cache_set(f"{PROJ_OWNER_CACHE}{project_id}", response.data)
         return response
 
     def retrieve(self, request, *args, **kwargs):
         """Retrieve single project"""
         project_id = kwargs.get("pk")
-        project = cache.get(f"{PROJ_OWNER_CACHE}{project_id}")
+        project = safe_cache_get(f"{PROJ_OWNER_CACHE}{project_id}")
         if project:
             return Response(project)
         # pylint: disable=attribute-defined-outside-init

--- a/onadata/apps/api/viewsets/user_profile_viewset.py
+++ b/onadata/apps/api/viewsets/user_profile_viewset.py
@@ -44,10 +44,10 @@ from onadata.libs.utils.cache_tools import (
     CHANGE_PASSWORD_ATTEMPTS,
     LOCKOUT_CHANGE_PASSWORD_USER,
     USER_PROFILE_PREFIX,
+    safe_cache_delete,
     safe_cache_get,
     safe_cache_incr,
     safe_cache_set,
-    safe_delete,
 )
 from onadata.libs.utils.email import get_verification_email_data, get_verification_url
 from onadata.libs.utils.user_auth import invalidate_and_regen_tokens
@@ -212,7 +212,7 @@ class UserProfileViewSet(
         """Update user in cache and db"""
         username = kwargs.get("user")
         request_username = request.user.username if request.user else ""
-        safe_delete(f"{USER_PROFILE_PREFIX}{username}{request_username}")
+        safe_cache_delete(f"{USER_PROFILE_PREFIX}{username}{request_username}")
         return super().update(request, *args, **kwargs)
 
     def retrieve(self, request, *args, **kwargs):
@@ -244,7 +244,7 @@ class UserProfileViewSet(
         Change user's password.
         """
         # clear cache
-        safe_delete(f"{USER_PROFILE_PREFIX}{request.user.username}")
+        safe_cache_delete(f"{USER_PROFILE_PREFIX}{request.user.username}")
         user_profile = self.get_object()
         current_password = request.data.get("current_password", None)
         new_password = request.data.get("new_password", None)
@@ -318,7 +318,7 @@ class UserProfileViewSet(
     def monthly_submissions(self, request, *args, **kwargs):
         """Get the total number of submissions for a user"""
         # clear cache
-        safe_delete(f"{USER_PROFILE_PREFIX}{request.user.username}")
+        safe_cache_delete(f"{USER_PROFILE_PREFIX}{request.user.username}")
         profile = self.get_object()
         month_param = self.request.query_params.get("month", None)
         year_param = self.request.query_params.get("year", None)
@@ -386,7 +386,7 @@ class UserProfileViewSet(
                 username = registration_profile.user.username
                 set_is_email_verified(registration_profile.user.profile, True)
                 # Clear profiles cache
-                safe_delete(f"{USER_PROFILE_PREFIX}{username}")
+                safe_cache_delete(f"{USER_PROFILE_PREFIX}{username}")
 
                 response_data = {"username": username, "is_email_verified": True}
 

--- a/onadata/apps/api/viewsets/xform_viewset.py
+++ b/onadata/apps/api/viewsets/xform_viewset.py
@@ -83,7 +83,7 @@ from onadata.libs.utils.api_export_tools import (
     process_async_export,
     response_for_format,
 )
-from onadata.libs.utils.cache_tools import PROJ_OWNER_CACHE, safe_delete
+from onadata.libs.utils.cache_tools import PROJ_OWNER_CACHE, safe_cache_delete
 from onadata.libs.utils.common_tools import json_stream
 from onadata.libs.utils.csv_import import (
     get_async_csv_submission_status,
@@ -838,7 +838,7 @@ class XFormViewSet(
             }
 
             # clear project from cache
-            safe_delete(f"{PROJ_OWNER_CACHE}{xform.project.pk}")
+            safe_cache_delete(f"{PROJ_OWNER_CACHE}{xform.project.pk}")
             resp_code = status.HTTP_202_ACCEPTED
 
         if request.method == "GET":

--- a/onadata/apps/logger/models/data_view.py
+++ b/onadata/apps/logger/models/data_view.py
@@ -25,7 +25,7 @@ from onadata.libs.utils.cache_tools import (  # noqa pylint: disable=unused-impo
     DATAVIEW_LAST_SUBMISSION_TIME,
     PROJ_OWNER_CACHE,
     XFORM_LINKED_DATAVIEWS,
-    safe_delete,
+    safe_cache_delete,
 )
 from onadata.libs.utils.common_tags import (
     ATTACHMENTS,
@@ -448,15 +448,15 @@ class DataView(models.Model):
 
 def clear_cache(sender, instance, **kwargs):  # pylint: disable=unused-argument
     """Post delete handler for clearing the dataview cache."""
-    safe_delete(f"{XFORM_LINKED_DATAVIEWS}{instance.xform.pk}")
+    safe_cache_delete(f"{XFORM_LINKED_DATAVIEWS}{instance.xform.pk}")
 
 
 def clear_dataview_cache(sender, instance, **kwargs):  # pylint: disable=unused-argument
     """Post Save handler for clearing dataview cache on serialized fields."""
-    safe_delete(f"{PROJ_OWNER_CACHE}{instance.project.pk}")
-    safe_delete(f"{DATAVIEW_COUNT}{instance.xform.pk}")
-    safe_delete(f"{DATAVIEW_LAST_SUBMISSION_TIME}{instance.xform.pk}")
-    safe_delete(f"{XFORM_LINKED_DATAVIEWS}{instance.xform.pk}")
+    safe_cache_delete(f"{PROJ_OWNER_CACHE}{instance.project.pk}")
+    safe_cache_delete(f"{DATAVIEW_COUNT}{instance.xform.pk}")
+    safe_cache_delete(f"{DATAVIEW_LAST_SUBMISSION_TIME}{instance.xform.pk}")
+    safe_cache_delete(f"{XFORM_LINKED_DATAVIEWS}{instance.xform.pk}")
 
 
 post_save.connect(clear_dataview_cache, sender=DataView, dispatch_uid="clear_cache")

--- a/onadata/apps/logger/models/instance.py
+++ b/onadata/apps/logger/models/instance.py
@@ -45,10 +45,10 @@ from onadata.libs.utils.cache_tools import (
     XFORM_SUBMISSION_COUNT_FOR_DAY,
     XFORM_SUBMISSION_COUNT_FOR_DAY_DATE,
     safe_cache_decr,
+    safe_cache_delete,
     safe_cache_get,
     safe_cache_incr,
     safe_cache_set,
-    safe_delete,
 )
 from onadata.libs.utils.common_tags import (
     ATTACHMENTS,
@@ -244,9 +244,9 @@ def update_xform_submission_count(instance):
     # Track submissions made today
     _update_submission_count_for_today(instance.xform_id)
 
-    safe_delete(f"{XFORM_DATA_VERSIONS}{instance.xform_id}")
-    safe_delete(f"{DATAVIEW_COUNT}{instance.xform_id}")
-    safe_delete(f"{XFORM_COUNT}{instance.xform_id}")
+    safe_cache_delete(f"{XFORM_DATA_VERSIONS}{instance.xform_id}")
+    safe_cache_delete(f"{DATAVIEW_COUNT}{instance.xform_id}")
+    safe_cache_delete(f"{XFORM_COUNT}{instance.xform_id}")
     # Clear project cache
     # pylint: disable=import-outside-toplevel
     from onadata.apps.logger.models.xform import clear_project_cache
@@ -282,12 +282,12 @@ def _update_xform_submission_count_delete(instance):
     )
 
     for cache_prefix in [PROJ_NUM_DATASET_CACHE, PROJ_SUB_DATE_CACHE]:
-        safe_delete(f"{cache_prefix}{xform.project.pk}")
+        safe_cache_delete(f"{cache_prefix}{xform.project.pk}")
 
-    safe_delete(f"{IS_ORG}{xform.pk}")
-    safe_delete(f"{XFORM_DATA_VERSIONS}{xform.pk}")
-    safe_delete(f"{DATAVIEW_COUNT}{xform.pk}")
-    safe_delete(f"{XFORM_COUNT}{xform.pk}")
+    safe_cache_delete(f"{IS_ORG}{xform.pk}")
+    safe_cache_delete(f"{XFORM_DATA_VERSIONS}{xform.pk}")
+    safe_cache_delete(f"{DATAVIEW_COUNT}{xform.pk}")
+    safe_cache_delete(f"{XFORM_COUNT}{xform.pk}")
 
 
 # pylint: disable=unused-argument

--- a/onadata/apps/logger/models/xform.py
+++ b/onadata/apps/logger/models/xform.py
@@ -52,8 +52,8 @@ from onadata.libs.utils.cache_tools import (
     XFORM_DEC_SUBMISSION_COUNT,
     XFORM_SUBMISSION_COUNT_FOR_DAY,
     XFORM_SUBMISSION_COUNT_FOR_DAY_DATE,
+    safe_cache_delete,
     safe_cache_get,
-    safe_delete,
 )
 from onadata.libs.utils.common_tags import (
     DATE_MODIFIED,
@@ -1312,7 +1312,7 @@ class XForm(XFormMixin, BaseModel):
 
                 # clear cache
                 key = f"{XFORM_COUNT}{self.pk}"
-                safe_delete(key)
+                safe_cache_delete(key)
 
         return self.num_of_submissions
 
@@ -1383,7 +1383,7 @@ class XForm(XFormMixin, BaseModel):
             count = 0
 
         # Delete cached delta counter
-        safe_delete(f"{XFORM_DEC_SUBMISSION_COUNT}{self.pk}")
+        safe_cache_delete(f"{XFORM_DEC_SUBMISSION_COUNT}{self.pk}")
 
         self.num_of_decrypted_submissions = count
         self.save(update_fields=["num_of_decrypted_submissions"])
@@ -1428,11 +1428,11 @@ post_delete.connect(
 
 def clear_project_cache(project_id):
     """Clear project cache"""
-    safe_delete(f"{PROJ_OWNER_CACHE}{project_id}")
-    safe_delete(f"{PROJ_FORMS_CACHE}{project_id}")
-    safe_delete(f"{PROJ_BASE_FORMS_CACHE}{project_id}")
-    safe_delete(f"{PROJ_SUB_DATE_CACHE}{project_id}")
-    safe_delete(f"{PROJ_NUM_DATASET_CACHE}{project_id}")
+    safe_cache_delete(f"{PROJ_OWNER_CACHE}{project_id}")
+    safe_cache_delete(f"{PROJ_FORMS_CACHE}{project_id}")
+    safe_cache_delete(f"{PROJ_BASE_FORMS_CACHE}{project_id}")
+    safe_cache_delete(f"{PROJ_SUB_DATE_CACHE}{project_id}")
+    safe_cache_delete(f"{PROJ_NUM_DATASET_CACHE}{project_id}")
 
 
 # pylint: disable=unused-argument

--- a/onadata/apps/logger/models/xform.py
+++ b/onadata/apps/logger/models/xform.py
@@ -16,7 +16,6 @@ from xml.dom import Node
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.fields import GenericRelation
-from django.core.cache import cache
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import models, transaction
 from django.db.models import Sum
@@ -1324,8 +1323,8 @@ class XForm(XFormMixin, BaseModel):
         """Returns the submissions count for the current day."""
         current_date = timezone.localdate().isoformat()
         count = (
-            cache.get(f"{XFORM_SUBMISSION_COUNT_FOR_DAY}{self.id}")
-            if cache.get(f"{XFORM_SUBMISSION_COUNT_FOR_DAY_DATE}{self.id}")
+            safe_cache_get(f"{XFORM_SUBMISSION_COUNT_FOR_DAY}{self.id}")
+            if safe_cache_get(f"{XFORM_SUBMISSION_COUNT_FOR_DAY_DATE}{self.id}")
             == current_date
             else 0
         )

--- a/onadata/apps/logger/tasks.py
+++ b/onadata/apps/logger/tasks.py
@@ -3,7 +3,6 @@
 import logging
 
 from django.contrib.auth import get_user_model
-from django.core.cache import cache
 from django.db import DatabaseError, OperationalError
 
 from celery.exceptions import MaxRetriesExceededError
@@ -28,7 +27,11 @@ from onadata.libs.kms.tools import (
     send_key_rotation_reminder,
 )
 from onadata.libs.permissions import set_project_perms_to_object
-from onadata.libs.utils.cache_tools import PROJECT_DATE_MODIFIED_CACHE, safe_delete
+from onadata.libs.utils.cache_tools import (
+    PROJECT_DATE_MODIFIED_CACHE,
+    safe_cache_get,
+    safe_delete,
+)
 from onadata.libs.utils.common_tags import DECRYPTION_FAILURE_MAX_RETRIES
 from onadata.libs.utils.entities_utils import (
     adjust_elist_num_entities,
@@ -72,7 +75,7 @@ def apply_project_date_modified_async():
     """
     Batch update projects date_modified field periodically
     """
-    project_ids = cache.get(PROJECT_DATE_MODIFIED_CACHE, {})
+    project_ids = safe_cache_get(PROJECT_DATE_MODIFIED_CACHE, {})
     if not project_ids:
         return
 

--- a/onadata/apps/logger/tasks.py
+++ b/onadata/apps/logger/tasks.py
@@ -29,8 +29,8 @@ from onadata.libs.kms.tools import (
 from onadata.libs.permissions import set_project_perms_to_object
 from onadata.libs.utils.cache_tools import (
     PROJECT_DATE_MODIFIED_CACHE,
+    safe_cache_delete,
     safe_cache_get,
-    safe_delete,
 )
 from onadata.libs.utils.common_tags import DECRYPTION_FAILURE_MAX_RETRIES
 from onadata.libs.utils.entities_utils import (
@@ -84,7 +84,7 @@ def apply_project_date_modified_async():
         Project.objects.filter(pk=project_id).update(date_modified=timestamp)
 
     # Clear cache after updating
-    safe_delete(PROJECT_DATE_MODIFIED_CACHE)
+    safe_cache_delete(PROJECT_DATE_MODIFIED_CACHE)
 
 
 @app.task(base=AutoRetryTask)

--- a/onadata/apps/logger/views.py
+++ b/onadata/apps/logger/views.py
@@ -2,6 +2,7 @@
 """
 logger views.
 """
+
 import os
 import tempfile
 
@@ -36,7 +37,7 @@ from onadata.apps.logger.models.instance import Instance
 from onadata.apps.logger.models.xform import XForm
 from onadata.apps.main.models import MetaData, UserProfile
 from onadata.libs.exceptions import EnketoError
-from onadata.libs.utils.cache_tools import USER_PROFILE_PREFIX, cache
+from onadata.libs.utils.cache_tools import USER_PROFILE_PREFIX, safe_cache_get
 from onadata.libs.utils.decorators import is_owner
 from onadata.libs.utils.log import Actions, audit_log
 from onadata.libs.utils.logger_tools import (
@@ -202,7 +203,7 @@ def formList(request, username):  # noqa N802
     formList view, /formList OpenRosa Form Discovery API 1.0.
     """
     formlist_user = get_object_or_404(User, username__iexact=username)
-    profile = cache.get(f"{USER_PROFILE_PREFIX}{formlist_user.username}")
+    profile = safe_cache_get(f"{USER_PROFILE_PREFIX}{formlist_user.username}")
     if not profile:
         profile, __ = UserProfile.objects.get_or_create(
             user__username=formlist_user.username
@@ -265,7 +266,7 @@ def xformsManifest(request, username, id_string):  # noqa N802
 
     xform = get_form(xform_kwargs)
     formlist_user = xform.user
-    profile = cache.get(f"{USER_PROFILE_PREFIX}{formlist_user.username}")
+    profile = safe_cache_get(f"{USER_PROFILE_PREFIX}{formlist_user.username}")
     if not profile:
         profile, __ = UserProfile.objects.get_or_create(
             user__username=formlist_user.username

--- a/onadata/apps/main/models/meta_data.py
+++ b/onadata/apps/main/models/meta_data.py
@@ -30,7 +30,7 @@ from onadata.apps.logger.models.xform import XForm
 from onadata.libs.utils.cache_tools import (
     XFORM_MANIFEST_CACHE,
     XFORM_METADATA_CACHE,
-    safe_delete,
+    safe_cache_delete,
 )
 from onadata.libs.utils.common_tags import (
     GOOGLE_SHEET_DATA_TYPE,
@@ -602,10 +602,10 @@ def clear_cached_metadata_instance_object(
     Clear the cache for the metadata object.
     """
     xform_id = instance.object_id
-    safe_delete(f"{XFORM_METADATA_CACHE}{xform_id}")
+    safe_cache_delete(f"{XFORM_METADATA_CACHE}{xform_id}")
 
     if instance.data_type == "media":
-        safe_delete(f"{XFORM_MANIFEST_CACHE}{xform_id}")
+        safe_cache_delete(f"{XFORM_MANIFEST_CACHE}{xform_id}")
 
 
 # pylint: disable=unused-argument

--- a/onadata/apps/main/views.py
+++ b/onadata/apps/main/views.py
@@ -9,14 +9,13 @@ import os
 from datetime import datetime
 from http import HTTPStatus
 
-from django.db import connections
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth import get_user_model
 from django.contrib.auth.decorators import login_required
 from django.core.cache import cache
 from django.core.files.storage import default_storage, storages
-from django.db import IntegrityError
+from django.db import IntegrityError, connections
 from django.http import (
     HttpResponse,
     HttpResponseBadRequest,
@@ -38,6 +37,7 @@ from guardian.shortcuts import assign_perm, remove_perm
 from oauth2_provider.views.base import AuthorizationView
 from rest_framework.authtoken.models import Token
 
+import onadata
 from onadata.apps.logger.models import Instance, XForm
 from onadata.apps.logger.models.xform import get_forms_shared_with_user
 from onadata.apps.logger.views import enter_data
@@ -64,11 +64,11 @@ from onadata.apps.sms_support.tools import check_form_sms_compatibility, is_sms_
 from onadata.apps.viewer.models.data_dictionary import DataDictionary, upload_to
 from onadata.apps.viewer.models.parsed_instance import (
     DATETIME_FORMAT,
-    query_data,
-    query_fields_data,
-    query_count,
     ParsedInstance,
     _get_sort_fields,
+    query_count,
+    query_data,
+    query_fields_data,
 )
 from onadata.apps.viewer.views import attachment_url
 from onadata.libs.exceptions import EnketoError
@@ -92,7 +92,6 @@ from onadata.libs.utils.user_auth import (
     set_profile_data,
 )
 from onadata.libs.utils.viewer_tools import get_enketo_urls, get_form
-import onadata
 
 # pylint: disable=invalid-name
 User = get_user_model()

--- a/onadata/apps/viewer/models/data_dictionary.py
+++ b/onadata/apps/viewer/models/data_dictionary.py
@@ -38,7 +38,7 @@ from onadata.apps.main.models.meta_data import MetaData
 from onadata.libs.utils.cache_tools import (
     PROJ_BASE_FORMS_CACHE,
     PROJ_FORMS_CACHE,
-    safe_delete,
+    safe_cache_delete,
 )
 from onadata.libs.utils.common_tags import XFORM_META_PERMS
 from onadata.libs.utils.model_tools import get_columns_with_hxl, set_uuid
@@ -444,8 +444,8 @@ def invalidate_caches(sender, instance=None, created=False, **kwargs):
 
     xform = XForm.objects.get(pk=instance.pk)
 
-    safe_delete(f"{PROJ_FORMS_CACHE}{instance.project.pk}")
-    safe_delete(f"{PROJ_BASE_FORMS_CACHE}{instance.project.pk}")
+    safe_cache_delete(f"{PROJ_FORMS_CACHE}{instance.project.pk}")
+    safe_cache_delete(f"{PROJ_BASE_FORMS_CACHE}{instance.project.pk}")
     api_tools.invalidate_xform_list_cache(xform)
 
 

--- a/onadata/libs/models/share_project.py
+++ b/onadata/libs/models/share_project.py
@@ -12,20 +12,18 @@ from onadata.libs.permissions import (
     OwnerRole,
     ReadOnlyRoleNoDownload,
 )
-
 from onadata.libs.utils.cache_tools import (
     PROJ_OWNER_CACHE,
     PROJ_PERM_CACHE,
-    safe_delete,
-)
-from onadata.libs.utils.xform_utils import (
-    update_role_by_meta_xform_perms,
-    clear_permissions_cache,
+    safe_cache_delete,
 )
 from onadata.libs.utils.common_tags import XFORM_META_PERMS
 from onadata.libs.utils.model_tools import queryset_iterator
 from onadata.libs.utils.project_utils import propagate_project_permissions_async
-
+from onadata.libs.utils.xform_utils import (
+    clear_permissions_cache,
+    update_role_by_meta_xform_perms,
+)
 
 # pylint: disable=invalid-name
 User = get_user_model()
@@ -78,8 +76,8 @@ class ShareProject:
     def save(self, **kwargs):
         """Assigns role permissions to a project for the user."""
         # pylint: disable=too-many-nested-blocks
-        safe_delete(f"{PROJ_OWNER_CACHE}{self.project.pk}")
-        safe_delete(f"{PROJ_PERM_CACHE}{self.project.pk}")
+        safe_cache_delete(f"{PROJ_OWNER_CACHE}{self.project.pk}")
+        safe_cache_delete(f"{PROJ_PERM_CACHE}{self.project.pk}")
         if self.remove:
             self.__remove_user()
         else:
@@ -117,8 +115,8 @@ class ShareProject:
                     role.add(self.user, entity_list)
 
         # clear cache
-        safe_delete(f"{PROJ_OWNER_CACHE}{self.project.pk}")
-        safe_delete(f"{PROJ_PERM_CACHE}{self.project.pk}")
+        safe_cache_delete(f"{PROJ_OWNER_CACHE}{self.project.pk}")
+        safe_cache_delete(f"{PROJ_PERM_CACHE}{self.project.pk}")
         # propagate KPI permissions
         propagate_project_permissions_async.apply_async(args=[self.project.pk])
 

--- a/onadata/libs/models/share_team_project.py
+++ b/onadata/libs/models/share_team_project.py
@@ -3,12 +3,10 @@
 ShareTeamProject model - facilitate sharing a project to a team.
 """
 
-from onadata.libs.permissions import (
-    ROLES,
-)
-from onadata.libs.utils.cache_tools import PROJ_PERM_CACHE, safe_delete
-from onadata.libs.utils.xform_utils import update_role_by_meta_xform_perms
+from onadata.libs.permissions import ROLES
+from onadata.libs.utils.cache_tools import PROJ_PERM_CACHE, safe_cache_delete
 from onadata.libs.utils.common_tags import XFORM_META_PERMS
+from onadata.libs.utils.xform_utils import update_role_by_meta_xform_perms
 
 
 class ShareTeamProject:
@@ -43,7 +41,7 @@ class ShareTeamProject:
                         role.add(self.team, dataview.xform)
 
             # clear cache
-            safe_delete(f"{PROJ_PERM_CACHE}{self.project.pk}")
+            safe_cache_delete(f"{PROJ_PERM_CACHE}{self.project.pk}")
 
     def remove_team(self):
         """Removes team permissions from a project."""

--- a/onadata/libs/renderers/renderers.py
+++ b/onadata/libs/renderers/renderers.py
@@ -31,9 +31,9 @@ from onadata.libs.utils.cache_tools import (
     XFORM_MANIFEST_CACHE_LOCK_TTL,
     XFORM_MANIFEST_CACHE_TTL,
     safe_cache_add,
+    safe_cache_delete,
     safe_cache_get,
     safe_cache_set,
-    safe_delete,
 )
 from onadata.libs.utils.osm import get_combined_osm
 
@@ -407,7 +407,7 @@ class XFormManifestRenderer(XFormListRenderer, StreamRendererMixin):
 
                 if data.endswith("</manifest>"):
                     # We are done, release the lock
-                    safe_delete(self.cache_lock_key)
+                    safe_cache_delete(self.cache_lock_key)
 
             else:
                 safe_cache_set(self.cache_key, data, XFORM_MANIFEST_CACHE_TTL)

--- a/onadata/libs/serializers/fields/utils.py
+++ b/onadata/libs/serializers/fields/utils.py
@@ -1,13 +1,15 @@
 # -*- coding: utf-8 -*-
 """Serializer fields utils module."""
+
 from django.contrib.contenttypes.models import ContentType
-from django.core.cache import cache
+
+from onadata.libs.utils.cache_tools import safe_cache_get, safe_cache_set
 
 
 def get_object_id_by_content_type(instance, model_class):
     """Return instance.object_id from a cached model's content type"""
     key = f"{model_class.__name__}-content_type_id"
-    content_type_id = cache.get(key)
+    content_type_id = safe_cache_get(key)
     if not content_type_id:
         try:
             content_type_id = ContentType.objects.get(
@@ -18,7 +20,7 @@ def get_object_id_by_content_type(instance, model_class):
             if instance and isinstance(instance.content_object, model_class):
                 return instance.object_id
         else:
-            cache.set(key, content_type_id)
+            safe_cache_set(key, content_type_id)
 
     if instance and instance.content_type_id == content_type_id:
         return instance.object_id

--- a/onadata/libs/serializers/project_serializer.py
+++ b/onadata/libs/serializers/project_serializer.py
@@ -29,9 +29,9 @@ from onadata.libs.utils.cache_tools import (
     PROJ_SUB_DATE_CACHE,
     PROJ_TEAM_USERS_CACHE,
     PROJECT_LINKED_DATAVIEWS,
+    safe_cache_delete,
     safe_cache_get,
     safe_cache_set,
-    safe_delete,
 )
 from onadata.libs.utils.decorators import check_obj
 
@@ -542,7 +542,7 @@ class ProjectSerializer(serializers.HyperlinkedModelSerializer):
                 )
 
             # clear cache
-            safe_delete(f"{PROJ_PERM_CACHE}{instance.pk}")
+            safe_cache_delete(f"{PROJ_PERM_CACHE}{instance.pk}")
 
         project = super().update(instance, validated_data)
 

--- a/onadata/libs/serializers/project_serializer.py
+++ b/onadata/libs/serializers/project_serializer.py
@@ -5,7 +5,6 @@ Project Serializer module.
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
-from django.core.cache import cache
 from django.core.management import call_command
 from django.db.utils import IntegrityError
 from django.utils.translation import gettext as _
@@ -30,6 +29,8 @@ from onadata.libs.utils.cache_tools import (
     PROJ_SUB_DATE_CACHE,
     PROJ_TEAM_USERS_CACHE,
     PROJECT_LINKED_DATAVIEWS,
+    safe_cache_get,
+    safe_cache_set,
     safe_delete,
 )
 from onadata.libs.utils.decorators import check_obj
@@ -58,7 +59,7 @@ def get_last_submission_date(project):
     :param project: The project to find the last submission date for.
     """
     cache_key = f"{PROJ_SUB_DATE_CACHE}{project.pk}"
-    last_submission_date = cache.get(cache_key)
+    last_submission_date = safe_cache_get(cache_key)
     if last_submission_date:
         return last_submission_date
     xforms = get_project_xforms(project)
@@ -68,7 +69,7 @@ def get_last_submission_date(project):
     dates.sort(reverse=True)
     last_submission_date = dates[0] if dates else None
 
-    cache.set(cache_key, last_submission_date)
+    safe_cache_set(cache_key, last_submission_date)
 
     return last_submission_date
 
@@ -80,12 +81,12 @@ def get_num_datasets(project):
     :param project: The project to find datasets for.
     """
     project_cache_key = f"{PROJ_NUM_DATASET_CACHE}{project.pk}"
-    count = cache.get(project_cache_key)
+    count = safe_cache_get(project_cache_key)
     if count:
         return count
 
     count = len(get_project_xforms(project))
-    cache.set(project_cache_key, count)
+    safe_cache_set(project_cache_key, count)
     return count
 
 
@@ -111,7 +112,7 @@ def get_teams(project):
     Return the teams with access to the project.
     """
     project_team_cache_key = f"{PROJ_TEAM_USERS_CACHE}{project.pk}"
-    teams_users = cache.get(project_team_cache_key)
+    teams_users = safe_cache_get(project_team_cache_key)
     if teams_users:
         return teams_users
 
@@ -127,7 +128,7 @@ def get_teams(project):
             {"name": team.name, "role": get_role(perms, project), "users": users}
         )
 
-    cache.set(project_team_cache_key, teams_users)
+    safe_cache_set(project_team_cache_key, teams_users)
     return teams_users
 
 
@@ -138,7 +139,7 @@ def get_users(project, context, all_perms=True):
     """
     project_permissions_cache_key = f"{PROJ_PERM_CACHE}{project.pk}"
     if all_perms:
-        users = cache.get(project_permissions_cache_key)
+        users = safe_cache_get(project_permissions_cache_key)
         if users:
             return users
 
@@ -192,7 +193,7 @@ def get_users(project, context, all_perms=True):
     results = list(itervalues(data))
 
     if all_perms:
-        cache.set(project_permissions_cache_key, results)
+        safe_cache_set(project_permissions_cache_key, results)
 
     return results
 
@@ -375,7 +376,7 @@ class BaseProjectSerializer(serializers.HyperlinkedModelSerializer):
         Return list of xforms in the project.
         """
         project_forms_cache_key = f"{PROJ_BASE_FORMS_CACHE}{obj.pk}"
-        forms = cache.get(project_forms_cache_key)
+        forms = safe_cache_get(project_forms_cache_key)
         if forms:
             return forms
 
@@ -385,7 +386,7 @@ class BaseProjectSerializer(serializers.HyperlinkedModelSerializer):
             xforms, context={"request": request}, many=True
         )
         forms = list(serializer.data)
-        cache.set(project_forms_cache_key, forms)
+        safe_cache_set(project_forms_cache_key, forms)
 
         return forms
 
@@ -584,7 +585,7 @@ class ProjectSerializer(serializers.HyperlinkedModelSerializer):
         request = self.context.get("request")
         serializer = ProjectSerializer(project, context={"request": request})
         response = serializer.data
-        cache.set(f"{PROJ_OWNER_CACHE}{project.pk}", response)
+        safe_cache_set(f"{PROJ_OWNER_CACHE}{project.pk}", response)
         return project
 
     def get_users(self, obj):
@@ -600,7 +601,7 @@ class ProjectSerializer(serializers.HyperlinkedModelSerializer):
         Return list of xforms in the project.
         """
         project_forms_cache_key = f"{PROJ_FORMS_CACHE}{obj.pk}"
-        forms = cache.get(project_forms_cache_key)
+        forms = safe_cache_get(project_forms_cache_key)
         if forms:
             return forms
         xforms = get_project_xforms(obj)
@@ -609,7 +610,7 @@ class ProjectSerializer(serializers.HyperlinkedModelSerializer):
             xforms, context={"request": request}, many=True
         )
         forms = list(serializer.data)
-        cache.set(project_forms_cache_key, forms)
+        safe_cache_set(project_forms_cache_key, forms)
 
         return forms
 
@@ -643,7 +644,7 @@ class ProjectSerializer(serializers.HyperlinkedModelSerializer):
         Return a list of filtered datasets.
         """
         project_dataview_cache_key = f"{PROJECT_LINKED_DATAVIEWS}{obj.pk}"
-        data_views = cache.get(project_dataview_cache_key)
+        data_views = safe_cache_get(project_dataview_cache_key)
         if data_views:
             return data_views
 
@@ -663,6 +664,6 @@ class ProjectSerializer(serializers.HyperlinkedModelSerializer):
         )
         data_views = list(serializer.data)
 
-        cache.set(project_dataview_cache_key, data_views)
+        safe_cache_set(project_dataview_cache_key, data_views)
 
         return data_views

--- a/onadata/libs/serializers/stats_serializer.py
+++ b/onadata/libs/serializers/stats_serializer.py
@@ -2,8 +2,8 @@
 """
 Stats API endpoint serializer.
 """
+
 from django.conf import settings
-from django.core.cache import cache
 from django.utils.translation import gettext as _
 
 from rest_framework import exceptions, serializers
@@ -18,7 +18,11 @@ from onadata.libs.data.statistics import (
     get_min_max_range,
     get_mode_for_numeric_fields_in_form,
 )
-from onadata.libs.utils.cache_tools import XFORM_SUBMISSION_STAT
+from onadata.libs.utils.cache_tools import (
+    XFORM_SUBMISSION_STAT,
+    safe_cache_get,
+    safe_cache_set,
+)
 
 SELECT_FIELDS = ["select one", "select multiple"]
 
@@ -63,7 +67,7 @@ class SubmissionStatsInstanceSerializer(serializers.Serializer):
 
         cache_key = f"{XFORM_SUBMISSION_STAT}{instance.pk}{field}{name}"
 
-        data = cache.get(cache_key)
+        data = safe_cache_get(cache_key)
         if data:
             return data
 
@@ -79,7 +83,7 @@ class SubmissionStatsInstanceSerializer(serializers.Serializer):
                     label = instance.get_choice_label(element, record[name])
                     record[name] = label
 
-        cache.set(cache_key, data, settings.XFORM_SUBMISSION_STAT_CACHE_TIME)
+        safe_cache_set(cache_key, data, settings.XFORM_SUBMISSION_STAT_CACHE_TIME)
 
         return data
 

--- a/onadata/libs/tests/models/test_share_project.py
+++ b/onadata/libs/tests/models/test_share_project.py
@@ -1,6 +1,6 @@
 """Tests for module onadata.libs.models.share_project"""
 
-from unittest.mock import patch, call
+from unittest.mock import call, patch
 
 from onadata.apps.logger.models.data_view import DataView
 from onadata.apps.logger.models.entity_list import EntityList
@@ -32,8 +32,8 @@ class ShareProjectTestCase(TestBase):
         self.entity_list = EntityList.objects.create(name="trees", project=self.project)
         self.alice = self._create_user("alice", "Yuao8(-)")
 
-    @patch("onadata.libs.models.share_project.safe_delete")
-    def test_share(self, mock_safe_delete, mock_propagate):
+    @patch("onadata.libs.models.share_project.safe_cache_delete")
+    def test_share(self, mock_safe_cache_delete, mock_propagate):
         """A project is shared with a user
 
         Permissions assigned to project, xform, mergedxform and dataview
@@ -49,15 +49,15 @@ class ShareProjectTestCase(TestBase):
         self.assertTrue(ManagerRole.user_has_role(self.alice, self.entity_list))
         mock_propagate.assert_called_once_with(args=[self.project.pk])
         # Cache is invalidated
-        mock_safe_delete.assert_has_calls(
+        mock_safe_cache_delete.assert_has_calls(
             [
                 call(f"ps-project_owner-{self.project.pk}"),
                 call(f"ps-project_permissions-{self.project.pk}"),
             ]
         )
 
-    @patch("onadata.libs.models.share_project.safe_delete")
-    def test_remove(self, mock_safe_delete, mock_propagate):
+    @patch("onadata.libs.models.share_project.safe_cache_delete")
+    def test_remove(self, mock_safe_cache_delete, mock_propagate):
         """A user is removed from a project
 
         Permissions removed from project, xform, mergedxform and dataview
@@ -89,7 +89,7 @@ class ShareProjectTestCase(TestBase):
         self.assertFalse(ManagerRole.user_has_role(self.alice, self.entity_list))
         mock_propagate.assert_called_once_with(args=[self.project.pk])
         # Cache is invalidated
-        mock_safe_delete.assert_has_calls(
+        mock_safe_cache_delete.assert_has_calls(
             [
                 call(f"ps-project_owner-{self.project.pk}"),
                 call(f"ps-project_permissions-{self.project.pk}"),

--- a/onadata/libs/utils/cache_tools.py
+++ b/onadata/libs/utils/cache_tools.py
@@ -214,6 +214,21 @@ def safe_cache_incr(key, delta=1):
     return _safe_cache_operation(lambda: cache.incr(key, delta))
 
 
+def safe_cache_decr(key, delta=1):
+    """
+    Safely decrement a value in the cache.
+
+    If the cache is not reachable, the operation silently fails.
+
+    Args:
+        key (str): The cache key to decrement.
+        delta (int): The amount to decrement by (default: 1).
+    Returns:
+        int: The new value after decrementing, or None if the operation fails.
+    """
+    return _safe_cache_operation(lambda: cache.decr(key, delta))
+
+
 class CacheLockError(Exception):
     """Custom exception raised when a cache lock cannot be acquired."""
 

--- a/onadata/libs/utils/cache_tools.py
+++ b/onadata/libs/utils/cache_tools.py
@@ -14,7 +14,7 @@ from django.utils.encoding import force_bytes
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_CACHE_TIMEOUT = cache.default_timeout
+DEFAULT_TIMEOUT = cache.default_timeout
 
 # Cache names used in project serializer
 PROJ_PERM_CACHE = "ps-project_permissions-"
@@ -146,7 +146,7 @@ def _safe_cache_operation(operation, default_return=None):
         return default_return
 
 
-def safe_cache_set(key, value, timeout=DEFAULT_CACHE_TIMEOUT):
+def safe_cache_set(key, value, timeout=DEFAULT_TIMEOUT):
     """
     Safely set a value in the cache.
 
@@ -173,7 +173,7 @@ def safe_cache_get(key, default=None):
     return _safe_cache_operation(lambda: cache.get(key, default), default)
 
 
-def safe_cache_add(key, value, timeout=DEFAULT_CACHE_TIMEOUT):
+def safe_cache_add(key, value, timeout=DEFAULT_TIMEOUT):
     """
     Safely add a value to the cache.
 
@@ -262,7 +262,7 @@ def with_cache_lock(cache_key, lock_expire=30, lock_timeout=10):
 def set_cache_with_lock(
     cache_key,
     modify_callback,
-    cache_timeout=DEFAULT_CACHE_TIMEOUT,
+    cache_timeout=DEFAULT_TIMEOUT,
     lock_expire=30,
     lock_timeout=10,
 ):

--- a/onadata/libs/utils/cache_tools.py
+++ b/onadata/libs/utils/cache_tools.py
@@ -12,9 +12,9 @@ from contextlib import contextmanager
 from django.core.cache import cache
 from django.utils.encoding import force_bytes
 
-DEFAULT_CACHE_TIMEOUT = cache.default_timeout
-
 logger = logging.getLogger(__name__)
+
+DEFAULT_CACHE_TIMEOUT = cache.default_timeout
 
 # Cache names used in project serializer
 PROJ_PERM_CACHE = "ps-project_permissions-"

--- a/onadata/libs/utils/logger_tools.py
+++ b/onadata/libs/utils/logger_tools.py
@@ -84,7 +84,7 @@ from onadata.apps.viewer.models.data_dictionary import DataDictionary
 from onadata.apps.viewer.models.parsed_instance import ParsedInstance
 from onadata.apps.viewer.signals import process_submission
 from onadata.libs.utils.analytics import TrackObjectEvent
-from onadata.libs.utils.cache_tools import XFORM_SUBMISSIONS_DELETING, safe_delete
+from onadata.libs.utils.cache_tools import XFORM_SUBMISSIONS_DELETING, safe_cache_delete
 from onadata.libs.utils.common_tags import METADATA_FIELDS
 from onadata.libs.utils.common_tools import get_uuid, report_exception
 from onadata.libs.utils.model_tools import set_uuid
@@ -1162,7 +1162,7 @@ def delete_xform_submissions(
     xform.project.date_modified = timezone.now()
     xform.project.save(update_fields=["date_modified"])
 
-    safe_delete(f"{XFORM_SUBMISSIONS_DELETING}{xform.pk}")
+    safe_cache_delete(f"{XFORM_SUBMISSIONS_DELETING}{xform.pk}")
     send_message(
         instance_id=instance_ids or [],
         target_id=xform.id,

--- a/onadata/libs/utils/model_tools.py
+++ b/onadata/libs/utils/model_tools.py
@@ -12,7 +12,7 @@ from django.core.cache import cache
 from django.db.models import F, Model
 from django.utils import timezone
 
-from onadata.libs.utils.cache_tools import safe_delete, set_cache_with_lock
+from onadata.libs.utils.cache_tools import set_cache_with_lock
 from onadata.libs.utils.common_tools import get_uuid, report_exception
 
 logger = logging.getLogger(__name__)
@@ -120,11 +120,11 @@ def commit_cached_counters(
         if counter:
             adjust_numeric_field(model, pk=pk, field_name=field_name, delta=counter)
 
-        safe_delete(counter_key)
+        cache.delete(counter_key)
 
-    safe_delete(tracked_ids_key)
-    safe_delete(lock_key)
-    safe_delete(created_at_key)
+    cache.delete(tracked_ids_key)
+    cache.delete(lock_key)
+    cache.delete(created_at_key)
 
 
 def _execute_cached_counter_commit_failover(

--- a/onadata/libs/utils/model_tools.py
+++ b/onadata/libs/utils/model_tools.py
@@ -200,10 +200,12 @@ def _increment_cached_counter(
         current_ids.add(pk)
         return current_ids
 
+    # We set the cache with no expiration (timeout=None). The cache will
+    # be cleared when commiting the cached counters to the database.
     set_cache_with_lock(
         cache_key=tracked_ids_key,
         modify_callback=add_to_modified_ids,
-        cache_timeout=None,
+        cache_timeout=None,  # No expiration
     )
     cache.add(created_at_key, timezone.now(), timeout=None)
 

--- a/onadata/libs/utils/openid_connect_tools.py
+++ b/onadata/libs/utils/openid_connect_tools.py
@@ -2,15 +2,17 @@
 """
 OpenID Connect Tools
 """
+
 import json
 
-from django.core.cache import cache
 from django.http import Http404, HttpResponseRedirect
 from django.utils.translation import gettext as _
 
 import jwt
 import requests
 from jwt.algorithms import RSAAlgorithm
+
+from onadata.libs.utils.cache_tools import safe_cache_get
 
 EMAIL = "email"
 NAME = "name"
@@ -184,7 +186,7 @@ class OpenIDHandler:
                 # Verify that the cached nonce is present and that
                 # the provider the nonce was initiated for, is the same
                 # provider returning it
-                provider_initiated_for = cache.get(decoded_token.get(NONCE))
+                provider_initiated_for = safe_cache_get(decoded_token.get(NONCE))
 
                 if provider_initiated_for != openid_provider:
                     raise ValueError("Incorrect nonce value returned")

--- a/onadata/libs/utils/xform_utils.py
+++ b/onadata/libs/utils/xform_utils.py
@@ -5,39 +5,39 @@ project_utils module - apply project permissions to a form.
 
 import sys
 
+from django.apps import apps
 from django.conf import settings
 from django.db import IntegrityError
-from django.apps import apps
-from guardian.shortcuts import get_perms
 
+from guardian.shortcuts import get_perms
 from multidb.pinning import use_master
 
 from onadata.celeryapp import app
-from onadata.libs.utils.cache_tools import (
-    XFORM_DATA_VERSIONS,
-    XFORM_METADATA_CACHE,
-    XFORM_PERMISSIONS_CACHE,
-    PROJ_OWNER_CACHE,
-    safe_delete,
-)
-from onadata.libs.utils.model_tools import queryset_iterator
 from onadata.libs.permissions import (
     ROLES,
-    ReadOnlyRole,
-    get_object_users_with_permissions,
-    set_project_perms_to_object,
-    get_role,
-    is_organization,
     DataEntryMinorRole,
     DataEntryOnlyRole,
     DataEntryRole,
-    EditorNoDownload,
     EditorMinorRole,
+    EditorNoDownload,
     EditorRole,
+    ReadOnlyRole,
     ReadOnlyRoleNoDownload,
+    get_object_users_with_permissions,
+    get_role,
+    is_organization,
+    set_project_perms_to_object,
 )
-from onadata.libs.utils.common_tools import report_exception
+from onadata.libs.utils.cache_tools import (
+    PROJ_OWNER_CACHE,
+    XFORM_DATA_VERSIONS,
+    XFORM_METADATA_CACHE,
+    XFORM_PERMISSIONS_CACHE,
+    safe_cache_delete,
+)
 from onadata.libs.utils.common_tags import MEMBERS
+from onadata.libs.utils.common_tools import report_exception
+from onadata.libs.utils.model_tools import queryset_iterator
 from onadata.libs.utils.project_utils import get_project_users
 
 
@@ -147,10 +147,10 @@ def get_xform_users(xform):
 
 
 def clear_permissions_cache(xform):
-    safe_delete(f"{PROJ_OWNER_CACHE}{xform.project.pk}")
-    safe_delete(f"{XFORM_METADATA_CACHE}{xform.pk}")
-    safe_delete(f"{XFORM_DATA_VERSIONS}{xform.pk}")
-    safe_delete(f"{XFORM_PERMISSIONS_CACHE}{xform.pk}")
+    safe_cache_delete(f"{PROJ_OWNER_CACHE}{xform.project.pk}")
+    safe_cache_delete(f"{XFORM_METADATA_CACHE}{xform.pk}")
+    safe_cache_delete(f"{XFORM_DATA_VERSIONS}{xform.pk}")
+    safe_cache_delete(f"{XFORM_PERMISSIONS_CACHE}{xform.pk}")
 
 
 def update_role_by_meta_xform_perms(xform, user=None, user_role=None):


### PR DESCRIPTION
### Changes/Features implemented

- Refactor to use safe cache operations. Enforces fault and partition tolerance incase the cache node/service is unreachable
- Fix bug where `safe_cache_set` has keys never expire if `timeout` is not provided because the default timeout was `None`. The fix defaults to the timeout argument of the appropriate backend. 

### Side effects of implementing this change

If the cache is inaccessible, the cache operation fails silently, and the database becomes the fallback for retrieving the data. This results in graceful degradation instead of zero downtime.

Closes #2861 
