### PR TITLE
chore: bump version to v5.16.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,18 @@ Changelog for Onadata
 
 ``* represents releases that introduce new migrations``
 
+v5.16.0 (2026-05-18)
+--------------------
+- Make django.contrib.admin optional
+  [@ukanga]
+  `PR #3070 https://github.com/onaio/onadata/pull/3070`
+- fix(security): set Secure flag on session/CSRF/Enketo cookies
+  [@ukanga]
+  `PR #3078 https://github.com/onaio/onadata/pull/3078`
+- fix: guard user reset against primitive JSON bodies
+  [@ukanga]
+  `PR #3080 https://github.com/onaio/onadata/pull/3080`
+
 v5.15.3 (2026-04-22)
 --------------------
 - fix: disable Google OAuth PKCE code verifier auto-generation

--- a/onadata/__init__.py
+++ b/onadata/__init__.py
@@ -7,7 +7,7 @@ visualization.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "5.15.3"
+__version__ = "5.16.0"
 
 
 # This will make sure the app is always imported when

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = onadata
-version = 5.15.3
+version = 5.16.0
 description = Collect Analyze and Share Data
 long_description = file: README.rst
 long_description_content_type = text/x-rst


### PR DESCRIPTION
## Summary
- Bump onadata package version to 5.16.0.
- Add v5.16.0 changelog entries for PRs #3070, #3078, and #3080.

## Testing
- Not run (release metadata/changelog only).