### PR TITLE
fix: guard user reset against primitive JSON bodies

### DIFF
--- a/onadata/apps/api/tests/viewsets/test_connect_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_connect_viewset.py
@@ -347,6 +347,13 @@ class TestConnectViewSet(TestAbstractViewSet):
         response = self.view(request)
         self.assertEqual(response.status_code, 400)
 
+    def test_reset_user_password_with_invalid_json_body(self):
+        request = self.factory.post("/", data=1, format="json")
+
+        response = self.view(request)
+
+        self.assertEqual(response.status_code, 400)
+
     def test_reset_user_password_with_updated_user_email(self):
         # set user.last_login, ensures we get same/valid token
         # https://code.djangoproject.com/ticket/10265

--- a/onadata/apps/api/viewsets/connect_viewset.py
+++ b/onadata/apps/api/viewsets/connect_viewset.py
@@ -5,6 +5,8 @@ The /api/v1/user API implementation
 User authentication API support to access API tokens.
 """
 
+from collections.abc import Mapping
+
 from django.core.exceptions import MultipleObjectsReturned
 from django.utils import timezone
 from django.utils.translation import gettext as _
@@ -119,8 +121,8 @@ class ConnectViewSet(
         Allows a user to reset and change their password.
         """
         context = {"request": request}
-        data = request.data if request.data is not None else {}
-        if "token" in request.data:
+        data = request.data if isinstance(request.data, Mapping) else {}
+        if "token" in data:
             serializer = PasswordResetChangeSerializer(data=data, context=context)
 
             if serializer.is_valid():


### PR DESCRIPTION
## Summary
- Guard `/api/v1/user/reset` against primitive JSON bodies before checking for `token`
- Add a regression test that posts JSON body `1` and asserts `400`

Closes #3079

## Verification
- `python manage.py test onadata.apps.api.tests.viewsets.test_connect_viewset.TestConnectViewSet --settings=onadata.settings.github_actions_test 2>&1`