### PR TITLE
Make django.contrib.admin optional

### DIFF
--- a/onadata/apps/api/urls/v1_urls.py
+++ b/onadata/apps/api/urls/v1_urls.py
@@ -3,7 +3,6 @@
 Custom rest_framework Router - MultiLookupRouter.
 """
 
-from django.contrib import admin
 from django.urls import re_path
 
 from rest_framework import routers
@@ -19,6 +18,7 @@ from onadata.apps.api.viewsets.export_viewset import ExportViewSet
 from onadata.apps.api.viewsets.floip_viewset import FloipViewSet
 from onadata.apps.api.viewsets.media_viewset import MediaViewSet
 from onadata.apps.api.viewsets.merged_xform_viewset import MergedXFormViewSet
+from onadata.apps.api.viewsets.messaging_stats_viewset import MessagingStatsViewSet
 from onadata.apps.api.viewsets.metadata_viewset import MetaDataViewSet
 from onadata.apps.api.viewsets.note_viewset import NoteViewSet
 from onadata.apps.api.viewsets.open_data_viewset import OpenDataViewSet
@@ -37,11 +37,8 @@ from onadata.apps.api.viewsets.widget_viewset import WidgetViewSet
 from onadata.apps.api.viewsets.xform_list_viewset import XFormListViewSet
 from onadata.apps.api.viewsets.xform_submission_viewset import XFormSubmissionViewSet
 from onadata.apps.api.viewsets.xform_viewset import XFormViewSet
-from onadata.apps.api.viewsets.messaging_stats_viewset import MessagingStatsViewSet
 from onadata.apps.messaging.viewsets import MessagingViewSet
 from onadata.apps.restservice.viewsets.restservices_viewset import RestServicesViewSet
-
-admin.autodiscover()
 
 
 class MultiLookupRouter(routers.DefaultRouter):

--- a/onadata/apps/main/tests/test_urls_without_admin.py
+++ b/onadata/apps/main/tests/test_urls_without_admin.py
@@ -1,0 +1,83 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for URL configuration when django.contrib.admin toggles in INSTALLED_APPS.
+"""
+import importlib
+
+from django.conf import settings
+from django.test import SimpleTestCase, override_settings
+from django.urls import NoReverseMatch, clear_url_caches, resolve, reverse
+
+from onadata.apps.api.urls import v1_urls as api_v1_urls_module
+from onadata.apps.main import urls as main_urls_module
+
+
+class TestUrlsAdminToggle(SimpleTestCase):
+    """Verify the admin conditional in main/urls.py actually toggles."""
+
+    def tearDown(self):
+        # override_settings reverts settings, but the URL modules were
+        # reloaded under the override. Reload again under the real settings
+        # so later tests in the suite see the expected URLconf.
+        clear_url_caches()
+        importlib.reload(main_urls_module)
+        importlib.reload(api_v1_urls_module)
+
+    def _adminless_installed_apps(self):
+        return [
+            app
+            for app in settings.INSTALLED_APPS
+            if app not in ("django.contrib.admin", "django.contrib.admindocs")
+        ]
+
+    def _adminful_installed_apps(self):
+        apps = list(settings.INSTALLED_APPS)
+        for app in ("django.contrib.admin", "django.contrib.admindocs"):
+            if app not in apps:
+                apps.append(app)
+        return apps
+
+    def _reload_urlconfs(self):
+        clear_url_caches()
+        importlib.reload(main_urls_module)
+        importlib.reload(api_v1_urls_module)
+
+    def test_main_urls_reload_without_admin(self):
+        """main/urls.py re-executes cleanly when admin is absent."""
+        with override_settings(INSTALLED_APPS=self._adminless_installed_apps()):
+            self._reload_urlconfs()
+            self.assertIsNotNone(main_urls_module.urlpatterns)
+
+    def test_v1_urls_reload_without_admin(self):
+        """api/urls/v1_urls.py re-executes cleanly when admin is absent."""
+        with override_settings(INSTALLED_APPS=self._adminless_installed_apps()):
+            self._reload_urlconfs()
+            self.assertIsNotNone(api_v1_urls_module.router)
+
+    def test_api_v1_route_resolves_without_admin(self):
+        """/api/v1/ resolves when admin is absent."""
+        with override_settings(INSTALLED_APPS=self._adminless_installed_apps()):
+            self._reload_urlconfs()
+            resolved = resolve("/api/v1/")
+            self.assertEqual(resolved.url_name, "api-root")
+
+    def test_api_v2_route_resolves_without_admin(self):
+        """/api/v2/ resolves when admin is absent."""
+        with override_settings(INSTALLED_APPS=self._adminless_installed_apps()):
+            self._reload_urlconfs()
+            resolved = resolve("/api/v2/")
+            self.assertEqual(resolved.url_name, "api-root")
+
+    def test_admin_namespace_absent_without_admin(self):
+        """admin: URL namespace is not registered when admin is absent."""
+        with override_settings(INSTALLED_APPS=self._adminless_installed_apps()):
+            self._reload_urlconfs()
+            with self.assertRaises(NoReverseMatch):
+                reverse("admin:index")
+
+    def test_admin_namespace_present_with_admin(self):
+        """admin: URL namespace is registered when admin is in INSTALLED_APPS."""
+        with override_settings(INSTALLED_APPS=self._adminful_installed_apps()):
+            self._reload_urlconfs()
+            # Should not raise.
+            reverse("admin:index")

--- a/onadata/apps/main/tests/test_urls_without_admin.py
+++ b/onadata/apps/main/tests/test_urls_without_admin.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-"""
-Tests for URL configuration when django.contrib.admin toggles in INSTALLED_APPS.
-"""
+"""Tests for URL configuration when django.contrib.admin toggles in INSTALLED_APPS."""
 import importlib
 
 from django.conf import settings
