### PR TITLE
Bump onadata to v5.15.1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,22 @@ Changelog for Onadata
 
 ``* represents releases that introduce new migrations``
 
+v5.15.1 (2026-04-10)
+--------------------
+- chore(deps): regenerate requirements with Python 3.13 and django 5.2.13
+  [@ukanga]
+  `PR #3055 https://github.com/onaio/onadata/pull/3055`
+- fix: set explicit fileLabel for SavWriter to avoid getpass.getuser() call
+  [@FrankApiyo]
+  `PR #3053 https://github.com/onaio/onadata/pull/3053`
+- fix: stale project caches after sharing project w/ team
+  [@kelvin-muchiri]
+  `PR #3052 https://github.com/onaio/onadata/pull/3052`
+- Project reversion api tracking
+  [@ukanga]
+  `PR #3051 https://github.com/onaio/onadata/pull/3051`
+
+
 v5.15.0 (2026-03-19)
 --------------------
 - Switch to Python 3.13 from 3.10.19

--- a/onadata/__init__.py
+++ b/onadata/__init__.py
@@ -7,7 +7,7 @@ visualization.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "5.15.0"
+__version__ = "5.15.1"
 
 
 # This will make sure the app is always imported when

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = onadata
-version = 5.15.0
+version = 5.15.1
 description = Collect Analyze and Share Data
 long_description = file: README.rst
 long_description_content_type = text/x-rst


### PR DESCRIPTION
* chore(deps): regenerate requirements with Python 3.13 and django 5.2.13 by @ukanga in https://github.com/onaio/onadata/pull/3055
* fix: set explicit fileLabel for SavWriter to avoid getpass.getuser() call by @FrankApiyo in https://github.com/onaio/onadata/pull/3053
* fix: stale project caches after sharing project w/ team by @kelvin-muchiri in https://github.com/onaio/onadata/pull/3052
* Project reversion api tracking by @ukanga in https://github.com/onaio/onadata/pull/3051