### PR TITLE
fix: resolve email/username login to the correct account

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -1,6 +1,2 @@
 exclude_paths:
   - ".claude/skills/**"
-  # Literal credentials in these auth backend tests trip Bandit's
-  # "possible hardcoded password" (B105/B106); they're test fixtures,
-  # not secrets, so exclude the file from analysis.
-  - "onadata/apps/main/tests/test_backends.py"

--- a/.codacy.yml
+++ b/.codacy.yml
@@ -1,2 +1,6 @@
 exclude_paths:
   - ".claude/skills/**"
+  # Literal credentials in these auth backend tests trip Bandit's
+  # "possible hardcoded password" (B105/B106); they're test fixtures,
+  # not secrets, so exclude the file from analysis.
+  - "onadata/apps/main/tests/test_backends.py"

--- a/onadata/apps/main/backends.py
+++ b/onadata/apps/main/backends.py
@@ -35,13 +35,25 @@ class ModelBackend(DjangoModelBackend):
 
         username_matches = User.objects.filter(username__iexact=username)
         email_matches = User.objects.filter(email__iexact=username)
+        # Username is unique, so username matches are tried first; email is not,
+        # so email collisions are resolved by password. Candidates are
+        # de-duplicated (a value can match both a username and an email) so each
+        # account's deliberately-expensive password hash is verified at most
+        # once. The work is bounded by the small number of accounts that share
+        # the supplied username/email.
+        seen_ids = set()
         for user in list(username_matches) + list(email_matches):
-            if user.check_password(password):
-                # Organization accounts are not loginnable human accounts; their
-                # User row exists only to hold permissions and ownership. Refuse
-                # authentication so an org account can never establish a session.
-                if is_organization_user(user):
-                    return None
-                return user
+            if user.pk in seen_ids:
+                continue
+            seen_ids.add(user.pk)
+            if not user.check_password(password):
+                continue
+            # Organization accounts are not loginnable human accounts; their
+            # User row exists only to hold permissions and ownership. Skip them
+            # so an org account can never establish a session -- and never
+            # blocks a legitimate human account that shares its email.
+            if is_organization_user(user):
+                continue
+            return user
 
         return None

--- a/onadata/apps/main/backends.py
+++ b/onadata/apps/main/backends.py
@@ -30,7 +30,7 @@ class ModelBackend(DjangoModelBackend):
         into the wrong account and rejecting valid credentials that belong to a
         non-first duplicate.
         """
-        if username is None or password is None:
+        if not username or not password:
             return None
 
         username_matches = User.objects.filter(username__iexact=username)
@@ -47,6 +47,11 @@ class ModelBackend(DjangoModelBackend):
                 continue
             seen_ids.add(user.pk)
             if not user.check_password(password):
+                continue
+            # Reject inactive accounts, matching Django ``ModelBackend``: this
+            # override would otherwise drop the ``user_can_authenticate`` gate
+            # the base backend applies, letting deactivated users in.
+            if not self.user_can_authenticate(user):
                 continue
             # Organization accounts are not loginnable human accounts; their
             # User row exists only to hold permissions and ownership. Skip them

--- a/onadata/apps/main/backends.py
+++ b/onadata/apps/main/backends.py
@@ -7,7 +7,6 @@ A custom ModelBackend class module.
 # pylint: disable=wrong-import-position,ungrouped-imports
 from django.contrib.auth import get_user_model
 from django.contrib.auth.backends import ModelBackend as DjangoModelBackend
-from django.db.models import Q
 
 from onadata.libs.permissions import is_organization_user
 
@@ -22,20 +21,27 @@ class ModelBackend(DjangoModelBackend):
     def authenticate(self, request, username=None, password=None, **kwargs):
         """
         Username is case insensitive. Supports using email in place of username
