### PR TITLE
fix(docker): include /usr/bin/date in runtime image

### DIFF
--- a/docker/onadata-uwsgi/Dockerfile.ubuntu
+++ b/docker/onadata-uwsgi/Dockerfile.ubuntu
@@ -92,6 +92,7 @@ COPY --from=base /usr/bin/env /usr/bin/env
 COPY --from=base /usr/bin/bash /usr/bin/bash
 COPY --from=base /usr/bin/bash /bin/bash
 COPY --from=base /usr/bin/bash /bin/sh
+COPY --from=base /usr/bin/date /usr/bin/date
 
 # Java is required by pyxform's ODK Validate for XForm validation.
 # The JRE lives under /usr/lib/jvm/ (already covered by /usr/lib/ copy above)


### PR DESCRIPTION
### Changes / Features implemented

Copy `/usr/bin/date` from the `base` build stage into the runtime stage of `docker/onadata-uwsgi/Dockerfile.ubuntu`, alongside the existing `env`, `bash`, and `java` binaries.

The runtime image is `FROM dhi.io/python:3.13-debian13`, a hardened/minimal image that ships almost no userland tools, so any binary the runtime needs has to be cherry-picked from the build stage. `date` was previously omitted, which broke shell scripts that call it (e.g. cronjob scripts computing "previous month" / a timestamp suffix with `date --date="-1 month"` or `date +"%Y-%m-%d"`).

### Steps taken to verify this change does what is intended

- `docker build -f docker/onadata-uwsgi/Dockerfile.ubuntu -t onadata:test .`
- `docker run --rm onadata:test bash -c 'date'` — succeeds and prints the current date.
- `docker run --rm onadata:test bash -c 'date --date="-1 month" +"%Y-%m"'` — succeeds and prints last month.
- Existing `bash`, `env`, and `java` invocations still work.

### Side effects of implementing this change

- Adds one extra binary (~120 KB) to the runtime image. No new shared libraries — `date` only depends on `libc`, which is already pulled in by the existing `/usr/lib/` copy.
- Slightly broadens the runtime tool surface beyond the minimum, but `date` is a benign, read-only coreutil with no network or write side effects.

**Before submitting this PR for review, please make sure you have:**

  - [ ] Included tests
  - [ ] Updated documentation

(No tests added — Dockerfile-only change; behavior is verified by running `date` in a built image.)

Closes #3083