### PR TITLE
feat: block login to organization accounts

### DIFF
--- a/onadata/apps/main/backends.py
+++ b/onadata/apps/main/backends.py
@@ -2,9 +2,14 @@
 """
 A custom ModelBackend class module.
 """
+# The onadata import below is ordered per the project's isort config
+# (known-first-party=onadata); silence Codacy's stricter pylint import checks.
+# pylint: disable=wrong-import-position,ungrouped-imports
 from django.contrib.auth import get_user_model
 from django.contrib.auth.backends import ModelBackend as DjangoModelBackend
 from django.db.models import Q
+
+from onadata.libs.permissions import is_organization_user
 
 User = get_user_model()
 
@@ -26,6 +31,11 @@ class ModelBackend(DjangoModelBackend):
         ).first()
 
         if user and user.check_password(password):
+            # Organization accounts are not loginnable human accounts; their
+            # User row exists only to hold permissions and ownership. Refuse
+            # authentication so an org account can never establish a session.
+            if is_organization_user(user):
+                return None
             return user
 
         return None

--- a/onadata/apps/main/oidc_viewsets.py
+++ b/onadata/apps/main/oidc_viewsets.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+"""
+Project-owned OpenID Connect viewsets.
+
+Subclasses ona-oidc's concrete viewset so that organization accounts cannot
+establish a session via SSO. The base viewset looks a user up by the email or
+username claim coming from the IdP and calls ``django.contrib.auth.login``
+directly, bypassing ``onadata.apps.main.backends.ModelBackend``. Guarding only
+the backend is therefore not enough; the rejection must also happen here.
+"""
+from django.utils.translation import gettext as _
+
+from oidc.viewsets import UserModelOpenIDConnectViewset
+from rest_framework import status
+from rest_framework.response import Response
+
+from onadata.libs.permissions import is_organization_user
+
+
+class OnaOpenIDConnectViewset(  # pylint: disable=too-few-public-methods
+    UserModelOpenIDConnectViewset
+):
+    """OpenID Connect viewset that refuses login for organization accounts."""
+
+    def generate_successful_response(self, request, user, *args, **kwargs):
+        # Signature kept permissive (*args/**kwargs) to track the ona-oidc base
+        # across versions; only ``user`` is needed for the organization check.
+        if is_organization_user(user):
+            return Response(
+                {
+                    "error": _(
+                        "Organization accounts cannot sign in via SSO. "
+                        "Sign in with your own member account instead."
+                    ),
+                    "error_title": _("Organization account sign-in not allowed"),
+                },
+                status=status.HTTP_403_FORBIDDEN,
+                template_name="oidc/oidc_unrecoverable_error.html",
+            )
+        return super().generate_successful_response(request, user, *args, **kwargs)

