### PR TITLE
fix: save a new form version when a form is replaced

### DIFF
--- a/onadata/apps/api/tests/viewsets/test_xform_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_xform_viewset.py
@@ -125,6 +125,15 @@ def raise_bad_status_line(arg):
     raise BadStatusLine("RANDOM STATUS")
 
 
+def _xml_data_node_version(xml_str, id_string):
+    """Return the ``version`` attribute on the primary <data id="..."> node."""
+    doc = minidom.parseString(xml_str)
+    for node in doc.getElementsByTagName("data"):
+        if node.getAttribute("id") == id_string:
+            return node.getAttribute("version")
+    return None
+
+
 class XFormViewSetBaseTestCase(TestAbstractViewSet):
     def _make_submission_over_date_range(self, start, days=1):
         self._publish_xls_form_to_project()
@@ -4200,6 +4209,80 @@ nhMo+jI88L3qfm4/rtWKuQ9/a268phlNj34uQeoDDHuRViQo00L5meE/pFptm
 
             for v in expected:
                 self.assertIn(v, response.data.get("form_versions"))
+
+    def test_replace_form_with_same_version_saves_new_xform_version(self):
+        """Replacing a form whose XLSForm carries the same version string
+        still saves a new XFormVersion (the new version is auto-bumped)."""
+        with HTTMock(enketo_mock):
+            self._publish_xls_form_to_project()
+            initial_version = self.xform.version
+            initial_count = XFormVersion.objects.filter(xform=self.xform).count()
+
+            view = XFormViewSet.as_view({"patch": "partial_update"})
+            path = os.path.join(
+                settings.PROJECT_ROOT,
+                "apps",
+                "main",
+                "tests",
+                "fixtures",
+                "transportation",
+                "transportation.xlsx",
+            )
+            with open(path, "rb") as xls_file:
+                request = self.factory.patch(
+                    "/", data={"xls_file": xls_file}, **self.extra
+                )
+                response = view(request, pk=self.xform.pk)
+                self.assertEqual(response.status_code, 200)
+
+            self.xform.refresh_from_db()
+            self.assertEqual(
+                XFormVersion.objects.filter(xform=self.xform).count(),
+                initial_count + 1,
+            )
+            self.assertNotEqual(self.xform.version, initial_version)
+            self.assertTrue(
+                XFormVersion.objects.filter(
+                    xform=self.xform, version=initial_version
+                ).exists()
+            )
+            self.assertTrue(
+                XFormVersion.objects.filter(
+                    xform=self.xform, version=self.xform.version
+                ).exists()
+            )
+
+    def test_replace_form_same_version_bumps_with_numeric_suffix(self):
+        """Successive replacements with the same version walk -2, -3, ..."""
+        with HTTMock(enketo_mock):
+            self._publish_xls_form_to_project()
+            base_version = self.xform.version
+
+            view = XFormViewSet.as_view({"patch": "partial_update"})
+            path = os.path.join(
+                settings.PROJECT_ROOT,
+                "apps",
+                "main",
+                "tests",
+                "fixtures",
+                "transportation",
+                "transportation.xlsx",
+            )
+
+            for expected_suffix in (2, 3):
+                with open(path, "rb") as xls_file:
+                    request = self.factory.patch(
+                        "/", data={"xls_file": xls_file}, **self.extra
+                    )
+                    response = view(request, pk=self.xform.pk)
+                    self.assertEqual(response.status_code, 200)
+                self.xform.refresh_from_db()
+                expected_version = f"{base_version}-{expected_suffix}"
+                self.assertEqual(self.xform.version, expected_version)
+                self.assertEqual(
+                    _xml_data_node_version(self.xform.xml, self.xform.id_string),
+                    expected_version,
+                )
 
     def test_versions_endpoint(self):
         """

--- a/onadata/apps/logger/models/xform.py
+++ b/onadata/apps/logger/models/xform.py
@@ -9,7 +9,6 @@ import json
 import os
 import re
 import uuid
-from datetime import datetime
 from io import BytesIO
 from pathlib import Path
 from xml.dom import Node
@@ -274,7 +273,7 @@ def check_version_set(survey):
 
     # get the json and check for the version key
     if survey.version == "":
-        survey.version = datetime.utcnow().strftime("%Y%m%d%H%M")
+        survey.version = timezone.now().strftime("%Y%m%d%H%M")
     return survey
 
 

--- a/onadata/apps/viewer/models/data_dictionary.py
+++ b/onadata/apps/viewer/models/data_dictionary.py
@@ -34,6 +34,7 @@ from onadata.apps.logger.models.xform import (
     get_survey_from_file_object,
     get_xls_upload_path,
 )
+from onadata.apps.logger.models.xform_version import XFormVersion
 from onadata.apps.logger.xform_instance_parser import XLSFormError
 from onadata.apps.main.models.meta_data import MetaData
 from onadata.libs.utils.cache_tools import (
@@ -165,6 +166,8 @@ class DataDictionary(XForm):  # pylint: disable=too-many-instance-attributes
             if has_external_choices(workbook_json):
                 self.has_external_choices = True
             survey = check_version_set(survey)
+            if self.pk is not None:
+                survey.version = self.get_unique_version(survey.get("version"))
             workbook_json["version"] = survey.get("version")
             if get_columns_with_hxl(survey.get("children")):
                 self.has_hxl_support = True
@@ -219,6 +222,24 @@ class DataDictionary(XForm):  # pylint: disable=too-many-instance-attributes
             if self.xls.name is not None
             else self.id_string + ".xml"
         )
+
+    def get_unique_version(self, version):
+        """Return ``version`` unchanged if no XFormVersion exists for this xform
+        with that string; otherwise append "-N" with the smallest unused N >= 2.
+        Empty / None versions pass through unchanged (no sensible suffix)."""
+        if not version:
+            return version
+        existing = set(
+            XFormVersion.objects.filter(xform_id=self.pk).values_list(
+                "version", flat=True
+            )
+        )
+        if version not in existing:
+            return version
+        suffix = 2
+        while f"{version}-{suffix}" in existing:
+            suffix += 1
+        return f"{version}-{suffix}"
 
 
 # pylint: disable=unused-argument

--- a/onadata/apps/viewer/models/data_dictionary.py
+++ b/onadata/apps/viewer/models/data_dictionary.py
@@ -225,10 +225,7 @@ class DataDictionary(XForm):  # pylint: disable=too-many-instance-attributes
 
     def get_unique_version(self, version):
         """Return ``version`` unchanged if no XFormVersion exists for this xform
