### PR TITLE
fix: pin bulk submission delete to primary DB

### DIFF
--- a/onadata/apps/api/tasks.py
+++ b/onadata/apps/api/tasks.py
@@ -17,6 +17,7 @@ from django.utils import timezone
 from django.utils.datastructures import MultiValueDict
 
 from celery.result import AsyncResult
+from multidb.pinning import use_master
 
 from onadata.apps.api import tools
 from onadata.apps.logger.models import Instance, Project, ProjectInvitation, XForm
@@ -213,6 +214,7 @@ def share_project_async(project_id, username, role, remove=False):
 
 
 @app.task(base=AutoRetryTask)
+@use_master
 def delete_xform_submissions_async(
     xform_id: int,
     deleted_by_id: int,

--- a/onadata/libs/utils/logger_tools.py
+++ b/onadata/libs/utils/logger_tools.py
@@ -1313,6 +1313,7 @@ class PublishXForm:  # pylint: disable=too-few-public-methods
         return publish_xml_form(self.xml_file, self.user, self.project)
 
 
+@use_master
 def delete_xform_submissions(
     xform: XForm,
     deleted_by: User,


### PR DESCRIPTION

### Changes / Features implemented

delete_xform_submissions and its async wrapper lack @use_master, so the submission_count correction reads from a replica that may have replication lag. The stale count matches num_of_submissions, skipping the correction entirely.


### Steps taken to verify this change does what is intended

Existing tests still pass.

### Side effects of implementing this change

None

**Before submitting this PR for review, please make sure you have:**

  - [ ] Included tests
  - [ ] Updated documentation

Closes #
