### PR TITLE
fix: catch InvalidStorageError when storage backend module is missing

### DIFF
--- a/onadata/libs/tests/utils/test_logger_tools.py
+++ b/onadata/libs/tests/utils/test_logger_tools.py
@@ -12,6 +12,7 @@ from unittest.mock import Mock, patch
 from django.conf import settings
 from django.core.cache import cache
 from django.core.exceptions import PermissionDenied
+from django.core.files.storage import InvalidStorageError
 from django.core.files.uploadedfile import InMemoryUploadedFile
 from django.http.request import HttpRequest
 from django.test.utils import override_settings
@@ -1312,3 +1313,27 @@ class GetStoragesMediaDownloadUrlTestCase(TestBase):
         self.assertEqual(called_kwargs["content_type"], "text/csv")
         self.assertIsInstance(called_kwargs["permission"], AccountSasPermissions)
         self.assertTrue(called_kwargs["permission"].read)
+
+    @override_settings(
+        STORAGES={
+            "default": {"BACKEND": "django.core.files.storage.FileSystemStorage"}
+        },
+    )
+    @patch("onadata.libs.utils.logger_tools.storages")
+    def test_invalid_storage_error_is_handled_gracefully(self, mock_storages):
+        """InvalidStorageError from create_storage is caught gracefully.
+
+        Regression test for https://github.com/onaio/onadata/issues/2960.
+        When the azure or boto3 packages are not installed, Django's
+        create_storage raises InvalidStorageError (wrapping ModuleNotFoundError).
+        The function should return None without raising.
+        """
+        mock_storages.create_storage.side_effect = InvalidStorageError(
+            "Could not find backend: No module named 'azure'"
+        )
+        mock_storages.__getitem__ = lambda self, key: None
+
+        url = get_storages_media_download_url(
+            "test.csv", 'attachment; filename="test.csv"', "text/csv", 3600
+        )
+        self.assertIsNone(url)

--- a/onadata/libs/utils/logger_tools.py
+++ b/onadata/libs/utils/logger_tools.py
@@ -28,7 +28,7 @@ from django.core.exceptions import (
     PermissionDenied,
     ValidationError,
 )
-from django.core.files.storage import storages
+from django.core.files.storage import InvalidStorageError, storages
 from django.db import DataError, IntegrityError, transaction
 from django.http import (
     HttpResponse,
@@ -944,14 +944,14 @@ def get_storages_media_download_url(
         s3_class = storages.create_storage(
             {"BACKEND": "storages.backends.s3boto3.S3Boto3Storage"}
         )
-    except ModuleNotFoundError:
+    except (ModuleNotFoundError, InvalidStorageError):
         pass
 
     try:
         azure_class = storages.create_storage(
             {"BACKEND": "storages.backends.azure_storage.AzureStorage"}
         )
-    except ModuleNotFoundError:
+    except (ModuleNotFoundError, InvalidStorageError):
         pass
 
     # Check if the storage backend is S3


### PR DESCRIPTION
### Changes / Features implemented

Django's StorageHandler.create_storage() wraps ImportError in InvalidStorageError (a subclass of ImproperlyConfigured), not ModuleNotFoundError. The existing except clauses only caught ModuleNotFoundError, so any environment without the azure or boto3 packages would raise an unhandled InvalidStorageError on every media file request.

Fix: also catch InvalidStorageError in both the S3 and Azure create_storage calls in get_storages_media_download_url().



### Steps taken to verify this change does what is intended

- Added testinvalidstorageerrorishandledgracefully to GetStoragesMediaDownloadUrlTestCase in onadata/libs/tests/utils/testloggertools.py
- Test mocks storages.create_storage to raise InvalidStorageError and asserts the function returns None without raising

### Side effects of implementing this change

None. The fix only broadens the exception handling in the storage backend detection logic. The behaviour in all other cases (S3, Azure, or local storage) is unchanged.

**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  - [ ] Updated documentation

Fixes #2960 (Sentry: ONADATA-E5N)