-        with that string; otherwise append "-N" with the smallest unused N >= 2.
-        Empty / None versions pass through unchanged (no sensible suffix)."""
-        if not version:
-            return version
+        with that string; otherwise append "-N" with the smallest unused N >= 2."""
         existing = set(
             XFormVersion.objects.filter(xform_id=self.pk).values_list(
                 "version", flat=True

--- a/onadata/libs/tests/utils/test_logger_tools.py
+++ b/onadata/libs/tests/utils/test_logger_tools.py
@@ -19,11 +19,14 @@ from django.test.utils import override_settings
 from django.utils import timezone
 
 from azure.storage.blob import AccountSasPermissions
+from defusedxml import minidom
 from defusedxml.ElementTree import ParseError
 
 from onadata.apps.logger.import_tools import django_file
 from onadata.apps.logger.models import Instance, InstanceHistory
 from onadata.apps.logger.models.survey_type import SurveyType
+from onadata.apps.logger.models.xform import XForm
+from onadata.apps.logger.models.xform_version import XFormVersion
 from onadata.apps.logger.xform_instance_parser import AttachmentNameError
 from onadata.apps.main.tests.test_base import TestBase
 from onadata.libs.test_utils.pyxform_test_case import PyxformTestCase
@@ -34,9 +37,11 @@ from onadata.libs.utils.logger_tools import (
     delete_xform_submissions,
     generate_content_disposition_header,
     get_storages_media_download_url,
+    publish_xml_form,
     response_with_mimetype_and_name,
     safe_create_instance,
 )
+from onadata.libs.utils.user_auth import get_user_default_project
 
 
 class CreateInstanceTestCase(PyxformTestCase, TestBase):
@@ -1415,3 +1420,52 @@ class ResponseNosniffHeaderTestCase(TestBase):
 
         self.assertEqual(response["X-Content-Type-Options"], "nosniff")
         self.assertIn("attachment", response["Content-Disposition"])
+
+
+class PublishXmlFormReplaceTestCase(TestBase):
+    """Replacing an XML form should always create a new XFormVersion."""
+
+    def setUp(self):
+        super().setUp()
+        self.project = get_user_default_project(self.user)
+        self.xml_path = os.path.join(
+            settings.PROJECT_ROOT,
+            "apps",
+            "main",
+            "tests",
+            "fixtures",
+            "transportation",
+            "transportation.xml",
+        )
+
+    def _publish(self, id_string=None):
+        with open(self.xml_path, "rb") as xml_file:
+            return publish_xml_form(xml_file, self.user, self.project, id_string)
+
+    def test_replace_with_same_version_creates_new_xform_version(self):
+        dd = self._publish()
+        xform_id = dd.pk
+        initial_version = dd.version
+        initial_count = XFormVersion.objects.filter(xform_id=xform_id).count()
+
+        self._publish(id_string=dd.id_string)
+
+        self.assertEqual(
+            XFormVersion.objects.filter(xform_id=xform_id).count(),
+            initial_count + 1,
+        )
+        xform = XForm.objects.get(pk=xform_id)
+        self.assertNotEqual(xform.version, initial_version)
+        self.assertEqual(xform.version, f"{initial_version}-2")
+        doc = minidom.parseString(xform.xml)
+        data_node = next(
+            node
+            for node in doc.getElementsByTagName("data")
+            if node.getAttribute("id") == xform.id_string
+        )
+        self.assertEqual(data_node.getAttribute("version"), xform.version)
+        self.assertTrue(
+            XFormVersion.objects.filter(
+                xform_id=xform_id, version=xform.version
+            ).exists()
+        )

--- a/onadata/libs/utils/logger_tools.py
+++ b/onadata/libs/utils/logger_tools.py
@@ -1137,6 +1137,52 @@ def publish_xls_form(xls_file, user, project, id_string=None, created_by=None):
     return dd
 
 
+def _get_xform_xml_data_node(doc, id_string):
+    """Return the primary <data id="..."> node from a parsed XForm XML doc,
+    or None if not found."""
+    model_nodes = [
+        n
+        for n in doc.getElementsByTagName("model")
+        if n.parentNode.nodeName == "h:head"
+    ]
+    if len(model_nodes) != 1:
+        return None
+    instance_nodes = [
+        n
+        for n in model_nodes[0].childNodes
+        if n.nodeType == Node.ELEMENT_NODE
+        and n.tagName.lower() == "instance"
+        and not n.hasAttribute("id")
+    ]
+    if len(instance_nodes) != 1:
+        return None
+    survey_nodes = [
+        n
+        for n in instance_nodes[0].childNodes
+        if n.nodeType == Node.ELEMENT_NODE and n.getAttribute("id") == id_string
+    ]
+    if len(survey_nodes) != 1:
+        return None
+    return survey_nodes[0]
+
+
+def _get_version_from_xform_xml(xml_str, id_string):
+    """Return the version attribute from the primary <data> node, or ""."""
+    data_node = _get_xform_xml_data_node(clean_and_parse_xml(xml_str), id_string)
+    return data_node.getAttribute("version") if data_node else ""
+
+
+def _set_version_in_xform_xml(xml_str, id_string, version):
+    """Set the ``version`` attribute on the primary <data> node. Returns the
+    updated XML string (unchanged if the data node cannot be located)."""
+    doc = clean_and_parse_xml(xml_str)
+    data_node = _get_xform_xml_data_node(doc, id_string)
+    if data_node is None:
+        return xml_str
+    data_node.setAttribute("version", version)
+    return doc.toxml()
+
+
 @TrackObjectEvent(
     user_field="user",
     properties={"created_by": "user", "xform_id": "pk", "xform_name": "title"},
@@ -1149,8 +1195,13 @@ def publish_xml_form(xml_file, user, project, id_string=None, created_by=None):
         xml = xml.decode("utf-8")
     survey = create_survey_element_from_xml(xml)
     form_json = survey.to_json()
+    xml_version = _get_version_from_xform_xml(xml, survey.id_string)
     if id_string:
         dd = DataDictionary.objects.get(user=user, id_string=id_string, project=project)
+        new_version = dd.get_unique_version(xml_version)
+        if new_version != xml_version:
+            xml = _set_version_in_xform_xml(xml, dd.id_string, new_version)
+        dd.version = new_version
         dd.xml = xml
         dd.json = form_json
         dd.mark_start_time_boolean()
@@ -1161,7 +1212,12 @@ def publish_xml_form(xml_file, user, project, id_string=None, created_by=None):
     else:
         created_by = created_by or user
         dd = DataDictionary(
-            created_by=created_by, user=user, xml=xml, json=form_json, project=project
+            created_by=created_by,
+            user=user,
+            xml=xml,
+            json=form_json,
+            project=project,
+            version=xml_version,
         )
         dd.mark_start_time_boolean()
         set_uuid(dd)

--- a/onadata/libs/utils/logger_tools.py
+++ b/onadata/libs/utils/logger_tools.py
@@ -1198,7 +1198,9 @@ def publish_xml_form(xml_file, user, project, id_string=None, created_by=None):
     xml_version = _get_version_from_xform_xml(xml, survey.id_string)
     if id_string:
         dd = DataDictionary.objects.get(user=user, id_string=id_string, project=project)
-        new_version = dd.get_unique_version(xml_version)
+        new_version = xml_version
+        if xml_version:
+            new_version = dd.get_unique_version(xml_version)
         if new_version != xml_version:
             xml = _set_version_in_xform_xml(xml, dd.id_string, new_version)
         dd.version = new_version


### PR DESCRIPTION
### Changes / Features implemented

Previously, replacing a form whose XLSForm or XML carried the same version string as an existing XFormVersion row silently swallowed the unique_together IntegrityError in create_xform_version, leaving only the overwritten dd.xls/xml behind with no audit trail.

Auto-bump the version to "<original>-N" (smallest unused N >= 2) when a replacement would otherwise collide.

### Steps taken to verify this change does what is intended

- [ ] QA

### Side effects of implementing this change


**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  - [ ] Updated documentation

Closes #3076
