### PR TITLE
fix(logger): force viewer.0001 before partition cutover

### DIFF
--- a/onadata/apps/logger/migrations/0034_partition_instance_table_structure.py
+++ b/onadata/apps/logger/migrations/0034_partition_instance_table_structure.py
@@ -612,6 +612,14 @@ class Migration(migrations.Migration):
 
     dependencies = [
         ("logger", "0036_save_elist_properties"),
+        # viewer_parsedinstance has an FK to logger_instance(id); it must be
+        # created BEFORE the cutover because the partitioned logger_instance
+        # only has a composite unique key (id, xform_id). Without this dep,
+        # Django can schedule viewer.0001 after the cutover, at which point
+        # creating the single-column FK raises:
+        #   "no unique constraint matching given keys for referenced table
+        #   'logger_instance'".
+        ("viewer", "0001_pre-django-3-upgrade"),
     ]
 
     operations = [


### PR DESCRIPTION
### Changes / Features implemented
Add `('viewer', '0001_pre-django-3-upgrade')` as a dependency of `logger.0034_partition_instance_table_structure`.

Without it, Django could schedule `viewer.0001` after the partition cutover. By then `logger_instance` is partitioned with PK `(id, xform_id)` and has no unique constraint on `id` alone, so creating `viewer_parsedinstance.instance_id → logger_instance(id)` raised:
`ProgrammingError: there is no unique constraint matching given keys for referenced table "logger_instance"`.

With the dep, viewer.0001 runs first; `0036_partition_table_cutover` later drops that single-column FK as designed (no composite re-creation because `viewer_parsedinstance` has no `xform_id`).

### Steps taken to verify this change does what is intended
- Fresh DB, `ENABLE_TABLE_PARTITIONING=False`: `python manage.py migrate` succeeds (unchanged path).
- Fresh DB, `ENABLE_TABLE_PARTITIONING=True`: `python manage.py migrate` now completes; `pg_class.relkind` for `logger_instance` is `p`; `viewer_parsedinstance` exists.

### Side effects of implementing this change
- Migration-graph-only change; no schema or runtime behavior diff for already-populated databases.
- On a fresh DB with partitioning enabled, the `viewer_parsedinstance → logger_instance` FK is dropped by the cutover (same outcome as a production cutover, where the FK is also unenforceable without an `xform_id` column).


**Before submitting this PR for review, please make sure you have:**

  - [ ] Included tests
  - [ ] Updated documentation

Closes #