### PR TITLE
Fix bug where encrypted XLSForm with choice filter has invalid XML

### DIFF
--- a/onadata/apps/logger/models/xform.py
+++ b/onadata/apps/logger/models/xform.py
@@ -27,7 +27,7 @@ from django.utils.translation import gettext as _
 from django.utils.translation import gettext_lazy
 
 from guardian.models import GroupObjectPermissionBase, UserObjectPermissionBase
-from pyxform import SurveyElementBuilder, constants, create_survey_element_from_dict
+from pyxform import SurveyElementBuilder, constants
 from pyxform.errors import PyXFormError
 from pyxform.question import Question
 from pyxform.section import RepeatingSection
@@ -1113,11 +1113,10 @@ class XForm(XFormMixin, BaseModel):
             self.encrypted = "public_key" in json_dict
 
     def _set_public_key_field(self):
-        if self.json and self.json != "":
+        if self.json and self.json != "" and not self.is_managed:
             if self.num_of_submissions == 0 and self.public_key:
-                json_dict = self.json_dict()
-                json_dict["public_key"] = self.public_key
-                survey = create_survey_element_from_dict(json_dict)
+                survey = self.get_survey_from_xlsform()
+                survey.public_key = self.public_key
                 self.json = survey.to_json_dict()
                 self.xml = survey.to_xml()
                 self._set_encrypted_field()

--- a/onadata/apps/logger/models/xform.py
+++ b/onadata/apps/logger/models/xform.py
@@ -1116,7 +1116,6 @@ class XForm(XFormMixin, BaseModel):
         if self.public_key and self.num_of_submissions == 0:
             survey = self.get_survey_from_xlsform()
             survey.public_key = self.public_key
-            survey.version = self.version
             self.json = survey.to_json_dict()
             self.xml = survey.to_xml()
             self._set_encrypted_field()

--- a/onadata/apps/logger/models/xform.py
+++ b/onadata/apps/logger/models/xform.py
@@ -1113,13 +1113,18 @@ class XForm(XFormMixin, BaseModel):
             self.encrypted = "public_key" in json_dict
 
     def _set_public_key_field(self):
-        if self.json and self.json != "" and not self.is_managed:
-            if self.num_of_submissions == 0 and self.public_key:
-                survey = self.get_survey_from_xlsform()
-                survey.public_key = self.public_key
-                self.json = survey.to_json_dict()
-                self.xml = survey.to_xml()
-                self._set_encrypted_field()
+        if (
+            not self.is_managed
+            and self.public_key
+            and self.num_of_submissions == 0
+            and self.json
+            and self.json != ""
+        ):
+            survey = self.get_survey_from_xlsform()
+            survey.public_key = self.public_key
+            self.json = survey.to_json_dict()
+            self.xml = survey.to_xml()
+            self._set_encrypted_field()
 
     def json_dict(self):
         """Returns the `self.json` field data as a dict."""

--- a/onadata/apps/logger/models/xform.py
+++ b/onadata/apps/logger/models/xform.py
@@ -1118,7 +1118,6 @@ class XForm(XFormMixin, BaseModel):
             and self.public_key
             and self.num_of_submissions == 0
             and self.json
-            and self.json != ""
         ):
             survey = self.get_survey_from_xlsform()
             survey.public_key = self.public_key

--- a/onadata/apps/logger/models/xform.py
+++ b/onadata/apps/logger/models/xform.py
@@ -1113,14 +1113,10 @@ class XForm(XFormMixin, BaseModel):
             self.encrypted = "public_key" in json_dict
 
     def _set_public_key_field(self):
-        if (
-            not self.is_managed
-            and self.public_key
-            and self.num_of_submissions == 0
-            and self.json
-        ):
+        if self.public_key and self.num_of_submissions == 0:
             survey = self.get_survey_from_xlsform()
             survey.public_key = self.public_key
+            survey.version = self.version
             self.json = survey.to_json_dict()
             self.xml = survey.to_xml()
             self._set_encrypted_field()

--- a/onadata/libs/kms/tools.py
+++ b/onadata/libs/kms/tools.py
@@ -42,7 +42,6 @@ from onadata.apps.logger.models import (
     XForm,
     XFormKey,
 )
-from onadata.apps.logger.models.xform import create_survey_element_from_dict
 from onadata.libs.exceptions import DecryptionError, EncryptionError
 from onadata.libs.permissions import is_organization
 from onadata.libs.utils.cache_tools import (
@@ -310,11 +309,9 @@ def _invalidate_xform_list_cache(xform: XForm):
 def _encrypt_xform(xform, kms_key, encrypted_by=None):
     version = timezone.now().strftime("%Y%m%d%H%M")
 
-    json_dict = xform.json_dict()
-    json_dict["public_key"] = kms_key.public_key
-    json_dict["version"] = version
-
-    survey = create_survey_element_from_dict(json_dict)
+    survey = xform.get_survey_from_xlsform()
+    survey.public_key = kms_key.public_key
+    survey.version = version
 
     xform.json = survey.to_json_dict()
     xform.xml = survey.to_xml()
@@ -615,11 +612,9 @@ def disable_xform_encryption(xform, disabled_by=None) -> None:
 
     new_version = timezone.now().strftime("%Y%m%d%H%M")
 
-    json_dict = xform.json_dict()
-    json_dict["version"] = new_version
-    del json_dict["public_key"]
-
-    survey = create_survey_element_from_dict(json_dict)
+    survey = xform.get_survey_from_xlsform()
+    survey.public_key = None
+    survey.version = new_version
 
     xform.json = survey.to_json_dict()
     xform.xml = survey.to_xml()

--- a/onadata/libs/tests/kms/test_tools.py
+++ b/onadata/libs/tests/kms/test_tools.py
@@ -21,6 +21,7 @@ import boto3
 from Crypto.Cipher import AES
 from Crypto.Util.Padding import pad
 from moto import mock_aws
+from pyxform.builder import create_survey_element_from_dict
 from valigetta.decryptor import _get_submission_iv
 from valigetta.exceptions import (
     AliasAlreadyExistsException,
@@ -32,7 +33,6 @@ from valigetta.kms import APIKMSClient as BaseAPIClient
 from valigetta.kms import AWSKMSClient as BaseAWSClient
 
 from onadata.apps.logger.models import Attachment, Instance, KMSKey, SurveyType, XForm
-from onadata.apps.logger.models.xform import create_survey_element_from_dict
 from onadata.apps.main.tests.test_base import TestBase
 from onadata.libs.exceptions import DecryptionError, EncryptionError
 from onadata.libs.kms.clients import AWSKMSClient


### PR DESCRIPTION
### Changes / Features implemented

The bug arises from `SurveyElementBuilder.to_json_dict()`generating an incorrect JSON schema when publishing the XLSForm. A `SurveyElementBuilder` object created from an existing `XForm`'s JSON schema generates invalid XML

### Steps taken to verify this change does what is intended

- [x] QA

### Side effects of implementing this change

**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  - [ ] Updated documentation

Closes #
