### PR TITLE
fix: decryption error metadata lost if Instance re-saved

### DIFF
--- a/onadata/apps/logger/models/instance.py
+++ b/onadata/apps/logger/models/instance.py
@@ -54,6 +54,7 @@ from onadata.libs.utils.common_tags import (
     ATTACHMENTS,
     BAMBOO_DATASET_ID,
     DATE_MODIFIED,
+    DECRYPTION_ERROR,
     DELETEDAT,
     DURATION,
     EDITED,
@@ -345,7 +346,16 @@ def save_full_json(instance, include_related=True):
     Args:
         include_related (bool): Whether to include related objects
     """
-    update_fields_directly(instance, json=instance.get_full_dict(include_related))
+    json = instance.get_full_dict(include_related)
+
+    # Preserve dynamic metadata fields if present
+    if (
+        instance.decryption_status == Instance.DecryptionStatus.FAILED
+        and instance.json.get(DECRYPTION_ERROR) is not None
+    ):
+        json[DECRYPTION_ERROR] = instance.json[DECRYPTION_ERROR]
+
+    update_fields_directly(instance, json=json)
 
 
 def update_project_date_modified(instance):

--- a/onadata/apps/logger/tasks.py
+++ b/onadata/apps/logger/tasks.py
@@ -182,6 +182,8 @@ def update_project_date_modified_async(instance_id):
 class DecryptInstanceAutoRetryTask(AutoRetryTask):
     """Custom task class for decrypting instances with auto-retry"""
 
+    autoretry_for = AutoRetryTask.autoretry_for + (ValigettaConnectionException,)
+
     # pylint: disable=too-many-arguments, too-many-positional-arguments
     def on_failure(self, exc, task_id, args, kwargs, einfo):
         """Override `on_failure` to save decryption error if max retries exceeded"""
@@ -204,11 +206,7 @@ class DecryptInstanceAutoRetryTask(AutoRetryTask):
         return None
 
 
-@app.task(
-    base=DecryptInstanceAutoRetryTask,
-    bind=True,
-    autoretry_for=AutoRetryTask.autoretry_for + (ValigettaConnectionException,),
-)
+@app.task(base=DecryptInstanceAutoRetryTask, bind=True)
 @use_master
 def decrypt_instance_async(self, instance_id: int):
     """Decrypt encrypted Instance asynchronously.

--- a/onadata/libs/kms/tools.py
+++ b/onadata/libs/kms/tools.py
@@ -466,7 +466,8 @@ def save_decryption_error(instance: Instance, error_name: str):
     :param instance: Instance
     :param error_name: Error code
     """
-    json = instance.json
+    # Create a copy that we'll mutate
+    json = dict(instance.json or {})
     json[DECRYPTION_ERROR] = error_name
     update_fields_directly(
         instance,


### PR DESCRIPTION
### Changes / Features implemented

Fix decryption error metadata is lost if  a `Instance` is re-saved
Refactor task `decrypt_instance_async`

### Steps taken to verify this change does what is intended

- [ ] QA

### Side effects of implementing this change

No side effect

**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  - [ ] Updated documentation

Closes #2919
