### PR TITLE
Update to Django 5.1.14

### DIFF
--- a/requirements/azure.pip
+++ b/requirements/azure.pip
@@ -22,7 +22,7 @@ cryptography==44.0.2
     # via
     #   -r requirements/azure.in
     #   azure-storage-blob
-django==5.1.13
+django==5.1.14
     # via
     #   -r requirements/azure.in
     #   django-storages

--- a/requirements/base.pip
+++ b/requirements/base.pip
@@ -91,7 +91,7 @@ deprecated==1.2.18
     # via onadata
 dict2xml==1.7.6
     # via onadata
-django==5.1.13
+django==5.1.14
     # via
     #   django-activity-stream
     #   django-cors-headers

--- a/requirements/dev.pip
+++ b/requirements/dev.pip
@@ -111,7 +111,7 @@ dill==0.3.9
     # via pylint
 distlib==0.3.9
     # via virtualenv
-django==5.1.13
+django==5.1.14
     # via
     #   django-activity-stream
     #   django-cors-headers

--- a/requirements/s3.pip
+++ b/requirements/s3.pip
@@ -12,7 +12,7 @@ botocore==1.37.29
     # via
     #   boto3
     #   s3transfer
-django==5.1.13
+django==5.1.14
     # via
     #   -r requirements/s3.in
     #   django-storages

--- a/requirements/ses.pip
+++ b/requirements/ses.pip
@@ -14,7 +14,7 @@ botocore==1.37.29
     # via
     #   boto3
     #   s3transfer
-django==5.1.13
+django==5.1.14
     # via
     #   -r requirements/ses.in
     #   django-ses

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ tests_require =
     httmock
     requests-mock
 install_requires =
-    Django>=5.1.13,<5.2
+    Django>=5.1.14,<5.2
     django-guardian
     django-registration-redux
     django-templated-email


### PR DESCRIPTION
Address CVE-2025-64459 and CVE-2025-64458

Closes https://github.com/onaio/onadata/security/code-scanning/4828 and https://github.com/onaio/onadata/security/code-scanning/4829

