### PR TITLE
chore: bump version to v5.15.3

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,12 @@ Changelog for Onadata
 
 ``* represents releases that introduce new migrations``
 
+v5.15.3 (2026-04-22)
+--------------------
+- fix: disable Google OAuth PKCE code verifier auto-generation
+  [@kelvin-muchiri]
+  `PR #3067 https://github.com/onaio/onadata/pull/3067`
+
 v5.15.2 (2026-04-16)
 --------------------
 - fix: stale CSV exports after Entity soft delete
@@ -11,7 +17,6 @@ v5.15.2 (2026-04-16)
 - fix: handle pylibmc.TooBig in cache operations
   [@ukanga]
   `PR #3063 https://github.com/onaio/onadata/pull/3063`
-
 
 v5.15.1 (2026-04-10)
 --------------------

--- a/onadata/__init__.py
+++ b/onadata/__init__.py
@@ -7,7 +7,7 @@ visualization.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "5.15.2"
+__version__ = "5.15.3"
 
 
 # This will make sure the app is always imported when

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = onadata
-version = 5.15.2
+version = 5.15.3
 description = Collect Analyze and Share Data
 long_description = file: README.rst
 long_description_content_type = text/x-rst


### PR DESCRIPTION
### Changes

Bump version to v5.15.3

**Bug fixes**

- https://github.com/onaio/onadata/pull/3067