### PR TITLE
fix: add validation to prevent replacing encrypted forms

### DIFF
--- a/onadata/apps/api/tests/viewsets/test_xform_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_xform_viewset.py
@@ -5510,7 +5510,7 @@ nhMo+jI88L3qfm4/rtWKuQ9/a268phlNj34uQeoDDHuRViQo00L5meE/pFptm
 
                 self.assertEqual(response.status_code, 400)
                 self.assertEqual(
-                    response.data["detail"],
+                    response.data["message"],
                     "This form is encrypted and cannot be replaced.",
                 )
 


### PR DESCRIPTION
### Changes / Features implemented

Add validation to prevent replacing encrypted forms

### Steps taken to verify this change does what is intended

- [ ] QA

### Side effects of implementing this change

Encrypted forms can no longer be replaced.

**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  - [ ] Updated documentation

Closes #2951 
