### PR TITLE
fix: submission using project pk uses creator's require auth status

### DIFF
--- a/onadata/apps/api/permissions.py
+++ b/onadata/apps/api/permissions.py
@@ -554,7 +554,7 @@ class IsAuthenticatedSubmission(BasePermission):
                 user = form.user
             elif project_pk:
                 project = get_object_or_404(Project, pk=project_pk)
-                user = project.user
+                user = project.organization
             else:
                 # Raises a permission denied exception, forces authentication
                 return False


### PR DESCRIPTION
### Changes / Features implemented

The project owner's require auth status should be used and not the project creator's require auth status. This bug affected projects within an organization where the project's creator disabled require auth but the organization required auth was enabled. This resulted in a 403 response instead of a 401 for anonymous users.

### Steps taken to verify this change does what is intended

- [ ] QA

### Side effects of implementing this change

ODK Collect users will be prompted to entre their credentials instead of receiving a 403 error if the credentials are stale or missing when sending submissions


**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  - [ ] Updated documentation

Closes #2918
