### PR TITLE
fix(security): set Secure flag on session/CSRF/Enketo cookies

### DIFF
--- a/onadata/apps/api/tests/viewsets/test_xform_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_xform_viewset.py
@@ -2121,6 +2121,17 @@ class TestXFormViewSet(XFormViewSetBaseTestCase):
             # example cookie: bob:1jlVih:i2KvHoAtsQOlYB71CJeNuVUlEY0
             self.assertEqual(username_cookie.split(":")[0], "bob")
             self.assertEqual(uid_cookie.split(":")[0], "bob")
+            for cookie_name in (
+                settings.ENKETO_META_UID_COOKIE,
+                settings.ENKETO_META_USERNAME_COOKIE,
+                settings.ENKETO_AUTH_COOKIE,
+            ):
+                morsel = cookies[cookie_name]
+                self.assertTrue(morsel["secure"], f"{cookie_name} missing Secure flag")
+                self.assertTrue(
+                    morsel["httponly"], f"{cookie_name} missing HttpOnly flag"
+                )
+                self.assertEqual(morsel["samesite"], "Lax")
 
     @patch("onadata.apps.api.viewsets.xform_viewset.XFormViewSet.list")
     def test_return_400_on_xlsform_error_on_list_action(self, mock_set_title):

--- a/onadata/apps/api/tools.py
+++ b/onadata/apps/api/tools.py
@@ -762,8 +762,14 @@ def set_enketo_signed_cookies(resp, username=None, json_web_token=None):
         return None
 
     max_age = 30 * 24 * 60 * 60 * 1000
-    enketo_meta_uid = {"max_age": max_age, "salt": settings.ENKETO_API_SALT}
-    enketo = {"secure": False, "salt": settings.ENKETO_API_SALT}
+    cookie_kwargs = {
+        "secure": getattr(settings, "SESSION_COOKIE_SECURE", True),
+        "httponly": getattr(settings, "SESSION_COOKIE_HTTPONLY", True),
+        "samesite": getattr(settings, "SESSION_COOKIE_SAMESITE", "Lax"),
+        "salt": settings.ENKETO_API_SALT,
+    }
+    enketo_meta_uid = {**cookie_kwargs, "max_age": max_age}
+    enketo = {**cookie_kwargs}
 
     # add domain attribute if ENKETO_AUTH_COOKIE_DOMAIN is set in settings
     # i.e. don't add in development environment because cookie automatically

--- a/onadata/settings/common.py
+++ b/onadata/settings/common.py
@@ -109,6 +109,22 @@ ENKETO_AUTH_COOKIE = "__enketo"
 ENKETO_META_UID_COOKIE = "__enketo_meta_uid"
 ENKETO_META_USERNAME_COOKIE = "__enketo_meta_username"
 
+# Cookie security — all cookies issued by the app (session, CSRF, Enketo)
+# get Secure/HttpOnly/SameSite by default. Set DJANGO_*_SECURE=false in
+# local dev if you need to test over plain HTTP.
+SESSION_COOKIE_SECURE = (
+    os.environ.get("DJANGO_SESSION_COOKIE_SECURE", "true").lower() == "true"
+)
+SESSION_COOKIE_HTTPONLY = True
+SESSION_COOKIE_SAMESITE = os.environ.get("DJANGO_SESSION_COOKIE_SAMESITE", "Lax")
+CSRF_COOKIE_SECURE = (
+    os.environ.get("DJANGO_CSRF_COOKIE_SECURE", "true").lower() == "true"
+)
+CSRF_COOKIE_SAMESITE = os.environ.get("DJANGO_CSRF_COOKIE_SAMESITE", "Lax")
+# CSRF_COOKIE_HTTPONLY is left at Django's default (False) because the
+# JS client reads the CSRF token from the cookie to set the X-CSRFToken
+# header on AJAX requests.
+
 # Login URLs
 LOGIN_URL = "/accounts/login/"
 LOGIN_REDIRECT_URL = "/login_redirect/"


### PR DESCRIPTION
## Summary

- Configure `SESSION_COOKIE_SECURE`, `CSRF_COOKIE_SECURE`, and `SameSite=Lax` defaults so Django's own session and CSRF cookies carry the `Secure` attribute. Overridable via `DJANGO_*_SECURE` env vars for local HTTP dev.
- Rewire `set_enketo_signed_cookies()` to read `Secure` / `HttpOnly` / `SameSite` from the Django session settings instead of hardcoding `secure=False` on `__enketo` and omitting the flag on `__enketo_meta_uid` / `__enketo_meta_username`.
- Add test assertions that all three Enketo cookies carry the expected flags.

Addresses CWE-614 / OWASP A02:2025. Fixes #3077.

## Out of scope (follow-ups)

- **`SSO` cookie** (set by [ona-oidc](https://github.com/onaio/ona-oidc) at `oidc/viewsets.py:191`) — already `Secure` in production because `settings.DEBUG=False` there. A separate upstream PR would expose the flag as `OPENID_CONNECT_VIEWSET_CONFIG["SSO_COOKIE_SECURE"]` so it stops being coupled to `DEBUG`.
- **`INGRESSCOOKIE`** (set by the NGINX ingress controller) — needs `nginx.ingress.kubernetes.io/session-cookie-secure: "true"` on the Ingress manifest in the deployment Helm chart.

## Test plan

- [x] `python manage.py test onadata.apps.api.tests.viewsets.test_xform_viewset.TestXFormViewSet.test_login_enketo_online_url_using_jwt --settings=onadata.settings.github_actions_test` passes
- [ ] CI full suite green
- [ ] Manual: deploy to dev, hit a flow that issues Enketo cookies, confirm every `Set-Cookie` response header carries `; Secure; HttpOnly; SameSite=Lax` via `curl -v` and browser dev-tools
- [ ] Confirm local HTTP dev still works by running with `DJANGO_SESSION_COOKIE_SECURE=false DJANGO_CSRF_COOKIE_SECURE=false`