### PR TITLE
Resolve corrupted submission decryption failure reason and status not saved

### DIFF
--- a/onadata/libs/kms/tools.py
+++ b/onadata/libs/kms/tools.py
@@ -526,19 +526,12 @@ def decrypt_instance(instance: Instance) -> None:
     kms_client = get_kms_client()
     # Decrypt submission files
     attachment_qs = instance.attachments.all()
-
-    try:
-        decrypted_files = decrypt_submission(
-            kms_client=kms_client,
-            key_id=xform_key.kms_key.key_id,
-            submission_xml=submission_xml,
-            enc_files=get_encrypted_files(attachment_qs),
-        )
-
-    except InvalidSubmissionException as exc:
-        save_decryption_error(instance, DECRYPTION_FAILURE_INVALID_SUBMISSION)
-        raise DecryptionError(str(exc)) from exc
-
+    decrypted_files = decrypt_submission(
+        kms_client=kms_client,
+        key_id=xform_key.kms_key.key_id,
+        submission_xml=submission_xml,
+        enc_files=get_encrypted_files(attachment_qs),
+    )
     # Replace encrypted submission with decrypted submission
     # Initialize InstanceHistory before replacement
     history = InstanceHistory(
@@ -551,44 +544,50 @@ def decrypt_instance(instance: Instance) -> None:
     )
     decrypted_attachment_ids = []
 
-    with transaction.atomic():
-        for original_name, decrypted_file in decrypted_files:
-            if original_name.lower() == "submission.xml":
-                # Replace submission with decrypted submission
-                xml = decrypted_file.getvalue()
+    try:
+        with transaction.atomic():
+            for original_name, decrypted_file in decrypted_files:
+                if original_name.lower() == "submission.xml":
+                    # Replace submission with decrypted submission
+                    xml = decrypted_file.getvalue()
 
-                instance.xml = xml.decode("utf-8")
-                instance.checksum = sha256(xml).hexdigest()
-                instance.is_encrypted = False
-                instance.decryption_status = Instance.DecryptionStatus.SUCCESS
-                instance.save()
+                    instance.xml = xml.decode("utf-8")
+                    instance.checksum = sha256(xml).hexdigest()
+                    instance.is_encrypted = False
+                    instance.decryption_status = Instance.DecryptionStatus.SUCCESS
+                    instance.save()
 
-            else:
-                # Save decrypted media file
-                media_file = File(decrypted_file, name=original_name)
-                mimetype, _ = mimetypes.guess_type(original_name)
-                _, extension = os.path.splitext(original_name)
-                attachment = instance.attachments.create(
-                    xform=instance.xform,
-                    media_file=media_file,
-                    name=original_name,
-                    mimetype=mimetype or "application/octet-stream",
-                    extension=extension.lstrip("."),
-                    file_size=len(decrypted_file.getbuffer()),
-                )
-                decrypted_attachment_ids.append(attachment.id)
-        # Commit history after saving decrypted files
-        history.save()
-        # Soft delete encrypted attachments
-        attachment_qs.exclude(id__in=decrypted_attachment_ids).update(
-            deleted_at=timezone.now()
-        )
-        # Increment XForm num_of_decrypted_submissions
-        transaction.on_commit(
-            lambda: logger_tasks.adjust_xform_num_of_decrypted_submissions_async.delay(
-                instance.xform_id, delta=1
+                else:
+                    # Save decrypted media file
+                    media_file = File(decrypted_file, name=original_name)
+                    mimetype, _ = mimetypes.guess_type(original_name)
+                    _, extension = os.path.splitext(original_name)
+                    attachment = instance.attachments.create(
+                        xform=instance.xform,
+                        media_file=media_file,
+                        name=original_name,
+                        mimetype=mimetype or "application/octet-stream",
+                        extension=extension.lstrip("."),
+                        file_size=len(decrypted_file.getbuffer()),
+                    )
+                    decrypted_attachment_ids.append(attachment.id)
+
+            # Commit history after saving decrypted files
+            history.save()
+            # Soft delete encrypted attachments
+            attachment_qs.exclude(id__in=decrypted_attachment_ids).update(
+                deleted_at=timezone.now()
             )
-        )
+            # Increment XForm num_of_decrypted_submissions
+            transaction.on_commit(
+                lambda: logger_tasks.adjust_xform_num_of_decrypted_submissions_async.delay(
+                    instance.xform_id, delta=1
+                )
+            )
+
+    except InvalidSubmissionException as exc:
+        save_decryption_error(instance, DECRYPTION_FAILURE_INVALID_SUBMISSION)
+        raise DecryptionError(str(exc)) from exc
 
 
 @transaction.atomic()

--- a/onadata/libs/tests/kms/test_tools.py
+++ b/onadata/libs/tests/kms/test_tools.py
@@ -1288,10 +1288,17 @@ class DecryptInstanceTestCase(TestBase):
             self.instance.json.get("_decryption_error"), "KMS_KEY_NOT_FOUND"
         )
 
+    def _mock_decrypt_submission(*args, **kwargs):
+        def _gen():
+            raise InvalidSubmissionException("Invalid signature.")
+            yield  # unreachable, but needed to make it a generator
+
+        return _gen()
+
     @patch("onadata.libs.kms.tools.decrypt_submission")
-    def test_decryption_failure(self, mock_decrypt):
+    def test_decryption_failure(self, mock_decrypt_submission):
         """Decryption failure is handled."""
-        mock_decrypt.side_effect = InvalidSubmissionException("Invalid signature.")
+        mock_decrypt_submission.side_effect = self._mock_decrypt_submission
 
         old_xml = self.instance.xml
 


### PR DESCRIPTION
### Changes / Features implemented

Resolve corrupted submission decryption failure reason and status not saved. `valigetta.decryptor.decrypt_submission` returns a generator. Any exception will be raised when the generator is consumed.

### Steps taken to verify this change does what is intended

- [ ] QA

### Side effects of implementing this change

Submissions that fail decryption because of corrupted data will have a `decryption_status` of `failed` and a JSON metadata key `_decryption_error` with a value of `INVALID_SUBMISSION`

**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  - [ ] Updated documentation

Closes #
