### PR TITLE
Bump onadata version to 5.11.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,36 @@ Changelog for Onadata
 
 ``* represents releases that introduce new migrations``
 
+v5.11.0 (2025-11-24)
+-------------------
+- Handle failures during partitioning cutover in
+  [@ukanga]
+  `PR #2962 https://github.com/onaio/onadata/pull/2962`
+- fix: add validation to prevent replacing encrypted forms
+  [@kelvin-muchiri]
+  `PR #2953 https://github.com/onaio/onadata/pull/2953`
+- Fix bug in get_xform_users_with_perms fn
+  [@FrankApiyo]
+  `PR #2950 https://github.com/onaio/onadata/pull/2950`
+- feat: support select from dataset within group in follow up form
+  [@kelvin-muchiri]
+  `PR #2963 https://github.com/onaio/onadata/pull/2963`
+- Use PostgreSQL 15 in tests
+  [@ukanga]
+  `PR #2964 https://github.com/onaio/onadata/pull/2964`
+- feat: create EntityList export after linking follow up form
+  [@kelvin-muchiri]
+  `PR #2965 https://github.com/onaio/onadata/pull/2965`
+- For GeoJSON endpoint ensure all relevant fields are requested
+  [@ukanga]
+  `PR #2968 https://github.com/onaio/onadata/pull/2968`
+- Optimize merged dataset queries
+  [@FrankApiyo]
+  `PR #2967 https://github.com/onaio/onadata/pull/2967`
+- Add message folding for Actstream messages
+  [@FrankApiyo]
+  `PR #2967 https://github.com/onaio/onadata/pull/2956`
+
 v5.10.0 (2025-11-24)*
 -------------------
 - dependency: Django 5.2.8
@@ -11,7 +41,6 @@ v5.10.0 (2025-11-24)*
 - feat: Add submission table partitioning
   [@ukanga]
   `PR #2952 https://github.com/onaio/onadata/pull/2952`
-
 
 v5.9.0 (2025-11-18)
 -------------------

--- a/onadata/__init__.py
+++ b/onadata/__init__.py
@@ -7,7 +7,7 @@ visualization.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "5.10.0"
+__version__ = "5.11.0"
 
 
 # This will make sure the app is always imported when

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = onadata
-version = 5.10.0
+version = 5.11.0
 description = Collect Analyze and Share Data
 long_description = file: README.rst
 long_description_content_type = text/x-rst


### PR DESCRIPTION
## What's Changed
* Handle failures during partitioning cutover by @ukanga in https://github.com/onaio/onadata/pull/2962
* fix: add validation to prevent replacing encrypted forms by @kelvin-muchiri in https://github.com/onaio/onadata/pull/2953
* Fix bug in get_xform_users_with_perms fn by @FrankApiyo in https://github.com/onaio/onadata/pull/2950
* feat: support select from dataset within group in follow up form by @kelvin-muchiri in https://github.com/onaio/onadata/pull/2963
* Use PostgreSQL 15 in tests by @ukanga in https://github.com/onaio/onadata/pull/2964
* feat: create EntityList export after linking follow up form by @kelvin-muchiri in https://github.com/onaio/onadata/pull/2965
* For GeoJSON endpoint ensure all relevant fields are requested by @ukanga in https://github.com/onaio/onadata/pull/2968
* Optimize merged dataset queries by @FrankApiyo in https://github.com/onaio/onadata/pull/2967
* Add message folding for Actstream messages by @FrankApiyo https://github.com/onaio/onadata/pull/2956


**Full Changelog**: https://github.com/onaio/onadata/compare/v5.10.0...75829fb40827131c1a81d8f50a492c1f139b1ec4