### PR TITLE
WIP: add bbox endpoint for forms, dataviews, and merged datasets

### DIFF
--- a/onadata/apps/api/tests/viewsets/test_dataview_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_dataview_viewset.py
@@ -2062,3 +2062,18 @@ class TestDataViewViewSet(TestAbstractViewSet):
             self.assertEqual(
                 csv_file.read(), "name,age,gender\nDennis Wambua,28,male\n"
             )
+
+    def test_bbox_returns_null_without_geolocated_submissions(self):
+        """The tutorial fixture has no geom, so bbox is ``null``.
+
+        Verifies the endpoint is wired and returns the expected envelope; the
+        geolocated-extent path is covered by the XFormViewSet bbox test which
+        shares the same underlying helper.
+        """
+        self._create_dataview()
+        view = DataViewViewSet.as_view({"get": "bbox"})
+        request = self.factory.get("/", **self.extra)
+        response = view(request, pk=self.data_view.pk)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIsNone(response.data["bbox"])

--- a/onadata/apps/api/tests/viewsets/test_merged_xform_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_merged_xform_viewset.py
@@ -898,3 +898,17 @@ class TestMergedXFormViewSet(TestAbstractViewSet):
         self.assertTrue(response.data["instances_with_geopoints"])
         # deleted parents, 0 submissions
         self.assertEqual(response.data["num_of_submissions"], 0)
+
+    def test_bbox_returns_null_without_geolocated_submissions(self):
+        """Merged dataset bbox returns ``null`` when no underlying xform has
+        geolocated rows. Shape verification keeps parity with the XForm and
+        DataView bbox endpoints; geolocated-extent is covered by the shared
+        helper via the XForm bbox test.
+        """
+        merged_dataset = self._create_merged_dataset()
+        view = MergedXFormViewSet.as_view({"get": "bbox"})
+        request = self.factory.get("/", **self.extra)
+        response = view(request, pk=merged_dataset["id"])
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIsNone(response.data["bbox"])

--- a/onadata/apps/api/tests/viewsets/test_xform_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_xform_viewset.py
@@ -6318,3 +6318,32 @@ class ExportAsyncTestCase(XFormViewSetBaseTestCase):
             print(response.data)
             # Ensure response is renderable
             response.render()
+
+    def test_bbox_returns_extent_of_geolocated_submissions(self):
+        """The bbox action returns [min_lng, min_lat, max_lng, max_lat]."""
+        xls_path = self._fixture_path("gps", "gps.xlsx")
+        self._publish_xls_file_and_set_xform(xls_path)
+        self._make_submissions_gps()
+
+        view = XFormViewSet.as_view({"get": "bbox"})
+        request = self.factory.get("/", **self.extra)
+        response = view(request, pk=self.xform.pk)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("bbox", response.data)
+        bbox = response.data["bbox"]
+        self.assertIsNotNone(bbox)
+        self.assertEqual(len(bbox), 4)
+        min_lng, min_lat, max_lng, max_lat = bbox
+        self.assertLessEqual(min_lng, max_lng)
+        self.assertLessEqual(min_lat, max_lat)
+
+    def test_bbox_null_when_no_geolocated_submissions(self):
+        """Returns ``bbox: null`` when no submission has a geom."""
+        self._publish_xls_form_to_project()
+        view = XFormViewSet.as_view({"get": "bbox"})
+        request = self.factory.get("/", **self.extra)
+        response = view(request, pk=self.xform.pk)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIsNone(response.data["bbox"])

--- a/onadata/apps/api/viewsets/dataview_viewset.py
+++ b/onadata/apps/api/viewsets/dataview_viewset.py
@@ -43,6 +43,7 @@ from onadata.libs.utils.chart_tools import (
     get_chart_data_for_field,
     get_field_from_field_name,
 )
+from onadata.libs.utils.bbox_tools import compute_instance_bbox
 from onadata.libs.utils.common_tools import get_abbreviated_xpath
 from onadata.libs.utils.export_tools import parse_request_export_options, str_to_bool
 
