### PR TITLE
fix: disable Google OAuth PKCE code verifier auto-generation

### DIFF
--- a/onadata/libs/tests/utils/test_google_tools.py
+++ b/onadata/libs/tests/utils/test_google_tools.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+"""
+Test google_tools module.
+"""
+
+from urllib.parse import parse_qs, urlparse
+
+from django.test import SimpleTestCase
+
+from onadata.libs.utils.google_tools import create_flow
+
+
+class CreateFlowTests(SimpleTestCase):
+    """Tests for create_flow."""
+
+    def test_autogenerate_code_verifier_is_explicitly_disabled(self):
+        """
+        The returned Flow must have PKCE code-verifier auto-generation
+        explicitly turned off. The verifier is not persisted across the OAuth
+        redirect, so any auto-generated verifier produces an authorization
+        URL the callback cannot complete. Since the flow uses a confidential
+        web client (client_secret), PKCE is not required.
+        """
+        flow = create_flow()
+
+        self.assertIs(flow.autogenerate_code_verifier, False)
+
+    def test_authorization_url_has_no_pkce_code_challenge(self):
+        """The generated authorization URL must not carry PKCE params."""
+        flow = create_flow()
+
+        url, _state = flow.authorization_url()
+
+        query = parse_qs(urlparse(url).query)
+        self.assertNotIn("code_challenge", query)
+        self.assertNotIn("code_challenge_method", query)
+
+    def test_custom_redirect_uri_is_used(self):
+        """An explicit redirect_uri overrides settings.GOOGLE_STEP2_URI."""
+        custom = "https://example.test/oauth/callback"
+
+        flow = create_flow(redirect_uri=custom)
+
+        url, _state = flow.authorization_url()
+        query = parse_qs(urlparse(url).query)
+        self.assertEqual(query.get("redirect_uri"), [custom])

--- a/onadata/libs/utils/google_tools.py
+++ b/onadata/libs/utils/google_tools.py
@@ -2,6 +2,7 @@
 """
 Google utility functions.
 """
+
 from typing import Optional
 
 from django.conf import settings
@@ -15,4 +16,5 @@ def create_flow(redirect_uri: Optional[str] = None) -> Flow:
         settings.GOOGLE_FLOW,
         scopes=settings.GOOGLE_FLOW_SCOPES,
         redirect_uri=redirect_uri or settings.GOOGLE_STEP2_URI,
+        autogenerate_code_verifier=False,
     )


### PR DESCRIPTION
### Changes / Features implemented

Google's confidential web-client OAuth flow does not require PKCE, and this codebase does not persist a code_verifier across the redirect, so an auto-generated verifier causes token exchange to fail. Explicitly pass autogenerate_code_verifier=False to lock in the pre-upgrade behavior regardless of upstream google-auth-oauthlib defaults.

### Steps taken to verify this change does what is intended

- [x] QA

### Side effects of implementing this change


**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  - [ ] Updated documentation

Closes #3068