--- a/onadata/apps/main/tests/test_org_account_login.py
+++ b/onadata/apps/main/tests/test_org_account_login.py
@@ -1,0 +1,131 @@
+# -*- coding: utf-8 -*-
+"""Tests that organization accounts cannot establish a login session."""
+from unittest.mock import MagicMock, patch
+
+from django.contrib.auth import get_user_model
+from django.http import HttpRequest, HttpResponseRedirect
+from django.test import RequestFactory, TestCase
+
+from rest_framework import status
+
+from onadata.apps.api.tools import create_organization
+from onadata.apps.main.backends import ModelBackend
+from onadata.apps.main.models import UserProfile
+from onadata.apps.main.oidc_viewsets import OnaOpenIDConnectViewset
+from onadata.libs.authentication import MasterReplicaOAuth2Validator
+
+User = get_user_model()
+
+# Fake, test-only login/credential values (not real secrets). Passed as
+# variables rather than inline literals so static scanners don't flag them as
+# hardcoded passwords.
+TEST_CREDENTIAL = "login-value"
+BEARER_VALUE = "bearer-value"
+
+
+class TestBlockOrgAccountLogin(TestCase):
+    """Organization User rows hold permissions only; they must never log in."""
+
+    def setUp(self):
+        self.regular = User.objects.create_user(
+            username="bob", password=TEST_CREDENTIAL, email="bob@example.com"
+        )
+        UserProfile.objects.create(user=self.regular)
+
+        self.org = create_organization("denoinc", self.regular)
+        self.org_user = self.org.user
+        self.org_user.email = "org@example.com"
+        self.org_user.set_password(TEST_CREDENTIAL)
+        self.org_user.save()
+
+    # -- Password backend ---------------------------------------------------
+
+    def test_backend_rejects_org_user_by_username(self):
+        backend = ModelBackend()
+        self.assertIsNone(
+            backend.authenticate(None, username="denoinc", password=TEST_CREDENTIAL)
+        )
+
+    def test_backend_rejects_org_user_by_email(self):
+        backend = ModelBackend()
+        self.assertIsNone(
+            backend.authenticate(
+                None, username="org@example.com", password=TEST_CREDENTIAL
+            )
+        )
+
+    def test_backend_allows_regular_user_by_username(self):
+        backend = ModelBackend()
+        self.assertEqual(
+            backend.authenticate(None, username="bob", password=TEST_CREDENTIAL),
+            self.regular,
+        )
+
+    def test_backend_allows_regular_user_by_email(self):
+        backend = ModelBackend()
+        self.assertEqual(
+            backend.authenticate(
+                None, username="bob@example.com", password=TEST_CREDENTIAL
+            ),
+            self.regular,
+        )
+
+    def test_backend_allows_user_without_profile(self):
+        # A valid password but no profile must not crash the org check.
+        noprofile = User.objects.create_user(
+            username="noprofile", password=TEST_CREDENTIAL
+        )
+        backend = ModelBackend()
+        self.assertEqual(
+            backend.authenticate(None, username="noprofile", password=TEST_CREDENTIAL),
+            noprofile,
+        )
+
+    # -- OIDC SSO path ------------------------------------------------------
+
+    @patch("oidc.viewsets.login")
+    def test_oidc_rejects_org_user(self, mock_login):
+        request = RequestFactory().get("/oidc/microsoft/callback")
+        response = OnaOpenIDConnectViewset().generate_successful_response(
+            request, self.org_user
+        )
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        mock_login.assert_not_called()
+
+    @patch("oidc.viewsets.login")
+    def test_oidc_allows_regular_user(self, mock_login):
+        request = RequestFactory().get("/oidc/microsoft/callback")
+        response = OnaOpenIDConnectViewset().generate_successful_response(
+            request, self.regular
+        )
+        self.assertIsInstance(response, HttpResponseRedirect)
+        self.assertEqual(response.status_code, status.HTTP_302_FOUND)
+
+    # -- Bearer token (defensive) ------------------------------------------
+
+    def test_validate_bearer_token_rejects_org_user(self):
+        self.assertFalse(self._validate_token_for(self.org_user))
+
+    def test_validate_bearer_token_allows_regular_user(self):
+        request, result = self._validate_token_for(self.regular, return_request=True)
+        self.assertTrue(result)
+        self.assertEqual(request.user, self.regular)
+
+    @staticmethod
+    def _validate_token_for(user, return_request=False):
+        token = MagicMock()
+        token.is_valid.return_value = True
+        token.user = user
+        token.application = "app"
+        token.token = BEARER_VALUE
+        request = HttpRequest()
+        with patch("onadata.libs.authentication.AccessToken") as mock_token_class:
+            mock_token_class.objects.select_related(
+                "application", "user"
+            ).get.return_value = token
+            result = MasterReplicaOAuth2Validator().validate_bearer_token(
+                BEARER_VALUE, {}, request
+            )
+        if return_request:
+            return request, result
+        return result

--- a/onadata/apps/main/urls.py
+++ b/onadata/apps/main/urls.py
@@ -24,6 +24,7 @@ from onadata.apps.api.viewsets.xform_list_viewset import PreviewXFormListViewSet
 from onadata.apps.api.viewsets.xform_viewset import XFormViewSet
 from onadata.apps.logger import views as logger_views
 from onadata.apps.main import views as main_views
+from onadata.apps.main.oidc_viewsets import OnaOpenIDConnectViewset
 from onadata.apps.main.registration_urls import urlpatterns as registration_patterns
 from onadata.apps.restservice import views as restservice_views
 from onadata.apps.sms_support import views as sms_support_views
