### PR TITLE
fix: incorrect cors middlware placement

### DIFF
--- a/onadata/settings/common.py
+++ b/onadata/settings/common.py
@@ -161,9 +161,9 @@ TEMPLATES = [
 DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
 
 MIDDLEWARE = (
+    "corsheaders.middleware.CorsMiddleware",
     "onadata.libs.profiling.sql.SqlTimingMiddleware",
     "django.middleware.http.ConditionalGetMiddleware",
-    "corsheaders.middleware.CorsMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     # 'django.middleware.locale.LocaleMiddleware',


### PR DESCRIPTION
### Changes / Features implemented

CorsMiddleware should be placed as high as possible, especially before any middleware that can generate responses such as Django’s CommonMiddleware or Whitenoise’s WhiteNoiseMiddleware. If it is not before, it will not be able to add the CORS headers to these responses. Reference: https://pypi.org/project/django-cors-headers/

One side effect of this bug was that `corsheaders`  settings were not being applied e.g `CORS_ORIGIN_ALLOW_ALL=True` wasn't working for local development flow

