### PR TITLE
Added collations migration to make username lookups case-insensitive (#2803)

### DIFF
--- a/onadata/apps/api/migrations/0009_case_insensitive_username.py
+++ b/onadata/apps/api/migrations/0009_case_insensitive_username.py
@@ -16,11 +16,6 @@ class Migration(migrations.Migration):
             sql='CREATE COLLATION IF NOT EXISTS case_insensitive (provider = icu, locale = \'und-u-ks-level2\', deterministic = false);',
             reverse_sql='DROP COLLATION IF EXISTS case_insensitive;',
         ),
-        # Create deterministic collation for LIKE queries
-        migrations.RunSQL(
-            sql='CREATE COLLATION IF NOT EXISTS deterministic_unicode (provider = icu, locale = \'und-x-icu\', deterministic = true);',
-            reverse_sql='DROP COLLATION IF EXISTS deterministic_unicode;',
-        ),
         # Drop the existing index
         migrations.RunSQL(
             sql='DROP INDEX IF EXISTS auth_user_username_6821ab7c_like;',

--- a/onadata/apps/api/tests/viewsets/test_case_insensitive_username_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_case_insensitive_username_viewset.py
@@ -25,11 +25,6 @@ class TestCaseInsensitiveUserQuery(TestCase):
                 (provider = icu, locale = 'und-u-ks-level2', deterministic = false);
             """)
             
-            cursor.execute("""
-                CREATE COLLATION IF NOT EXISTS deterministic_unicode 
-                (provider = icu, locale = 'und-x-icu', deterministic = true);
-            """)
-            
             # Drop the old index
             cursor.execute("DROP INDEX IF EXISTS auth_user_username_6821ab7c_like;")
             


### PR DESCRIPTION
### Changes / Features implemented

Updated solution from the previous pull request #2966

Added a database migration that adds collations to the auth_user username field so username lookups within the API endpoints become case-insensitive.

Added a regression test (TestCaseInsensitiveUserQuery) that confirms /api/v1/profiles.json?users=<username> correctly matches users regardless of casing (bob, Bob, bOb, etc.). 

### Steps taken to verify this change does what is intended

Manual verification of the migration was done to ensure that the collation was properly added
Manual verification of the API endpoints in curl was done in accordance to the example in the original #2803 post to ensure correct behavior
Test case was ran with different variants of the target username in order to make sure applying the collation leads for case insensitivity.


### Side effects of implementing this change

Api endpoints such as:
```
    /api/v1/profiles.json?users=<username>
```
and 
```
 /api/v1/profiles/<username>/
```
are now case insensitive


**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  - [ ] Updated documentation