@@ -13,12 +11,11 @@ from onadata.apps.main import urls as main_urls_module
 
 
 class TestUrlsAdminToggle(SimpleTestCase):
+
     """Verify the admin conditional in main/urls.py actually toggles."""
 
     def tearDown(self):
-        # override_settings reverts settings, but the URL modules were
-        # reloaded under the override. Reload again under the real settings
-        # so later tests in the suite see the expected URLconf.
+        """Reload URL modules so later tests see the real settings URLconf."""
         clear_url_caches()
         importlib.reload(main_urls_module)
         importlib.reload(api_v1_urls_module)

--- a/onadata/apps/main/tests/test_urls_without_admin.py
+++ b/onadata/apps/main/tests/test_urls_without_admin.py
@@ -11,7 +11,6 @@ from onadata.apps.main import urls as main_urls_module
 
 
 class TestUrlsAdminToggle(SimpleTestCase):
-
     """Verify the admin conditional in main/urls.py actually toggles."""
 
     def tearDown(self):

--- a/onadata/apps/main/urls.py
+++ b/onadata/apps/main/urls.py
@@ -8,9 +8,6 @@ import sys
 import django
 from django.conf import settings
 from django.conf.urls import i18n
-
-# enable the admin:
-from django.contrib import admin
 from django.contrib.staticfiles import views as staticfiles_views
 from django.urls import include, re_path
 from django.views.generic import RedirectView
@@ -36,9 +33,24 @@ from onadata.libs.utils.analytics import init_analytics
 TESTING = len(sys.argv) > 1 and sys.argv[1] == "test"
 ADMIN_URL_PATH = getattr(settings, "ADMIN_URL_PATH", "admin")
 
-admin.autodiscover()
+ADMIN_INSTALLED = "django.contrib.admin" in settings.INSTALLED_APPS
 
-urlpatterns = [
+if ADMIN_INSTALLED:
+    from django.contrib import admin
+
+    admin.autodiscover()
+    urlpatterns = [re_path(f"^{ADMIN_URL_PATH}/", admin.site.urls)]
+    if "django.contrib.admindocs" in settings.INSTALLED_APPS:
+        urlpatterns += [
+            re_path(
+                f"^{ADMIN_URL_PATH}/doc/",
+                include("django.contrib.admindocs.urls"),
+            ),
+        ]
+else:
+    urlpatterns = []
+
+urlpatterns += [
     # change Language
     re_path(r"^i18n/", include(i18n)),
     re_path("^api/v1/", include(api_v1_router.urls)),
@@ -52,8 +64,6 @@ urlpatterns = [
     re_path(r"^api/v1$", RedirectView.as_view(url="/api/v1/", permanent=True)),
     # django default stuff
     re_path(r"^accounts/", include(registration_patterns)),
-    re_path(f"^{ADMIN_URL_PATH}/", admin.site.urls),
-    re_path(f"^{ADMIN_URL_PATH}/doc/", include("django.contrib.admindocs.urls")),
     # oath2_provider
     re_path(
         r"^o/authorize/$",

--- a/onadata/apps/main/urls.py
+++ b/onadata/apps/main/urls.py
@@ -36,7 +36,7 @@ ADMIN_URL_PATH = getattr(settings, "ADMIN_URL_PATH", "admin")
 ADMIN_INSTALLED = "django.contrib.admin" in settings.INSTALLED_APPS
 
 if ADMIN_INSTALLED:
-    from django.contrib import admin
+    from django.contrib import admin  # pylint: disable=ungrouped-imports
 
     admin.autodiscover()
     urlpatterns = [re_path(f"^{ADMIN_URL_PATH}/", admin.site.urls)]

--- a/onadata/settings/common.py
+++ b/onadata/settings/common.py
@@ -198,8 +198,10 @@ INSTALLED_APPS = (
     "django.contrib.messages",
     "django.contrib.staticfiles",
     "django.contrib.humanize",
-    "django.contrib.admin",
-    "django.contrib.admindocs",
+    # Django admin is optional. To enable it, add to INSTALLED_APPS in a
+    # downstream settings module:
+    #     "django.contrib.admin",
+    #     "django.contrib.admindocs",
     "django.contrib.gis",
     "registration",
     # "django_nose",


### PR DESCRIPTION
## Summary

- Drop `django.contrib.admin` and `django.contrib.admindocs` from the default `INSTALLED_APPS` in `onadata/settings/common.py`. Operators that still want the admin can re-add both apps in a downstream settings module.
- Gate `admin.autodiscover()` and the `/admin/` + `/admin/doc/` URL routes in `onadata/apps/main/urls.py` on `"django.contrib.admin" in settings.INSTALLED_APPS`, so the URL layer no longer assumes the admin is installed.
- Remove a redundant `admin.autodiscover()` call from `onadata/apps/api/urls/v1_urls.py` — it duplicated the one in `main/urls.py` and pulled an unnecessary admin import into the API router.
- Add `onadata/apps/main/tests/test_urls_without_admin.py` (`SimpleTestCase`, 6 tests) that reloads `main.urls` and `v1_urls` under `override_settings` to exercise both branches of the toggle: admin absent → `admin:index` raises `NoReverseMatch` and `/api/v1/` + `/api/v2/` still resolve; admin present → `admin:index` reverses.

## Test plan

- [ ] `python manage.py test onadata.apps.main.tests.test_urls_without_admin --settings=onadata.settings.github_actions_test`
- [ ] `python manage.py check --settings=onadata.settings.github_actions_test`
- [ ] Smoke-test with admin re-enabled: add `django.contrib.admin` and `django.contrib.admindocs` to a local settings override, run `python manage.py check`, hit `/admin/` and confirm the login page renders.
- [ ] CI passes on the branch.