### PR TITLE
feat(security): enforce strict file-type validation on uploads

### DIFF
--- a/onadata/apps/api/tasks.py
+++ b/onadata/apps/api/tasks.py
@@ -59,7 +59,10 @@ def publish_xlsform_async(self, user_id, post_data, owner_id, file_data):
     """Publishes an XLSForm"""
     try:
         files = MultiValueDict()
-        files["xls_file"] = default_storage.open(file_data.get("path"))
+        xls_file = default_storage.open(file_data.get("path"))
+        xls_file.name = file_data.get("name")
+        xls_file.content_type = file_data.get("content_type")
+        files["xls_file"] = xls_file
 
         owner = User.objects.get(id=owner_id)
         if owner_id == user_id:

--- a/onadata/apps/api/tests/viewsets/test_abstract_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_abstract_viewset.py
@@ -19,6 +19,7 @@ import requests
 from django_digest.test import Client as DigestClient
 from django_digest.test import DigestAuth
 from httmock import HTTMock
+from requests.structures import CaseInsensitiveDict
 from rest_framework.test import APIRequestFactory
 
 from onadata.apps.api.models import OrganizationProfile, Team
@@ -82,20 +83,29 @@ def add_uuid_to_submission_xml(path, xform):
 
 
 # pylint: disable=invalid-name
-def get_mocked_response_for_file(file_object, filename, status_code=200):
+def get_mocked_response_for_file(
+    file_object, filename, status_code=200, content_type=None
+):
     """Returns a requests.Response() object for mocked tests."""
+    if content_type is None:
+        content_type = (
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+        )
     mock_response = requests.Response()
     mock_response.status_code = status_code
-    mock_response.headers = {
-        "content-type": (
-            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
-        ),
-        "Content-Disposition": (
-            f"attachment; filename=\"transportation.xlsx\"; filename*=UTF-8''{filename}"
-        ),
-    }
+    mock_response.headers = CaseInsensitiveDict(
+        {
+            "content-type": content_type,
+            "Content-Disposition": (
+                f'attachment; filename="{filename}";' f" filename*=UTF-8''{filename}"
+            ),
+        }
+    )
     # pylint: disable=protected-access
     mock_response._content = file_object.read()
+    # Mark content as consumed so Response.iter_content() yields from _content
+    # rather than trying to stream from the absent .raw underlying socket.
+    mock_response._content_consumed = True
 
     return mock_response
 

--- a/onadata/apps/api/tests/viewsets/test_media_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_media_viewset.py
@@ -127,6 +127,7 @@ class TestMediaViewSet(TestAbstractViewSet, TestBase):
         mock_download_url.assert_called_once_with(
             self.attachment.media_file.name,
             f'attachment; filename="{filename}"',
+            self.attachment.mimetype,
             expires_in=3600,
         )
 

--- a/onadata/apps/api/tests/viewsets/test_metadata_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_metadata_viewset.py
@@ -10,7 +10,9 @@ from unittest.mock import patch
 
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
-from django.core.files.uploadedfile import InMemoryUploadedFile
+from django.core.files.storage import default_storage
+from django.core.files.uploadedfile import InMemoryUploadedFile, SimpleUploadedFile
+from django.test import override_settings
 
 from onadata.apps.api.tests.viewsets.test_abstract_viewset import TestAbstractViewSet
 from onadata.apps.api.viewsets.metadata_viewset import MetaDataViewSet
@@ -195,17 +197,19 @@ class TestMetaDataViewSet(TestAbstractViewSet):
         self.path = os.path.join(self.fixture_dir, self.data_value)
 
         self._add_form_metadata(self.xform, "media", self.data_value, self.path)
