### PR TITLE
fix: catch pylibmc.Error in _safe_cache_operation

### DIFF
--- a/onadata/libs/tests/utils/test_cache_tools.py
+++ b/onadata/libs/tests/utils/test_cache_tools.py
@@ -11,6 +11,8 @@ from django.core.cache import cache
 from django.http.request import HttpRequest
 from django.test import TestCase
 
+import pylibmc
+
 from onadata.apps.logger.models.project import Project
 from onadata.apps.main.models.user_profile import UserProfile
 from onadata.libs.serializers.project_serializer import ProjectSerializer
@@ -138,6 +140,7 @@ class SafeCacheSetTestCase(TestCase):
             (ConnectionError, "ConnectionError"),
             (socket.error, "socket.error"),
             (ValueError, "ValueError"),
+            (pylibmc.TooBig, "pylibmc.TooBig"),
         ]
 
         for exception_class, exception_name in test_cases:
@@ -178,6 +181,7 @@ class SafeCacheGetTestCase(TestCase):
             (ConnectionError, "ConnectionError"),
             (socket.error, "socket.error"),
             (ValueError, "ValueError"),
+            (pylibmc.TooBig, "pylibmc.TooBig"),
         ]
 
         for exception_class, exception_name in test_cases:
@@ -219,6 +223,7 @@ class SafeCacheAddTestCase(TestCase):
             (ConnectionError, "ConnectionError"),
             (socket.error, "socket.error"),
             (ValueError, "ValueError"),
+            (pylibmc.TooBig, "pylibmc.TooBig"),
         ]
 
         for exception_class, exception_name in test_cases:
@@ -260,6 +265,7 @@ class SafeCacheIncrTestCase(TestCase):
             (ConnectionError, "ConnectionError"),
             (socket.error, "socket.error"),
             (ValueError, "ValueError"),
+            (pylibmc.TooBig, "pylibmc.TooBig"),
         ]
 
         for exception_class, exception_name in test_cases:
@@ -301,6 +307,7 @@ class SafeCacheDecrTestCase(TestCase):
             (ConnectionError, "ConnectionError"),
             (socket.error, "socket.error"),
             (ValueError, "ValueError"),
+            (pylibmc.TooBig, "pylibmc.TooBig"),
         ]
 
         for exception_class, exception_name in test_cases:
@@ -334,6 +341,7 @@ class SafeCacheDeleteTestCase(TestCase):
             (ConnectionError, "ConnectionError"),
             (socket.error, "socket.error"),
             (ValueError, "ValueError"),
+            (pylibmc.TooBig, "pylibmc.TooBig"),
         ]
 
         for exception_class, exception_name in test_cases:

--- a/onadata/libs/utils/cache_tools.py
+++ b/onadata/libs/utils/cache_tools.py
@@ -13,6 +13,8 @@ from django.conf import settings
 from django.core.cache import cache
 from django.utils.encoding import force_bytes
 
+import pylibmc
+
 logger = logging.getLogger(__name__)
 
 DEFAULT_TIMEOUT = cache.default_timeout
@@ -150,7 +152,7 @@ def _safe_cache_operation(operation, default_return=None):
     """
     try:
         return operation()
-    except (ConnectionError, socket.error, ValueError) as exc:
+    except (ConnectionError, socket.error, ValueError, pylibmc.Error) as exc:
         logger.exception(exc)
 
         return default_return


### PR DESCRIPTION
### Changes / Features implemented

pylibmc raises its own exception hierarchy (rooted at pylibmc.Error) for backend-level failures such as TooBig (value exceeds memcached slab size) and ServerDown. These bypassed the safe_cache_* wrappers and bubbled up to callers, producing 500s for what should be best-effort cache operations.

Add pylibmc.Error to the except tuple so all pylibmc backend errors are swallowed and logged, matching the existing behavior for ConnectionError and socket.error.

### Steps taken to verify this change does what is intended

- [ ] QA

### Side effects of implementing this change

None

**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  - [ ] Updated documentation