### PR TITLE
Security: Object permission bypass when fetching widgets by `key`

### DIFF
--- a/onadata/apps/api/viewsets/widget_viewset.py
+++ b/onadata/apps/api/viewsets/widget_viewset.py
@@ -71,6 +71,7 @@ class WidgetViewSet(
         if "key" in request.GET:
             key = request.GET["key"]
             obj = get_object_or_404(Widget, key=key)
+            self.check_object_permissions(request, obj)
 
             serializer = self.get_serializer(obj)
 


### PR DESCRIPTION
## Summary

Security: Object permission bypass when fetching widgets by `key`

## Problem

**Severity**: `High` | **File**: `onadata/apps/api/viewsets/widget_viewset.py:L81`

The `list()` method returns a widget looked up by `key` (`get_object_or_404(Widget, key=key)`) without calling `self.check_object_permissions()` or filtering through permission-aware queryset logic. An attacker who can guess or obtain a widget key may read widget data they are not authorized to access (IDOR).

## Solution

Enforce object-level permission checks for key-based lookup. For example, after fetching by key, call `self.check_object_permissions(request, obj)` before serialization, or fetch from a permission-filtered queryset (`self.filter_queryset(self.get_queryset())`) and then resolve by key.

## Changes

- `onadata/apps/api/viewsets/widget_viewset.py` (modified)