### PR TITLE
chore: bump version to v5.6.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,12 @@ Changelog for Onadata
 
 ``* represents releases that introduce new migrations``
 
+v5.6.0(2025-09-19)
+------------------
+- feat: bump oidc to add ability to import user
+  [@kelvin-muchiri]
+  `PR #2911 https://github.com/onaio/onadata/pull/2911`
+
 v5.5.0(2025-09-15)
 ------------------
 - fix: bump valigetta to v0.2.1 to resolve uncaught incorrect padding error

--- a/onadata/__init__.py
+++ b/onadata/__init__.py
@@ -7,7 +7,7 @@ visualization.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "5.5.0"
+__version__ = "5.6.0"
 
 
 # This will make sure the app is always imported when

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = onadata
-version = 5.5.0
+version = 5.6.0
 description = Collect Analyze and Share Data
 long_description = file: README.rst
 long_description_content_type = text/x-rst


### PR DESCRIPTION
### Changes

chore: bump version to v5.6.0

**Features**

- https://github.com/onaio/onadata/pull/2911
