### PR TITLE
fix: upgrade trivy-action to v0.34.0 (CWE-78)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,7 +206,7 @@ jobs:
           trivy vex repo download
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.33.1
+        uses: aquasecurity/trivy-action@c1824fd6edce30d7ab345a9989de00bbd46ef284 # v0.34.0
         if: github.event_name == 'pull_request' || github.event_name == 'push'
         with:
           version: "v0.69.1"
@@ -236,7 +236,7 @@ jobs:
           wget -q "$url" -O html.tpl
 
       - name: Run Trivy vulnerability scanner (HTML report)
-        uses: aquasecurity/trivy-action@0.33.1
+        uses: aquasecurity/trivy-action@c1824fd6edce30d7ab345a9989de00bbd46ef284 # v0.34.0
         if: github.event_name == 'pull_request' || github.event_name == 'push'
         with:
           version: "v0.69.1"

--- a/.github/workflows/ecr-image-build.yml
+++ b/.github/workflows/ecr-image-build.yml
@@ -172,7 +172,7 @@ jobs:
           trivy vex repo download
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.33.1
+        uses: aquasecurity/trivy-action@c1824fd6edce30d7ab345a9989de00bbd46ef284 # v0.34.0
         with:
           version: "v0.69.1"
           image-ref: ${{ env.docker_repo }}
@@ -201,7 +201,7 @@ jobs:
           wget -q "$url" -O html.tpl
 
       - name: Run Trivy vulnerability scanner (HTML report)
-        uses: aquasecurity/trivy-action@0.33.1
+        uses: aquasecurity/trivy-action@c1824fd6edce30d7ab345a9989de00bbd46ef284 # v0.34.0
         with:
           version: "v0.69.1"
           image-ref: ${{ env.docker_repo }}


### PR DESCRIPTION
Pin aquasecurity/trivy-action to v0.34.0 commit SHA to fix command injection via unsanitized env var export in versions
>= 0.31.0 and <= 0.33.1.

### Changes / Features implemented

### Steps taken to verify this change does what is intended

### Side effects of implementing this change


**Before submitting this PR for review, please make sure you have:**

  - [ ] Included tests
  - [ ] Updated documentation

Closes #
