### PR TITLE
Dockerfile cleanup

### DIFF
--- a/docker/onadata-uwsgi/Dockerfile.ubuntu
+++ b/docker/onadata-uwsgi/Dockerfile.ubuntu
@@ -44,13 +44,9 @@ FROM base AS docs
 
 ENV PYENV_ROOT="$HOME/.pyenv"
 ENV PATH=$PYENV_ROOT/versions/3.10.19/bin:$PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH
-COPY --from=base /home/appuser/.pyenv/ /home/appuser/.pyenv/
-COPY --from=base /srv/onadata/ /srv/onadata/
 
 USER root
-
 RUN chown -R appuser:appuser /srv/onadata/
-
 USER appuser
 
 # install sphinx and build API docs.
@@ -85,9 +81,7 @@ RUN apt-get install -y --no-install-recommends \
     libpcre3 \
     openjdk-17-jre-headless \
     libxml2 \
-    libxml2-dev \
     libxslt1.1 \
-    libxslt1-dev \
     && apt-get autoremove -y \
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/* \


### PR DESCRIPTION
### Changes / Features implemented

- Fixes a runtime error caused by a missing dependency:
```
error: uwsgi: error while loading shared libraries:
  libpcre.so.3: cannot open shared object file: No such file or directory
```
- Dockerfile cleanup:
      - docs layer does not need to copy from base because it inherits from base
      - remove uneeded `-dev` dependencies
