### PR TITLE
feat: Add background-audio media type support

### DIFF
--- a/onadata/apps/logger/tests/models/test_xform.py
+++ b/onadata/apps/logger/tests/models/test_xform.py
@@ -433,3 +433,32 @@ class TestXForm(TestBase):
         self.xform.refresh_from_db()
 
         self.assertEqual(self.xform.num_of_pending_decryption_submissions, 0)
+
+    def test_get_media_survey_xpaths_with_background_audio(self):
+        """Test that get_media_survey_xpaths includes background-audio elements"""
+        md = """
+        | survey |
+        |        | type            | name         | label        |
+        |        | photo           | photo1       | Photo        |
+        |        | audio           | audio1       | Audio        |
+        |        | background-audio| bg_audio1    | Background Audio |
+        |        | video           | video1       | Video        |
+        |        | file            | file1        | File         |
+        |        | image           | image1       | Image        |
+        """
+
+        xform = self._publish_markdown(md, self.user, id_string="media_test")
+        media_xpaths = xform.get_media_survey_xpaths()
+
+        # Verify all media types are included
+        self.assertIn("photo1", media_xpaths)
+        self.assertIn("audio1", media_xpaths)
+        self.assertIn("bg_audio1", media_xpaths)
+        self.assertIn("video1", media_xpaths)
+        self.assertIn("file1", media_xpaths)
+        self.assertIn("image1", media_xpaths)
+
+        # Verify background-audio is specifically detected
+        bg_audio_elements = xform.get_survey_elements_of_type("background-audio")
+        self.assertEqual(len(bg_audio_elements), 1)
+        self.assertEqual(bg_audio_elements[0].name, "bg_audio1")

--- a/onadata/libs/utils/common_tags.py
+++ b/onadata/libs/utils/common_tags.py
@@ -111,7 +111,7 @@ OWNER_TEAM_NAME = "Owners"
 
 API_TOKEN = "api-token"  # nosec
 ONADATA_KOBOCAT_AUTH_HEADER = "X-ONADATA-KOBOCAT-AUTH"
-KNOWN_MEDIA_TYPES = ["photo", "image", "audio", "video", "file"]
+KNOWN_MEDIA_TYPES = ["photo", "image", "background-audio", "audio", "video", "file"]
 MEDIA_FILE_TYPES = {
     "image": ["image/png", "image/jpeg", "image/jpg"],
     "audio": ["audio/mp3", "audio/mp4"],


### PR DESCRIPTION
### Changes / Features implemented
Add `background-audio` media type support

### Steps taken to verify this change does what is intended
- Added test cases
- Run onadata locally and tested manually

### Side effects of implementing this change
N/A

**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  - [ ] Updated documentation