@@ -196,6 +197,20 @@ class DataViewViewSet(
         return custom_response_handler(
             request, self.object.xform, query, export_type, dataview=self.object
         )
+
+    # pylint: disable=unused-argument
+    @action(methods=["GET"], detail=True)
+    def bbox(self, request, *args, **kwargs):
+        """Return the bounding box of the dataview's geolocated submissions.
+
+        Applies the dataview's query filter to match the rows `form_tiles()`
+        would serve. Shape: ``{"bbox": [min_lng, min_lat, max_lng, max_lat] |
+        null}``. ``null`` when the filtered set has no geolocated rows.
+        """
+        # pylint: disable=attribute-defined-outside-init
+        self.object = self.get_object()
+        bbox = compute_instance_bbox([self.object.xform_id], dataview=self.object)
+        return Response({"bbox": bbox})
 
     # pylint: disable=too-many-locals
     @action(methods=["GET"], detail=True)

--- a/onadata/apps/api/viewsets/merged_xform_viewset.py
+++ b/onadata/apps/api/viewsets/merged_xform_viewset.py
@@ -20,6 +20,7 @@ from onadata.libs.pagination import StandardPageNumberPagination
 from onadata.libs.renderers import renderers
 from onadata.libs.serializers.geojson_serializer import GeoJsonSerializer
 from onadata.libs.serializers.merged_xform_serializer import MergedXFormSerializer
+from onadata.libs.utils.bbox_tools import compute_instance_bbox
 
 
 # pylint: disable=too-many-ancestors
@@ -92,6 +93,20 @@ class MergedXFormViewSet(
             data = json.loads(data) if isinstance(data, str) else data
 
         return Response(data)
+
+    # pylint: disable=unused-argument
+    @action(methods=["GET"], detail=True)
+    def bbox(self, request, *args, **kwargs):
+        """Return the bounding box across all xforms in this merged dataset.
+
+        Shape: ``{"bbox": [min_lng, min_lat, max_lng, max_lat] | null}``.
+        Matches the xform set `form_tiles()` serves when called with
+        ``merged_dataset_id``.
+        """
+        merged_xform = self.get_object()
+        xform_ids = list(merged_xform.xforms.values_list("pk", flat=True))
+        bbox = compute_instance_bbox(xform_ids)
+        return Response({"bbox": bbox})
 
     # pylint: disable=unused-argument
     @action(methods=["GET"], detail=True)

--- a/onadata/apps/api/viewsets/xform_viewset.py
+++ b/onadata/apps/api/viewsets/xform_viewset.py
@@ -65,6 +65,7 @@ from onadata.libs.utils.cache_tools import (
     safe_cache_get,
     safe_cache_set,
 )
+from onadata.libs.utils.bbox_tools import compute_instance_bbox
 from onadata.apps.logger.xform_instance_parser import XLSFormError
 from onadata.apps.messaging.constants import FORM_UPDATED, XFORM
 from onadata.apps.messaging.serializers import send_message
@@ -989,6 +990,20 @@ class XFormViewSet(
         )
 
         return Response(data=serializer.data, status=status.HTTP_200_OK)
+
+    # pylint: disable=unused-argument
+    @action(methods=["GET"], detail=True)
+    def bbox(self, request, *args, **kwargs):
+        """Return the bounding box of all geolocated submissions.
+
+        Shape: ``{"bbox": [min_lng, min_lat, max_lng, max_lat] | null}``.
+        ``null`` when the form has no geolocated submissions. Used by the
+        frontend tile map to fit the viewport on load without fetching the
+        full submission set.
+        """
+        xform = self.get_object()
+        bbox = compute_instance_bbox([xform.pk])
+        return Response({"bbox": bbox})
 
     @action(methods=["GET"], detail=True)
     def export_async(self, request, *args, **kwargs):

--- a/onadata/libs/utils/bbox_tools.py
+++ b/onadata/libs/utils/bbox_tools.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+"""
+Geometry bbox helpers for tile-based map views.
+
+Mirrors the filter shape of the `form_tiles()` PostGIS function so the frontend
+can fit the map to the same dataset Martin serves: non-deleted instances whose
+`xform_id` is in the requested set, optionally filtered by a DataView's query
+JSON (same semantics `form_tiles()` applies server-side).
+"""
+
+from django.contrib.gis.db.models import Extent
+
+from onadata.apps.logger.models import Instance
+
+
+def compute_instance_bbox(xform_ids, dataview=None):
+    """Return ``[min_lng, min_lat, max_lng, max_lat]`` for the requested forms.
+
+    ``xform_ids`` is an iterable of XForm primary keys; for regular forms this
+    is a single-element list, for merged datasets it's the underlying xforms.
+
+    ``dataview``, when supplied, applies its ``query`` JSON as additional
+    filters via the same ``apply_filters`` helper used by the data endpoint.
+
+    Returns ``None`` when no instances match (empty dataset or all rows have
+    NULL geoms) so callers can render a fallback view.
+    """
+    ids = list(xform_ids)
+    if not ids:
+        return None
+
+    queryset = Instance.objects.filter(
+        xform_id__in=ids,
+        deleted_at__isnull=True,
+        geom__isnull=False,
+    )
+
+    if dataview is not None:
+        # Imported lazily to avoid a circular import: dataview_viewset pulls in
+        # this module transitively via the viewset action.
+        from onadata.apps.api.viewsets.dataview_viewset import apply_filters
+
+        queryset = apply_filters(queryset, dataview.query)
+
+    extent = queryset.aggregate(extent=Extent("geom")).get("extent")
+    if not extent:
+        return None
+    return list(extent)


### PR DESCRIPTION
## Summary

Adds `GET /api/v1/forms/{id}/bbox`, `/api/v1/dataviews/{id}/bbox`, and `/api/v1/merged-datasets/{id}/bbox`.

Each returns `{"bbox": [min_lng, min_lat, max_lng, max_lat] | null}` — the extent of geolocated submissions (null when the target has no geolocated rows, so callers can fall back to a default view cleanly).

## Motivation

The frontend's tile-based map view (Martin + `form_tiles()`) cannot compute bounds client-side since features are paged per MVT tile. A dedicated endpoint lets the frontend fit the viewport on first load without fetching the full submission set.

## Design

- `onadata/libs/utils/bbox_tools.py` — shared `compute_instance_bbox(xform_ids, dataview=None)` helper using Django GIS `Extent` aggregate
- Filter shape mirrors the `form_tiles()` PostGIS function (non-deleted, geom non-null, optional dataview query filter) so the fit matches the data Martin serves
- Three viewset `@action` methods (`XFormViewSet`, `DataViewViewSet`, `MergedXFormViewSet`) wrap the helper; permissions inherit from each viewset's existing class

## Test plan

- [x] `test_bbox_returns_extent_of_geolocated_submissions` — XForm with the gps fixture returns a valid 4-tuple bbox
- [x] `test_bbox_null_when_no_geolocated_submissions` — returns `{"bbox": null}` for forms without geoms
- [x] DataView + MergedXForm bbox actions return the correct shape (null-case covered; the helper is exercised via the XForm extent test)
- [ ] Run full onadata test suite in CI
- [ ] Verify against a live form on stage once deployed

## Consumers

- Frontend tile map view (`TileMapView`) → `useFormBbox` hook → `fitBounds` on map load (frontend integration in progress).

## Why WIP

Marking WIP pending:
- Discussion on whether the `bbox_tools` helper should live in `libs/utils/` or somewhere closer to the logger models
- Decision on whether to cache the endpoint (bbox changes slowly; 5-min Redis cache would be cheap)
- Review of whether the null-return for empty datasets is preferable to 404 (I went with null to make the frontend branch simpler)