+        stored_basename = os.path.basename(self.metadata.data_file.name)
+        media_path_prefix = (
+            f"http://localhost:8000/media/{self.user.username}/formid-media/"
+        )
         data = {
             "id": self.metadata.pk,
             "xform": self.xform.pk,
             "data_value": "1335783522563.jpg",
             "data_type": "media",
             "extra_data": None,
-            "data_file": "http://localhost:8000/media/%s/formid-media/"
-            "1335783522563.jpg" % self.user.username,
+            "data_file": f"{media_path_prefix}{stored_basename}",
             "data_file_type": "image/jpeg",
-            "media_url": "http://localhost:8000/media/%s/formid-media/"
-            "1335783522563.jpg" % self.user.username,
+            "media_url": f"{media_path_prefix}{stored_basename}",
             "file_hash": "md5:2ca0d22073a9b6b4ebe51368b08da60c",
             "url": "http://testserver/api/v1/metadata/%s" % self.metadata.pk,
             "date_created": self.metadata.date_created,
@@ -214,6 +218,9 @@ class TestMetaDataViewSet(TestAbstractViewSet):
         response = self.view(request, pk=self.metadata.pk)
         self.assertEqual(response.status_code, 200)
         self.assertDictEqual(dict(response.data), data)
+        # Stored basename must be a UUID, not the client-supplied name.
+        self.assertNotEqual(stored_basename, "1335783522563.jpg")
+        self.assertTrue(stored_basename.endswith(".jpg"))
 
     def test_add_mapbox_layer(self):
         data_type = "mapbox_layer"
@@ -247,21 +254,27 @@ class TestMetaDataViewSet(TestAbstractViewSet):
         self.assertEqual(len(response2.data), 0)
         self.assertEqual(response2.data, [])
 
-    def test_windows_csv_file_upload_to_metadata(self):
+    def test_octet_stream_csv_file_upload_to_metadata_is_accepted(self):
+        """A CSV uploaded with ``application/octet-stream`` is accepted.
+
+        Windows browsers and similar clients commonly omit a precise MIME
+        type. The magic-byte/CSV parser validation still runs.
+        """
         data_value = "transportation.csv"
         path = os.path.join(self.fixture_dir, data_value)
-        with open(path) as f:
-            f = InMemoryUploadedFile(
+        with open(path, "rb") as f:
+            uploaded = InMemoryUploadedFile(
                 f, "media", data_value, "application/octet-stream", 2625, None
             )
             data = {
                 "data_value": data_value,
-                "data_file": f,
+                "data_file": uploaded,
                 "data_type": "media",
                 "xform": self.xform.pk,
             }
-            self._post_metadata(data)
-            self.assertEqual(self.metadata.data_file_type, "text/csv")
+            response = self._post_metadata(data)
+            self.assertEqual(response.status_code, 201)
+            self.assertEqual(response.data["data_file_type"], "text/csv")
 
     def test_add_media_url(self):
         data_type = "media"
@@ -404,7 +417,9 @@ class TestMetaDataViewSet(TestAbstractViewSet):
         self.assertEqual(response.status_code, 400)
 
     def test_list_public_metadata_excludes_deleted_forms(self):
-        self._add_form_metadata(self.xform, "supporting_doc", self.data_value, self.path)
+        self._add_form_metadata(
+            self.xform, "supporting_doc", self.data_value, self.path
+        )
         self.xform.shared_data = True
         self.xform.save()
 
@@ -672,3 +687,189 @@ class TestMetaDataViewSet(TestAbstractViewSet):
 
         self.assertEqual(d_response.status_code, 400)
         self.assertIn(UNIQUE_TOGETHER_ERROR, d_response.data)
+
+    def _post_media_upload(self, name, content, content_type):
+        view = MetaDataViewSet.as_view({"post": "create"})
+        uploaded = SimpleUploadedFile(name, content, content_type=content_type)
+        data = {
+            "data_type": "media",
+            "data_value": name,
+            "xform": self.xform.id,
+            "data_file": uploaded,
+        }
+        request = self.factory.post("/", data=data, **self.extra)
+        return view(request)
+
+    def test_media_upload_rejects_double_extension(self):
+        """A `putty.exe.png` filename is rejected and no MetaData row remains."""
+        before = MetaData.objects.count()
+
+        response = self._post_media_upload("putty.exe.png", b"MZpayload", "image/png")
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(MetaData.objects.count(), before)
+
+    def test_media_upload_rejects_signature_mismatch(self):
+        """PNG content-type with executable bytes is rejected without persistence."""
+        before = MetaData.objects.count()
+        before_files = MetaData.objects.exclude(data_file="").count()
+
+        response = self._post_media_upload(
+            "putty.png", b"MZ\x90\x00payload", "image/png"
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(MetaData.objects.count(), before)
+        self.assertEqual(MetaData.objects.exclude(data_file="").count(), before_files)
+
+    def test_media_upload_rejects_content_type_spoof(self):
+        """A real PNG file uploaded under text/csv is rejected."""
+        before = MetaData.objects.count()
+        with open(self.path, "rb") as png:
+            png_bytes = png.read()
+
+        response = self._post_media_upload("data.csv", png_bytes, "text/csv")
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(MetaData.objects.count(), before)
+
+    def test_media_upload_stores_uuid_filename(self):
+        """Accepted media uploads store a UUID-based filename, not the client name."""
+        with open(self.path, "rb") as png:
+            png_bytes = png.read()
+
+        response = self._post_media_upload("screenshot.png", png_bytes, "image/png")
+
+        self.assertEqual(response.status_code, 201, response.data)
+        metadata = MetaData.objects.get(pk=response.data["id"])
+        stored_name = os.path.basename(metadata.data_file.name)
+        self.assertNotEqual(stored_name, "screenshot.png")
+        self.assertTrue(stored_name.endswith(".png"))
+        # 32 hex chars + ".png"
+        self.assertEqual(len(stored_name), 32 + len(".png"))
+        # Original filename is preserved as display value
+        self.assertEqual(metadata.data_value, "screenshot.png")
+        # Stored file actually exists in storage
+        self.assertTrue(default_storage.exists(metadata.data_file.name))
+
+    def test_media_upload_mp4_stores_uuid_filename(self):
+        """An MP4 form-media upload is accepted and stored under a UUID name."""
+        # Minimal valid ftyp box (size 0x18, major brand "isom").
+        mp4_bytes = b"\x00\x00\x00\x18ftypisom\x00\x00\x02\x00isomiso2"
+
+        response = self._post_media_upload("clip.mp4", mp4_bytes, "video/mp4")
+
+        self.assertEqual(response.status_code, 201, response.data)
+        metadata = MetaData.objects.get(pk=response.data["id"])
+        stored_name = os.path.basename(metadata.data_file.name)
+        self.assertNotEqual(stored_name, "clip.mp4")
+        self.assertTrue(stored_name.endswith(".mp4"))
+        # 32 hex chars + ".mp4"
+        self.assertEqual(len(stored_name), 32 + len(".mp4"))
+        self.assertEqual(metadata.data_value, "clip.mp4")
+        self.assertTrue(default_storage.exists(metadata.data_file.name))
+
+    def _post_supporting_doc_upload(self, name, content, content_type):
+        view = MetaDataViewSet.as_view({"post": "create"})
+        uploaded = SimpleUploadedFile(name, content, content_type=content_type)
+        data = {
+            "data_type": "supporting_doc",
+            "data_value": name,
+            "xform": self.xform.id,
+            "data_file": uploaded,
+        }
+        request = self.factory.post("/", data=data, **self.extra)
+        return view(request)
+
+    @staticmethod
+    def _pdf_bytes():
+        return b"%PDF-1.4\nbody\n%%EOF\n"
+
+    def test_supporting_doc_upload_rejects_double_extension(self):
+        """report.pdf.html is rejected before persistence."""
+        before = MetaData.objects.count()
+
+        response = self._post_supporting_doc_upload(
+            "report.pdf.html", self._pdf_bytes(), "application/pdf"
+        )
+
+        self.assertEqual(response.status_code, 400, response.data)
+        self.assertEqual(MetaData.objects.count(), before)
+
+    def test_supporting_doc_upload_rejects_content_type_spoof(self):
+        """application/pdf header with non-PDF bytes is rejected."""
+        before = MetaData.objects.count()
+
+        response = self._post_supporting_doc_upload(
+            "report.pdf", b"not a pdf", "application/pdf"
+        )
+
+        self.assertEqual(response.status_code, 400, response.data)
+        self.assertEqual(MetaData.objects.count(), before)
+
+    def test_supporting_doc_upload_rejects_svg(self):
+        """SVG is no longer in the supporting-doc allowlist."""
+        before = MetaData.objects.count()
+
+        response = self._post_supporting_doc_upload(
+            "icon.svg", b"<svg xmlns='http://www.w3.org/2000/svg'/>", "image/svg+xml"
+        )
+
+        self.assertEqual(response.status_code, 400, response.data)
+        self.assertEqual(MetaData.objects.count(), before)
+
+    def test_supporting_doc_upload_rejects_zip(self):
+        """ZIP is no longer in the supporting-doc allowlist."""
+        before = MetaData.objects.count()
+        # Empty but structurally valid ZIP
+        zip_bytes = b"PK\x05\x06" + b"\x00" * 18
+
+        response = self._post_supporting_doc_upload(
+            "archive.zip", zip_bytes, "application/zip"
+        )
+
+        self.assertEqual(response.status_code, 400, response.data)
+        self.assertEqual(MetaData.objects.count(), before)
+
+    def test_supporting_doc_upload_rejects_legacy_doc(self):
+        """Legacy .doc (OLE) uploads are rejected."""
+        before = MetaData.objects.count()
+
+        response = self._post_supporting_doc_upload(
+            "report.doc",
+            b"\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1payload",
+            "application/msword",
+        )
+
+        self.assertEqual(response.status_code, 400, response.data)
+        self.assertEqual(MetaData.objects.count(), before)
+
+    def test_supporting_doc_upload_stores_uuid_filename(self):
+        """Accepted supporting-doc uploads store a UUID-based filename."""
+        response = self._post_supporting_doc_upload(
+            "report.pdf", self._pdf_bytes(), "application/pdf"
+        )
+
+        self.assertEqual(response.status_code, 201, response.data)
+        metadata = MetaData.objects.get(pk=response.data["id"])
+        stored_name = os.path.basename(metadata.data_file.name)
+        self.assertNotEqual(stored_name, "report.pdf")
+        self.assertTrue(stored_name.endswith(".pdf"))
+        # 32 hex chars + ".pdf"
+        self.assertEqual(len(stored_name), 32 + len(".pdf"))
+        # Original filename preserved as display value
+        self.assertEqual(metadata.data_value, "report.pdf")
+
+    @override_settings(
+        STRICT_UPLOAD_MAX_BYTES={"supporting_doc": {"*": 8}},
+    )
+    def test_supporting_doc_oversized_upload_rejected(self):
+        """A supporting-doc upload over the whole-context byte cap is rejected."""
+        before = MetaData.objects.count()
+
+        response = self._post_supporting_doc_upload(
+            "report.pdf", self._pdf_bytes() * 10, "application/pdf"
+        )
+
+        self.assertEqual(response.status_code, 400, response.data)
+        self.assertEqual(MetaData.objects.count(), before)

--- a/onadata/apps/api/tests/viewsets/test_project_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_project_viewset.py
@@ -142,7 +142,7 @@ class TestProjectViewSet(TestAbstractViewSet):
                 request = self.factory.post("/", data=post_data, **self.extra)
                 response = view(request, pk=project_id)
 
-                mock_requests.get.assert_called_with(xls_url, timeout=30)
+                mock_requests.get.assert_called_with(xls_url, stream=True, timeout=30)
                 xls_file.close()
                 self.assertEqual(response.status_code, 201)
                 self.assertEqual(XForm.objects.count(), pre_count + 1)

--- a/onadata/apps/api/tests/viewsets/test_project_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_project_viewset.py
@@ -142,7 +142,9 @@ class TestProjectViewSet(TestAbstractViewSet):
                 request = self.factory.post("/", data=post_data, **self.extra)
                 response = view(request, pk=project_id)
 
-                mock_requests.get.assert_called_with(xls_url, stream=True, timeout=30)
+                mock_requests.get.assert_called_with(
+                    xls_url, stream=True, timeout=30, allow_redirects=False
+                )
                 xls_file.close()
                 self.assertEqual(response.status_code, 201)
                 self.assertEqual(XForm.objects.count(), pre_count + 1)

--- a/onadata/apps/api/tests/viewsets/test_xform_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_xform_viewset.py
@@ -5644,18 +5644,18 @@ nhMo+jI88L3qfm4/rtWKuQ9/a268phlNj34uQeoDDHuRViQo00L5meE/pFptm
             request = self.factory.post("/", data=post_data, **self.extra)
             response = view(request, pk=self.xform.id)
             self.assertEqual(response.status_code, 400)
-            self.assertIn(
-                "Unsupported file extension '.csv'",
+            self.assertEqual(
                 response.data.get("error"),
+                "The uploaded file could not be validated.",
             )
 
             post_data = {"csv_file": xls_import}
             request = self.factory.post("/", data=post_data, **self.extra)
             response = view(request, pk=self.xform.id)
             self.assertEqual(response.status_code, 400)
-            self.assertIn(
-                "Unsupported file extension '.xlsx'",
+            self.assertEqual(
                 response.data.get("error"),
+                "The uploaded file could not be validated.",
             )
 
     @override_settings(TIME_ZONE="UTC")

--- a/onadata/apps/api/tests/viewsets/test_xform_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_xform_viewset.py
@@ -348,7 +348,9 @@ class PublishXLSFormTestCase(XFormViewSetBaseTestCase):
                 request = self.factory.post("/", data=post_data, **self.extra)
                 response = self.view(request)
 
-                mock_requests.get.assert_called_with(xls_url, stream=True, timeout=30)
+                mock_requests.get.assert_called_with(
+                    xls_url, stream=True, timeout=30, allow_redirects=False
+                )
                 xls_file.close()
 
                 self.assertEqual(response.status_code, 201)
@@ -481,7 +483,9 @@ class PublishXLSFormTestCase(XFormViewSetBaseTestCase):
                 request = self.factory.post("/", data=post_data, **self.extra)
                 response = self.view(request)
 
-                mock_requests.get.assert_called_with(csv_url, stream=True, timeout=30)
+                mock_requests.get.assert_called_with(
+                    csv_url, stream=True, timeout=30, allow_redirects=False
+                )
                 csv_file.close()
 
                 self.assertEqual(response.status_code, 201)

--- a/onadata/apps/api/tests/viewsets/test_xform_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_xform_viewset.py
@@ -22,6 +22,7 @@ from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.core.cache import cache
 from django.core.files.storage import default_storage
+from django.core.files.uploadedfile import SimpleUploadedFile
 from django.db.models import Q
 from django.http import HttpResponseRedirect
 from django.test.utils import override_settings
@@ -86,6 +87,7 @@ from onadata.libs.serializers.xform_serializer import (
 from onadata.libs.utils.api_export_tools import get_existing_file_format
 from onadata.libs.utils.cache_tools import (
     ENKETO_URL_CACHE,
+    ENKETO_URLS_CACHE,
     PROJ_FORMS_CACHE,
     XFORM_DATA_VERSIONS,
     XFORM_PERMISSIONS_CACHE,
@@ -346,7 +348,7 @@ class PublishXLSFormTestCase(XFormViewSetBaseTestCase):
                 request = self.factory.post("/", data=post_data, **self.extra)
                 response = self.view(request)
 
-                mock_requests.get.assert_called_with(xls_url, timeout=30)
+                mock_requests.get.assert_called_with(xls_url, stream=True, timeout=30)
                 xls_file.close()
 
                 self.assertEqual(response.status_code, 201)
@@ -467,7 +469,10 @@ class PublishXLSFormTestCase(XFormViewSetBaseTestCase):
 
             with open(path, "rb") as csv_file:
                 mock_response = get_mocked_response_for_file(
-                    csv_file, "text_and_integer.csv", 200
+                    csv_file,
+                    "text_and_integer.csv",
+                    200,
+                    content_type="text/csv",
                 )
                 mock_requests.head.return_value = mock_response
                 mock_requests.get.return_value = mock_response
@@ -476,7 +481,7 @@ class PublishXLSFormTestCase(XFormViewSetBaseTestCase):
                 request = self.factory.post("/", data=post_data, **self.extra)
                 response = self.view(request)
 
-                mock_requests.get.assert_called_with(csv_url, timeout=30)
+                mock_requests.get.assert_called_with(csv_url, stream=True, timeout=30)
                 csv_file.close()
 
                 self.assertEqual(response.status_code, 201)
@@ -1736,8 +1741,6 @@ class TestXFormViewSet(XFormViewSetBaseTestCase):
             ).delete()
 
             # Verify cache is cleared
-            from onadata.libs.utils.cache_tools import ENKETO_URLS_CACHE
-
             self.assertIsNone(cache.get(f"{ENKETO_URLS_CACHE}{formid}"))
 
             # Subsequent request should call the Enketo API since both
@@ -3745,6 +3748,89 @@ nhMo+jI88L3qfm4/rtWKuQ9/a268phlNj34uQeoDDHuRViQo00L5meE/pFptm
         self.assertEqual(response.data, {"job_status": "PENDING"})
 
     @override_settings(CELERY_TASK_ALWAYS_EAGER=True)
+    def test_publish_form_async_rejects_double_extension(self):
+        """create_async rejects XLSForm filenames with stacked extensions."""
+        count = XForm.objects.count()
+        view = XFormViewSet.as_view({"post": "create_async"})
+        path = os.path.join(
+            settings.PROJECT_ROOT,
+            "apps",
+            "main",
+            "tests",
+            "fixtures",
+            "transportation",
+            "transportation.xlsx",
+        )
+        with open(path, "rb") as src:
+            data = src.read()
+        uploaded = SimpleUploadedFile(
+            "transportation.exe.xlsx",
+            data,
+            content_type=(
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+            ),
+        )
+        post_data = {"xls_file": uploaded}
+        request = self.factory.post("/", data=post_data, **self.extra)
+        response = view(request)
+
+        self.assertEqual(response.status_code, 400, getattr(response, "data", None))
+        self.assertEqual(count, XForm.objects.count())
+
+    @override_settings(CELERY_TASK_ALWAYS_EAGER=True)
+    def test_publish_form_async_rejects_content_type_spoof(self):
+        """create_async rejects XLSForm content masquerading as a different MIME."""
+        count = XForm.objects.count()
+        view = XFormViewSet.as_view({"post": "create_async"})
+        path = os.path.join(
+            settings.PROJECT_ROOT,
+            "apps",
+            "main",
+            "tests",
+            "fixtures",
+            "transportation",
+            "transportation.xlsx",
+        )
+        with open(path, "rb") as src:
+            data = src.read()
+        # Valid XLSX bytes uploaded with a CSV content-type/extension
+        uploaded = SimpleUploadedFile(
+            "transportation.csv", data, content_type="text/csv"
+        )
+        post_data = {"xls_file": uploaded}
+        request = self.factory.post("/", data=post_data, **self.extra)
+        response = view(request)
+
+        self.assertEqual(response.status_code, 400, getattr(response, "data", None))
+        self.assertEqual(count, XForm.objects.count())
+
+    @override_settings(CELERY_TASK_ALWAYS_EAGER=True)
+    def test_publish_form_sync_stores_uuid_filename(self):
+        """A successful sync XLSForm upload stores under a UUID-based name."""
+        view = XFormViewSet.as_view({"post": "create"})
+        path = os.path.join(
+            settings.PROJECT_ROOT,
+            "apps",
+            "main",
+            "tests",
+            "fixtures",
+            "transportation",
+            "transportation.xlsx",
+        )
+        with open(path, "rb") as xls_file:
+            post_data = {"xls_file": xls_file}
+            request = self.factory.post("/", data=post_data, **self.extra)
+            response = view(request)
+
+        self.assertEqual(response.status_code, 201, getattr(response, "data", None))
+        xform = XForm.objects.get(pk=response.data["formid"])
+        stored_name = os.path.basename(xform.xls.name)
+        self.assertNotEqual(stored_name, "transportation.xlsx")
+        self.assertTrue(stored_name.endswith(".xlsx"))
+        # 32 hex chars + ".xlsx"
+        self.assertEqual(len(stored_name), 32 + len(".xlsx"))
+
+    @override_settings(CELERY_TASK_ALWAYS_EAGER=True)
     @patch(
         "onadata.apps.api.tasks.tools.do_publish_xlsform",
         side_effect=[MemoryError(), MemoryError(), Mock()],
@@ -5474,6 +5560,70 @@ nhMo+jI88L3qfm4/rtWKuQ9/a268phlNj34uQeoDDHuRViQo00L5meE/pFptm
             self.assertEqual(response.data.get("additions"), 9)
             self.assertEqual(response.data.get("updates"), 0)
 
+    def test_data_import_rejects_extension_spoofing(self):
+        """data_import rejects CSV bytes renamed with .xlsx extension."""
+        with HTTMock(enketo_mock):
+            xls_path = os.path.join(
+                settings.PROJECT_ROOT,
+                "apps",
+                "main",
+                "tests",
+                "fixtures",
+                "tutorial.xlsx",
+            )
+            self._publish_xls_form_to_project(xlsform_path=xls_path)
+            view = XFormViewSet.as_view({"post": "data_import"})
+
+            spoofed = SimpleUploadedFile(
+                "evil.xlsx",
+                b"name,age\nAlice,30\n",
+                content_type=(
+                    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+                ),
+            )
+            post_data = {"xls_file": spoofed}
+            request = self.factory.post("/", data=post_data, **self.extra)
+            response = view(request, pk=self.xform.id)
+
+            self.assertEqual(response.status_code, 400, response.data)
+            self.assertIn("error", response.data)
+
+    def test_csv_import_rejects_extension_spoofing(self):
+        """csv_import rejects PNG bytes renamed with .csv extension."""
+        with HTTMock(enketo_mock):
+            xls_path = os.path.join(
+                settings.PROJECT_ROOT,
+                "apps",
+                "main",
+                "tests",
+                "fixtures",
+                "tutorial.xlsx",
+            )
+            self._publish_xls_form_to_project(xlsform_path=xls_path)
+            view = XFormViewSet.as_view({"post": "csv_import"})
+
+            png_path = os.path.join(
+                settings.PROJECT_ROOT,
+                "apps",
+                "main",
+                "tests",
+                "fixtures",
+                "transportation",
+                "screenshot.png",
+            )
+            with open(png_path, "rb") as src:
+                spoofed_bytes = src.read()
+
+            spoofed = SimpleUploadedFile(
+                "evil.csv", spoofed_bytes, content_type="text/csv"
+            )
+            post_data = {"csv_file": spoofed}
+            request = self.factory.post("/", data=post_data, **self.extra)
+            response = view(request, pk=self.xform.id)
+
+            self.assertEqual(response.status_code, 400, response.data)
+            self.assertIn("error", response.data)
+
     def test_csv_xls_import_errors(self):
         with HTTMock(enketo_mock):
             xls_path = os.path.join(
@@ -5494,13 +5644,19 @@ nhMo+jI88L3qfm4/rtWKuQ9/a268phlNj34uQeoDDHuRViQo00L5meE/pFptm
             request = self.factory.post("/", data=post_data, **self.extra)
             response = view(request, pk=self.xform.id)
             self.assertEqual(response.status_code, 400)
-            self.assertEqual(response.data.get("error"), "xls_file not an excel file")
+            self.assertIn(
+                "Unsupported file extension '.csv'",
+                response.data.get("error"),
+            )
 
             post_data = {"csv_file": xls_import}
             request = self.factory.post("/", data=post_data, **self.extra)
             response = view(request, pk=self.xform.id)
             self.assertEqual(response.status_code, 400)
-            self.assertEqual(response.data.get("error"), "csv_file not a csv file")
+            self.assertIn(
+                "Unsupported file extension '.xlsx'",
+                response.data.get("error"),
+            )
 
     @override_settings(TIME_ZONE="UTC")
     def test_get_single_registration_form(self):

--- a/onadata/apps/api/viewsets/attachment_viewset.py
+++ b/onadata/apps/api/viewsets/attachment_viewset.py
@@ -3,6 +3,8 @@
 The /api/v1/attachments API implementation.
 """
 
+from urllib.parse import quote
+
 from django.conf import settings
 from django.core.files.storage import default_storage
 from django.http import Http404
@@ -85,7 +87,13 @@ class AttachmentViewSet(
                     raise Http404() from error
 
                 raise ParseError(error) from error
-            return Response(data, content_type=self.object.mimetype)
+            response = Response(data, content_type=self.object.mimetype)
+            filename = quote(
+                self.object.name or self.object.media_file.name.split("/")[-1]
+            )
+            response["Content-Disposition"] = f'attachment; filename="{filename}"'
+            response["X-Content-Type-Options"] = "nosniff"
+            return response
 
         filename = request.query_params.get("filename")
         serializer = self.get_serializer(self.object)
@@ -94,7 +102,9 @@ class AttachmentViewSet(
             if filename == self.object.media_file.name:
                 return Response(serializer.get_download_url(self.object))
 
-            raise Http404(_(f"Filename '{filename}' not found."))
+            raise Http404(
+                _("Filename '%(filename)s' not found.") % {"filename": filename}
+            )
 
         return Response(serializer.data)
 

--- a/onadata/apps/api/viewsets/xform_viewset.py
+++ b/onadata/apps/api/viewsets/xform_viewset.py
@@ -149,7 +149,8 @@ def _prepare_import_csv(csv_file, xls_file):
         elif csv_file:
             _validate_api_upload(csv_file, (CSV_EXTENSION,), DATA_IMPORT_UPLOAD_CONTEXT)
     except UploadValidationError as error:
-        return None, str(error)
+        logger.warning("Data import upload validation failed: %s", error)
+        return None, _("The uploaded file could not be validated.")
 
     if xls_file:
         csv_file = submission_xls_to_csv(xls_file)
@@ -180,7 +181,11 @@ def _publish_xlsform_async(request):
             xls_file, ("csv", "xls", "xlsx"), XLSFORM_UPLOAD_CONTEXT
         )
     except UploadValidationError as error:
-        return Response({"message": str(error)}, status=status.HTTP_400_BAD_REQUEST)
+        logger.warning("XLSForm upload validation failed: %s", error)
+        return Response(
+            {"message": _("The uploaded file could not be validated.")},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
 
     xls_file.seek(0)
     xls_file_path = default_storage.save(
@@ -936,8 +941,9 @@ class XFormViewSet(
                         csv_file, (CSV_EXTENSION,), DATA_IMPORT_UPLOAD_CONTEXT
                     )
                 except UploadValidationError as error:
+                    logger.warning("CSV import upload validation failed: %s", error)
                     return Response(
-                        data={"error": str(error)},
+                        data={"error": _("The uploaded file could not be validated.")},
                         status=status.HTTP_400_BAD_REQUEST,
                     )
 

--- a/onadata/apps/api/viewsets/xform_viewset.py
+++ b/onadata/apps/api/viewsets/xform_viewset.py
@@ -134,6 +134,76 @@ def _validate_api_upload(uploaded_file, allowed_extensions, context):
     return upload
 
 
+def _prepare_import_csv(csv_file, xls_file):
+    """Validate an import upload and return the CSV file to submit.
+
+    Returns ``(csv_file, None)`` on success or ``(None, error_message)`` when
+    validation fails. An XLS upload is converted to CSV after validation.
+    """
+    xls_upload = None
+    try:
+        if xls_file:
+            xls_upload = _validate_api_upload(
+                xls_file, XLS_EXTENSIONS, DATA_IMPORT_UPLOAD_CONTEXT
+            )
+        elif csv_file:
+            _validate_api_upload(csv_file, (CSV_EXTENSION,), DATA_IMPORT_UPLOAD_CONTEXT)
+    except UploadValidationError as error:
+        return None, str(error)
+
+    if xls_file:
+        csv_file = submission_xls_to_csv(xls_file)
+        csv_file.name = f"{os.path.splitext(xls_upload.storage_basename)[0]}.csv"
+        csv_file.content_type = "text/csv"
+
+    return csv_file, None
+
+
+def _publish_xlsform_async(request):
+    """Validate and queue an async XLSForm publish; return the API response."""
+    try:
+        owner = _get_owner(request)
+    except ValidationError as error:
+        return Response(
+            {"message": error.messages[0]}, status=status.HTTP_400_BAD_REQUEST
+        )
+
+    xls_file = request.FILES.get("xls_file")
+    if xls_file is None:
+        return Response(
+            {"message": _("xls_file field empty")},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+
+    try:
+        upload = _validate_api_upload(
+            xls_file, ("csv", "xls", "xlsx"), XLSFORM_UPLOAD_CONTEXT
+        )
+    except UploadValidationError as error:
+        return Response({"message": str(error)}, status=status.HTTP_400_BAD_REQUEST)
+
+    xls_file.seek(0)
+    xls_file_path = default_storage.save(
+        f"tmp/async-upload-{owner.username}-{upload.storage_basename}",
+        (
+            ContentFile(xls_file.read())
+            if isinstance(xls_file, InMemoryUploadedFile)
+            else xls_file
+        ),
+    )
+    job_uuid = tasks.publish_xlsform_async.delay(
+        request.user.id,
+        request.POST,
+        owner.id,
+        {
+            "name": upload.original_name,
+            "path": xls_file_path,
+            "content_type": upload.content_type,
+        },
+    ).task_id
+    return Response(data={"job_uuid": job_uuid}, status=status.HTTP_202_ACCEPTED)
+
+
 def upload_to_survey_draft(filename, username):
     """Return the ``filename`` in the ``username`` survey-drafts directory."""
     return os.path.join(username, "survey-drafts", os.path.split(filename)[1])
@@ -449,75 +519,24 @@ class XFormViewSet(
     @action(methods=["POST", "GET"], detail=False)
     def create_async(self, request, *args, **kwargs):
         """Temporary Endpoint for Async form creation"""
-        resp = headers = {}
-        resp_code = status.HTTP_400_BAD_REQUEST
+        if request.method != "GET":
+            return _publish_xlsform_async(request)
 
-        if request.method == "GET":
-            # pylint: disable=attribute-defined-outside-init
-            self.etag_data = f"{timezone.now()}"
-            survey = tasks.get_async_status(request.query_params.get("job_uuid"))
+        # pylint: disable=attribute-defined-outside-init
+        self.etag_data = f"{timezone.now()}"
+        survey = tasks.get_async_status(request.query_params.get("job_uuid"))
 
-            if "pk" in survey:
-                xform = XForm.objects.get(pk=survey.get("pk"))
-                serializer = XFormSerializer(xform, context={"request": request})
-                headers = self.get_success_headers(serializer.data)
-                resp = serializer.data
-                resp_code = status.HTTP_201_CREATED
-            else:
-                resp_code = status.HTTP_202_ACCEPTED
-                resp.update(survey)
-        else:
-            try:
-                owner = _get_owner(request)
-            except ValidationError as e:
-                return Response(
-                    {"message": e.messages[0]}, status=status.HTTP_400_BAD_REQUEST
-                )
+        if "pk" not in survey:
+            return Response(data=survey, status=status.HTTP_202_ACCEPTED)
 
-            xls_file = request.FILES.get("xls_file")
-            if xls_file is None:
-                return Response(
-                    {"message": _("xls_file field empty")},
-                    status=status.HTTP_400_BAD_REQUEST,
-                )
-
-            try:
-                upload = _validate_api_upload(
-                    xls_file, ("csv", "xls", "xlsx"), XLSFORM_UPLOAD_CONTEXT
-                )
-            except UploadValidationError as error:
-                return Response(
-                    {"message": str(error)}, status=status.HTTP_400_BAD_REQUEST
-                )
-
-            fname = upload.original_name
-            xls_file.seek(0)
-            xls_file_path = default_storage.save(
-                f"tmp/async-upload-{owner.username}-{upload.storage_basename}",
-                (
-                    ContentFile(xls_file.read())
-                    if isinstance(xls_file, InMemoryUploadedFile)
-                    else xls_file
-                ),
-            )
-
-            resp.update(
-                {
-                    "job_uuid": tasks.publish_xlsform_async.delay(
-                        request.user.id,
-                        request.POST,
-                        owner.id,
-                        {
-                            "name": fname,
-                            "path": xls_file_path,
-                            "content_type": upload.content_type,
-                        },
-                    ).task_id
-                }
-            )
-            resp_code = status.HTTP_202_ACCEPTED
-
-        return Response(data=resp, status=resp_code, headers=headers)
+        serializer = XFormSerializer(
+            XForm.objects.get(pk=survey.get("pk")), context={"request": request}
+        )
+        return Response(
+            data=serializer.data,
+            status=status.HTTP_201_CREATED,
+            headers=self.get_success_headers(serializer.data),
+        )
 
     @action(methods=["GET", "HEAD"], detail=True)
     def form(self, request, **kwargs):
@@ -826,33 +845,16 @@ class XFormViewSet(
         else:
             csv_file = request.FILES.get("csv_file", None)
             xls_file = request.FILES.get("xls_file", None)
-            xls_upload = None
 
             if csv_file is None and xls_file is None:
                 resp.update({"error": _("csv_file and xls_file field empty")})
 
             else:
-                try:
-                    if xls_file:
-                        xls_upload = _validate_api_upload(
-                            xls_file, XLS_EXTENSIONS, DATA_IMPORT_UPLOAD_CONTEXT
-                        )
-                    elif csv_file:
-                        _validate_api_upload(
-                            csv_file, (CSV_EXTENSION,), DATA_IMPORT_UPLOAD_CONTEXT
-                        )
-                except UploadValidationError as error:
-                    resp.update({"error": str(error)})
-
-                if xls_file and resp.get("error") is None:
-                    csv_file = submission_xls_to_csv(xls_file)
-                    csv_file.name = (
-                        f"{os.path.splitext(xls_upload.storage_basename)[0]}.csv"
+                csv_file, error = _prepare_import_csv(csv_file, xls_file)
+                if error is not None:
+                    return Response(
+                        data={"error": error}, status=status.HTTP_400_BAD_REQUEST
                     )
-                    csv_file.content_type = "text/csv"
-
-                if resp.get("error") is not None:
-                    return Response(data=resp, status=status.HTTP_400_BAD_REQUEST)
 
                 overwrite = request.query_params.get("overwrite")
                 overwrite = (

--- a/onadata/apps/api/viewsets/xform_viewset.py
+++ b/onadata/apps/api/viewsets/xform_viewset.py
@@ -53,19 +53,8 @@ from onadata.apps.api.permissions import XFormPermissions
 from onadata.apps.api.tools import get_baseviewset_class
 from onadata.apps.logger.models.xform import XForm, XFormUserObjectPermission
 from onadata.apps.logger.models.xform_version import XFormVersion
-from onadata.apps.main.models.meta_data import MetaData
-from onadata.libs.utils.cache_tools import (
-    ENKETO_URL_CACHE,
-    ENKETO_URLS_CACHE,
-    get_enketo_urls_cache_ttl,
-    ENKETO_PREVIEW_URL_CACHE,
-    ENKETO_SINGLE_SUBMIT_URL_CACHE,
-    PROJ_OWNER_CACHE,
-    safe_cache_delete,
-    safe_cache_get,
-    safe_cache_set,
-)
 from onadata.apps.logger.xform_instance_parser import XLSFormError
+from onadata.apps.main.models.meta_data import MetaData
 from onadata.apps.messaging.constants import FORM_UPDATED, XFORM
 from onadata.apps.messaging.serializers import send_message
 from onadata.apps.viewer.models.export import Export
@@ -96,6 +85,17 @@ from onadata.libs.utils.api_export_tools import (
     process_async_export,
     response_for_format,
 )
+from onadata.libs.utils.cache_tools import (
+    ENKETO_PREVIEW_URL_CACHE,
+    ENKETO_SINGLE_SUBMIT_URL_CACHE,
+    ENKETO_URL_CACHE,
+    ENKETO_URLS_CACHE,
+    PROJ_OWNER_CACHE,
+    get_enketo_urls_cache_ttl,
+    safe_cache_delete,
+    safe_cache_get,
+    safe_cache_set,
+)
 from onadata.libs.utils.common_tools import json_stream
 from onadata.libs.utils.csv_import import (
     get_async_csv_submission_status,
@@ -106,6 +106,12 @@ from onadata.libs.utils.csv_import import (
 from onadata.libs.utils.export_tools import parse_request_export_options
 from onadata.libs.utils.logger_tools import publish_form
 from onadata.libs.utils.string import str2bool
+from onadata.libs.utils.upload_validation import (
+    DATA_IMPORT_UPLOAD_CONTEXT,
+    XLSFORM_UPLOAD_CONTEXT,
+    UploadValidationError,
+    validate_uploaded_file,
+)
 from onadata.libs.utils.viewer_tools import (
     generate_enketo_form_defaults,
     get_enketo_urls,
@@ -118,6 +124,14 @@ logger = logging.getLogger(__name__)
 # pylint: disable=invalid-name
 BaseViewset = get_baseviewset_class()
 User = get_user_model()
+
+
+def _validate_api_upload(uploaded_file, allowed_extensions, context):
+    """Validate an API upload and apply the generated storage filename."""
+    upload = validate_uploaded_file(uploaded_file, allowed_extensions, context)
+    uploaded_file.name = upload.storage_basename
+    uploaded_file.content_type = upload.content_type
+    return upload
 
 
 def upload_to_survey_draft(filename, username):
@@ -460,14 +474,32 @@ class XFormViewSet(
                     {"message": e.messages[0]}, status=status.HTTP_400_BAD_REQUEST
                 )
 
-            fname = request.FILES.get("xls_file").name
-            if isinstance(request.FILES.get("xls_file"), InMemoryUploadedFile):
-                xls_file_path = default_storage.save(
-                    f"tmp/async-upload-{owner.username}-{fname}",
-                    ContentFile(request.FILES.get("xls_file").read()),
+            xls_file = request.FILES.get("xls_file")
+            if xls_file is None:
+                return Response(
+                    {"message": _("xls_file field empty")},
+                    status=status.HTTP_400_BAD_REQUEST,
                 )
-            else:
-                xls_file_path = request.FILES.get("xls_file").temporary_file_path()
+
+            try:
+                upload = _validate_api_upload(
+                    xls_file, ("csv", "xls", "xlsx"), XLSFORM_UPLOAD_CONTEXT
+                )
+            except UploadValidationError as error:
+                return Response(
+                    {"message": str(error)}, status=status.HTTP_400_BAD_REQUEST
+                )
+
+            fname = upload.original_name
+            xls_file.seek(0)
+            xls_file_path = default_storage.save(
+                f"tmp/async-upload-{owner.username}-{upload.storage_basename}",
+                (
+                    ContentFile(xls_file.read())
+                    if isinstance(xls_file, InMemoryUploadedFile)
+                    else xls_file
+                ),
+            )
 
             resp.update(
                 {
@@ -475,7 +507,11 @@ class XFormViewSet(
                         request.user.id,
                         request.POST,
                         owner.id,
-                        {"name": fname, "path": xls_file_path},
+                        {
+                            "name": fname,
+                            "path": xls_file_path,
+                            "content_type": upload.content_type,
+                        },
                     ).task_id
                 }
             )
@@ -500,6 +536,7 @@ class XFormViewSet(
         form_format = get_existing_file_format(form.xls, form_format)
         filename = form.id_string + "." + form_format
         response["Content-Disposition"] = "attachment; filename=" + filename
+        response["X-Content-Type-Options"] = "nosniff"
 
         return response
 
@@ -789,19 +826,34 @@ class XFormViewSet(
         else:
             csv_file = request.FILES.get("csv_file", None)
             xls_file = request.FILES.get("xls_file", None)
+            xls_upload = None
 
             if csv_file is None and xls_file is None:
-                resp.update({"error": "csv_file and xls_file field empty"})
-
-            elif xls_file and xls_file.name.split(".")[-1] not in XLS_EXTENSIONS:
-                resp.update({"error": "xls_file not an excel file"})
-
-            elif csv_file and csv_file.name.split(".")[-1] != CSV_EXTENSION:
-                resp.update({"error": "csv_file not a csv file"})
+                resp.update({"error": _("csv_file and xls_file field empty")})
 
             else:
-                if xls_file and xls_file.name.split(".")[-1] in XLS_EXTENSIONS:
+                try:
+                    if xls_file:
+                        xls_upload = _validate_api_upload(
+                            xls_file, XLS_EXTENSIONS, DATA_IMPORT_UPLOAD_CONTEXT
+                        )
+                    elif csv_file:
+                        _validate_api_upload(
+                            csv_file, (CSV_EXTENSION,), DATA_IMPORT_UPLOAD_CONTEXT
+                        )
+                except UploadValidationError as error:
+                    resp.update({"error": str(error)})
+
+                if xls_file and resp.get("error") is None:
                     csv_file = submission_xls_to_csv(xls_file)
+                    csv_file.name = (
+                        f"{os.path.splitext(xls_upload.storage_basename)[0]}.csv"
+                    )
+                    csv_file.content_type = "text/csv"
+
+                if resp.get("error") is not None:
+                    return Response(data=resp, status=status.HTTP_400_BAD_REQUEST)
+
                 overwrite = request.query_params.get("overwrite")
                 overwrite = (
                     overwrite.lower() == "true"
@@ -875,10 +927,18 @@ class XFormViewSet(
         else:
             csv_file = request.FILES.get("csv_file", None)
             if csv_file is None:
-                resp.update({"error": "csv_file field empty"})
-            elif csv_file.name.split(".")[-1] != CSV_EXTENSION:
-                resp.update({"error": "csv_file not a csv file"})
+                resp.update({"error": _("csv_file field empty")})
             else:
+                try:
+                    _validate_api_upload(
+                        csv_file, (CSV_EXTENSION,), DATA_IMPORT_UPLOAD_CONTEXT
+                    )
+                except UploadValidationError as error:
+                    return Response(
+                        data={"error": str(error)},
+                        status=status.HTTP_400_BAD_REQUEST,
+                    )
+
                 overwrite = request.query_params.get("overwrite")
                 overwrite = (
                     overwrite.lower() == "true"

--- a/onadata/apps/logger/models/xform.py
+++ b/onadata/apps/logger/models/xform.py
@@ -8,6 +8,7 @@ import hashlib
 import json
 import os
 import re
+import uuid
 from datetime import datetime
 from io import BytesIO
 from pathlib import Path
@@ -139,8 +140,16 @@ def question_types_to_exclude(_type):
 
 
 def upload_to(instance, filename):
-    """Returns the path to upload an XLSForm file to."""
-    return os.path.join(instance.user.username, "xls", os.path.split(filename)[1])
+    """Returns the path to upload an XLSForm file to.
+
+    The basename is randomised so the stored path never includes any
+    client-supplied name. The original filename is preserved on the in-memory
+    file object during ``DataDictionary.save()`` so pyxform can derive
+    ``fallback_form_name`` from it for forms without an explicit
+    ``settings.id_string``.
+    """
+    extension = os.path.splitext(os.path.split(filename)[1])[1].lower()
+    return os.path.join(instance.user.username, "xls", f"{uuid.uuid4().hex}{extension}")
 
 
 def contains_xml_invalid_char(text, invalids=None):
@@ -874,7 +883,9 @@ class XFormMixin:
 
         if not hasattr(self, "_variable_names"):
             # pylint: disable=import-outside-toplevel
-            from onadata.apps.viewer.models.column_rename import ColumnRename
+            from onadata.apps.viewer.models.column_rename import (  # noqa: PLC0415
+                ColumnRename,
+            )
 
             self._variable_names = ColumnRename.get_dict()
 

--- a/onadata/apps/logger/models/xform.py
+++ b/onadata/apps/logger/models/xform.py
@@ -139,6 +139,16 @@ def question_types_to_exclude(_type):
     return _type in QUESTION_TYPES_TO_EXCLUDE
 
 
+def get_xls_upload_path(username, filename):
+    """Return ``{username}/xls/{uuid}{ext}`` with a randomised basename.
+
+    The basename is randomised so the stored path never includes any
+    client-supplied name, while the original extension is preserved.
+    """
+    extension = os.path.splitext(os.path.split(filename)[1])[1].lower()
+    return os.path.join(username, "xls", f"{uuid.uuid4().hex}{extension}")
+
+
 def upload_to(instance, filename):
     """Returns the path to upload an XLSForm file to.
 
@@ -148,8 +158,7 @@ def upload_to(instance, filename):
     ``fallback_form_name`` from it for forms without an explicit
     ``settings.id_string``.
     """
-    extension = os.path.splitext(os.path.split(filename)[1])[1].lower()
-    return os.path.join(instance.user.username, "xls", f"{uuid.uuid4().hex}{extension}")
+    return get_xls_upload_path(instance.user.username, filename)
 
 
 def contains_xml_invalid_char(text, invalids=None):

--- a/onadata/apps/main/forms.py
+++ b/onadata/apps/main/forms.py
@@ -21,7 +21,7 @@ from django.utils.translation import gettext_lazy
 import requests
 from registration.forms import RegistrationFormUniqueEmail
 from requests.exceptions import RequestException
-from six.moves.urllib.parse import urlparse
+from six.moves.urllib.parse import urljoin, urlparse
 
 # pylint: disable=ungrouped-imports
 from onadata.apps.api.constants import USERNAME_VALIDATION_REGEX
@@ -174,17 +174,49 @@ def _assert_url_not_internal(url):
             )
 
 
+MAX_DOWNLOAD_REDIRECTS = 5
+
+
+def _get_with_ssrf_guard(url):
+    """GET ``url`` following redirects manually, validating every hop.
+
+    Redirects are not auto-followed; instead each URL in the chain (the initial
+    URL and every ``Location``) is checked with :func:`_assert_url_not_internal`
+    before it is requested, so a public URL cannot redirect the download into an
+    internal address. The chain is capped at :data:`MAX_DOWNLOAD_REDIRECTS`.
+    """
+    current_url = url
+    for _hop in range(MAX_DOWNLOAD_REDIRECTS + 1):
+        _assert_url_not_internal(current_url)
+        try:
+            response = requests.get(
+                current_url,
+                stream=True,
+                timeout=DEFAULT_REQUEST_TIMEOUT,
+                allow_redirects=False,
+            )
+        except RequestException as error:
+            raise forms.ValidationError(
+                _("Could not download XLSForm from URL: %(url)s") % {"url": url}
+            ) from error
+
+        if not response.is_redirect:
+            return response
+
+        location = response.headers.get("Location")
+        response.close()
+        if not location:
+            raise forms.ValidationError(
+                _("Could not download XLSForm from URL: %(url)s") % {"url": url}
+            )
+        current_url = urljoin(current_url, location)
+
+    raise forms.ValidationError(_("Too many redirects while downloading the XLSForm."))
+
+
 def _download_url_upload(cleaned_url, original_name):
     """Download a remote XLSForm body with SSRF guards and the byte cap."""
-    _assert_url_not_internal(cleaned_url)
-    try:
-        response = requests.get(
-            cleaned_url, stream=True, timeout=DEFAULT_REQUEST_TIMEOUT
-        )
-    except RequestException as error:
-        raise forms.ValidationError(
-            _("Could not download XLSForm from URL: %(url)s") % {"url": cleaned_url}
-        ) from error
+    response = _get_with_ssrf_guard(cleaned_url)
 
     if response.status_code >= 400:
         raise forms.ValidationError(

--- a/onadata/apps/main/forms.py
+++ b/onadata/apps/main/forms.py
@@ -4,7 +4,6 @@ forms module.
 """
 
 import os
-import random
 import re
 
 from django import forms
@@ -19,6 +18,7 @@ from django.utils.translation import gettext_lazy
 
 import requests
 from registration.forms import RegistrationFormUniqueEmail
+from requests.exceptions import RequestException
 from six.moves.urllib.parse import urlparse
 
 # pylint: disable=ungrouped-imports
@@ -26,8 +26,19 @@ from onadata.apps.api.constants import USERNAME_VALIDATION_REGEX
 from onadata.apps.logger.models import Project
 from onadata.apps.main.models import UserProfile
 from onadata.apps.viewer.models.data_dictionary import upload_to
+from onadata.libs.utils.content_disposition import (
+    ContentDispositionError,
+    parse_filename,
+)
 from onadata.libs.utils.country_field import COUNTRIES
 from onadata.libs.utils.logger_tools import publish_xls_form, publish_xml_form
+from onadata.libs.utils.upload_validation import (
+    XLSFORM_ALLOWED_EXTENSIONS,
+    XLSFORM_UPLOAD_CONTEXT,
+    UploadValidationError,
+    get_upload_max_bytes,
+    validate_uploaded_file,
+)
 from onadata.libs.utils.user_auth import get_user_default_project
 
 FORM_LICENSES_CHOICES = (
@@ -56,13 +67,7 @@ PERM_CHOICES = (
     ("remove", gettext_lazy("Remove permissions")),
 )
 
-VALID_XLSFORM_CONTENT_TYPES = [
-    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-    "text/csv",
-    "application/vnd.ms-excel",
-]
-
-VALID_FILE_EXTENSIONS = [".xlsx", ".csv"]
+VALID_FILE_EXTENSIONS = [f".{extension}" for extension in XLSFORM_ALLOWED_EXTENSIONS]
 
 DEFAULT_REQUEST_TIMEOUT = getattr(settings, "DEFAULT_REQUEST_TIMEOUT", 30)
 
@@ -72,24 +77,94 @@ User = get_user_model()
 
 def get_filename(response):
     """
-    Get filename from a Content-Desposition header.
+    Get filename from a Content-Disposition header.
     """
-    # pylint: disable=line-too-long
-    # the value of 'content-disposition' contains the filename and has the
-    # following format:
-    # 'attachment; filename="ActApp_Survey_System.xlsx"; filename*=UTF-8\'\'ActApp_Survey_System.xlsx' # noqa
-    cleaned_xls_file = ""
-    content = response.headers.get("Content-Disposition").split("; ")
-    counter = [a for a in content if a.startswith("filename=")]
-    if counter:
-        filename_key_val = counter[0]
-        filename = filename_key_val.split("=")[1].replace('"', "")
-        name, extension = os.path.splitext(filename)
+    content_disposition = response.headers.get("Content-Disposition")
+    if not content_disposition:
+        return ""
 
-        if extension in VALID_FILE_EXTENSIONS and name:
-            cleaned_xls_file = filename
+    try:
+        parsed = parse_filename(content_disposition)
+    except ContentDispositionError:
+        # A malformed upstream header carries no usable filename; fall back to
+        # the caller's original name rather than raising.
+        return ""
 
-    return cleaned_xls_file
+    filename = os.path.basename(parsed or "")
+    name, extension = os.path.splitext(filename)
+
+    if extension in VALID_FILE_EXTENSIONS and name:
+        return filename
+
+    return ""
+
+
+def _validate_xlsform_upload(uploaded_file, allowed_extensions=None):
+    """Validate XLSForm-family uploads and map errors to form errors.
+
+    Returns the :class:`ValidatedUpload`. Does NOT mutate ``uploaded_file.name``
+    because XLSForm publishing reads the original filename via pyxform to
+    derive ``fallback_form_name`` (and, for forms without an explicit
+    ``settings.id_string``, the form's ``id_string``). Storage-path
+    randomisation for ``XForm.xls`` happens at the FileField ``upload_to``
+    callable instead.
+    """
+    try:
+        result = validate_uploaded_file(
+            uploaded_file,
+            allowed_extensions or XLSFORM_ALLOWED_EXTENSIONS,
+            XLSFORM_UPLOAD_CONTEXT,
+        )
+    except UploadValidationError as error:
+        raise forms.ValidationError(str(error)) from error
+
+    uploaded_file.content_type = result.content_type
+
+    return result
+
+
+def _download_url_upload(cleaned_url, original_name):
+    """Download a remote XLSForm body with the strict upload byte cap."""
+    try:
+        response = requests.get(
+            cleaned_url, stream=True, timeout=DEFAULT_REQUEST_TIMEOUT
+        )
+    except RequestException as error:
+        raise forms.ValidationError(
+            _("Could not download XLSForm from URL: %(url)s") % {"url": cleaned_url}
+        ) from error
+
+    if response.status_code >= 400:
+        raise forms.ValidationError(
+            _("Could not download XLSForm from URL: %(url)s") % {"url": cleaned_url}
+        )
+
+    _name, extension = os.path.splitext(original_name)
+    if extension not in VALID_FILE_EXTENSIONS:
+        original_name = get_filename(response) or original_name
+
+    max_bytes = get_upload_max_bytes(XLSFORM_UPLOAD_CONTEXT)
+    chunks = []
+    total_size = 0
+    try:
+        for chunk in response.iter_content(chunk_size=64 * 1024):
+            if not chunk:
+                continue
+            total_size += len(chunk)
+            if total_size > max_bytes:
+                raise forms.ValidationError(
+                    _("File exceeds the maximum upload size of %(max_bytes)d bytes.")
+                    % {"max_bytes": max_bytes}
+                )
+            chunks.append(chunk)
+    except RequestException as error:
+        raise forms.ValidationError(
+            _("Could not download XLSForm from URL: %(url)s") % {"url": cleaned_url}
+        ) from error
+
+    downloaded_file = ContentFile(b"".join(chunks), name=original_name)
+    downloaded_file.content_type = response.headers.get("Content-Type", "")
+    return downloaded_file
 
 
 class DataLicenseForm(forms.Form):
@@ -216,7 +291,8 @@ class RegistrationFormUserProfile(RegistrationFormUniqueEmail, UserProfileFormRe
 
         if username in self.RESERVED_USERNAMES:
             raise forms.ValidationError(
-                _(f"{username} is a reserved name, please choose another")
+                _("%(username)s is a reserved name, please choose another")
+                % {"username": username}
             )
         # Use match() with the validation regex that includes ^ and $ anchors
         if not self.legal_usernames_re.match(username):
@@ -370,7 +446,9 @@ class QuickConverter(
                 # pylint: disable=attribute-defined-outside-init,no-member
                 self._project = Project.objects.get(pk=int(project))
             except (Project.DoesNotExist, ValueError) as e:
-                raise forms.ValidationError(_(f"Unknown project id: {project}")) from e
+                raise forms.ValidationError(
+                    _("Unknown project id: %(project)s") % {"project": project}
+                ) from e
 
         return project
 
@@ -389,22 +467,23 @@ class QuickConverter(
                 and self.cleaned_data["text_xls_form"].strip()
             ):
                 csv_data = self.cleaned_data["text_xls_form"]
-
-                # assigning the filename to a random string (quick fix)
-
-                random_string = "".join(
-                    random.sample("abcdefghijklmnopqrstuvwxyz0123456789", 6)
+                csv_file = ContentFile(csv_data.encode(), name="uploaded_form.csv")
+                csv_file.content_type = "text/csv"
+                validated_upload = _validate_xlsform_upload(
+                    csv_file, allowed_extensions=("csv",)
                 )
-                rand_name = f"uploaded_form_{random_string}.csv"
-
                 cleaned_xls_file = default_storage.save(
-                    upload_to(None, rand_name, user.username),
-                    ContentFile(csv_data.encode()),
+                    upload_to(None, validated_upload.storage_basename, user.username),
+                    csv_file,
                 )
             if "xls_file" in self.cleaned_data and self.cleaned_data["xls_file"]:
                 cleaned_xls_file = self.cleaned_data["xls_file"]
+                _validate_xlsform_upload(
+                    cleaned_xls_file, allowed_extensions=("csv", "xls", "xlsx")
+                )
             if "floip_file" in self.cleaned_data and self.cleaned_data["floip_file"]:
                 cleaned_xls_file = self.cleaned_data["floip_file"]
+                _validate_xlsform_upload(cleaned_xls_file, allowed_extensions=("json",))
 
             cleaned_url = (
                 self.cleaned_data["xls_url"].strip()
@@ -414,28 +493,18 @@ class QuickConverter(
 
             if cleaned_url:
                 self.validate(cleaned_url)
-                cleaned_xls_file = urlparse(cleaned_url)
-                cleaned_xls_file = "_".join(cleaned_xls_file.path.split("/")[-2:])
-                name, extension = os.path.splitext(cleaned_xls_file)
-
-                if extension not in VALID_FILE_EXTENSIONS and name:
-                    response = requests.head(
-                        cleaned_url,
-                        allow_redirects=True,
-                        timeout=DEFAULT_REQUEST_TIMEOUT,
-                    )
-                    if (
-                        response.headers.get("content-type")
-                        in VALID_XLSFORM_CONTENT_TYPES
-                        and response.status_code < 400
-                    ):
-                        cleaned_xls_file = get_filename(response)
-
-                cleaned_xls_file = upload_to(None, cleaned_xls_file, user.username)
-                response = requests.get(cleaned_url, timeout=DEFAULT_REQUEST_TIMEOUT)
-                if response.status_code < 400:
-                    xls_data = ContentFile(response.content)
-                    cleaned_xls_file = default_storage.save(cleaned_xls_file, xls_data)
+                parsed_url = urlparse(cleaned_url)
+                cleaned_xls_file = os.path.basename(parsed_url.path)
+                downloaded_file = _download_url_upload(cleaned_url, cleaned_xls_file)
+                validated_upload = _validate_xlsform_upload(
+                    downloaded_file, allowed_extensions=("csv", "xls", "xlsx")
+                )
+                cleaned_xls_file = upload_to(
+                    None, validated_upload.storage_basename, user.username
+                )
+                cleaned_xls_file = default_storage.save(
+                    cleaned_xls_file, downloaded_file
+                )
 
             project = self.cleaned_data["project"]
 
@@ -446,6 +515,7 @@ class QuickConverter(
 
             cleaned_xml_file = self.cleaned_data["xml_file"]
             if cleaned_xml_file:
+                _validate_xlsform_upload(cleaned_xml_file, allowed_extensions=("xml",))
                 return publish_xml_form(
                     cleaned_xml_file, user, project, id_string, created_by or user
                 )

--- a/onadata/apps/main/forms.py
+++ b/onadata/apps/main/forms.py
@@ -3,8 +3,10 @@
 forms module.
 """
 
+import ipaddress
 import os
 import re
+import socket
 
 from django import forms
 from django.conf import settings
@@ -123,8 +125,58 @@ def _validate_xlsform_upload(uploaded_file, allowed_extensions=None):
     return result
 
 
+def _is_non_public_ip(ip_address):
+    """Return True for addresses an XLSForm download must never reach."""
+    return any(
+        (
+            ip_address.is_private,
+            ip_address.is_loopback,
+            ip_address.is_link_local,
+            ip_address.is_reserved,
+            ip_address.is_multicast,
+            ip_address.is_unspecified,
+        )
+    )
+
+
+def _assert_url_not_internal(url):
+    """Reject XLSForm URLs that resolve to non-public addresses (SSRF guard).
+
+    The host is resolved and every returned address is checked; the download is
+    blocked if any maps to a private, loopback, link-local, reserved, multicast
+    or unspecified address. Hosts listed in
+    ``settings.XLSFORM_URL_ALLOWED_HOSTS`` bypass the check so deployments can
+    permit trusted internal form hosts explicitly.
+    """
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        raise forms.ValidationError(_("Only http and https URLs are allowed."))
+
+    hostname = parsed.hostname
+    if not hostname:
+        raise forms.ValidationError(_("Could not determine the URL host."))
+
+    allowed_hosts = getattr(settings, "XLSFORM_URL_ALLOWED_HOSTS", None) or []
+    if hostname in allowed_hosts:
+        return
+
+    try:
+        addrinfo = socket.getaddrinfo(hostname, None)
+    except socket.gaierror as error:
+        raise forms.ValidationError(
+            _("Could not resolve URL host: %(host)s") % {"host": hostname}
+        ) from error
+
+    for info in addrinfo:
+        if _is_non_public_ip(ipaddress.ip_address(info[4][0])):
+            raise forms.ValidationError(
+                _("Downloading XLSForms from this URL host is not permitted.")
+            )
+
+
 def _download_url_upload(cleaned_url, original_name):
-    """Download a remote XLSForm body with the strict upload byte cap."""
+    """Download a remote XLSForm body with SSRF guards and the byte cap."""
+    _assert_url_not_internal(cleaned_url)
     try:
         response = requests.get(
             cleaned_url, stream=True, timeout=DEFAULT_REQUEST_TIMEOUT

--- a/onadata/apps/main/models/meta_data.py
+++ b/onadata/apps/main/models/meta_data.py
@@ -28,10 +28,10 @@ import requests
 from onadata.apps.logger.models import EntityList, XForm
 from onadata.apps.logger.models.data_view import DataView
 from onadata.libs.utils.cache_tools import (
-    ENKETO_URL_CACHE,
-    ENKETO_URLS_CACHE,
     ENKETO_PREVIEW_URL_CACHE,
     ENKETO_SINGLE_SUBMIT_URL_CACHE,
+    ENKETO_URL_CACHE,
+    ENKETO_URLS_CACHE,
     XFORM_MANIFEST_CACHE,
     XFORM_METADATA_CACHE,
     safe_cache_delete,
@@ -41,6 +41,14 @@ from onadata.libs.utils.common_tags import (
     TEXTIT,
     TEXTIT_DETAILS,
     XFORM_META_PERMS,
+)
+from onadata.libs.utils.upload_validation import (
+    FORM_MEDIA_ALLOWED_EXTENSIONS,
+    FORM_MEDIA_UPLOAD_CONTEXT,
+    SUPPORTING_DOC_ALLOWED_EXTENSIONS,
+    SUPPORTING_DOC_UPLOAD_CONTEXT,
+    UploadValidationError,
+    validate_uploaded_file,
 )
 
 ANONYMOUS_USERNAME = "anonymous"
@@ -407,16 +415,27 @@ class MetaData(models.Model):
         """
         data_type = "supporting_doc"
         if data_file:
+            try:
+                upload = validate_uploaded_file(
+                    data_file,
+                    SUPPORTING_DOC_ALLOWED_EXTENSIONS,
+                    SUPPORTING_DOC_UPLOAD_CONTEXT,
+                )
+            except UploadValidationError as error:
+                raise ValidationError({"data_file": str(error)}) from error
+
+            data_file.name = upload.storage_basename
+            data_file.content_type = upload.content_type
             content_type = ContentType.objects.get_for_model(content_object)
 
             _doc, _created = MetaData.objects.update_or_create(
                 data_type=data_type,
                 content_type=content_type,
                 object_id=content_object.id,
-                data_value=data_file.name,
+                data_value=upload.original_name,
                 defaults={
                     "data_file": data_file,
-                    "data_file_type": data_file.content_type,
+                    "data_file_type": upload.content_type,
                 },
             )
 
@@ -429,26 +448,27 @@ class MetaData(models.Model):
         """
         data_type = "media"
         if data_file:
-            allowed_types = settings.SUPPORTED_MEDIA_UPLOAD_TYPES
-            data_content_type = (
-                data_file.content_type
-                if data_file.content_type in allowed_types
-                else mimetypes.guess_type(data_file.name)[0]
-            )
-
-            if data_content_type in allowed_types:
-                content_type = ContentType.objects.get_for_model(content_object)
-
-                _media, _created = MetaData.objects.update_or_create(
-                    data_type=data_type,
-                    content_type=content_type,
-                    object_id=content_object.id,
-                    data_value=data_file.name,
-                    defaults={
-                        "data_file": data_file,
-                        "data_file_type": data_content_type,
-                    },
+            try:
+                upload = validate_uploaded_file(
+                    data_file, FORM_MEDIA_ALLOWED_EXTENSIONS, FORM_MEDIA_UPLOAD_CONTEXT
                 )
+            except UploadValidationError as error:
+                raise ValidationError({"data_file": str(error)}) from error
+
+            data_file.name = upload.storage_basename
+            data_file.content_type = upload.content_type
+            content_type = ContentType.objects.get_for_model(content_object)
+
+            _media, _created = MetaData.objects.update_or_create(
+                data_type=data_type,
+                content_type=content_type,
+                object_id=content_object.id,
+                data_value=upload.original_name,
+                defaults={
+                    "data_file": data_file,
+                    "data_file_type": upload.content_type,
+                },
+            )
         return media_resources(type_for_form(content_object, data_type), download)
 
     @staticmethod

--- a/onadata/apps/main/models/meta_data.py
+++ b/onadata/apps/main/models/meta_data.py
@@ -220,6 +220,35 @@ def media_resources(media_list, download=False):
     return data
 
 
+def _store_validated_metadata_file(
+    content_object, data_type, data_file, allowed_extensions, upload_context
+):
+    """Validate ``data_file`` and persist it as a ``MetaData`` record.
+
+    Shared by :meth:`MetaData.supporting_docs` and :meth:`MetaData.media_upload`
+    which differ only in the data type and the allowed extensions/context.
+    """
+    try:
+        upload = validate_uploaded_file(data_file, allowed_extensions, upload_context)
+    except UploadValidationError as error:
+        raise ValidationError({"data_file": str(error)}) from error
+
+    data_file.name = upload.storage_basename
+    data_file.content_type = upload.content_type
+    content_type = ContentType.objects.get_for_model(content_object)
+
+    MetaData.objects.update_or_create(
+        data_type=data_type,
+        content_type=content_type,
+        object_id=content_object.id,
+        data_value=upload.original_name,
+        defaults={
+            "data_file": data_file,
+            "data_file_type": upload.content_type,
+        },
+    )
+
+
 # pylint: disable=too-many-public-methods
 class MetaData(models.Model):
     """MetaData class model."""
@@ -415,28 +444,12 @@ class MetaData(models.Model):
         """
         data_type = "supporting_doc"
         if data_file:
-            try:
-                upload = validate_uploaded_file(
-                    data_file,
-                    SUPPORTING_DOC_ALLOWED_EXTENSIONS,
-                    SUPPORTING_DOC_UPLOAD_CONTEXT,
-                )
-            except UploadValidationError as error:
-                raise ValidationError({"data_file": str(error)}) from error
-
-            data_file.name = upload.storage_basename
-            data_file.content_type = upload.content_type
-            content_type = ContentType.objects.get_for_model(content_object)
-
-            _doc, _created = MetaData.objects.update_or_create(
-                data_type=data_type,
-                content_type=content_type,
-                object_id=content_object.id,
-                data_value=upload.original_name,
-                defaults={
-                    "data_file": data_file,
-                    "data_file_type": upload.content_type,
-                },
+            _store_validated_metadata_file(
+                content_object,
+                data_type,
+                data_file,
+                SUPPORTING_DOC_ALLOWED_EXTENSIONS,
+                SUPPORTING_DOC_UPLOAD_CONTEXT,
             )
 
         return type_for_form(content_object, data_type)
@@ -448,26 +461,12 @@ class MetaData(models.Model):
         """
         data_type = "media"
         if data_file:
-            try:
-                upload = validate_uploaded_file(
-                    data_file, FORM_MEDIA_ALLOWED_EXTENSIONS, FORM_MEDIA_UPLOAD_CONTEXT
-                )
-            except UploadValidationError as error:
-                raise ValidationError({"data_file": str(error)}) from error
-
-            data_file.name = upload.storage_basename
-            data_file.content_type = upload.content_type
-            content_type = ContentType.objects.get_for_model(content_object)
-
-            _media, _created = MetaData.objects.update_or_create(
-                data_type=data_type,
-                content_type=content_type,
-                object_id=content_object.id,
-                data_value=upload.original_name,
-                defaults={
-                    "data_file": data_file,
-                    "data_file_type": upload.content_type,
-                },
+            _store_validated_metadata_file(
+                content_object,
+                data_type,
+                data_file,
+                FORM_MEDIA_ALLOWED_EXTENSIONS,
+                FORM_MEDIA_UPLOAD_CONTEXT,
             )
         return media_resources(type_for_form(content_object, data_type), download)
 

--- a/onadata/apps/main/tests/test_forms.py
+++ b/onadata/apps/main/tests/test_forms.py
@@ -3,10 +3,24 @@
 Tests for onadata.apps.main.forms helpers.
 """
 
+from unittest.mock import patch
+
 from django import forms
 from django.test import SimpleTestCase, override_settings
 
-from onadata.apps.main.forms import _assert_url_not_internal
+import requests
+
+from onadata.apps.main.forms import _assert_url_not_internal, _get_with_ssrf_guard
+
+
+def _redirect_to(location):
+    """Build a 302 response pointing at ``location``."""
+    response = requests.Response()
+    response.status_code = 302
+    response.headers["Location"] = location
+    # No underlying connection to release on these synthetic responses.
+    response._content_consumed = True  # pylint: disable=protected-access
+    return response
 
 
 class AssertUrlNotInternalTestCase(SimpleTestCase):
@@ -40,3 +54,36 @@ class AssertUrlNotInternalTestCase(SimpleTestCase):
     def test_allowlisted_host_bypasses_check(self):
         """An allowlisted host bypasses the private-address check."""
         _assert_url_not_internal("http://127.0.0.1/form.xlsx")
+
+
+class GetWithSsrfGuardTestCase(SimpleTestCase):
+    """Tests for the per-hop redirect validation in the XLSForm downloader."""
+
+    @patch("onadata.apps.main.forms.requests.get")
+    def test_blocks_redirect_to_internal_address(self, mock_get):
+        """A public URL that redirects to an internal address is blocked."""
+        mock_get.return_value = _redirect_to("http://169.254.169.254/latest/meta-data/")
+
+        with self.assertRaises(forms.ValidationError):
+            _get_with_ssrf_guard("https://8.8.8.8/form.xlsx")
+
+        # The internal redirect target is never requested.
+        self.assertEqual(mock_get.call_count, 1)
+
+    @patch("onadata.apps.main.forms.requests.get")
+    def test_rejects_too_many_redirects(self, mock_get):
+        """A redirect loop is capped rather than followed indefinitely."""
+        mock_get.return_value = _redirect_to("https://8.8.4.4/form.xlsx")
+
+        with self.assertRaises(forms.ValidationError):
+            _get_with_ssrf_guard("https://8.8.8.8/form.xlsx")
+
+    @patch("onadata.apps.main.forms.requests.get")
+    def test_returns_non_redirect_response(self, mock_get):
+        """A direct (non-redirect) response is returned to the caller."""
+        ok_response = requests.Response()
+        ok_response.status_code = 200
+        mock_get.return_value = ok_response
+
+        self.assertIs(_get_with_ssrf_guard("https://8.8.8.8/form.xlsx"), ok_response)
+        self.assertEqual(mock_get.call_count, 1)

--- a/onadata/apps/main/tests/test_forms.py
+++ b/onadata/apps/main/tests/test_forms.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for onadata.apps.main.forms helpers.
+"""
+
+from django import forms
+from django.test import SimpleTestCase, override_settings
+
+from onadata.apps.main.forms import _assert_url_not_internal
+
+
+class AssertUrlNotInternalTestCase(SimpleTestCase):
+    """Tests for the XLSForm-by-URL SSRF guard."""
+
+    def test_rejects_non_http_scheme(self):
+        """Only http and https URLs are allowed."""
+        with self.assertRaises(forms.ValidationError):
+            _assert_url_not_internal("ftp://example.com/form.xlsx")
+
+    def test_rejects_loopback_address(self):
+        """A loopback URL is blocked."""
+        with self.assertRaises(forms.ValidationError):
+            _assert_url_not_internal("http://127.0.0.1/form.xlsx")
+
+    def test_rejects_link_local_metadata_address(self):
+        """The cloud metadata endpoint (link-local) is blocked."""
+        with self.assertRaises(forms.ValidationError):
+            _assert_url_not_internal("http://169.254.169.254/latest/meta-data/")
+
+    def test_rejects_private_address(self):
+        """A private RFC 1918 URL is blocked."""
+        with self.assertRaises(forms.ValidationError):
+            _assert_url_not_internal("http://10.0.0.5/form.xlsx")
+
+    def test_allows_public_address(self):
+        """A public IP literal is permitted."""
+        _assert_url_not_internal("https://8.8.8.8/form.xlsx")
+
+    @override_settings(XLSFORM_URL_ALLOWED_HOSTS=["127.0.0.1"])
+    def test_allowlisted_host_bypasses_check(self):
+        """An allowlisted host bypasses the private-address check."""
+        _assert_url_not_internal("http://127.0.0.1/form.xlsx")

--- a/onadata/apps/main/tests/test_process.py
+++ b/onadata/apps/main/tests/test_process.py
@@ -24,6 +24,7 @@ import requests
 from defusedxml import minidom
 from django_digest.test import Client as DigestClient
 from flaky import flaky
+from requests.structures import CaseInsensitiveDict
 from six import iteritems
 
 from onadata.apps.logger.models import XForm
@@ -139,28 +140,27 @@ class TestProcess(TestBase, SerializeMixin):
             with open(path, "rb") as xls_file:
                 mock_response = requests.Response()
                 mock_response.status_code = 200
-                mock_response.headers = {
-                    "content-type": (
-                        "application/vnd.openxmlformats-"
-                        "officedocument.spreadsheetml.sheet"
-                    ),
-                    "Content-Disposition": (
-                        'attachment; filename="transportation.'
-                        "xlsx\"; filename*=UTF-8''transportation.xlsx"
-                    ),
-                }
-                mock_requests.head.return_value = mock_response
+                mock_response.headers = CaseInsensitiveDict(
+                    {
+                        "content-type": (
+                            "application/vnd.openxmlformats-"
+                            "officedocument.spreadsheetml.sheet"
+                        ),
+                        "Content-Disposition": (
+                            'attachment; filename="transportation.'
+                            "xlsx\"; filename*=UTF-8''transportation.xlsx"
+                        ),
+                    }
+                )
                 # pylint: disable=protected-access
                 mock_response._content = xls_file.read()
+                mock_response._content_consumed = True
                 mock_requests.get.return_value = mock_response
                 response = self.client.post(
                     f"/{self.user.username}/", {"xls_url": xls_url}
                 )
 
-                mock_requests.get.assert_called_with(xls_url, timeout=30)
-                mock_requests.head.assert_called_with(
-                    xls_url, allow_redirects=True, timeout=30
-                )
+                mock_requests.get.assert_called_with(xls_url, stream=True, timeout=30)
                 # make sure publishing the survey worked
                 self.assertEqual(response.status_code, 200)
                 self.assertEqual(XForm.objects.count(), pre_count + 1)
@@ -187,24 +187,27 @@ class TestProcess(TestBase, SerializeMixin):
             with open(path, "rb") as xls_file:
                 mock_response = requests.Response()
                 mock_response.status_code = 200
-                mock_response.headers = {
-                    "content-type": (
-                        "application/vnd.openxmlformats-"
-                        "officedocument.spreadsheetml.sheet"
-                    ),
-                    "content-disposition": (
-                        'attachment; filename="transportation.'
-                        "xlsx\"; filename*=UTF-8''transportation.xlsx"
-                    ),
-                }
+                mock_response.headers = CaseInsensitiveDict(
+                    {
+                        "content-type": (
+                            "application/vnd.openxmlformats-"
+                            "officedocument.spreadsheetml.sheet"
+                        ),
+                        "content-disposition": (
+                            'attachment; filename="transportation.'
+                            "xlsx\"; filename*=UTF-8''transportation.xlsx"
+                        ),
+                    }
+                )
                 # pylint: disable=protected-access
                 mock_response._content = xls_file.read()
+                mock_response._content_consumed = True
                 mock_requests.get.return_value = mock_response
 
                 response = self.client.post(
                     f"/{self.user.username}/", {"xls_url": xls_url}
                 )
-                mock_requests.get.assert_called_with(xls_url, timeout=30)
+                mock_requests.get.assert_called_with(xls_url, stream=True, timeout=30)
 
                 # make sure publishing the survey worked
                 self.assertEqual(response.status_code, 200)

--- a/onadata/apps/main/tests/test_process.py
+++ b/onadata/apps/main/tests/test_process.py
@@ -160,7 +160,9 @@ class TestProcess(TestBase, SerializeMixin):
                     f"/{self.user.username}/", {"xls_url": xls_url}
                 )
 
-                mock_requests.get.assert_called_with(xls_url, stream=True, timeout=30)
+                mock_requests.get.assert_called_with(
+                    xls_url, stream=True, timeout=30, allow_redirects=False
+                )
                 # make sure publishing the survey worked
                 self.assertEqual(response.status_code, 200)
                 self.assertEqual(XForm.objects.count(), pre_count + 1)
@@ -207,7 +209,9 @@ class TestProcess(TestBase, SerializeMixin):
                 response = self.client.post(
                     f"/{self.user.username}/", {"xls_url": xls_url}
                 )
-                mock_requests.get.assert_called_with(xls_url, stream=True, timeout=30)
+                mock_requests.get.assert_called_with(
+                    xls_url, stream=True, timeout=30, allow_redirects=False
+                )
 
                 # make sure publishing the survey worked
                 self.assertEqual(response.status_code, 200)

--- a/onadata/apps/main/views.py
+++ b/onadata/apps/main/views.py
@@ -14,6 +14,7 @@ from django.contrib import messages
 from django.contrib.auth import get_user_model
 from django.contrib.auth.decorators import login_required
 from django.core.cache import cache
+from django.core.exceptions import ValidationError
 from django.core.files.storage import default_storage, storages
 from django.db import IntegrityError, connections
 from django.http import (
@@ -155,7 +156,7 @@ def clone_xlsform(request, username):
                 Actions.FORM_CLONED,
                 request.user,
                 request.user,
-                _(f"Cloned form '{survey.id_string}'."),
+                _("Cloned form '%(id_string)s'.") % {"id_string": survey.id_string},
                 audit,
                 request,
             )
@@ -224,7 +225,7 @@ def profile(request, username):
                 Actions.FORM_PUBLISHED,
                 request.user,
                 content_user,
-                _(f"Published form '{survey.id_string}'."),
+                _("Published form '%(id_string)s'.") % {"id_string": survey.id_string},
                 audit,
                 request,
             )
@@ -805,7 +806,8 @@ def edit(request, username, id_string):  # noqa C901
                 Actions.FORM_UPDATED,
                 request.user,
                 owner,
-                _(f"Source for '{xform.id_string}' updated to '{source}'."),
+                _("Source for '%(id_string)s' updated to '%(source)s'.")
+                % {"id_string": xform.id_string, "source": source},
                 audit,
                 request,
             )
@@ -857,12 +859,15 @@ def edit(request, username, id_string):  # noqa C901
                 Actions.FORM_UPDATED,
                 request.user,
                 owner,
-                _(f"Media added to '{xform.id_string}'."),
+                _("Media added to '%(id_string)s'.") % {"id_string": xform.id_string},
                 audit,
                 request,
             )
             for media_file in request.FILES.getlist("media"):
-                MetaData.media_upload(xform, media_file)
+                try:
+                    MetaData.media_upload(xform, media_file)
+                except ValidationError as error:
+                    return HttpResponseBadRequest("; ".join(error.messages))
         elif request.POST.get("map_name"):
             mapbox_layer = MapboxLayerForm(request.POST)
             if mapbox_layer.is_valid():
@@ -871,7 +876,8 @@ def edit(request, username, id_string):  # noqa C901
                     Actions.FORM_UPDATED,
                     request.user,
                     owner,
-                    _(f"Map layer added to '{xform.id_string}'."),
+                    _("Map layer added to '%(id_string)s'.")
+                    % {"id_string": xform.id_string},
                     audit,
                     request,
                 )
@@ -882,11 +888,15 @@ def edit(request, username, id_string):  # noqa C901
                 Actions.FORM_UPDATED,
                 request.user,
                 owner,
-                _(f"Supporting document added to '{xform.id_string}'."),
+                _("Supporting document added to '%(id_string)s'.")
+                % {"id_string": xform.id_string},
                 audit,
                 request,
             )
-            MetaData.supporting_docs(xform, request.FILES.get("doc"))
+            try:
+                MetaData.supporting_docs(xform, request.FILES.get("doc"))
+            except ValidationError as error:
+                return HttpResponseBadRequest("; ".join(error.messages))
         elif request.POST.get("template_token") and request.POST.get("template_token"):
             template_name = request.POST.get("template_name")
             template_token = request.POST.get("template_token")
@@ -895,7 +905,8 @@ def edit(request, username, id_string):  # noqa C901
                 Actions.FORM_UPDATED,
                 request.user,
                 owner,
-                _(f"External export added to '{xform.id_string}'."),
+                _("External export added to '%(id_string)s'.")
+                % {"id_string": xform.id_string},
                 audit,
                 request,
             )
@@ -1086,7 +1097,8 @@ def delete_metadata(request, username, id_string, data_id):
             Actions.FORM_UPDATED,
             request.user,
             owner,
-            _(f"Document '{filename}' deleted from '{xform.id_string}'."),
+            _("Document '%(filename)s' deleted from '%(id_string)s'.")
+            % {"filename": filename, "id_string": xform.id_string},
             audit,
             request,
         )
@@ -1102,7 +1114,8 @@ def delete_metadata(request, username, id_string, data_id):
             Actions.FORM_UPDATED,
             request.user,
             owner,
-            _(f"Map layer deleted from '{xform.id_string}'."),
+            _("Map layer deleted from '%(id_string)s'.")
+            % {"id_string": xform.id_string},
             audit,
             request,
         )
@@ -1243,7 +1256,7 @@ def set_perm(request, username, id_string):  # noqa C901
             messages.add_message(
                 request,
                 messages.INFO,
-                _(f"Wrong username <b>{for_user}</b>."),
+                _("Wrong username <b>%(for_user)s</b>.") % {"for_user": for_user},
                 extra_tags="alert-error",
             )
         else:
@@ -1322,7 +1335,8 @@ def set_perm(request, username, id_string):  # noqa C901
             Actions.FORM_PERMISSIONS_UPDATED,
             request.user,
             owner,
-            _(f"Public link on '{xform.id_string}' {action}."),
+            _("Public link on '%(id_string)s' %(action)s.")
+            % {"id_string": xform.id_string, "action": action},
             audit,
             request,
         )
@@ -1354,7 +1368,8 @@ def delete_data(request, username=None, id_string=None):
         Actions.SUBMISSION_DELETED,
         request.user,
         owner,
-        _(f"Deleted submission with id '{data_id}' on '{xform.id_string}'."),
+        _("Deleted submission with id '%(data_id)s' on '%(id_string)s'.")
+        % {"data_id": data_id, "id_string": xform.id_string},
         audit,
         request,
     )
@@ -1389,7 +1404,7 @@ def update_xform(request, username, id_string):
             Actions.FORM_XLS_UPDATED,
             request.user,
             owner,
-            _(f"XLS for '{xform.id_string}' updated."),
+            _("XLS for '%(id_string)s' updated.") % {"id_string": xform.id_string},
             audit,
             request,
         )
@@ -1505,7 +1520,7 @@ def qrcode(request, username, id_string):
     try:
         enketo_urls = get_enketo_urls(formhub_url, id_string)
     except EnketoError as e:
-        error_msg = _(f"Error Generating QRCODE: {e}")
+        error_msg = _("Error Generating QRCODE: %(error)s") % {"error": e}
         results = f"""<div class="alert alert-error">{error_msg}</div>"""
         status = HTTPStatus.BAD_REQUEST
     else:

--- a/onadata/apps/viewer/models/data_dictionary.py
+++ b/onadata/apps/viewer/models/data_dictionary.py
@@ -6,7 +6,6 @@ DataDictionary model.
 import importlib
 import json
 import os
-import uuid
 from io import BytesIO
 
 from django.conf import settings
@@ -33,6 +32,7 @@ from onadata.apps.logger.models.xform import (
     check_version_set,
     check_xform_uuid,
     get_survey_from_file_object,
+    get_xls_upload_path,
 )
 from onadata.apps.logger.xform_instance_parser import XLSFormError
 from onadata.apps.main.models.meta_data import MetaData
@@ -137,9 +137,7 @@ def upload_to(instance, filename, username=None):
     """
     if instance:
         username = instance.xform.user.username
-    original_basename = os.path.split(filename)[1]
-    extension = os.path.splitext(original_basename)[1].lower()
-    return os.path.join(username, "xls", f"{uuid.uuid4().hex}{extension}")
+    return get_xls_upload_path(username, filename)
 
 
 class DataDictionary(XForm):  # pylint: disable=too-many-instance-attributes

--- a/onadata/apps/viewer/models/data_dictionary.py
+++ b/onadata/apps/viewer/models/data_dictionary.py
@@ -6,10 +6,9 @@ DataDictionary model.
 import importlib
 import json
 import os
+import uuid
 from io import BytesIO
 
-import openpyxl
-import unicodecsv as csv
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.core.files.uploadedfile import InMemoryUploadedFile
@@ -17,6 +16,9 @@ from django.db import transaction
 from django.db.models.signals import post_save, pre_save
 from django.utils import timezone
 from django.utils.translation import gettext as _
+
+import openpyxl
+import unicodecsv as csv
 from floip import FloipSurvey
 from kombu.exceptions import OperationalError
 from pyxform.utils import has_external_choices
@@ -126,11 +128,18 @@ def sheet_to_csv(xls_content, sheet_name):
 
 def upload_to(instance, filename, username=None):
     """
-    Return XLSForm file upload path.
+    Return XLSForm file upload path with a UUID-based basename.
+
+    The original filename is preserved on the in-memory file object so pyxform
+    can derive ``fallback_form_name`` from it during publication, but the
+    stored basename is randomised to prevent client-influenced storage paths
+    and double-extension reads from the filesystem.
     """
     if instance:
         username = instance.xform.user.username
-    return os.path.join(username, "xls", os.path.split(filename)[1])
+    original_basename = os.path.split(filename)[1]
+    extension = os.path.splitext(original_basename)[1].lower()
+    return os.path.join(username, "xls", f"{uuid.uuid4().hex}{extension}")
 
 
 class DataDictionary(XForm):  # pylint: disable=too-many-instance-attributes
@@ -225,7 +234,7 @@ def set_object_permissions(sender, instance=None, created=False, **kwargs):
 
     if created:
         # pylint: disable=import-outside-toplevel
-        from onadata.libs.permissions import OwnerRole
+        from onadata.libs.permissions import OwnerRole  # noqa: PLC0415
 
         OwnerRole.add(instance.user, xform)
 
@@ -510,7 +519,7 @@ def auto_encrypt_xform(sender, instance, created, **kwargs):
     # Avoid cyclic import by using importlib
     kms_tools = importlib.import_module("onadata.libs.kms.tools")
     # pylint: disable=import-outside-toplevel
-    from onadata.libs.permissions import is_organization
+    from onadata.libs.permissions import is_organization  # noqa: PLC0415
 
     if (
         created

--- a/onadata/libs/serializers/metadata_serializer.py
+++ b/onadata/libs/serializers/metadata_serializer.py
@@ -185,6 +185,28 @@ class MetaDataSerializer(serializers.HyperlinkedModelSerializer):
             return reverse("xform-media", **kwargs)
         return None
 
+    @staticmethod
+    def _validate_data_file(attrs, data_type, data_file):
+        """Validate ``data_file`` and update ``attrs`` with the stored metadata."""
+        if data_type == MEDIA_TYPE:
+            allowed_extensions = FORM_MEDIA_ALLOWED_EXTENSIONS
+            upload_context = FORM_MEDIA_UPLOAD_CONTEXT
+        else:
+            allowed_extensions = SUPPORTING_DOC_ALLOWED_EXTENSIONS
+            upload_context = SUPPORTING_DOC_UPLOAD_CONTEXT
+
+        try:
+            upload = validate_uploaded_file(
+                data_file, allowed_extensions, upload_context
+            )
+        except UploadValidationError as error:
+            raise serializers.ValidationError({"data_file": str(error)}) from error
+
+        data_file.name = upload.storage_basename
+        data_file.content_type = upload.content_type
+        attrs["data_value"] = upload.original_name
+        attrs["data_file_type"] = upload.content_type
+
     # pylint: disable=too-many-branches
     def validate(self, attrs):
         """
@@ -204,24 +226,7 @@ class MetaDataSerializer(serializers.HyperlinkedModelSerializer):
             )
 
         if data_file:
-            if data_type == MEDIA_TYPE:
-                allowed_extensions = FORM_MEDIA_ALLOWED_EXTENSIONS
-                upload_context = FORM_MEDIA_UPLOAD_CONTEXT
-            else:
-                allowed_extensions = SUPPORTING_DOC_ALLOWED_EXTENSIONS
-                upload_context = SUPPORTING_DOC_UPLOAD_CONTEXT
-
-            try:
-                upload = validate_uploaded_file(
-                    data_file, allowed_extensions, upload_context
-                )
-            except UploadValidationError as error:
-                raise serializers.ValidationError({"data_file": str(error)}) from error
-
-            data_file.name = upload.storage_basename
-            data_file.content_type = upload.content_type
-            attrs["data_value"] = upload.original_name
-            attrs["data_file_type"] = upload.content_type
+            self._validate_data_file(attrs, data_type, data_file)
 
         if data_type == "media" and data_file is None:
             try:

--- a/onadata/libs/serializers/metadata_serializer.py
+++ b/onadata/libs/serializers/metadata_serializer.py
@@ -3,10 +3,8 @@
 MetaData Serializer
 """
 
-import mimetypes
 import os
 
-from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
 from django.core.validators import URLValidator
@@ -18,7 +16,6 @@ from rest_framework import serializers
 from rest_framework.reverse import reverse
 from six.moves.urllib.parse import urlparse
 
-from onadata.libs.utils.xform_utils import update_role_by_meta_xform_perms
 from onadata.apps.logger.models import DataView, Instance, Project, XForm
 from onadata.apps.main.models import MetaData
 from onadata.libs.permissions import ROLES, ManagerRole
@@ -32,11 +29,19 @@ from onadata.libs.utils.common_tags import (
     SUBMISSION_REVIEW,
     XFORM_META_PERMS,
 )
-from onadata.libs.utils.image_tools import is_azure_storage, generate_media_url_with_sas
+from onadata.libs.utils.image_tools import generate_media_url_with_sas, is_azure_storage
+from onadata.libs.utils.upload_validation import (
+    FORM_MEDIA_ALLOWED_EXTENSIONS,
+    FORM_MEDIA_UPLOAD_CONTEXT,
+    SUPPORTING_DOC_ALLOWED_EXTENSIONS,
+    SUPPORTING_DOC_UPLOAD_CONTEXT,
+    UploadValidationError,
+    validate_uploaded_file,
+)
+from onadata.libs.utils.xform_utils import update_role_by_meta_xform_perms
 
 UNIQUE_TOGETHER_ERROR = "Object already exists"
 
-CSV_CONTENT_TYPE = "text/csv"
 MEDIA_TYPE = "media"
 DOC_TYPE = "supporting_doc"
 METADATA_TYPES = (
@@ -199,19 +204,24 @@ class MetaDataSerializer(serializers.HyperlinkedModelSerializer):
             )
 
         if data_file:
-            allowed_types = settings.SUPPORTED_MEDIA_UPLOAD_TYPES
-            # add geojson mimetype
-            mimetypes.add_type("application/geo+json", ".geojson")
-            data_content_type = (
-                data_file.content_type
-                if data_file.content_type in allowed_types
-                else mimetypes.guess_type(data_file.name)[0]
-            )
-            if data_content_type not in allowed_types:
-                raise serializers.ValidationError(
-                    {"data_file": _(f"Unsupported media file type {data_content_type}")}
+            if data_type == MEDIA_TYPE:
+                allowed_extensions = FORM_MEDIA_ALLOWED_EXTENSIONS
+                upload_context = FORM_MEDIA_UPLOAD_CONTEXT
+            else:
+                allowed_extensions = SUPPORTING_DOC_ALLOWED_EXTENSIONS
+                upload_context = SUPPORTING_DOC_UPLOAD_CONTEXT
+
+            try:
+                upload = validate_uploaded_file(
+                    data_file, allowed_extensions, upload_context
                 )
-            attrs["data_file_type"] = data_content_type
+            except UploadValidationError as error:
+                raise serializers.ValidationError({"data_file": str(error)}) from error
+
+            data_file.name = upload.storage_basename
+            data_file.content_type = upload.content_type
+            attrs["data_value"] = upload.original_name
+            attrs["data_file_type"] = upload.content_type
 
         if data_type == "media" and data_file is None:
             try:
@@ -242,7 +252,7 @@ class MetaDataSerializer(serializers.HyperlinkedModelSerializer):
                         ) from error
                 else:
                     raise serializers.ValidationError(
-                        {"data_value": _(f"Invalid url '{value}'.")}
+                        {"data_value": _("Invalid url '%(value)s'.") % {"value": value}}
                     ) from error
             else:
                 # check if we have a value for the filename.
@@ -250,10 +260,11 @@ class MetaDataSerializer(serializers.HyperlinkedModelSerializer):
                     raise serializers.ValidationError(
                         {
                             "data_value": _(
-                                f"Cannot get filename from URL {value}. URL should "
+                                "Cannot get filename from URL %(value)s. URL should "
                                 "include the filename e.g "
                                 "http://example.com/data.csv"
                             )
+                            % {"value": value}
                         }
                     )
 
@@ -291,18 +302,9 @@ class MetaDataSerializer(serializers.HyperlinkedModelSerializer):
         extra_data = validated_data.get("extra_data")
 
         content_object = self.get_content_object(validated_data)
-        data_value = data_file.name if data_file else validated_data.get("data_value")
-
-        # not exactly sure what changed in the requests.FILES for django 1.7
-        # csv files uploaded in windows do not have the text/csv content_type
-        # this works around that
-        if (
-            data_type == MEDIA_TYPE
-            and data_file
-            and data_file.name.lower().endswith(".csv")
-            and data_file_type != CSV_CONTENT_TYPE
-        ):
-            data_file_type = CSV_CONTENT_TYPE
+        data_value = validated_data.get("data_value") or (
+            data_file.name if data_file else None
+        )
 
         content_type = ContentType.objects.get_for_model(content_object)
 

--- a/onadata/libs/serializers/metadata_serializer.py
+++ b/onadata/libs/serializers/metadata_serializer.py
@@ -3,6 +3,7 @@
 MetaData Serializer
 """
 
+import logging
 import os
 
 from django.contrib.contenttypes.models import ContentType
@@ -39,6 +40,8 @@ from onadata.libs.utils.upload_validation import (
     validate_uploaded_file,
 )
 from onadata.libs.utils.xform_utils import update_role_by_meta_xform_perms
+
+logger = logging.getLogger(__name__)
 
 UNIQUE_TOGETHER_ERROR = "Object already exists"
 
@@ -200,7 +203,10 @@ class MetaDataSerializer(serializers.HyperlinkedModelSerializer):
                 data_file, allowed_extensions, upload_context
             )
         except UploadValidationError as error:
-            raise serializers.ValidationError({"data_file": str(error)}) from error
+            logger.warning("Metadata file upload validation failed: %s", error)
+            raise serializers.ValidationError(
+                {"data_file": _("The uploaded file could not be validated.")}
+            ) from error
 
         data_file.name = upload.storage_basename
         data_file.content_type = upload.content_type

--- a/onadata/libs/tests/serializers/test_metadata_serializer.py
+++ b/onadata/libs/tests/serializers/test_metadata_serializer.py
@@ -68,7 +68,7 @@ class TestMetaDataViewSerializer(TestAbstractViewSet):
             serializer = MetaDataSerializer(data=data)
             self.assertFalse(serializer.is_valid())
             self.assertIn(
-                "Unsupported file extension '.svg'",
+                "The uploaded file could not be validated.",
                 serializer.errors["data_file"][0],
             )
 
@@ -93,7 +93,7 @@ class TestMetaDataViewSerializer(TestAbstractViewSet):
             serializer = MetaDataSerializer(data=data)
             self.assertFalse(serializer.is_valid())
             self.assertIn(
-                "Unsupported file extension '.svg'",
+                "The uploaded file could not be validated.",
                 serializer.errors["data_file"][0],
             )
 

--- a/onadata/libs/tests/serializers/test_metadata_serializer.py
+++ b/onadata/libs/tests/serializers/test_metadata_serializer.py
@@ -5,7 +5,6 @@ Test onadata.libs.serializers.metadata_serializer
 import os
 
 from django.core.files.uploadedfile import InMemoryUploadedFile
-from django.test.utils import override_settings
 
 from onadata.apps.api.tests.viewsets.test_abstract_viewset import TestAbstractViewSet
 from onadata.libs.serializers.metadata_serializer import MetaDataSerializer
@@ -48,7 +47,6 @@ class TestMetaDataViewSerializer(TestAbstractViewSet):
             ],
         )
 
-    @override_settings(SUPPORTED_MEDIA_UPLOAD_TYPES=[])
     def test_unsupported_media_files(self):
         """
         Test unsupported media files
@@ -69,14 +67,14 @@ class TestMetaDataViewSerializer(TestAbstractViewSet):
             }
             serializer = MetaDataSerializer(data=data)
             self.assertFalse(serializer.is_valid())
-            self.assertEqual(
-                serializer.errors["data_file"],
-                [("Unsupported media file type image/svg+xml")],
+            self.assertIn(
+                "Unsupported file extension '.svg'",
+                serializer.errors["data_file"][0],
             )
 
     def test_svg_media_files(self):
         """
-        Test that an SVG file is uploaded
+        Test that an SVG file is rejected
         """
         self._login_user_and_profile()
         self._publish_form_with_hxl_support()
@@ -93,37 +91,30 @@ class TestMetaDataViewSerializer(TestAbstractViewSet):
                 "xform": self.xform.pk,
             }
             serializer = MetaDataSerializer(data=data)
-            self.assertTrue(serializer.is_valid())
-            self.assertEqual(
-                serializer.validated_data["data_file_type"], "image/svg+xml"
+            self.assertFalse(serializer.is_valid())
+            self.assertIn(
+                "Unsupported file extension '.svg'",
+                serializer.errors["data_file"][0],
             )
 
     def test_geojson_media_files(self):
         """
-        Test that an geojson file is uploaded ok
+        GeoJSON media files are accepted (used by select_one_from_file map
+        widgets in ODK).
         """
         self._login_user_and_profile()
         self._publish_form_with_hxl_support()
-        data_value = 'sample.geojson'
-        path = os.path.join(os.path.dirname(__file__), 'fixtures',
-                            'sample.geojson')
-        with open(path) as f:
+        data_value = "sample.geojson"
+        path = os.path.join(os.path.dirname(__file__), "fixtures", "sample.geojson")
+        with open(path, "rb") as media_fp:
             f = InMemoryUploadedFile(
-                f, 'media', data_value, None, 2324, None)
+                media_fp, "media", data_value, "application/geo+json", 2324, None
+            )
             data = {
-                'data_value': data_value,
-                'data_file': f,
-                'data_type': 'media',
-                'xform': self.xform.pk
+                "data_value": data_value,
+                "data_file": f,
+                "data_type": "media",
+                "xform": self.xform.pk,
             }
             serializer = MetaDataSerializer(data=data)
-            self.assertTrue(serializer.is_valid())
-            self.assertEqual(
-                serializer.validated_data['data_file_type'],
-                'application/geo+json')
-            self.assertEqual(
-                serializer.validated_data['data_value'],
-                'sample.geojson')
-            self.assertEqual(
-                serializer.validated_data['data_type'],
-                'media')
+            self.assertTrue(serializer.is_valid(), serializer.errors)

--- a/onadata/libs/tests/utils/test_content_disposition.py
+++ b/onadata/libs/tests/utils/test_content_disposition.py
@@ -1,0 +1,136 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for the RFC 6266 Content-Disposition parser.
+"""
+
+from django.test import SimpleTestCase
+
+from onadata.apps.main.forms import get_filename
+from onadata.libs.utils.content_disposition import (
+    ContentDispositionError,
+    parse_filename,
+    secure_filename,
+)
+
+
+class _FakeResponse:
+    """Minimal stand-in exposing the ``headers`` attribute ``get_filename`` reads."""
+
+    def __init__(self, content_disposition=None):
+        self.headers = {}
+        if content_disposition is not None:
+            self.headers["Content-Disposition"] = content_disposition
+
+
+class ParseFilenameTestCase(SimpleTestCase):
+    """Tests for :func:`parse_filename`."""
+
+    def test_plain_unquoted_filename(self):
+        self.assertEqual(parse_filename("attachment; filename=form.xls"), "form.xls")
+
+    def test_quoted_filename(self):
+        self.assertEqual(
+            parse_filename('attachment; filename="form.xlsx"'), "form.xlsx"
+        )
+
+    def test_quoted_filename_with_escaped_quote(self):
+        self.assertEqual(parse_filename('attachment; filename="a\\"b.xml"'), 'a"b.xml')
+
+    def test_extended_utf8_percent_decoded(self):
+        self.assertEqual(
+            parse_filename("attachment; filename*=UTF-8''my%20form.xlsx"),
+            "my form.xlsx",
+        )
+
+    def test_extended_utf8_multibyte(self):
+        self.assertEqual(
+            parse_filename("attachment; filename*=UTF-8''%E2%82%ac-rate.csv"),
+            "€-rate.csv",
+        )
+
+    def test_extended_iso8859_1(self):
+        self.assertEqual(
+            parse_filename("attachment; filename*=ISO-8859-1''%A3rates.xls"),
+            "\xa3rates.xls",
+        )
+
+    def test_extended_iso8859_1_control_char_is_rejected(self):
+        with self.assertRaises(ContentDispositionError):
+            parse_filename("attachment; filename*=ISO-8859-1''%7Frates.xls")
+
+    def test_extended_form_takes_precedence_over_plain(self):
+        # RFC 6266 §4.3: recipients prefer ``filename*`` when both are present.
+        self.assertEqual(
+            parse_filename(
+                "attachment; filename=plain.xlsx; filename*=UTF-8''extended.csv"
+            ),
+            "extended.csv",
+        )
+
+    def test_rfc2231_continuation_is_combined(self):
+        self.assertEqual(
+            parse_filename('attachment; filename*0="long"; filename*1="name.csv"'),
+            "longname.csv",
+        )
+
+    def test_no_filename_returns_none(self):
+        self.assertIsNone(parse_filename("attachment"))
+        self.assertIsNone(parse_filename("inline"))
+
+    def test_path_separators_are_stripped(self):
+        self.assertEqual(
+            parse_filename('attachment; filename="../../etc/passwd"'),
+            ".._.._etc_passwd",
+        )
+
+    def test_malformed_header_raises(self):
+        # Does not start with a disposition-type token.
+        with self.assertRaises(ContentDispositionError):
+            parse_filename("=oops")
+
+    def test_duplicate_parameter_raises(self):
+        with self.assertRaises(ContentDispositionError):
+            parse_filename('attachment; filename="a.csv"; filename="b.csv"')
+
+    def test_unsupported_charset_raises(self):
+        with self.assertRaises(ContentDispositionError):
+            parse_filename("attachment; filename*=Shift_JIS''x.csv")
+
+
+class GetFilenameTestCase(SimpleTestCase):
+    """Tests for :func:`onadata.apps.main.forms.get_filename`."""
+
+    def test_no_content_disposition_returns_empty(self):
+        self.assertEqual(get_filename(_FakeResponse()), "")
+
+    def test_allowed_extension_is_returned(self):
+        response = _FakeResponse('attachment; filename="form.xlsx"')
+        self.assertEqual(get_filename(response), "form.xlsx")
+
+    def test_disallowed_extension_is_dropped(self):
+        response = _FakeResponse('attachment; filename="malware.exe"')
+        self.assertEqual(get_filename(response), "")
+
+    def test_path_separators_are_neutralised(self):
+        # secure_filename collapses separators to underscores, so the returned
+        # name carries no traversal sequence.
+        response = _FakeResponse('attachment; filename="../../uploads/form.xlsx"')
+        result = get_filename(response)
+        self.assertEqual(result, ".._.._uploads_form.xlsx")
+        self.assertNotIn("/", result)
+        self.assertNotIn("\\", result)
+
+    def test_malformed_header_returns_empty(self):
+        # A header that cannot be parsed must not raise out of get_filename.
+        response = _FakeResponse("=oops")
+        self.assertEqual(get_filename(response), "")
+
+
+class SecureFilenameTestCase(SimpleTestCase):
+    """Tests for :func:`secure_filename`."""
+
+    def test_separators_replaced(self):
+        self.assertEqual(secure_filename("a/b\\c.csv"), "a_b_c.csv")
+
+    def test_plain_name_unchanged(self):
+        self.assertEqual(secure_filename("form.xlsx"), "form.xlsx")

--- a/onadata/libs/tests/utils/test_logger_tools.py
+++ b/onadata/libs/tests/utils/test_logger_tools.py
@@ -1204,6 +1204,7 @@ class ResponseWithMimetypeAndNameTestCase(TestBase):
             show_date=False,
         )
         self.assertEqual(response.status_code, 302)
+        self.assertEqual(response["X-Content-Type-Options"], "nosniff")
         mock_download_url.assert_called_once_with(
             "test.csv",
             "attachment; filename=\"download.csv\"; filename*=UTF-8''test.csv",
@@ -1224,6 +1225,7 @@ class ResponseWithMimetypeAndNameTestCase(TestBase):
             show_date=False,
         )
         self.assertEqual(response.status_code, 302)
+        self.assertEqual(response["X-Content-Type-Options"], "nosniff")
         mock_download_url.assert_called_once_with(
             "test.csv",
             "attachment; filename=\"download.csv\"; filename*=UTF-8''test.csv",
@@ -1337,3 +1339,79 @@ class GetStoragesMediaDownloadUrlTestCase(TestBase):
             "test.csv", 'attachment; filename="test.csv"', "text/csv", 3600
         )
         self.assertIsNone(url)
+
+
+class ResponseNosniffHeaderTestCase(TestBase):
+    """Confirm download helpers set X-Content-Type-Options: nosniff."""
+
+    def test_local_filesystem_path_sets_nosniff(self):
+        """Local filesystem download response includes the nosniff header."""
+        fixture_path = os.path.join(
+            settings.PROJECT_ROOT,
+            "apps",
+            "main",
+            "tests",
+            "fixtures",
+            "transportation",
+            "screenshot.png",
+        )
+
+        response = response_with_mimetype_and_name(
+            "image/png",
+            "screenshot",
+            extension="png",
+            file_path=fixture_path,
+            use_local_filesystem=True,
+            full_mime=True,
+            show_date=False,
+        )
+
+        self.assertEqual(response["X-Content-Type-Options"], "nosniff")
+        self.assertIn("attachment", response["Content-Disposition"])
+
+    def test_no_file_path_response_sets_nosniff(self):
+        """Empty-payload response (no file_path) still sets the nosniff header."""
+        response = response_with_mimetype_and_name(
+            "csv",
+            "report",
+            extension="csv",
+            file_path=None,
+            full_mime=False,
+            show_date=False,
+        )
+
+        self.assertEqual(response["X-Content-Type-Options"], "nosniff")
+
+    @patch("onadata.libs.utils.image_tools.get_storages_media_download_url")
+    def test_generate_media_download_url_redirect_sets_nosniff(self, mock_download_url):
+        """Signed-URL redirect from generate_media_download_url has nosniff."""
+        from onadata.libs.utils.image_tools import generate_media_download_url
+
+        mock_download_url.return_value = "https://signed.example.com/file.png"
+        obj = Mock()
+        obj.media_file.name = "user/attachments/file.png"
+        obj.mimetype = "image/png"
+
+        response = generate_media_download_url(obj)
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response["X-Content-Type-Options"], "nosniff")
+
+    @patch("onadata.libs.utils.image_tools.open")
+    @patch("onadata.libs.utils.image_tools.get_storages_media_download_url")
+    def test_generate_media_download_url_local_sets_nosniff(
+        self, mock_download_url, mock_open
+    ):
+        """Local-filesystem path from generate_media_download_url has nosniff."""
+        from onadata.libs.utils.image_tools import generate_media_download_url
+
+        mock_download_url.return_value = None
+        mock_open.return_value = BytesIO(b"payload")
+        obj = Mock()
+        obj.media_file.name = "user/attachments/file.png"
+        obj.mimetype = "image/png"
+
+        response = generate_media_download_url(obj)
+
+        self.assertEqual(response["X-Content-Type-Options"], "nosniff")
+        self.assertIn("attachment", response["Content-Disposition"])

--- a/onadata/libs/tests/utils/test_upload_validation.py
+++ b/onadata/libs/tests/utils/test_upload_validation.py
@@ -1,0 +1,542 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for strict upload validation helpers.
+"""
+
+import io
+import zipfile
+
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import SimpleTestCase, override_settings
+
+import openpyxl
+from PIL import Image
+
+from onadata.libs.utils.upload_validation import (
+    DATA_IMPORT_UPLOAD_CONTEXT,
+    FORM_MEDIA_ALLOWED_EXTENSIONS,
+    FORM_MEDIA_UPLOAD_CONTEXT,
+    SUPPORTING_DOC_ALLOWED_EXTENSIONS,
+    SUPPORTING_DOC_UPLOAD_CONTEXT,
+    XLSFORM_ALLOWED_EXTENSIONS,
+    XLSFORM_UPLOAD_CONTEXT,
+    UploadValidationError,
+    validate_uploaded_file,
+)
+
+
+class _CountingUpload:
+    """A seekable upload-like object that counts bytes read.
+
+    ``size`` may be set larger than the backing data so a bounded validator can
+    be checked against a "large" file without materialising one.
+    """
+
+    def __init__(self, name, data, content_type, size=None):
+        self.name = name
+        self.content_type = content_type
+        self._stream = io.BytesIO(data)
+        self.size = len(data) if size is None else size
+        self.bytes_read = 0
+
+    def read(self, amount=-1):
+        chunk = self._stream.read(amount)
+        self.bytes_read += len(chunk)
+        return chunk
+
+    def seek(self, offset, whence=0):
+        return self._stream.seek(offset, whence)
+
+    def tell(self):
+        return self._stream.tell()
+
+
+# A minimal valid MP4 ftyp box (box size 0x18 = 24 bytes, major brand "isom").
+VALID_MP4_FTYP = b"\x00\x00\x00\x18ftypisom\x00\x00\x02\x00isomiso2"
+
+# An illustrative "large" per-(context, extension) cap for exercising the
+# bounded-validation path. Any value above the 1 MB default works; this is a
+# test value, not a recommended deployment setting.
+LARGE_TEST_CAP = 32 * 1024 * 1024
+
+
+class UploadValidationTestCase(SimpleTestCase):
+    """Strict upload validation tests."""
+
+    def _upload(self, name, data, content_type):
+        return SimpleUploadedFile(name, data, content_type=content_type)
+
+    def _image_bytes(self, image_format):
+        image = Image.new("RGB", (1, 1), color=(255, 0, 0))
+        stream = io.BytesIO()
+        image.save(stream, image_format)
+        return stream.getvalue()
+
+    def _xlsx_bytes(self):
+        stream = io.BytesIO()
+        workbook = openpyxl.Workbook()
+        workbook.active["A1"] = "name"
+        workbook.save(stream)
+        workbook.close()
+        return stream.getvalue()
+
+    def test_valid_uploads_are_accepted(self):
+        """Valid files from the strict allowlist pass validation."""
+        # (name, bytes, content_type, allowed_extensions, context)
+        samples = [
+            (
+                "image.png",
+                self._image_bytes("PNG"),
+                "image/png",
+                FORM_MEDIA_ALLOWED_EXTENSIONS,
+                FORM_MEDIA_UPLOAD_CONTEXT,
+            ),
+            (
+                "image.jpg",
+                self._image_bytes("JPEG"),
+                "image/jpeg",
+                FORM_MEDIA_ALLOWED_EXTENSIONS,
+                FORM_MEDIA_UPLOAD_CONTEXT,
+            ),
+            (
+                "video.mp4",
+                b"\x00\x00\x00\x18ftypisom\x00\x00\x02\x00isomiso2",
+                "video/mp4",
+                FORM_MEDIA_ALLOWED_EXTENSIONS,
+                FORM_MEDIA_UPLOAD_CONTEXT,
+            ),
+            (
+                "data.csv",
+                b"name\nAlice\n",
+                "text/csv",
+                FORM_MEDIA_ALLOWED_EXTENSIONS,
+                FORM_MEDIA_UPLOAD_CONTEXT,
+            ),
+            (
+                "form.xml",
+                b"<data><name>Alice</name></data>",
+                "text/xml",
+                FORM_MEDIA_ALLOWED_EXTENSIONS,
+                FORM_MEDIA_UPLOAD_CONTEXT,
+            ),
+            (
+                "legacy.xls",
+                b"\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1payload",
+                "application/vnd.ms-excel",
+                XLSFORM_ALLOWED_EXTENSIONS,
+                XLSFORM_UPLOAD_CONTEXT,
+            ),
+            (
+                "workbook.xlsx",
+                self._xlsx_bytes(),
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                XLSFORM_ALLOWED_EXTENSIONS,
+                XLSFORM_UPLOAD_CONTEXT,
+            ),
+        ]
+
+        for name, data, content_type, allowed_extensions, context in samples:
+            with self.subTest(name=name):
+                uploaded_file = self._upload(name, data, content_type)
+                result = validate_uploaded_file(
+                    uploaded_file, allowed_extensions, context
+                )
+                self.assertEqual(uploaded_file.tell(), 0)
+                self.assertNotEqual(result.storage_basename, result.original_name)
+                self.assertTrue(
+                    result.storage_basename.endswith(f".{result.extension}")
+                )
+
+    def test_double_extension_is_rejected(self):
+        """Filenames such as putty.exe.png are rejected before persistence."""
+        uploaded_file = self._upload("putty.exe.png", b"MZpayload", "image/png")
+
+        with self.assertRaisesRegex(UploadValidationError, r"'\.exe' suffix"):
+            validate_uploaded_file(
+                uploaded_file, FORM_MEDIA_ALLOWED_EXTENSIONS, FORM_MEDIA_UPLOAD_CONTEXT
+            )
+
+    def test_benign_multi_dot_filename_is_accepted(self):
+        """Filenames with multiple dots but a safe penultimate suffix pass."""
+        uploaded_file = self._upload("report.v2.csv", b"name\nAlice\n", "text/csv")
+
+        result = validate_uploaded_file(
+            uploaded_file, FORM_MEDIA_ALLOWED_EXTENSIONS, FORM_MEDIA_UPLOAD_CONTEXT
+        )
+
+        self.assertEqual(result.extension, "csv")
+        self.assertEqual(result.original_name, "report.v2.csv")
+
+    def test_content_type_mismatch_is_rejected(self):
+        """Mismatched MIME metadata does not pass validation."""
+        uploaded_file = self._upload("data.csv", b"name\nAlice\n", "image/png")
+
+        with self.assertRaisesRegex(UploadValidationError, "Unsupported content type"):
+            validate_uploaded_file(
+                uploaded_file, FORM_MEDIA_ALLOWED_EXTENSIONS, FORM_MEDIA_UPLOAD_CONTEXT
+            )
+
+    def test_octet_stream_content_type_is_accepted(self):
+        """``application/octet-stream`` is accepted as an unknown-type fallback.
+
+        Windows browsers, ODK Collect, curl without ``-H``, and various mobile
+        clients commonly submit uploads with this MIME. Magic-byte validation
+        still verifies the content matches the extension.
+        """
+        uploaded_file = self._upload(
+            "data.csv", b"name\nAlice\n", "application/octet-stream"
+        )
+
+        result = validate_uploaded_file(
+            uploaded_file, FORM_MEDIA_ALLOWED_EXTENSIONS, FORM_MEDIA_UPLOAD_CONTEXT
+        )
+
+        self.assertEqual(result.extension, "csv")
+        self.assertEqual(result.content_type, "text/csv")
+
+    def test_missing_content_type_is_accepted(self):
+        """An upload without a declared content type is accepted."""
+        uploaded_file = self._upload("data.csv", b"name\nAlice\n", None)
+
+        result = validate_uploaded_file(
+            uploaded_file, FORM_MEDIA_ALLOWED_EXTENSIONS, FORM_MEDIA_UPLOAD_CONTEXT
+        )
+
+        self.assertEqual(result.extension, "csv")
+        self.assertEqual(result.content_type, "text/csv")
+
+    def test_octet_stream_still_validates_content(self):
+        """``application/octet-stream`` does not bypass magic-byte validation."""
+        uploaded_file = self._upload(
+            "image.png", b"MZpayload", "application/octet-stream"
+        )
+
+        with self.assertRaisesRegex(UploadValidationError, "PNG signature mismatch"):
+            validate_uploaded_file(
+                uploaded_file,
+                FORM_MEDIA_ALLOWED_EXTENSIONS,
+                FORM_MEDIA_UPLOAD_CONTEXT,
+            )
+
+    def test_signature_mismatch_is_rejected(self):
+        """Executable bytes renamed as PNG are rejected."""
+        uploaded_file = self._upload("putty.png", b"MZpayload", "image/png")
+
+        with self.assertRaisesRegex(UploadValidationError, "PNG signature mismatch"):
+            validate_uploaded_file(
+                uploaded_file, FORM_MEDIA_ALLOWED_EXTENSIONS, FORM_MEDIA_UPLOAD_CONTEXT
+            )
+
+    def test_content_mismatch_is_rejected(self):
+        """Valid PNG bytes uploaded as CSV are rejected by content validation."""
+        uploaded_file = self._upload("data.csv", self._image_bytes("PNG"), "text/csv")
+
+        with self.assertRaisesRegex(UploadValidationError, "NUL bytes"):
+            validate_uploaded_file(
+                uploaded_file, FORM_MEDIA_ALLOWED_EXTENSIONS, FORM_MEDIA_UPLOAD_CONTEXT
+            )
+
+    @override_settings(STRICT_UPLOAD_MAX_BYTES={"*": 4})
+    def test_oversized_upload_is_rejected(self):
+        """Oversized uploads are rejected before parser validation."""
+        uploaded_file = self._upload("data.csv", b"name\nAlice\n", "text/csv")
+
+        with self.assertRaisesRegex(UploadValidationError, "maximum upload size"):
+            validate_uploaded_file(uploaded_file, ("csv",), DATA_IMPORT_UPLOAD_CONTEXT)
+
+    @override_settings(STRICT_UPLOAD_MAX_BYTES={"data_import": {"*": 4}})
+    def test_per_context_size_override_is_applied(self):
+        """A whole-context ("*") cap narrows the upload size limit."""
+        uploaded_file = self._upload("data.csv", b"name\nAlice\n", "text/csv")
+
+        with self.assertRaisesRegex(UploadValidationError, "maximum upload size"):
+            validate_uploaded_file(uploaded_file, ("csv",), DATA_IMPORT_UPLOAD_CONTEXT)
+
+    @override_settings(
+        STRICT_UPLOAD_MAX_BYTES={"*": 4, "data_import": {"*": 8, "csv": 64}},
+    )
+    def test_per_context_extension_override_takes_precedence(self):
+        """An exact extension cap wins over the "*" and global caps."""
+        # 30 bytes: above the global (4) and whole-context "*" (8) caps but below
+        # the (data_import, csv) cap (64), so it must be accepted.
+        uploaded_file = self._upload("data.csv", b"name\n" + b"a\n" * 12, "text/csv")
+        result = validate_uploaded_file(
+            uploaded_file, ("csv",), DATA_IMPORT_UPLOAD_CONTEXT
+        )
+        self.assertEqual(result.extension, "csv")
+        self.assertEqual(uploaded_file.tell(), 0)
+
+    @override_settings(STRICT_FORM_MEDIA_UPLOAD_TYPES=["image/png"])
+    def test_operator_form_media_allowlist_narrows_extensions(self):
+        """Operator-configured MIME allowlist filters form media extensions."""
+        uploaded_file = self._upload("data.csv", b"name\nAlice\n", "text/csv")
+
+        with self.assertRaisesRegex(
+            UploadValidationError, "Unsupported file extension"
+        ):
+            validate_uploaded_file(
+                uploaded_file,
+                FORM_MEDIA_ALLOWED_EXTENSIONS,
+                FORM_MEDIA_UPLOAD_CONTEXT,
+            )
+
+    @override_settings(STRICT_FORM_MEDIA_UPLOAD_TYPES=["image/png"])
+    def test_operator_form_media_allowlist_permits_listed_type(self):
+        """Operator-configured MIME allowlist permits its listed types."""
+        uploaded_file = self._upload("image.png", self._image_bytes("PNG"), "image/png")
+
+        result = validate_uploaded_file(
+            uploaded_file,
+            FORM_MEDIA_ALLOWED_EXTENSIONS,
+            FORM_MEDIA_UPLOAD_CONTEXT,
+        )
+        self.assertEqual(result.extension, "png")
+
+    @override_settings(
+        STRICT_UPLOAD_MAX_BYTES={
+            "*": 1 * 1024 * 1024,
+            "form_media": {"mp4": LARGE_TEST_CAP, "csv": LARGE_TEST_CAP},
+            "data_import": {"csv": LARGE_TEST_CAP},
+        },
+    )
+    def test_large_mp4_accepted_and_read_is_bounded(self):
+        """A large MP4 passes form_media validation reading only its header."""
+        uploaded = _CountingUpload(
+            "video.mp4", VALID_MP4_FTYP, "video/mp4", size=LARGE_TEST_CAP
+        )
+        result = validate_uploaded_file(
+            uploaded, FORM_MEDIA_ALLOWED_EXTENSIONS, FORM_MEDIA_UPLOAD_CONTEXT
+        )
+        self.assertEqual(result.extension, "mp4")
+        # Only the ftyp box is read, never the (claimed) large body.
+        self.assertLessEqual(uploaded.bytes_read, 1024)
+        self.assertEqual(uploaded.tell(), 0)
+
+    @override_settings(
+        STRICT_UPLOAD_MAX_BYTES={
+            "*": 1 * 1024 * 1024,
+            "form_media": {"mp4": LARGE_TEST_CAP, "csv": LARGE_TEST_CAP},
+            "data_import": {"csv": LARGE_TEST_CAP},
+        },
+    )
+    def test_large_csv_accepted_under_form_media_and_data_import(self):
+        """A CSV well above the 1 MB default is accepted where the cap allows."""
+        # ~2 MB CSV, larger than both the default cap and the head sample.
+        data = b"name\n" + (b"value\n" * 350_000)
+        self.assertGreater(len(data), 2 * 1024 * 1024)
+        for context in (FORM_MEDIA_UPLOAD_CONTEXT, DATA_IMPORT_UPLOAD_CONTEXT):
+            with self.subTest(context=context):
+                uploaded = self._upload("data.csv", data, "text/csv")
+                result = validate_uploaded_file(uploaded, ("csv",), context)
+                self.assertEqual(result.extension, "csv")
+                self.assertEqual(uploaded.tell(), 0)
+
+    @override_settings(
+        STRICT_UPLOAD_MAX_BYTES={
+            "*": 1 * 1024 * 1024,
+            "form_media": {"mp4": LARGE_TEST_CAP, "csv": LARGE_TEST_CAP},
+        },
+    )
+    def test_large_cap_does_not_leak_to_full_read_formats(self):
+        """Only mp4/csv get the large cap; png/xml/geojson stay at 1 MB."""
+        oversized = b"\x00" * (1 * 1024 * 1024 + 16)
+        cases = [
+            ("map.png", b"\x89PNG\r\n\x1a\n" + oversized, "image/png"),
+            ("form.xml", b"<data/>" + oversized, "application/xml"),
+            ("area.geojson", b'{"type":"Point"}' + oversized, "application/geo+json"),
+        ]
+        for name, data, content_type in cases:
+            with self.subTest(name=name):
+                uploaded = self._upload(name, data, content_type)
+                with self.assertRaisesRegex(
+                    UploadValidationError, "maximum upload size"
+                ):
+                    validate_uploaded_file(
+                        uploaded,
+                        FORM_MEDIA_ALLOWED_EXTENSIONS,
+                        FORM_MEDIA_UPLOAD_CONTEXT,
+                    )
+
+    def test_csv_streaming_scans_whole_file_for_invalid_utf8(self):
+        """Invalid UTF-8 past the first chunk is caught, not just the head."""
+        # Valid first chunk, invalid UTF-8 continuation byte in a later chunk.
+        data = b"name\n" + (b"value\n" * 20_000) + b"\xff\xfe\n"
+        self.assertGreater(len(data), 64 * 1024)
+        uploaded = self._upload("data.csv", data, "text/csv")
+        with self.assertRaisesRegex(UploadValidationError, "UTF-8"):
+            validate_uploaded_file(uploaded, ("csv",), DATA_IMPORT_UPLOAD_CONTEXT)
+
+    def test_csv_streaming_scans_whole_file_for_nul_bytes(self):
+        """A NUL byte past the first chunk is caught by the streaming scan."""
+        data = b"name\n" + (b"value\n" * 20_000) + b"bad\x00row\n"
+        self.assertGreater(len(data), 64 * 1024)
+        uploaded = self._upload("data.csv", data, "text/csv")
+        with self.assertRaisesRegex(UploadValidationError, "NUL bytes"):
+            validate_uploaded_file(uploaded, ("csv",), DATA_IMPORT_UPLOAD_CONTEXT)
+
+
+def _pdf_bytes(body=b"PDF body bytes\n", include_eof=True):
+    payload = b"%PDF-1.4\n" + body
+    if include_eof:
+        payload += b"%%EOF\n"
+    return payload
+
+
+def _ooxml_bytes(parts):
+    stream = io.BytesIO()
+    with zipfile.ZipFile(stream, "w") as archive:
+        for name, body in parts:
+            archive.writestr(name, body)
+    return stream.getvalue()
+
+
+def _odf_bytes(mimetype, extra_parts=()):
+    stream = io.BytesIO()
+    with zipfile.ZipFile(stream, "w") as archive:
+        archive.writestr("mimetype", mimetype)
+        for name, body in extra_parts:
+            archive.writestr(name, body)
+    return stream.getvalue()
+
+
+class SupportingDocUploadValidationTestCase(SimpleTestCase):
+    """Strict validation for supporting-doc uploads."""
+
+    def _upload(self, name, data, content_type):
+        return SimpleUploadedFile(name, data, content_type=content_type)
+
+    def test_pdf_header_and_eof_required(self):
+        """A PDF body without %%EOF is rejected."""
+        uploaded_file = self._upload(
+            "report.pdf", _pdf_bytes(include_eof=False), "application/pdf"
+        )
+
+        with self.assertRaisesRegex(UploadValidationError, "PDF EOF"):
+            validate_uploaded_file(
+                uploaded_file,
+                SUPPORTING_DOC_ALLOWED_EXTENSIONS,
+                SUPPORTING_DOC_UPLOAD_CONTEXT,
+            )
+
+    def test_pdf_with_javascript_action_rejected(self):
+        """A PDF containing a /JavaScript action is rejected."""
+        uploaded_file = self._upload(
+            "report.pdf",
+            _pdf_bytes(body=b"1 0 obj <</S /JavaScript /JS (alert(1))>> endobj\n"),
+            "application/pdf",
+        )
+
+        with self.assertRaisesRegex(UploadValidationError, "JavaScript"):
+            validate_uploaded_file(
+                uploaded_file,
+                SUPPORTING_DOC_ALLOWED_EXTENSIONS,
+                SUPPORTING_DOC_UPLOAD_CONTEXT,
+            )
+
+    def test_docx_structure_validated(self):
+        """A .docx archive lacking word/document.xml is rejected."""
+        data = _ooxml_bytes([("[Content_Types].xml", b"<types/>")])
+        uploaded_file = self._upload(
+            "report.docx",
+            data,
+            "application/vnd.openxmlformats-officedocument."
+            "wordprocessingml.document",
+        )
+
+        with self.assertRaisesRegex(UploadValidationError, "DOCX required entries"):
+            validate_uploaded_file(
+                uploaded_file,
+                SUPPORTING_DOC_ALLOWED_EXTENSIONS,
+                SUPPORTING_DOC_UPLOAD_CONTEXT,
+            )
+
+    def test_pptx_structure_validated(self):
+        """A .pptx archive lacking ppt/presentation.xml is rejected."""
+        data = _ooxml_bytes([("[Content_Types].xml", b"<types/>")])
+        uploaded_file = self._upload(
+            "deck.pptx",
+            data,
+            "application/vnd.openxmlformats-officedocument."
+            "presentationml.presentation",
+        )
+
+        with self.assertRaisesRegex(UploadValidationError, "PPTX required entries"):
+            validate_uploaded_file(
+                uploaded_file,
+                SUPPORTING_DOC_ALLOWED_EXTENSIONS,
+                SUPPORTING_DOC_UPLOAD_CONTEXT,
+            )
+
+    def test_odt_mimetype_member_required(self):
+        """ODT archives without a matching 'mimetype' entry are rejected."""
+        data = _odf_bytes("application/vnd.oasis.opendocument.spreadsheet")
+        uploaded_file = self._upload(
+            "report.odt", data, "application/vnd.oasis.opendocument.text"
+        )
+
+        with self.assertRaisesRegex(UploadValidationError, "'mimetype' entry"):
+            validate_uploaded_file(
+                uploaded_file,
+                SUPPORTING_DOC_ALLOWED_EXTENSIONS,
+                SUPPORTING_DOC_UPLOAD_CONTEXT,
+            )
+
+    def test_geojson_type_required(self):
+        """GeoJSON without a recognised 'type' field is rejected."""
+        uploaded_file = self._upload(
+            "shapes.geojson",
+            b'{"properties": {}}',
+            "application/geo+json",
+        )
+
+        with self.assertRaisesRegex(UploadValidationError, "valid 'type'"):
+            validate_uploaded_file(
+                uploaded_file,
+                SUPPORTING_DOC_ALLOWED_EXTENSIONS,
+                SUPPORTING_DOC_UPLOAD_CONTEXT,
+            )
+
+    def test_pdf_accepted(self):
+        """A minimal valid PDF passes."""
+        uploaded_file = self._upload("report.pdf", _pdf_bytes(), "application/pdf")
+
+        result = validate_uploaded_file(
+            uploaded_file,
+            SUPPORTING_DOC_ALLOWED_EXTENSIONS,
+            SUPPORTING_DOC_UPLOAD_CONTEXT,
+        )
+        self.assertEqual(result.extension, "pdf")
+        self.assertNotEqual(result.storage_basename, "report.pdf")
+
+    def test_odt_accepted(self):
+        """A minimal valid ODT passes."""
+        data = _odf_bytes("application/vnd.oasis.opendocument.text")
+        uploaded_file = self._upload(
+            "report.odt", data, "application/vnd.oasis.opendocument.text"
+        )
+
+        result = validate_uploaded_file(
+            uploaded_file,
+            SUPPORTING_DOC_ALLOWED_EXTENSIONS,
+            SUPPORTING_DOC_UPLOAD_CONTEXT,
+        )
+        self.assertEqual(result.extension, "odt")
+
+    @override_settings(
+        STRICT_SUPPORTING_DOC_UPLOAD_TYPES=["application/pdf"],
+    )
+    def test_supporting_doc_operator_allowlist_narrows_extensions(self):
+        """Narrowing the supporting-doc allowlist disables other extensions."""
+        data = _odf_bytes("application/vnd.oasis.opendocument.text")
+        uploaded_file = self._upload(
+            "report.odt", data, "application/vnd.oasis.opendocument.text"
+        )
+
+        with self.assertRaisesRegex(
+            UploadValidationError, "Unsupported file extension"
+        ):
+            validate_uploaded_file(
+                uploaded_file,
+                SUPPORTING_DOC_ALLOWED_EXTENSIONS,
+                SUPPORTING_DOC_UPLOAD_CONTEXT,
+            )

--- a/onadata/libs/utils/content_disposition.py
+++ b/onadata/libs/utils/content_disposition.py
@@ -1,0 +1,201 @@
+# -*- coding: utf-8 -*-
+"""
+RFC 6266 ``Content-Disposition`` header parsing.
+
+A small, dependency-free port of the subset of ``pyrfc6266`` used by this
+codebase to extract a filename from a ``Content-Disposition`` response header
+(see :func:`onadata.apps.main.forms.get_filename`). ``pyrfc6266`` is avoided
+because it pins ``pyparsing~=3.0.7``, which conflicts with ``httplib2``'s
+``pyparsing>=3.1`` requirement.
+
+Only the standard library is used. Behaviour (filename precedence, RFC 5987
+extended-value decoding, RFC 2231 continuations, and separator stripping) is
+kept identical to ``pyrfc6266.parse_filename``.
+"""
+
+import re
+from urllib.parse import unquote
+
+# RFC 7230 ``token`` characters (matches the set used by ``pyrfc6266``). ``-`` is
+# placed last so it is treated as a literal rather than a range delimiter inside
+# the character class.
+_TOKEN_RE = re.compile(r"[!#$%&'*+.0-9A-Za-z^_`|~-]+")
+
+# ISO-8859-1 code points that are control characters and therefore invalid in a
+# decoded extended value. ``urllib.parse.unquote`` will happily produce these,
+# so they are rejected explicitly (as ``pyrfc6266`` does).
+_INVALID_ISO8859_1_CHARACTERS = set(
+    bytes(list(range(0, 32)) + list(range(127, 160))).decode("iso-8859-1")
+)
+
+_SUPPORTED_EXT_CHARSETS = ("utf-8", "iso-8859-1")
+
+
+class ContentDispositionError(ValueError):
+    """Raised when a ``Content-Disposition`` header cannot be parsed."""
+
+
+def secure_filename(filename: str) -> str:
+    """Replace path separators so the filename cannot traverse directories.
+
+    Args:
+        filename: A potentially unsafe filename.
+
+    Returns:
+        The filename with ``\\`` and ``/`` replaced by ``_``.
+    """
+    return filename.replace("\\", "_").replace("/", "_")
+
+
+def _scan_params(header: str) -> "list[tuple[str, str, bool]]":
+    """Tokenise a ``Content-Disposition`` header into its parameters.
+
+    Args:
+        header: The raw header value.
+
+    Returns:
+        A list of ``(name, value, is_quoted)`` tuples in header order, where
+        ``name`` is lower-cased and ``is_quoted`` indicates the value came from
+        a quoted-string rather than a bare token.
+
+    Raises:
+        ContentDispositionError: If the header does not begin with a
+            disposition-type token or a parameter is malformed.
+    """
+    index, length = 0, len(header)
+
+    def skip_whitespace() -> None:
+        nonlocal index
+        while index < length and header[index] in " \t":
+            index += 1
+
+    skip_whitespace()
+    match = _TOKEN_RE.match(header, index)
+    if not match:
+        raise ContentDispositionError("missing disposition-type")
+    index = match.end()
+
+    params: "list[tuple[str, str, bool]]" = []
+    while True:
+        skip_whitespace()
+        if index >= length:
+            break
+        if header[index] != ";":
+            raise ContentDispositionError(f"expected ';' at position {index}")
+        index += 1
+        skip_whitespace()
+        if index >= length:
+            break
+
+        match = _TOKEN_RE.match(header, index)
+        if not match:
+            raise ContentDispositionError(f"invalid parameter name at {index}")
+        name = match.group(0).lower()
+        index = match.end()
+
+        skip_whitespace()
+        if index >= length or header[index] != "=":
+            raise ContentDispositionError("expected '=' after parameter name")
+        index += 1
+        skip_whitespace()
+
+        if index < length and header[index] == '"':
+            index += 1
+            buffer: "list[str]" = []
+            while index < length:
+                char = header[index]
+                if char == "\\" and index + 1 < length:
+                    buffer.append(header[index + 1])
+                    index += 2
+                    continue
+                if char == '"':
+                    index += 1
+                    break
+                buffer.append(char)
+                index += 1
+            params.append((name, "".join(buffer), True))
+        else:
+            match = _TOKEN_RE.match(header, index)
+            if not match:
+                raise ContentDispositionError("invalid parameter value")
+            params.append((name, match.group(0), False))
+            index = match.end()
+
+    return params
+
+
+def _decode_ext_value(raw: str) -> str:
+    """Decode an RFC 5987 extended value (``charset'lang'percent-encoded``).
+
+    Args:
+        raw: The raw parameter value.
+
+    Returns:
+        The decoded string.
+
+    Raises:
+        ContentDispositionError: If the value is malformed, uses an unsupported
+            charset, or decodes to invalid bytes.
+    """
+    parts = raw.split("'", 2)
+    if len(parts) != 3:
+        raise ContentDispositionError("malformed extended value")
+    charset = (parts[0] or "utf-8").lower()
+    if charset not in _SUPPORTED_EXT_CHARSETS:
+        raise ContentDispositionError(f"unsupported charset: {charset}")
+    try:
+        value = unquote(parts[2], encoding=charset, errors="strict")
+    except UnicodeDecodeError as error:
+        raise ContentDispositionError("invalid encoding in extended value") from error
+    if charset == "iso-8859-1" and (set(value) & _INVALID_ISO8859_1_CHARACTERS):
+        raise ContentDispositionError("invalid encoding in extended value")
+    return value
+
+
+def parse_filename(header: str) -> "str | None":
+    """Return a safe filename from a ``Content-Disposition`` header.
+
+    Mirrors ``pyrfc6266.parse_filename``: the RFC 6266 ``filename*`` (extended)
+    form takes precedence over plain ``filename``, RFC 2231 continuations
+    (``filename*0``/``filename*1`` …) are concatenated, and the result is passed
+    through :func:`secure_filename`.
+
+    Args:
+        header: The raw ``Content-Disposition`` header value.
+
+    Returns:
+        The decoded filename, or ``None`` if the header carries no filename.
+
+    Raises:
+        ContentDispositionError: If the header cannot be parsed or a parameter
+            is malformed.
+    """
+    decoded: "dict[str, str]" = {}
+    for name, raw, is_quoted in _scan_params(header):
+        if name in decoded:
+            raise ContentDispositionError(f"duplicate parameter: {name}")
+        # A parameter whose name ends with ``*`` carries an extended value,
+        # unless it was given as a quoted-string (which is never extended).
+        if name.endswith("*") and not is_quoted:
+            decoded[name] = _decode_ext_value(raw)
+        else:
+            decoded[name] = raw
+
+    def combine(start: str) -> str:
+        filename = decoded[start]
+        for idx in range(1, 99999):
+            for key in (f"filename*{idx}*", f"filename*{idx}"):
+                if key in decoded:
+                    filename += decoded[key]
+                    break
+            else:
+                break
+        return filename
+
+    for key in ("filename*", "filename", "filename*0*", "filename*0"):
+        if decoded.get(key):
+            filename = combine(key) if key.startswith("filename*0") else decoded[key]
+            if filename:
+                return secure_filename(filename)
+
+    return None

--- a/onadata/libs/utils/content_disposition.py
+++ b/onadata/libs/utils/content_disposition.py
@@ -47,6 +47,27 @@ def secure_filename(filename: str) -> str:
     return filename.replace("\\", "_").replace("/", "_")
 
 
+def _read_quoted_value(header: str, index: int, length: int) -> "tuple[str, int]":
+    """Read a quoted-string value starting just after the opening quote.
+
+    Returns the unescaped value and the index just past the closing quote (or
+    the end of the header if it is unterminated).
+    """
+    buffer: "list[str]" = []
+    while index < length:
+        char = header[index]
+        if char == "\\" and index + 1 < length:
+            buffer.append(header[index + 1])
+            index += 2
+            continue
+        if char == '"':
+            index += 1
+            break
+        buffer.append(char)
+        index += 1
+    return "".join(buffer), index
+
+
 def _scan_params(header: str) -> "list[tuple[str, str, bool]]":
     """Tokenise a ``Content-Disposition`` header into its parameters.
 
@@ -101,19 +122,8 @@ def _scan_params(header: str) -> "list[tuple[str, str, bool]]":
 
         if index < length and header[index] == '"':
             index += 1
-            buffer: "list[str]" = []
-            while index < length:
-                char = header[index]
-                if char == "\\" and index + 1 < length:
-                    buffer.append(header[index + 1])
-                    index += 2
-                    continue
-                if char == '"':
-                    index += 1
-                    break
-                buffer.append(char)
-                index += 1
-            params.append((name, "".join(buffer), True))
+            value, index = _read_quoted_value(header, index, length)
+            params.append((name, value, True))
         else:
             match = _TOKEN_RE.match(header, index)
             if not match:

--- a/onadata/libs/utils/image_tools.py
+++ b/onadata/libs/utils/image_tools.py
@@ -43,15 +43,18 @@ def generate_media_download_url(obj, expiration: int = 3600):
     # spaces or non-ASCII characters.
     content_disposition = f'attachment; filename="{filename}"'
     download_url = get_storages_media_download_url(
-        file_path, content_disposition, expires_in=expiration
+        file_path, content_disposition, obj.mimetype, expires_in=expiration
     )
     if download_url is not None:
-        return HttpResponseRedirect(download_url)
+        response = HttpResponseRedirect(download_url)
+        response["X-Content-Type-Options"] = "nosniff"
+        return response
 
     # pylint: disable=consider-using-with
     file_obj = open(settings.MEDIA_ROOT + file_path, "rb")
     response = HttpResponse(FileWrapper(file_obj), content_type=obj.mimetype)
     response["Content-Disposition"] = content_disposition
+    response["X-Content-Type-Options"] = "nosniff"
 
     return response
 

--- a/onadata/libs/utils/logger_tools.py
+++ b/onadata/libs/utils/logger_tools.py
@@ -780,9 +780,9 @@ def safe_instance_op(
         error = _create_duplicate_response(request)
     except PermissionDenied as e:
         error = OpenRosaResponseForbidden(e)
-    except UnreadablePostError as e:
+    except UnreadablePostError:
         error = OpenRosaResponseBadRequest(
-            _("Unable to read submitted file: %(error)s") % {"error": e}
+            _("Unable to read submitted file, please try re-submitting.")
         )
     except InstanceMultipleNodeError as e:
         error = OpenRosaResponseBadRequest(e)

--- a/onadata/libs/utils/logger_tools.py
+++ b/onadata/libs/utils/logger_tools.py
@@ -781,7 +781,9 @@ def safe_instance_op(
     except PermissionDenied as e:
         error = OpenRosaResponseForbidden(e)
     except UnreadablePostError as e:
-        error = OpenRosaResponseBadRequest(_(f"Unable to read submitted file: {e}"))
+        error = OpenRosaResponseBadRequest(
+            _("Unable to read submitted file: %(error)s") % {"error": e}
+        )
     except InstanceMultipleNodeError as e:
         error = OpenRosaResponseBadRequest(e)
     except DjangoUnicodeDecodeError:
@@ -904,7 +906,10 @@ def generate_media_url_with_sas(
     Generate Azure storage URL.
     """
     # pylint: disable=import-outside-toplevel
-    from azure.storage.blob import AccountSasPermissions, generate_blob_sas
+    from azure.storage.blob import (  # noqa: PLC0415
+        AccountSasPermissions,
+        generate_blob_sas,
+    )
 
     account_name = getattr(settings, "AZURE_ACCOUNT_NAME", "")
     container_name = getattr(settings, "AZURE_CONTAINER", "")
@@ -1013,7 +1018,9 @@ def response_with_mimetype_and_name(
                 file_path, content_disposition, mimetype, expires_in
             )
             if download_url is not None:
-                return HttpResponseRedirect(download_url)
+                response = HttpResponseRedirect(download_url)
+                response["X-Content-Type-Options"] = "nosniff"
+                return response
 
             try:
                 default_storage = storages["default"]
@@ -1037,6 +1044,7 @@ def response_with_mimetype_and_name(
     else:
         response = HttpResponse(content_type=mimetype)
     response["Content-Disposition"] = content_disposition
+    response["X-Content-Type-Options"] = "nosniff"
     return response
 
 

--- a/onadata/libs/utils/upload_validation.py
+++ b/onadata/libs/utils/upload_validation.py
@@ -364,10 +364,25 @@ def _validate_csv_stream(uploaded_file, max_bytes):
     """
     decoder = codecs.getincrementaldecoder("utf-8-sig")()
     head = io.StringIO()
-    head_len = 0
-    total_bytes = 0
-    decoded_any = False
+    state = {"head_len": 0, "decoded_any": False}
 
+    def accumulate(text):
+        if not text:
+            return
+        state["decoded_any"] = True
+        if state["head_len"] < CSV_HEAD_SAMPLE_CHARS:
+            head.write(text[: CSV_HEAD_SAMPLE_CHARS - state["head_len"]])
+            state["head_len"] += len(text)
+
+    def decode(chunk, final=False):
+        try:
+            return decoder.decode(chunk, final)
+        except UnicodeDecodeError as error:
+            raise UploadValidationError(
+                _("CSV files must be UTF-8 encoded.")
+            ) from error
+
+    total_bytes = 0
     _seek_zero(uploaded_file)
     try:
         while True:
@@ -387,35 +402,15 @@ def _validate_csv_stream(uploaded_file, max_bytes):
                     % {"max_bytes": max_bytes}
                 )
 
-            try:
-                text = decoder.decode(chunk)
-            except UnicodeDecodeError as error:
-                raise UploadValidationError(
-                    _("CSV files must be UTF-8 encoded.")
-                ) from error
+            accumulate(decode(chunk))
 
-            if text:
-                decoded_any = True
-                if head_len < CSV_HEAD_SAMPLE_CHARS:
-                    head.write(text[: CSV_HEAD_SAMPLE_CHARS - head_len])
-                    head_len += len(text)
-
-        try:
-            tail = decoder.decode(b"", final=True)
-        except UnicodeDecodeError as error:
-            raise UploadValidationError(
-                _("CSV files must be UTF-8 encoded.")
-            ) from error
-        if tail:
-            decoded_any = True
-            if head_len < CSV_HEAD_SAMPLE_CHARS:
-                head.write(tail[: CSV_HEAD_SAMPLE_CHARS - head_len])
+        accumulate(decode(b"", final=True))
     finally:
         _seek_zero(uploaded_file)
 
     _assert_csv_has_rows(head.getvalue())
 
-    if not decoded_any:
+    if not state["decoded_any"]:
         raise UploadValidationError(_("CSV files must not be empty."))
 
 
@@ -487,7 +482,7 @@ def _validate_mp4(data):
 MP4_FTYP_READ_LIMIT = 4096
 
 
-def _validate_mp4_stream(uploaded_file, max_bytes):  # noqa: ARG001
+def _validate_mp4_stream(uploaded_file, max_bytes):  # pylint: disable=unused-argument
     """Validate an MP4 upload by reading only its leading ``ftyp`` box.
 
     Reads at most :data:`MP4_FTYP_READ_LIMIT` bytes regardless of file size; the
@@ -571,8 +566,6 @@ def _validate_ooxml(data, label, required_entries):
                     _("%(label)s required entries missing: %(missing)s.")
                     % {"label": label, "missing": ", ".join(sorted(missing))}
                 )
-    except UploadValidationError:
-        raise
     except (OSError, zipfile.BadZipFile) as error:
         raise UploadValidationError(
             _("%(label)s archive content could not be parsed.") % {"label": label}
@@ -605,8 +598,6 @@ def _validate_odf(extension, data):
                     % {"label": label}
                 )
             mimetype_bytes = archive.read("mimetype")
-    except UploadValidationError:
-        raise
     except (OSError, zipfile.BadZipFile) as error:
         raise UploadValidationError(
             _("%(label)s archive content could not be parsed.") % {"label": label}

--- a/onadata/libs/utils/upload_validation.py
+++ b/onadata/libs/utils/upload_validation.py
@@ -1,0 +1,779 @@
+# -*- coding: utf-8 -*-
+"""
+Strict upload validation helpers.
+"""
+
+import codecs
+import csv
+import io
+import json
+import os
+import re
+import uuid
+import zipfile
+from dataclasses import dataclass
+from pathlib import PurePath, PurePosixPath
+
+from django.conf import settings
+from django.utils.translation import gettext as _
+
+import openpyxl
+from defusedxml import ElementTree
+from PIL import Image, UnidentifiedImageError
+
+FORM_MEDIA_UPLOAD_CONTEXT = "form_media"
+XLSFORM_UPLOAD_CONTEXT = "xlsform"
+DATA_IMPORT_UPLOAD_CONTEXT = "data_import"
+SUPPORTING_DOC_UPLOAD_CONTEXT = "supporting_doc"
+
+FORM_MEDIA_ALLOWED_EXTENSIONS = (
+    "csv",
+    "geojson",
+    "jpeg",
+    "jpg",
+    "mp4",
+    "png",
+    "xml",
+)
+XLSFORM_ALLOWED_EXTENSIONS = ("csv", "json", "xls", "xlsx", "xml")
+SUPPORTING_DOC_ALLOWED_EXTENSIONS = (
+    "csv",
+    "docx",
+    "geojson",
+    "jpeg",
+    "jpg",
+    "json",
+    "ods",
+    "odp",
+    "odt",
+    "pdf",
+    "png",
+    "pptx",
+    "xlsx",
+)
+
+FORM_MEDIA_DEFAULT_CONTENT_TYPES = (
+    "image/jpeg",
+    "image/png",
+    "text/csv",
+    "text/xml",
+    "application/xml",
+    "application/geo+json",
+    "application/json",
+    "video/mp4",
+)
+
+SUPPORTING_DOC_DEFAULT_CONTENT_TYPES = (
+    "application/pdf",
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+    "application/vnd.oasis.opendocument.text",
+    "application/vnd.oasis.opendocument.spreadsheet",
+    "application/vnd.oasis.opendocument.presentation",
+    "application/geo+json",
+    "application/json",
+    "text/csv",
+    # Images remain permitted for supporting documents (diagrams, scans,
+    # screenshots) per existing product behaviour. SVG, DOC/PPT/XLS (OLE),
+    # ZIP and audio types from the legacy allowlist remain removed.
+    "image/jpeg",
+    "image/png",
+)
+
+ODF_MIMETYPE_BY_EXTENSION = {
+    "odt": "application/vnd.oasis.opendocument.text",
+    "ods": "application/vnd.oasis.opendocument.spreadsheet",
+    "odp": "application/vnd.oasis.opendocument.presentation",
+}
+
+OLE_COMPOUND_FILE_SIGNATURE = b"\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1"
+PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
+JPEG_SIGNATURE = b"\xff\xd8"
+ZIP_LOCAL_FILE_SIGNATURE = b"PK\x03\x04"
+
+MP4_COMPATIBLE_BRANDS = {
+    b"avc1",
+    b"dash",
+    b"isom",
+    b"iso2",
+    b"iso5",
+    b"iso6",
+    b"m4v ",
+    b"M4V ",
+    b"mp41",
+    b"mp42",
+}
+
+UNKNOWN_CONTENT_TYPES = frozenset({"", "application/octet-stream"})
+
+ALLOWED_UPLOAD_TYPES = {
+    "csv": ("text/csv",),
+    "docx": (
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    ),
+    "geojson": ("application/geo+json", "application/json"),
+    "json": ("application/json", "text/json"),
+    "jpeg": ("image/jpeg",),
+    "jpg": ("image/jpeg",),
+    "mp4": ("video/mp4",),
+    "odp": ("application/vnd.oasis.opendocument.presentation",),
+    "ods": ("application/vnd.oasis.opendocument.spreadsheet",),
+    "odt": ("application/vnd.oasis.opendocument.text",),
+    "pdf": ("application/pdf",),
+    "png": ("image/png",),
+    "pptx": (
+        "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+    ),
+    "xml": ("application/xml", "text/xml"),
+    "xls": ("application/vnd.ms-excel",),
+    "xlsx": ("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",),
+}
+
+
+class UploadValidationError(ValueError):
+    """Raised when an uploaded file violates strict upload policy."""
+
+
+@dataclass(frozen=True)
+class ValidatedUpload:
+    """Validated upload metadata."""
+
+    extension: str
+    content_type: str
+    original_name: str
+    storage_basename: str
+
+
+def normalize_content_type(content_type):
+    """Return a normalized MIME type without parameters."""
+    if not content_type:
+        return ""
+    return content_type.split(";")[0].strip().lower()
+
+
+def sanitized_original_filename(name):
+    """Return a display-safe basename from a submitted filename."""
+    name = str(name or "").replace("\\", "/")
+    basename = PurePosixPath(PurePath(name).name).name
+    basename = re.sub(r"[\x00-\x1f\x7f]", "", basename).strip()
+    return basename
+
+
+DANGEROUS_PENULTIMATE_EXTENSIONS = frozenset(
+    {
+        ".asp",
+        ".aspx",
+        ".bat",
+        ".cgi",
+        ".cmd",
+        ".com",
+        ".dll",
+        ".exe",
+        ".htm",
+        ".html",
+        ".jar",
+        ".js",
+        ".jse",
+        ".jsp",
+        ".msi",
+        ".phar",
+        ".php",
+        ".phtml",
+        ".pif",
+        ".pl",
+        ".ps1",
+        ".py",
+        ".rb",
+        ".scr",
+        ".sh",
+        ".svg",
+        ".vbe",
+        ".vbs",
+        ".ws",
+        ".wsf",
+        ".wsh",
+    }
+)
+
+
+def reject_double_extension(name):
+    """Reject filenames missing a suffix or with a dangerous penultimate suffix.
+
+    The double-extension attack pattern (``putty.exe.png``) is blocked by
+    rejecting any filename whose penultimate suffix is in
+    :data:`DANGEROUS_PENULTIMATE_EXTENSIONS` (script/executable types that
+    misconfigured servers may execute). Legitimate multi-dot filenames like
+    ``report.v2.pdf`` or ``transportation.bad_id.xlsx`` are accepted; only
+    the final suffix is used for extension/MIME matching downstream.
+    """
+    basename = sanitized_original_filename(name)
+    suffixes = PurePath(basename).suffixes
+
+    if not suffixes:
+        raise UploadValidationError(
+            _("Unsupported filename '%(basename)s'. A file extension is required.")
+            % {"basename": basename}
+        )
+
+    if len(suffixes) > 1 and suffixes[-2].lower() in DANGEROUS_PENULTIMATE_EXTENSIONS:
+        raise UploadValidationError(
+            _(
+                "Unsupported filename '%(basename)s'. "
+                "The '%(suffix)s' suffix is not allowed."
+            )
+            % {"basename": basename, "suffix": suffixes[-2]}
+        )
+
+    return basename
+
+
+DEFAULT_UPLOAD_MAX_BYTES = 1 * 1024 * 1024
+
+
+def get_upload_max_bytes(context=None, extension=None):
+    """Return the configured upload size limit for a context/extension.
+
+    ``STRICT_UPLOAD_MAX_BYTES`` is a nested map where ``"*"`` is the global
+    default cap and each context maps to ``{extension-or-"*": byte_cap}``.
+    Resolution is most specific first:
+
+    1. ``STRICT_UPLOAD_MAX_BYTES[context][extension]``
+    2. ``STRICT_UPLOAD_MAX_BYTES[context]["*"]`` (whole-context cap)
+    3. ``STRICT_UPLOAD_MAX_BYTES["*"]`` (global default)
+    """
+    config = getattr(settings, "STRICT_UPLOAD_MAX_BYTES", None)
+
+    # Tolerate a bare int (legacy/simple config): treat it as the global cap.
+    if isinstance(config, int):
+        return config
+    if not isinstance(config, dict):
+        return DEFAULT_UPLOAD_MAX_BYTES
+
+    context_caps = config.get(context)
+    if isinstance(context_caps, dict):
+        if extension is not None and extension in context_caps:
+            return context_caps[extension]
+        if "*" in context_caps:
+            return context_caps["*"]
+
+    return config.get("*", DEFAULT_UPLOAD_MAX_BYTES)
+
+
+def get_form_media_allowed_content_types():
+    """Return the operator-configurable form media MIME allowlist."""
+    configured = getattr(settings, "STRICT_FORM_MEDIA_UPLOAD_TYPES", None)
+    if configured is None:
+        return {normalize_content_type(ct) for ct in FORM_MEDIA_DEFAULT_CONTENT_TYPES}
+    return {normalize_content_type(ct) for ct in configured if ct}
+
+
+def get_supporting_doc_allowed_content_types():
+    """Return the operator-configurable supporting doc MIME allowlist."""
+    configured = getattr(settings, "STRICT_SUPPORTING_DOC_UPLOAD_TYPES", None)
+    if configured is None:
+        return {
+            normalize_content_type(ct) for ct in SUPPORTING_DOC_DEFAULT_CONTENT_TYPES
+        }
+    return {normalize_content_type(ct) for ct in configured if ct}
+
+
+OPERATOR_ALLOWLIST_BY_CONTEXT = {
+    FORM_MEDIA_UPLOAD_CONTEXT: get_form_media_allowed_content_types,
+    SUPPORTING_DOC_UPLOAD_CONTEXT: get_supporting_doc_allowed_content_types,
+}
+
+
+def _seek_zero(uploaded_file):
+    """Best-effort rewind of an upload to position 0."""
+    try:
+        uploaded_file.seek(0)
+    except (AttributeError, OSError):
+        pass
+
+
+def _enforce_size_limit(uploaded_file, max_bytes):
+    """Reject an upload whose reported size exceeds ``max_bytes``."""
+    size = getattr(uploaded_file, "size", None)
+    if size is not None and size > max_bytes:
+        raise UploadValidationError(
+            _("File exceeds the maximum upload size of %(max_bytes)d bytes.")
+            % {"max_bytes": max_bytes}
+        )
+
+
+def _read_upload_bytes(uploaded_file, context, extension=None):
+    max_bytes = get_upload_max_bytes(context, extension)
+    _enforce_size_limit(uploaded_file, max_bytes)
+
+    position = None
+    try:
+        position = uploaded_file.tell()
+    except (AttributeError, OSError):
+        pass
+
+    _seek_zero(uploaded_file)
+
+    data = uploaded_file.read(max_bytes + 1)
+    if len(data) > max_bytes:
+        raise UploadValidationError(
+            _("File exceeds the maximum upload size of %(max_bytes)d bytes.")
+            % {"max_bytes": max_bytes}
+        )
+
+    if isinstance(data, str):
+        data = data.encode("utf-8")
+
+    try:
+        uploaded_file.seek(0 if position is None else position)
+    except (AttributeError, OSError):
+        pass
+
+    return data
+
+
+UPLOAD_CHUNK_SIZE = 64 * 1024
+CSV_HEAD_SAMPLE_CHARS = 1 * 1024 * 1024
+CSV_STRUCTURE_SAMPLE_ROWS = 10
+
+
+def _assert_csv_has_rows(sample_text):
+    """Confirm a CSV head sample parses and holds at least one row."""
+    try:
+        reader = csv.reader(io.StringIO(sample_text))
+        row_count = 0
+        for index, _row in enumerate(reader):
+            row_count = index + 1
+            if index >= CSV_STRUCTURE_SAMPLE_ROWS:
+                break
+    except csv.Error as error:
+        raise UploadValidationError(
+            _("CSV file content could not be parsed.")
+        ) from error
+
+    if row_count == 0:
+        raise UploadValidationError(_("CSV files must contain at least one row."))
+
+
+def _validate_csv_stream(uploaded_file, max_bytes):
+    """Validate a CSV upload without holding the whole file in memory.
+
+    NUL bytes and UTF-8 validity are checked across every 64 KB chunk while
+    only a ~1 MB head sample is buffered for structural parsing. Cumulative
+    bytes are counted so the cap is enforced even when ``.size`` is unavailable.
+    """
+    decoder = codecs.getincrementaldecoder("utf-8-sig")()
+    head = io.StringIO()
+    head_len = 0
+    total_bytes = 0
+    decoded_any = False
+
+    _seek_zero(uploaded_file)
+    try:
+        while True:
+            chunk = uploaded_file.read(UPLOAD_CHUNK_SIZE)
+            if not chunk:
+                break
+            if isinstance(chunk, str):
+                chunk = chunk.encode("utf-8")
+
+            if b"\x00" in chunk:
+                raise UploadValidationError(_("CSV files must not contain NUL bytes."))
+
+            total_bytes += len(chunk)
+            if total_bytes > max_bytes:
+                raise UploadValidationError(
+                    _("File exceeds the maximum upload size of %(max_bytes)d bytes.")
+                    % {"max_bytes": max_bytes}
+                )
+
+            try:
+                text = decoder.decode(chunk)
+            except UnicodeDecodeError as error:
+                raise UploadValidationError(
+                    _("CSV files must be UTF-8 encoded.")
+                ) from error
+
+            if text:
+                decoded_any = True
+                if head_len < CSV_HEAD_SAMPLE_CHARS:
+                    head.write(text[: CSV_HEAD_SAMPLE_CHARS - head_len])
+                    head_len += len(text)
+
+        try:
+            tail = decoder.decode(b"", final=True)
+        except UnicodeDecodeError as error:
+            raise UploadValidationError(
+                _("CSV files must be UTF-8 encoded.")
+            ) from error
+        if tail:
+            decoded_any = True
+            if head_len < CSV_HEAD_SAMPLE_CHARS:
+                head.write(tail[: CSV_HEAD_SAMPLE_CHARS - head_len])
+    finally:
+        _seek_zero(uploaded_file)
+
+    _assert_csv_has_rows(head.getvalue())
+
+    if not decoded_any:
+        raise UploadValidationError(_("CSV files must not be empty."))
+
+
+def _validate_json(data):
+    try:
+        json.loads(data.decode("utf-8-sig"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise UploadValidationError(
+            _("JSON file content could not be parsed.")
+        ) from error
+
+
+def _validate_xml(data):
+    try:
+        ElementTree.fromstring(data)
+    except Exception as error:  # defusedxml can raise several XML errors.
+        raise UploadValidationError(
+            _("XML file content could not be parsed.")
+        ) from error
+
+
+def _validate_png(data):
+    if not data.startswith(PNG_SIGNATURE):
+        raise UploadValidationError(_("PNG signature mismatch."))
+    _validate_image(data, "PNG")
+
+
+def _validate_jpeg(data):
+    if not data.startswith(JPEG_SIGNATURE):
+        raise UploadValidationError(_("JPEG signature mismatch."))
+    _validate_image(data, "JPEG")
+
+
+def _validate_image(data, expected_format):
+    try:
+        image = Image.open(io.BytesIO(data))
+        image.verify()
+    except (UnidentifiedImageError, OSError) as error:
+        raise UploadValidationError(
+            _("Image file content could not be verified.")
+        ) from error
+
+    if image.format != expected_format:
+        raise UploadValidationError(
+            _("Expected %(expected_format)s image content.")
+            % {"expected_format": expected_format}
+        )
+
+
+def _validate_mp4(data):
+    if len(data) < 16 or data[4:8] != b"ftyp":
+        raise UploadValidationError(_("MP4 ftyp box not found."))
+
+    box_size = int.from_bytes(data[:4], "big")
+    if box_size < 16 or box_size > len(data):
+        raise UploadValidationError(_("Invalid MP4 ftyp box."))
+
+    major_brand = data[8:12]
+    compatible_brands = {data[index : index + 4] for index in range(16, box_size, 4)}
+
+    if major_brand not in MP4_COMPATIBLE_BRANDS and not (
+        compatible_brands & MP4_COMPATIBLE_BRANDS
+    ):
+        raise UploadValidationError(_("Unsupported MP4 brand."))
+
+
+# A legitimate ``ftyp`` box is tiny (size + type + brands); cap the read so a
+# bogus box-size claim cannot make us read more than a few KB of a large file.
+MP4_FTYP_READ_LIMIT = 4096
+
+
+def _validate_mp4_stream(uploaded_file, max_bytes):  # noqa: ARG001
+    """Validate an MP4 upload by reading only its leading ``ftyp`` box.
+
+    Reads at most :data:`MP4_FTYP_READ_LIMIT` bytes regardless of file size; the
+    overall size cap is enforced by the caller via ``.size``. Delegates the
+    structural checks to :func:`_validate_mp4`.
+    """
+    _seek_zero(uploaded_file)
+    try:
+        header = uploaded_file.read(8)
+        if isinstance(header, str):
+            header = header.encode("utf-8")
+        if len(header) < 8 or header[4:8] != b"ftyp":
+            raise UploadValidationError(_("MP4 ftyp box not found."))
+
+        box_size = int.from_bytes(header[:4], "big")
+        to_read = min(max(box_size, 16), MP4_FTYP_READ_LIMIT) - len(header)
+        rest = uploaded_file.read(to_read) if to_read > 0 else b""
+        if isinstance(rest, str):
+            rest = rest.encode("utf-8")
+        _validate_mp4(header + rest)
+    finally:
+        _seek_zero(uploaded_file)
+
+
+def _validate_xls(data):
+    if not data.startswith(OLE_COMPOUND_FILE_SIGNATURE):
+        raise UploadValidationError(_("XLS OLE compound file signature mismatch."))
+
+
+def _validate_xlsx(data):
+    if not data.startswith(ZIP_LOCAL_FILE_SIGNATURE):
+        raise UploadValidationError(_("XLSX ZIP signature mismatch."))
+
+    try:
+        with zipfile.ZipFile(io.BytesIO(data)) as xlsx:
+            names = set(xlsx.namelist())
+            if "[Content_Types].xml" not in names or "xl/workbook.xml" not in names:
+                raise UploadValidationError(_("XLSX workbook entries not found."))
+
+        workbook = openpyxl.load_workbook(
+            io.BytesIO(data), read_only=True, data_only=True
+        )
+        workbook.close()
+    except UploadValidationError:
+        raise
+    except (OSError, ValueError, zipfile.BadZipFile) as error:
+        raise UploadValidationError(
+            _("XLSX workbook content could not be parsed.")
+        ) from error
+
+
+PDF_HEADER_SIGNATURE = b"%PDF-"
+PDF_EOF_MARKER = b"%%EOF"
+PDF_JAVASCRIPT_MARKERS = (b"/JavaScript", b"/JS")
+
+
+def _validate_pdf(data):
+    if not data.startswith(PDF_HEADER_SIGNATURE):
+        raise UploadValidationError(_("PDF header signature mismatch."))
+    if PDF_EOF_MARKER not in data[-1024:]:
+        raise UploadValidationError(_("PDF EOF marker not found."))
+    for marker in PDF_JAVASCRIPT_MARKERS:
+        if marker in data:
+            raise UploadValidationError(
+                _("PDF contains JavaScript actions which are not allowed.")
+            )
+
+
+def _validate_ooxml(data, label, required_entries):
+    if not data.startswith(ZIP_LOCAL_FILE_SIGNATURE):
+        raise UploadValidationError(
+            _("%(label)s ZIP signature mismatch.") % {"label": label}
+        )
+
+    try:
+        with zipfile.ZipFile(io.BytesIO(data)) as archive:
+            names = set(archive.namelist())
+            missing = [entry for entry in required_entries if entry not in names]
+            if missing:
+                raise UploadValidationError(
+                    _("%(label)s required entries missing: %(missing)s.")
+                    % {"label": label, "missing": ", ".join(sorted(missing))}
+                )
+    except UploadValidationError:
+        raise
+    except (OSError, zipfile.BadZipFile) as error:
+        raise UploadValidationError(
+            _("%(label)s archive content could not be parsed.") % {"label": label}
+        ) from error
+
+
+def _validate_docx(data):
+    _validate_ooxml(data, "DOCX", ("[Content_Types].xml", "word/document.xml"))
+
+
+def _validate_pptx(data):
+    _validate_ooxml(data, "PPTX", ("[Content_Types].xml", "ppt/presentation.xml"))
+
+
+def _validate_odf(extension, data):
+    expected_mimetype = ODF_MIMETYPE_BY_EXTENSION[extension]
+    label = extension.upper()
+
+    if not data.startswith(ZIP_LOCAL_FILE_SIGNATURE):
+        raise UploadValidationError(
+            _("%(label)s ZIP signature mismatch.") % {"label": label}
+        )
+
+    try:
+        with zipfile.ZipFile(io.BytesIO(data)) as archive:
+            names = archive.namelist()
+            if "mimetype" not in names:
+                raise UploadValidationError(
+                    _("%(label)s archive missing required 'mimetype' entry.")
+                    % {"label": label}
+                )
+            mimetype_bytes = archive.read("mimetype")
+    except UploadValidationError:
+        raise
+    except (OSError, zipfile.BadZipFile) as error:
+        raise UploadValidationError(
+            _("%(label)s archive content could not be parsed.") % {"label": label}
+        ) from error
+
+    if mimetype_bytes.strip().decode("ascii", errors="replace") != expected_mimetype:
+        raise UploadValidationError(
+            _("%(label)s 'mimetype' entry does not match %(expected)s.")
+            % {"label": label, "expected": expected_mimetype}
+        )
+
+
+def _validate_odt(data):
+    _validate_odf("odt", data)
+
+
+def _validate_ods(data):
+    _validate_odf("ods", data)
+
+
+def _validate_odp(data):
+    _validate_odf("odp", data)
+
+
+GEOJSON_OBJECT_TYPES = {
+    "Feature",
+    "FeatureCollection",
+    "Point",
+    "MultiPoint",
+    "LineString",
+    "MultiLineString",
+    "Polygon",
+    "MultiPolygon",
+    "GeometryCollection",
+}
+
+
+def _validate_geojson(data):
+    try:
+        decoded = json.loads(data.decode("utf-8-sig"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise UploadValidationError(
+            _("GeoJSON file content could not be parsed.")
+        ) from error
+
+    if not isinstance(decoded, dict):
+        raise UploadValidationError(_("GeoJSON root must be an object."))
+
+    if decoded.get("type") not in GEOJSON_OBJECT_TYPES:
+        raise UploadValidationError(
+            _("GeoJSON object must declare a valid 'type' field.")
+        )
+
+
+# Buffered validators read the whole file into memory. Formats that can be
+# verified with a bounded read (csv, mp4) live in STREAMING_VALIDATORS instead
+# and are dispatched in preference to this map.
+CONTENT_VALIDATORS = {
+    "docx": _validate_docx,
+    "geojson": _validate_geojson,
+    "json": _validate_json,
+    "jpeg": _validate_jpeg,
+    "jpg": _validate_jpeg,
+    "odp": _validate_odp,
+    "ods": _validate_ods,
+    "odt": _validate_odt,
+    "pdf": _validate_pdf,
+    "png": _validate_png,
+    "pptx": _validate_pptx,
+    "xml": _validate_xml,
+    "xls": _validate_xls,
+    "xlsx": _validate_xlsx,
+}
+
+# Formats whose authenticity can be confirmed with a bounded read of a
+# file-like object, so they may safely carry a large per-context cap. The
+# overall size cap is enforced separately via ``.size`` before dispatch.
+STREAMING_VALIDATORS = {
+    "csv": _validate_csv_stream,
+    "mp4": _validate_mp4_stream,
+}
+
+
+def validate_uploaded_file(uploaded_file, allowed_extensions, context):
+    """
+    Validate filename, MIME type, size, and content for an uploaded file.
+
+    Returns a :class:`ValidatedUpload` and rewinds the file to position 0.
+    """
+    original_name = reject_double_extension(getattr(uploaded_file, "name", ""))
+    extension = os.path.splitext(original_name)[1].lower().strip(".")
+    allowed_extensions = {ext.lower().strip(".") for ext in allowed_extensions}
+
+    operator_allowed_content_types = None
+    operator_allowlist_loader = OPERATOR_ALLOWLIST_BY_CONTEXT.get(context)
+    if operator_allowlist_loader is not None:
+        operator_allowed_content_types = operator_allowlist_loader()
+        allowed_extensions = {
+            ext
+            for ext in allowed_extensions
+            if any(
+                mime in operator_allowed_content_types
+                for mime in ALLOWED_UPLOAD_TYPES.get(ext, ())
+            )
+        }
+
+    if extension not in allowed_extensions:
+        allowed = ", ".join(sorted(allowed_extensions))
+        raise UploadValidationError(
+            _(
+                "Unsupported file extension '.%(extension)s'. "
+                "Allowed extensions: %(allowed)s."
+            )
+            % {"extension": extension, "allowed": allowed}
+        )
+
+    content_type = normalize_content_type(getattr(uploaded_file, "content_type", ""))
+    valid_content_types = ALLOWED_UPLOAD_TYPES[extension]
+    if operator_allowed_content_types is not None:
+        valid_content_types = tuple(
+            ct for ct in valid_content_types if ct in operator_allowed_content_types
+        )
+
+    if not valid_content_types:
+        raise UploadValidationError(
+            _("No allowed content types configured for '.%(extension)s'.")
+            % {"extension": extension}
+        )
+
+    # Clients (Windows browsers, ODK Collect, curl without -H, mobile apps)
+    # routinely send "application/octet-stream" or omit the content type
+    # entirely. Treat those as "unknown" and rely on the magic-byte and
+    # structural validators below to verify the file. A *declared* MIME that
+    # disagrees with the extension is still rejected.
+    if content_type in UNKNOWN_CONTENT_TYPES:
+        content_type = valid_content_types[0]
+    elif content_type not in valid_content_types:
+        expected = ", ".join(valid_content_types)
+        raise UploadValidationError(
+            _(
+                "Unsupported content type '%(content_type)s' "
+                "for '.%(extension)s'. "
+                "Expected: %(expected)s."
+            )
+            % {
+                "content_type": content_type,
+                "extension": extension,
+                "expected": expected,
+            }
+        )
+
+    streaming_validator = STREAMING_VALIDATORS.get(extension)
+    if streaming_validator is not None:
+        # mp4 reads only its header, so the cap is enforced up front via .size;
+        # csv counts bytes as it streams to guard the cap when .size is absent.
+        max_bytes = get_upload_max_bytes(context, extension)
+        _enforce_size_limit(uploaded_file, max_bytes)
+        streaming_validator(uploaded_file, max_bytes)
+    else:
+        data = _read_upload_bytes(uploaded_file, context, extension)
+        CONTENT_VALIDATORS[extension](data)
+
+    _seek_zero(uploaded_file)
+
+    return ValidatedUpload(
+        extension=extension,
+        content_type=content_type,
+        original_name=original_name,
+        storage_basename=f"{uuid.uuid4().hex}.{extension}",
+    )

--- a/onadata/settings/common.py
+++ b/onadata/settings/common.py
@@ -597,6 +597,11 @@ DATA_UPLOAD_MAX_MEMORY_SIZE = 10 * 1024 * 1024
 FILE_UPLOAD_MAX_MEMORY_SIZE = int(2.5 * 1024 * 1024)
 SECURE_CONTENT_TYPE_NOSNIFF = True
 
+# Hosts allowed to bypass the XLSForm-by-URL SSRF guard (which otherwise blocks
+# URLs resolving to private/loopback/link-local/reserved addresses). Add trusted
+# internal form hosts here, e.g. ["forms.internal.example.com"].
+XLSFORM_URL_ALLOWED_HOSTS = []
+
 STRICT_FORM_MEDIA_UPLOAD_TYPES = [
     "image/jpeg",
     "image/png",

--- a/onadata/settings/common.py
+++ b/onadata/settings/common.py
@@ -178,6 +178,7 @@ DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
 
 MIDDLEWARE = (
     "corsheaders.middleware.CorsMiddleware",
+    "django.middleware.security.SecurityMiddleware",
     "onadata.libs.profiling.sql.SqlTimingMiddleware",
     "django.middleware.http.ConditionalGetMiddleware",
     "django.middleware.common.CommonMiddleware",
@@ -548,32 +549,63 @@ if isinstance(TEMPLATE_OVERRIDE_ROOT_DIR, str):
 # Set wsgi url scheme to HTTPS
 os.environ["wsgi.url_scheme"] = "https"
 
-SUPPORTED_MEDIA_UPLOAD_TYPES = [
-    "audio/mp3",
-    "audio/mpeg",
-    "audio/wav",
-    "audio/x-m4a",
-    "image/jpeg",
-    "image/png",
-    "image/svg+xml",
-    "text/csv",
-    "text/json",
-    "video/3gpp",
-    "video/mp4",
-    "application/json",
-    "application/geo+json",
+SUPPORTED_SUPPORTING_DOC_UPLOAD_TYPES = [
     "application/pdf",
-    "application/msword",
-    "application/vnd.ms-excel",
-    "application/vnd.ms-powerpoint",
     "application/vnd.oasis.opendocument.text",
     "application/vnd.oasis.opendocument.spreadsheet",
     "application/vnd.oasis.opendocument.presentation",
     "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-    "application/vnd.openxmlformats-officedocument.presentationml.\
-     presentation",
+    "application/vnd.openxmlformats-officedocument.presentationml.presentation",
     "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-    "application/zip",
+    "application/geo+json",
+    "application/json",
+    "text/csv",
+    "image/jpeg",
+    "image/png",
+]
+
+# Operator override for the supporting-doc MIME allowlist. Set to a list of
+# MIME types to narrow the policy below SUPPORTED_SUPPORTING_DOC_UPLOAD_TYPES.
+STRICT_SUPPORTING_DOC_UPLOAD_TYPES = None
+
+# Strict upload size policy (deny-by-default). A single nested map:
+#   "*"        -> the global default cap (bytes)
+#   <context>  -> {"<extension>" or "*": bytes}
+# Resolution is most specific first: [context][extension] -> [context]["*"]
+# -> ["*"]. "*" always means "the default at this level". Context keys are the
+# constants in onadata.libs.utils.upload_validation (FORM_MEDIA_UPLOAD_CONTEXT,
+# XLSFORM_UPLOAD_CONTEXT, DATA_IMPORT_UPLOAD_CONTEXT, SUPPORTING_DOC_UPLOAD_CONTEXT).
+#
+# Only formats validated with BOUNDED reads should carry a cap above the
+# default: mp4 (verified from its ftyp header) and csv (a chunked head sample)
+# cost no extra worker memory; every other format reads the whole file to
+# validate, so keep it small. Raise an entry (and the proxy/ingress body
+# limits) to the size a deployment needs.
+STRICT_UPLOAD_MAX_BYTES = {
+    "*": 1 * 1024 * 1024,
+    "form_media": {"mp4": 10 * 1024 * 1024, "csv": 10 * 1024 * 1024},
+    "data_import": {"csv": 10 * 1024 * 1024},
+}
+
+# Django parser knobs, independent of the per-file cap above:
+# - DATA_UPLOAD_MAX_MEMORY_SIZE gates the *non-file* request body; multipart
+#   file-upload fields are EXCLUDED from this check. The real request-body
+#   ceiling is the proxy (nginx client_max_body_size).
+# - FILE_UPLOAD_MAX_MEMORY_SIZE is only the spool-to-disk threshold; anything
+#   larger is streamed to a temporary file instead of buffered in worker RAM.
+DATA_UPLOAD_MAX_MEMORY_SIZE = 10 * 1024 * 1024
+FILE_UPLOAD_MAX_MEMORY_SIZE = int(2.5 * 1024 * 1024)
+SECURE_CONTENT_TYPE_NOSNIFF = True
+
+STRICT_FORM_MEDIA_UPLOAD_TYPES = [
+    "image/jpeg",
+    "image/png",
+    "text/csv",
+    "text/xml",
+    "application/xml",
+    "application/geo+json",
+    "application/json",
+    "video/mp4",
 ]
 
 CSV_ROW_IMPORT_ASYNC_THRESHOLD = 100

--- a/script/etc/nginx/sites-available/onadata
+++ b/script/etc/nginx/sites-available/onadata
@@ -9,7 +9,11 @@ server {
     access_log    /var/log/onadata/nginx-access.log;
     error_log     /var/log/onadata/nginx-error.log;
 
-    # entity size
+    # entity size — the request-body ceiling. This must be at least as large as
+    # the largest per-(context, extension) upload cap configured in Django
+    # (the STRICT_UPLOAD_MAX_BYTES policy map).
+    # A deployment that raises a per-extension cap must raise this (and any
+    # external ingress / load balancer / CDN body limit) to match.
     client_max_body_size 10m;
 
     # static files


### PR DESCRIPTION
### Changes / Features implemented

Deny-by-default upload validation across all entry points via a central `upload_validation` module: per-extension MIME allowlist + magic-byte/structural content checks, configurable size caps (`STRICT_UPLOAD_MAX_BYTES`), and UUID storage names so client-supplied filenames never reach disk. Covers XLSForm publishing, CSV/XLS imports, form media, and supporting docs. Adds an RFC 6266 `Content-Disposition` parser and sets `X-Content-Type-Options: nosniff` on file downloads.

### Steps taken to verify this change does what is intended

`flake8`, `isort`, `black` clean; unit tests for the validator and parser pass.

### Side effects of implementing this change

Stricter uploads: the legacy content-type-only allowlist (and audio/SVG/DOC-OLE/ZIP types) is removed. Operators raising a per-extension cap must also raise nginx `client_max_body_size`.


**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  - [ ] Updated documentation

Closes #