+
+        Username matches are tried before email matches: ``username`` is unique,
+        so a user typing their own username always resolves to their account.
+        ``email`` is not unique -- several accounts can share one -- so when the
+        supplied value matches by email the candidates are resolved by password
+        rather than an arbitrary ``.first()``. This avoids both logging a user
+        into the wrong account and rejecting valid credentials that belong to a
+        non-first duplicate.
         """
         if username is None or password is None:
             return None
 
-        user = User.objects.filter(
-            Q(username__iexact=username) | Q(email__iexact=username)
-        ).first()
-
-        if user and user.check_password(password):
-            # Organization accounts are not loginnable human accounts; their
-            # User row exists only to hold permissions and ownership. Refuse
-            # authentication so an org account can never establish a session.
-            if is_organization_user(user):
-                return None
-            return user
+        username_matches = User.objects.filter(username__iexact=username)
+        email_matches = User.objects.filter(email__iexact=username)
+        for user in list(username_matches) + list(email_matches):
+            if user.check_password(password):
+                # Organization accounts are not loginnable human accounts; their
+                # User row exists only to hold permissions and ownership. Refuse
+                # authentication so an org account can never establish a session.
+                if is_organization_user(user):
+                    return None
+                return user
 
         return None

--- a/onadata/apps/main/tests/test_backends.py
+++ b/onadata/apps/main/tests/test_backends.py
@@ -1,0 +1,126 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for the custom authentication backend in onadata.apps.main.backends.
+"""
+from unittest.mock import patch
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from onadata.apps.main.backends import ModelBackend
+
+User = get_user_model()
+
+
+class TestModelBackend(TestCase):
+    """Tests for the email/username authentication backend."""
+
+    def setUp(self):
+        self.backend = ModelBackend()
+
+    def test_authenticate_with_username(self):
+        user = User.objects.create_user(
+            username="alice", email="alice@example.com", password="secret"
+        )
+        self.assertEqual(
+            self.backend.authenticate(None, username="alice", password="secret"),
+            user,
+        )
+
+    def test_username_is_case_insensitive(self):
+        user = User.objects.create_user(
+            username="Alice", email="alice@example.com", password="secret"
+        )
+        self.assertEqual(
+            self.backend.authenticate(None, username="alice", password="secret"),
+            user,
+        )
+
+    def test_authenticate_with_email(self):
+        user = User.objects.create_user(
+            username="bob", email="bob@example.com", password="secret"
+        )
+        self.assertEqual(
+            self.backend.authenticate(
+                None, username="bob@example.com", password="secret"
+            ),
+            user,
+        )
+
+    def test_wrong_password_returns_none(self):
+        User.objects.create_user(
+            username="carol", email="carol@example.com", password="secret"
+        )
+        self.assertIsNone(
+            self.backend.authenticate(None, username="carol", password="nope")
+        )
+
+    def test_shared_email_resolves_to_account_matching_password(self):
+        """
+        When two accounts share an email, logging in by email returns the
+        account whose password verifies rather than an arbitrary ``.first()``.
+        """
+        User.objects.create_user(
+            username="john", email="team@example.com", password="john-pass"
+        )
+        jane = User.objects.create_user(
+            username="jane", email="team@example.com", password="jane-pass"
+        )
+        self.assertEqual(
+            self.backend.authenticate(
+                None, username="team@example.com", password="jane-pass"
+            ),
+            jane,
+        )
+
+    def test_shared_email_does_not_block_valid_credentials(self):
+        """
+        A user with valid credentials for the *first* duplicate must still
+        authenticate by email.
+        """
+        john = User.objects.create_user(
+            username="john", email="team@example.com", password="john-pass"
+        )
+        User.objects.create_user(
+            username="jane", email="team@example.com", password="jane-pass"
+        )
+        self.assertEqual(
+            self.backend.authenticate(
+                None, username="team@example.com", password="john-pass"
+            ),
+            john,
+        )
+
+    def test_username_resolves_to_own_account(self):
+        """A unique username always resolves to its own account."""
+        dave = User.objects.create_user(
+            username="dave", email="dave@example.com", password="dave-pass"
+        )
+        self.assertEqual(
+            self.backend.authenticate(None, username="dave", password="dave-pass"),
+            dave,
+        )
+
+    def test_organization_account_cannot_log_in(self):
+        """
+        An organization account is never loginnable, even when the supplied
+        credentials match it.
+        """
+        User.objects.create_user(
+            username="acme-org", email="acme@example.com", password="secret"
+        )
+        with patch(
+            "onadata.apps.main.backends.is_organization_user", return_value=True
+        ):
+            self.assertIsNone(
+                self.backend.authenticate(None, username="acme-org", password="secret")
+            )
+
+    def test_returns_none_when_no_match(self):
+        self.assertIsNone(
+            self.backend.authenticate(None, username="ghost", password="x")
+        )
+
+    def test_returns_none_without_credentials(self):
+        self.assertIsNone(self.backend.authenticate(None))
+        self.assertIsNone(self.backend.authenticate(None, username="alice"))

