### PR TITLE
Bump onadata to v5.15.2

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,16 @@ Changelog for Onadata
 
 ``* represents releases that introduce new migrations``
 
+v5.15.2 (2026-04-16)
+--------------------
+- fix: stale CSV exports after Entity soft delete
+  [@kelvin-muchiri]
+  `PR #3054 https://github.com/onaio/onadata/pull/3054`
+- fix: handle pylibmc.TooBig in cache operations
+  [@ukanga]
+  `PR #3063 https://github.com/onaio/onadata/pull/3063`
+
+
 v5.15.1 (2026-04-10)
 --------------------
 - chore(deps): regenerate requirements with Python 3.13 and django 5.2.13

--- a/onadata/__init__.py
+++ b/onadata/__init__.py
@@ -7,7 +7,7 @@ visualization.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "5.15.1"
+__version__ = "5.15.2"
 
 
 # This will make sure the app is always imported when

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = onadata
-version = 5.15.1
+version = 5.15.2
 description = Collect Analyze and Share Data
 long_description = file: README.rst
 long_description_content_type = text/x-rst


### PR DESCRIPTION
## Summary
- Bump onadata version to v5.15.2
- Add changelog entry for two merged PRs since v5.15.1

## Changes included
- fix: stale CSV exports after Entity soft delete — PR #3054
- fix: handle pylibmc.TooBig in cache operations — PR #3063