### PR TITLE
Bump onadata version to v5.10.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,16 @@ Changelog for Onadata
 
 ``* represents releases that introduce new migrations``
 
+v5.10.0 (2025-11-24)*
+-------------------
+- dependency: Django 5.2.8
+  [@ukanga]
+  `PR #2955 https://github.com/onaio/onadata/pull/2955`
+- feat: Add submission table partitioning
+  [@ukanga]
+  `PR #2952 https://github.com/onaio/onadata/pull/2952`
+
+
 v5.9.0 (2025-11-18)
 -------------------
 - fix: export download fails if filename contains non-ascii

--- a/onadata/__init__.py
+++ b/onadata/__init__.py
@@ -7,7 +7,7 @@ visualization.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "5.9.0"
+__version__ = "5.10.0"
 
 
 # This will make sure the app is always imported when

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = onadata
-version = 5.9.0
+version = 5.10.0
 description = Collect Analyze and Share Data
 long_description = file: README.rst
 long_description_content_type = text/x-rst


### PR DESCRIPTION
## What's Changed
* Add submission table partitioning by @ukanga in https://github.com/onaio/onadata/pull/2952
* Django 5.2.8 by @ukanga in https://github.com/onaio/onadata/pull/2955


**Full Changelog**: https://github.com/onaio/onadata/compare/v5.9.0...v5.10.0