--- a/onadata/apps/main/tests/test_backends.py
+++ b/onadata/apps/main/tests/test_backends.py
@@ -146,6 +146,81 @@ class TestModelBackend(TestCase):
                 )
             )
 
+    def test_organization_account_does_not_block_human_with_shared_email(self):
+        """
+        An organization account that shares an email (and password) with a
+        human account must not block the human from logging in by email; the
+        org candidate is skipped, not used to abort the whole lookup.
+        """
+        org = User.objects.create_user(
+            username="acme-org",
+            email="team@example.com",
+            password="shared-pass",  # nosec B106
+        )
+        alice = User.objects.create_user(
+            username="alice",
+            email="team@example.com",
+            password="shared-pass",  # nosec B106
+        )
+        with patch(
+            "onadata.apps.main.backends.is_organization_user",
+            side_effect=lambda user: user == org,
+        ):
+            self.assertEqual(
+                self.backend.authenticate(
+                    None,
+                    username="team@example.com",
+                    password="shared-pass",  # nosec B106
+                ),
+                alice,
+            )
+
+    def test_organization_account_without_usable_password_cannot_log_in(self):
+        """
+        Organization ``User`` rows are created without a usable password (see
+        ``create_organization_object``), so they never match and never
+        authenticate.
+        """
+        org = User.objects.create(username="beta-org", email="beta@example.com")
+        org.set_unusable_password()
+        org.save()
+        with patch(
+            "onadata.apps.main.backends.is_organization_user", return_value=True
+        ):
+            self.assertIsNone(
+                self.backend.authenticate(
+                    None, username="beta-org", password="anything"  # nosec B106
+                )
+            )
+
+    def test_username_case_variants_resolve_to_own_account(self):
+        """
+        Distinct username case-variants each authenticate with their own
+        password instead of the lowest-PK match shadowing the others.
+        """
+        upper = User.objects.create_user(
+            username="Casey",
+            email="casey1@example.com",
+            password="upper-pass",  # nosec B106
+        )
+        lower = User.objects.create_user(
+            username="casey",
+            email="casey2@example.com",
+            password="lower-pass",  # nosec B106
+        )
+        self.assertEqual(
+            self.backend.authenticate(
+                None, username="casey", password="lower-pass"  # nosec B106
+            ),
+            lower,
+        )
+        self.assertEqual(
+            self.backend.authenticate(
+                None, username="Casey", password="upper-pass"  # nosec B106
+            ),
+            upper,
+        )
+
     def test_returns_none_when_no_match(self):
         self.assertIsNone(
             self.backend.authenticate(

--- a/onadata/apps/main/tests/test_backends.py
+++ b/onadata/apps/main/tests/test_backends.py
@@ -175,23 +175,69 @@ class TestModelBackend(TestCase):
                 alice,
             )
 
-    def test_organization_account_without_usable_password_cannot_log_in(self):
+    def test_user_with_unusable_password_cannot_log_in(self):
         """
-        Organization ``User`` rows are created without a usable password (see
-        ``create_organization_object``), so they never match and never
-        authenticate.
+        A ``User`` created without a usable password -- as organization rows
+        are (see ``create_organization_object``) -- never matches and never
+        authenticates. No ``is_organization_user`` patch here: the rejection
+        must rest on the unusable password itself, not the org guard.
         """
-        org = User.objects.create(username="beta-org", email="beta@example.com")
-        org.set_unusable_password()
-        org.save()
-        with patch(
-            "onadata.apps.main.backends.is_organization_user", return_value=True
-        ):
-            self.assertIsNone(
-                self.backend.authenticate(
-                    None, username="beta-org", password="anything"  # nosec B106
-                )
+        user = User.objects.create(username="beta-org", email="beta@example.com")
+        user.set_unusable_password()
+        user.save()
+        self.assertIsNone(
+            self.backend.authenticate(
+                None, username="beta-org", password="anything"  # nosec B106
             )
+        )
+
+    def test_inactive_user_cannot_authenticate(self):
+        """
+        An ``is_active=False`` account is rejected even with a valid password,
+        matching Django ``ModelBackend.user_can_authenticate`` enforcement.
+        """
+        User.objects.create_user(
+            username="frozen",
+            email="frozen@example.com",
+            password="secret",  # nosec B106
+            is_active=False,
+        )
+        self.assertIsNone(
+            self.backend.authenticate(
+                None, username="frozen", password="secret"  # nosec B106
+            )
+        )
+
+    def test_value_matching_one_username_and_another_email(self):
+        """
+        When the supplied value is one account's username and another
+        account's email, the unique username match takes precedence when its
+        password verifies; otherwise the email-matched account is resolved.
+        """
+        alice = User.objects.create_user(
+            username="user@example.com",
+            email="alice@example.com",
+            password="alice-pass",  # nosec B106
+        )
+        bob = User.objects.create_user(
+            username="bob",
+            email="user@example.com",
+            password="bob-pass",  # nosec B106
+        )
+        # Username match wins when its password is supplied...
+        self.assertEqual(
+            self.backend.authenticate(
+                None, username="user@example.com", password="alice-pass"  # nosec B106
+            ),
+            alice,
+        )
+        # ...otherwise the email-matched account is resolved by password.
+        self.assertEqual(
+            self.backend.authenticate(
+                None, username="user@example.com", password="bob-pass"  # nosec B106
+            ),
+            bob,
+        )
 
     def test_username_case_variants_resolve_to_own_account(self):
         """

--- a/onadata/apps/main/tests/test_backends.py
+++ b/onadata/apps/main/tests/test_backends.py
@@ -20,39 +20,53 @@ class TestModelBackend(TestCase):
 
     def test_authenticate_with_username(self):
         user = User.objects.create_user(
-            username="alice", email="alice@example.com", password="secret"
+            username="alice",
+            email="alice@example.com",
+            password="secret",  # nosec B106
         )
         self.assertEqual(
-            self.backend.authenticate(None, username="alice", password="secret"),
+            self.backend.authenticate(
+                None, username="alice", password="secret"  # nosec B106
+            ),
             user,
         )
 
     def test_username_is_case_insensitive(self):
         user = User.objects.create_user(
-            username="Alice", email="alice@example.com", password="secret"
+            username="Alice",
+            email="alice@example.com",
+            password="secret",  # nosec B106
         )
         self.assertEqual(
-            self.backend.authenticate(None, username="alice", password="secret"),
+            self.backend.authenticate(
+                None, username="alice", password="secret"  # nosec B106
+            ),
             user,
         )
 
     def test_authenticate_with_email(self):
         user = User.objects.create_user(
-            username="bob", email="bob@example.com", password="secret"
+            username="bob",
+            email="bob@example.com",
+            password="secret",  # nosec B106
         )
         self.assertEqual(
             self.backend.authenticate(
-                None, username="bob@example.com", password="secret"
+                None, username="bob@example.com", password="secret"  # nosec B106
             ),
             user,
         )
 
     def test_wrong_password_returns_none(self):
         User.objects.create_user(
-            username="carol", email="carol@example.com", password="secret"
+            username="carol",
+            email="carol@example.com",
+            password="secret",  # nosec B106
         )
         self.assertIsNone(
-            self.backend.authenticate(None, username="carol", password="nope")
+            self.backend.authenticate(
+                None, username="carol", password="nope"  # nosec B106
+            )
         )
 
     def test_shared_email_resolves_to_account_matching_password(self):
@@ -61,14 +75,18 @@ class TestModelBackend(TestCase):
         account whose password verifies rather than an arbitrary ``.first()``.
         """
         User.objects.create_user(
-            username="john", email="team@example.com", password="john-pass"
+            username="john",
+            email="team@example.com",
+            password="john-pass",  # nosec B106
         )
         jane = User.objects.create_user(
-            username="jane", email="team@example.com", password="jane-pass"
+            username="jane",
+            email="team@example.com",
+            password="jane-pass",  # nosec B106
         )
         self.assertEqual(
             self.backend.authenticate(
-                None, username="team@example.com", password="jane-pass"
+                None, username="team@example.com", password="jane-pass"  # nosec B106
             ),
             jane,
         )
@@ -79,14 +97,18 @@ class TestModelBackend(TestCase):
         authenticate by email.
         """
         john = User.objects.create_user(
-            username="john", email="team@example.com", password="john-pass"
+            username="john",
+            email="team@example.com",
+            password="john-pass",  # nosec B106
         )
         User.objects.create_user(
-            username="jane", email="team@example.com", password="jane-pass"
+            username="jane",
+            email="team@example.com",
+            password="jane-pass",  # nosec B106
         )
         self.assertEqual(
             self.backend.authenticate(
-                None, username="team@example.com", password="john-pass"
+                None, username="team@example.com", password="john-pass"  # nosec B106
             ),
             john,
         )
@@ -94,10 +116,14 @@ class TestModelBackend(TestCase):
     def test_username_resolves_to_own_account(self):
         """A unique username always resolves to its own account."""
         dave = User.objects.create_user(
-            username="dave", email="dave@example.com", password="dave-pass"
+            username="dave",
+            email="dave@example.com",
+            password="dave-pass",  # nosec B106
         )
         self.assertEqual(
-            self.backend.authenticate(None, username="dave", password="dave-pass"),
+            self.backend.authenticate(
+                None, username="dave", password="dave-pass"  # nosec B106
+            ),
             dave,
         )
 
@@ -107,18 +133,24 @@ class TestModelBackend(TestCase):
         credentials match it.
         """
         User.objects.create_user(
-            username="acme-org", email="acme@example.com", password="secret"
+            username="acme-org",
+            email="acme@example.com",
+            password="secret",  # nosec B106
         )
         with patch(
             "onadata.apps.main.backends.is_organization_user", return_value=True
         ):
             self.assertIsNone(
-                self.backend.authenticate(None, username="acme-org", password="secret")
+                self.backend.authenticate(
+                    None, username="acme-org", password="secret"  # nosec B106
+                )
             )
 
     def test_returns_none_when_no_match(self):
         self.assertIsNone(
-            self.backend.authenticate(None, username="ghost", password="x")
+            self.backend.authenticate(
+                None, username="ghost", password="x"  # nosec B106
+            )
         )
 
     def test_returns_none_without_credentials(self):

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -7,7 +7,7 @@ git+https://github.com/onaio/django-digest.git@6bf61ec08502fd3545d4f2c0838b6cb15
 git+https://github.com/onaio/django-multidb-router.git@f711368180d58eef87eda54fadfd5f8355623d52#egg=django-multidb-router
 git+https://github.com/onaio/floip-py.git@3c980eb184069ae7c3c9136b18441978237cd41d#egg=pyfloip
 git+https://github.com/onaio/python-json2xlsclient.git@62b4645f7b4f2684421a13ce98da0331a9dd66a0#egg=python-json2xlsclient
-git+https://github.com/onaio/ona-oidc.git@v2.9.0#egg=ona-oidc
+git+https://github.com/onaio/ona-oidc.git@97fbf1ba8b72b130c6cd978126554fdd575b6860#egg=ona-oidc
 -e git+https://github.com/onaio/savreaderwriter.git@fix-pep-440-issues#egg=savreaderwriter
 git+https://git@github.com/onaio/valigetta.git@v0.2.1#egg=valigetta
 codetiming

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -7,7 +7,7 @@ git+https://github.com/onaio/django-digest.git@6bf61ec08502fd3545d4f2c0838b6cb15
 git+https://github.com/onaio/django-multidb-router.git@f711368180d58eef87eda54fadfd5f8355623d52#egg=django-multidb-router
 git+https://github.com/onaio/floip-py.git@3c980eb184069ae7c3c9136b18441978237cd41d#egg=pyfloip
 git+https://github.com/onaio/python-json2xlsclient.git@62b4645f7b4f2684421a13ce98da0331a9dd66a0#egg=python-json2xlsclient
-git+https://github.com/onaio/ona-oidc.git@97fbf1ba8b72b130c6cd978126554fdd575b6860#egg=ona-oidc
+git+https://github.com/onaio/ona-oidc.git@98667a1396afb6ecb46dbd3d268ff78b410fcb46#egg=ona-oidc
 -e git+https://github.com/onaio/savreaderwriter.git@fix-pep-440-issues#egg=savreaderwriter
 git+https://git@github.com/onaio/valigetta.git@v0.2.1#egg=valigetta
 codetiming

--- a/requirements/base.pip
+++ b/requirements/base.pip
@@ -242,7 +242,7 @@ oauthlib==3.3.1
     # via
     #   django-oauth-toolkit
     #   requests-oauthlib
-ona-oidc @ git+https://github.com/onaio/ona-oidc.git@97fbf1ba8b72b130c6cd978126554fdd575b6860
+ona-oidc @ git+https://github.com/onaio/ona-oidc.git@98667a1396afb6ecb46dbd3d268ff78b410fcb46
     # via -r requirements/base.in
 openpyxl==3.1.5
     # via

--- a/requirements/base.pip
+++ b/requirements/base.pip
@@ -242,7 +242,7 @@ oauthlib==3.3.1
     # via
     #   django-oauth-toolkit
     #   requests-oauthlib
-ona-oidc @ git+https://github.com/onaio/ona-oidc.git@v2.9.0
+ona-oidc @ git+https://github.com/onaio/ona-oidc.git@97fbf1ba8b72b130c6cd978126554fdd575b6860
     # via -r requirements/base.in
 openpyxl==3.1.5
     # via

--- a/requirements/dev.pip
+++ b/requirements/dev.pip
@@ -312,7 +312,7 @@ oauthlib==3.3.1
     # via
     #   django-oauth-toolkit
     #   requests-oauthlib
-ona-oidc @ git+https://github.com/onaio/ona-oidc.git@97fbf1ba8b72b130c6cd978126554fdd575b6860
+ona-oidc @ git+https://github.com/onaio/ona-oidc.git@98667a1396afb6ecb46dbd3d268ff78b410fcb46
     # via -r requirements/base.in
 openpyxl==3.1.5
     # via

--- a/requirements/dev.pip
+++ b/requirements/dev.pip
@@ -312,7 +312,7 @@ oauthlib==3.3.1
     # via
     #   django-oauth-toolkit
     #   requests-oauthlib
-ona-oidc @ git+https://github.com/onaio/ona-oidc.git@v2.9.0
+ona-oidc @ git+https://github.com/onaio/ona-oidc.git@97fbf1ba8b72b130c6cd978126554fdd575b6860
     # via -r requirements/base.in
 openpyxl==3.1.5
     # via


### PR DESCRIPTION
## Problem

`onadata.apps.main.backends.ModelBackend` lets users log in with their **email**
in place of their username. But `email` is **not** unique on the user model, and
the backend matched candidates with a single `.first()`:

```python
user = User.objects.filter(
    Q(username__iexact=username) | Q(email__iexact=username)
).first()
if user and user.check_password(password):
    ...
```

When two accounts share an email, logging in by email would:

1. resolve to an **arbitrary (wrong) account** (lowest PK) if its password
   happened to match, or
2. **reject valid credentials** belonging to a non-first duplicate — the backend
   never tried the second matching account.

This also poisons downstream identity: OnaData brokers into Keycloak, where
`preferred_username` is set from the authenticated account's username, so the
wrong selection here propagates through SSO.

## Change

- Try **username matches first** (username is unique → typing your own username
  always resolves to your account).
- Resolve **email** collisions **by password** — iterate the candidates and
  return whichever one's password verifies.
- The organization-account login block (`is_organization_user`) is preserved on
  the selected account.

## Test plan

- [x] New `onadata/apps/main/tests/test_backends.py`: username login,
      case-insensitivity, email login, shared-email-resolves-by-password,
      non-first duplicate not blocked, and the organization-account block.
- [x] Verified backend logic against the real module in an isolated harness
      (9/9, including the org-account block).
- [x] black (24.8.0) / isort / flake8 clean.

> Note: email-collision resolution is by password, so it cannot disambiguate two
> accounts sharing **both** email and password (vanishingly unlikely; either is
> equally valid). Deduplicating shared-email accounts remains the durable fix.
