### PR TITLE
Fix/pylibmc too big cache error

### DIFF
--- a/onadata/libs/tests/utils/test_cache_tools.py
+++ b/onadata/libs/tests/utils/test_cache_tools.py
@@ -114,6 +114,24 @@ class TestCacheTools(TestCase):
         project_cache.pop("date_modified")
         self.assertEqual(project_cache, expected_project_cache)
 
+    @patch("onadata.libs.utils.cache_tools.cache.set")
+    def test_reset_project_cache_handles_oversized_data(self, mock_cache_set):
+        """reset_project_cache does not raise when cache value exceeds size limit"""
+        bob = User.objects.create(username="alice", first_name="alice")
+        UserProfile.objects.create(user=bob)
+        project = Project.objects.create(
+            name="Big Project", created_by=bob, organization=bob
+        )
+        mock_cache_set.side_effect = Exception("TooBig")
+
+        request = HttpRequest()
+        request.user = bob
+        request.META = {"SERVER_NAME": "testserver", "SERVER_PORT": "80"}
+
+        # Should not raise even when cache.set raises due to oversized data
+        reset_project_cache(project, request, ProjectSerializer)
+        mock_cache_set.assert_called()
+
 
 @patch("onadata.libs.utils.cache_tools.cache.set")
 class SafeCacheSetTestCase(TestCase):
@@ -138,6 +156,7 @@ class SafeCacheSetTestCase(TestCase):
             (ConnectionError, "ConnectionError"),
             (socket.error, "socket.error"),
             (ValueError, "ValueError"),
+            (Exception, "Exception"),
         ]
 
         for exception_class, exception_name in test_cases:
@@ -178,6 +197,7 @@ class SafeCacheGetTestCase(TestCase):
             (ConnectionError, "ConnectionError"),
             (socket.error, "socket.error"),
             (ValueError, "ValueError"),
+            (Exception, "Exception"),
         ]
 
         for exception_class, exception_name in test_cases:
@@ -219,6 +239,7 @@ class SafeCacheAddTestCase(TestCase):
             (ConnectionError, "ConnectionError"),
             (socket.error, "socket.error"),
             (ValueError, "ValueError"),
+            (Exception, "Exception"),
         ]
 
         for exception_class, exception_name in test_cases:
@@ -260,6 +281,7 @@ class SafeCacheIncrTestCase(TestCase):
             (ConnectionError, "ConnectionError"),
             (socket.error, "socket.error"),
             (ValueError, "ValueError"),
+            (Exception, "Exception"),
         ]
 
         for exception_class, exception_name in test_cases:
@@ -301,6 +323,7 @@ class SafeCacheDecrTestCase(TestCase):
             (ConnectionError, "ConnectionError"),
             (socket.error, "socket.error"),
             (ValueError, "ValueError"),
+            (Exception, "Exception"),
         ]
 
         for exception_class, exception_name in test_cases:
@@ -334,6 +357,7 @@ class SafeCacheDeleteTestCase(TestCase):
             (ConnectionError, "ConnectionError"),
             (socket.error, "socket.error"),
             (ValueError, "ValueError"),
+            (Exception, "Exception"),
         ]
 
         for exception_class, exception_name in test_cases:

--- a/onadata/libs/utils/cache_tools.py
+++ b/onadata/libs/utils/cache_tools.py
@@ -5,7 +5,6 @@ Cache utilities.
 
 import hashlib
 import logging
-import socket
 import time
 from contextlib import contextmanager
 
@@ -135,7 +134,7 @@ def reset_project_cache(project, request, project_serializer_class):
     project_cache_data = project_serializer_class(
         project, context={"request": request}
     ).data
-    cache.set(f"{PROJ_OWNER_CACHE}{project.pk}", project_cache_data)
+    safe_cache_set(f"{PROJ_OWNER_CACHE}{project.pk}", project_cache_data)
 
 
 def _safe_cache_operation(operation, default_return=None):
@@ -150,7 +149,7 @@ def _safe_cache_operation(operation, default_return=None):
     """
     try:
         return operation()
-    except (ConnectionError, socket.error, ValueError) as exc:
+    except Exception as exc:  # pylint: disable=broad-exception-caught
         logger.exception(exc)
 
         return default_return
@@ -294,8 +293,8 @@ def set_cache_with_lock(
     """
     with with_cache_lock(cache_key, lock_expire, lock_timeout):
         # Get the current value from cache
-        current_value = cache.get(cache_key)
+        current_value = safe_cache_get(cache_key)
         # Use the callback to get the modified value
         new_value = modify_callback(current_value)
         # Set the new value in the cache with the specified timeout
-        cache.set(cache_key, new_value, cache_timeout)
+        safe_cache_set(cache_key, new_value, cache_timeout)


### PR DESCRIPTION
### Changes / Features implemented

  - Broadened exception handling in _safe_cache_operation() from (ConnectionError, socket.error, ValueError) to Exception, so that pylibmc.TooBig (and any other unexpected cache
  backend errors) are caught, logged, and silently ignored instead of crashing the request.
  - Replaced bare cache.set() in reset_project_cache() with safe_cache_set() so the call goes through the safe wrapper.
  - Replaced bare cache.get() / cache.set() in safe_modify_cache_value() with safe_cache_get() / safe_cache_set() for consistency.


### Steps taken to verify this change does what is intended

  - Ran the full onadata.libs.tests.utils.test_cache_tools test suite (20 tests pass).
  - Added Exception to all test_exception_is_logged test matrices across safe_cache_set, safe_cache_get, safe_cache_add, safe_cache_incr, safe_cache_decr, and safe_cache_delete.
  - Added test_reset_project_cache_handles_oversized_data which patches cache.set to raise Exception("TooBig") and verifies reset_project_cache() does not propagate the
  exception.


### Side effects of implementing this change
 - Cache failures that previously raised unhandled exceptions (e.g. pylibmc.TooBig) will now be silently logged and the request will continue without caching. The project data
  will be fetched from the database on the next request instead of being served from cache.



**Before submitting this PR for review, please make sure you have:**

  - [X] Included tests
  - [ ] Updated documentation

  Closes https://github.com/onaio/onadata/issues/3062
