### PR TITLE
Fix CVE-2026-24049: upgrade wheel to 0.46.2 and update base image

### DIFF
--- a/docker/onadata-uwsgi/Dockerfile.ubuntu
+++ b/docker/onadata-uwsgi/Dockerfile.ubuntu
@@ -1,4 +1,4 @@
-FROM onaio/python-deps:3.10.19-20260119 AS base
+FROM onaio/python-deps:3.10.19-20260123 AS base
 
 ARG optional_packages
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,6 @@ requires = [
     "setuptools >= 48",
     "setuptools_scm[toml] >= 4, <6",
     "setuptools_scm_git_archive",
-    "wheel >= 0.29.0",
+    "wheel >= 0.46.2",
 ]
 build-backend = 'setuptools.build_meta'


### PR DESCRIPTION
- Update wheel build dependency minimum version from 0.29.0 to 0.46.2 to address CVE-2026-24049 (HIGH severity)
- Update Docker base image to python-deps:3.10.19-20260123 to address CVE-2026-24049 (HIGH severity)