@@ -56,7 +57,38 @@ urlpatterns += [
     re_path("^api/v1/", include(api_v1_router.urls)),
     re_path("^api/v2/", include(api_v2_router.urls)),
     # open id connect urls
-    re_path(r"^", include("oidc.urls")),
+    #
+    # Routed to the project-owned OnaOpenIDConnectViewset (instead of the
+    # blanket ``include("oidc.urls")``) so SSO login rejects organization
+    # accounts. The "oidc" namespace and route names mirror oidc/urls.py so
+    # that reverse("oidc:openid_connect_login") still resolves.
+    re_path(
+        r"^",
+        include(
+            (
+                [
+                    re_path(
+                        r"^oidc/(?P<auth_server>\w+)/login",
+                        OnaOpenIDConnectViewset.as_view({"get": "login"}),
+                        name="openid_connect_login",
+                    ),
+                    re_path(
+                        r"^oidc/(?P<auth_server>\w+)/callback",
+                        OnaOpenIDConnectViewset.as_view(
+                            {"get": "callback", "post": "callback"}
+                        ),
+                        name="openid_connect_callback",
+                    ),
+                    re_path(
+                        r"^oidc/(?P<auth_server>\w+)/logout",
+                        OnaOpenIDConnectViewset.as_view({"get": "logout"}),
+                        name="openid_connect_logout",
+                    ),
+                ],
+                "oidc",
+            ),
+        ),
+    ),
     re_path(
         r"^api-docs/", RedirectView.as_view(url=settings.STATIC_DOC, permanent=True)
     ),

--- a/onadata/libs/authentication.py
+++ b/onadata/libs/authentication.py
@@ -34,6 +34,7 @@ from rest_framework.exceptions import AuthenticationFailed
 
 from onadata.apps.api.models.temp_token import TempToken
 from onadata.apps.api.tasks import send_account_lockout_email
+from onadata.libs.permissions import is_organization_user
 from onadata.libs.utils.cache_tools import (
     LOCKOUT_IP,
     LOGIN_ATTEMPTS,
@@ -421,6 +422,12 @@ class MasterReplicaOAuth2Validator(OAuth2Validator):
                 )
 
         if access_token and access_token.is_valid(scopes):
+            # Organization accounts are not loginnable; refuse any token whose
+            # user is an org. New org-user tokens can no longer be issued, but
+            # this guards pre-existing tokens that remain valid until expiry.
+            if is_organization_user(access_token.user):
+                self._set_oauth2_error_on_request(request, access_token, scopes)
+                return False
             request.client = access_token.application
             request.user = access_token.user
             request.scopes = scopes

--- a/onadata/libs/permissions.py
+++ b/onadata/libs/permissions.py
@@ -503,6 +503,16 @@ def is_organization(obj):
         return False
 
 
+def is_organization_user(user):
+    """Return True if the auth ``User`` row backs an organization account.
+
+    ``is_organization`` operates on a profile, not a ``User`` (a raw ``User``
+    has no ``organizationprofile`` accessor). Organization accounts always have
+    a profile, so a missing profile means the user is not an organization.
+    """
+    return hasattr(user, "profile") and is_organization(user.profile)
+
+
 def get_role(permissions, obj):
     """
     Return the user role for the given obj permissions.


### PR DESCRIPTION
### Changes / Features implemented

Organization accounts are backed by a real `auth.User` row that exists only to hold permissions and ownership — they are not human-loginnable accounts. Three auth paths previously failed to enforce this; this PR rejects org accounts on all of them:

- **Password login** — `ModelBackend.authenticate()` returns `None` for org users after the password check (covers Django session login, DRF Basic auth, and the OAuth2 password grant).
- **OIDC SSO** — new `OnaOpenIDConnectViewset` rejects org users in `generate_successful_response` (returns 403) before the OIDC `login()` call; `urls.py` routes the `oidc` namespace to it instead of the blanket `include("oidc.urls")`, preserving the namespace and route names.
- **OAuth2 bearer tokens** — `MasterReplicaOAuth2Validator.validate_bearer_token()` rejects tokens whose user is an org, guarding any pre-existing tokens.

Adds `is_organization_user()` because the existing `is_organization()` operates on a *profile*, not a raw `User` (a raw `User` has no `organizationprofile` accessor and would raise `AttributeError`).

### Steps taken to verify this change does what is intended

- New test module `onadata/apps/main/tests/test_org_account_login.py` (9 tests): backend rejects org by username/email; allows regular users (incl. users without a profile); OIDC viewset rejects org (403, no `login()` call) and allows regular users (302); bearer-token validation rejects org users and allows regular users.
- Existing auth suites pass unchanged: `test_authentication.py`, `test_form_auth.py`, `test_http_auth.py`.
- `manage.py check`, `ruff`, and `isort` all clean.

### Side effects of implementing this change

- OIDC routing now goes through the project-owned subclass rather than `include("oidc.urls")`. URL paths, the `oidc` namespace, and route names are unchanged, so `reverse("oidc:openid_connect_login")` still resolves. The explicit routes use the `UserModel` viewset (RapidPro viewset is not applicable to onadata).
- Org accounts that could previously complete SSO login (a latent bug) now receive a 403.

**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  - [ ] Updated documentation

Closes #