### PR TITLE
Bump onadata version to v5.8.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,27 @@ Changelog for Onadata
 
 ``* represents releases that introduce new migrations``
 
+v5.8.0(2025-10-16)
+------------------
+- fix: Ensure decryption error metadata is not lost if Instance re-saved
+  [@kelvin-muchiri]
+  `PR #2920 https://github.com/onaio/onadata/pull/2920`
+- perf: Improve export outdated check performance
+  [@kelvin-muchiri]
+  `PR #2926 https://github.com/onaio/onadata/pull/2926`
+- Improve JSON submission docs
+  [@ukanga]
+  `PR #2929 https://github.com/onaio/onadata/pull/2929`
+- Security updates
+  [@ukanga]
+  `PR #2930 https://github.com/onaio/onadata/pull/2930`
+- Expose system errors to Sentry when uploading a form
+  [@FrankApiyo]
+  `PR #2935 https://github.com/onaio/onadata/pull/2935`
+- Bump ona-oidc version to v2.5.1
+  [@FrankApiyo]
+  `PR #2935 https://github.com/onaio/onadata/pull/2935`
+
 v5.7.0(2025-10-07)
 ------------------
 - Bug fix: Only send password reset emails to non-organizations

--- a/onadata/__init__.py
+++ b/onadata/__init__.py
@@ -7,7 +7,7 @@ visualization.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "5.7.0"
+__version__ = "5.8.0"
 
 
 # This will make sure the app is always imported when

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = onadata
-version = 5.7.0
+version = 5.8.0
 description = Collect Analyze and Share Data
 long_description = file: README.rst
 long_description_content_type = text/x-rst


### PR DESCRIPTION
## What's Changed
* fix: decryption error metadata lost if Instance re-saved by @kelvin-muchiri in https://github.com/onaio/onadata/pull/2920
* perf: improve export outdated check performance by @kelvin-muchiri in https://github.com/onaio/onadata/pull/2926
* Bump ona-oidc version to v2.5.1 by @FrankApiyo in https://github.com/onaio/onadata/pull/2935
* Improve JSON submission docs by @ukanga in https://github.com/onaio/onadata/pull/2929
* Security updates by @ukanga in https://github.com/onaio/onadata/pull/2930
* Expose system errors to Sentry when uploading a form by @FrankApiyo in https://github.com/onaio/onadata/pull/2935



**Full Changelog**: https://github.com/onaio/onadata/compare/v5.7.0...v5.8.0