### PR TITLE
Disable API auth challenges for OIDC endpoints

### DIFF
--- a/onadata/apps/main/oidc_viewsets.py
+++ b/onadata/apps/main/oidc_viewsets.py
@@ -22,6 +22,8 @@ class OnaOpenIDConnectViewset(  # pylint: disable=too-few-public-methods
 ):
     """OpenID Connect viewset that refuses login for organization accounts."""
 
+    authentication_classes = []
+
     def generate_successful_response(self, request, user, *args, **kwargs):
         # Signature kept permissive (*args/**kwargs) to track the ona-oidc base
         # across versions; only ``user`` is needed for the organization check.

--- a/onadata/apps/main/tests/test_org_account_login.py
+++ b/onadata/apps/main/tests/test_org_account_login.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
 """Tests that organization accounts cannot establish a login session."""
 from unittest.mock import MagicMock, patch
+from urllib.parse import parse_qs, urlparse
 
 from django.contrib.auth import get_user_model
 from django.http import HttpRequest, HttpResponseRedirect
-from django.test import RequestFactory, TestCase
+from django.test import RequestFactory, TestCase, override_settings
 
 from rest_framework import status
 
@@ -21,6 +22,22 @@ User = get_user_model()
 # hardcoded passwords.
 TEST_CREDENTIAL = "login-value"
 BEARER_VALUE = "bearer-value"
+OIDC_AUTHORIZATION_ENDPOINT = "https://login.example.com/oauth2/v2.0/authorize"
+OIDC_AUTH_SERVERS = {
+    "microsoft": {
+        "AUTHORIZATION_ENDPOINT": OIDC_AUTHORIZATION_ENDPOINT,
+        "CLIENT_ID": "test-client-id",
+        "JWKS_ENDPOINT": "https://login.example.com/discovery/keys",
+        "SCOPE": "openid profile",
+        "TOKEN_ENDPOINT": "https://login.example.com/oauth2/v2.0/token",
+        "END_SESSION_ENDPOINT": "https://login.example.com/logout",
+        "REDIRECT_URI": "http://testserver/oidc/microsoft/callback",
+        "RESPONSE_TYPE": "id_token",
+        "RESPONSE_MODE": "form_post",
+        "USE_NONCES": False,
+        "LOGIN_QUERY_PARAM_ALLOWLIST": ["kc_idp_hint"],
+    }
+}
 
 
 class TestBlockOrgAccountLogin(TestCase):
@@ -82,6 +99,23 @@ class TestBlockOrgAccountLogin(TestCase):
         )
 
     # -- OIDC SSO path ------------------------------------------------------
+
+    @override_settings(OPENID_CONNECT_AUTH_SERVERS=OIDC_AUTH_SERVERS)
+    def test_oidc_login_ignores_digest_auth_challenge_headers(self):
+        response = self.client.get(
+            "/oidc/microsoft/login?kc_idp_hint=onadata",
+            HTTP_AUTHORIZATION='Digest username="stale", realm="api", nonce="bad"',
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_302_FOUND)
+        self.assertFalse(response.has_header("WWW-Authenticate"))
+
+        redirect = urlparse(response["Location"])
+        self.assertEqual(
+            f"{redirect.scheme}://{redirect.netloc}{redirect.path}",
+            OIDC_AUTHORIZATION_ENDPOINT,
+        )
+        self.assertEqual(parse_qs(redirect.query)["kc_idp_hint"], ["onadata"])
 
     @patch("oidc.viewsets.login")
     def test_oidc_rejects_org_user(self, mock_login):


### PR DESCRIPTION
### Changes / Features implemented

- Disable DRF authentication on the project-owned OIDC viewset so browser OIDC endpoints do not emit API `WWW-Authenticate` challenges.
- Add a regression test covering a stale Digest header on `/oidc/<auth_server>/login`, preserving allowlisted `kc_idp_hint` forwarding.

### Steps taken to verify this change does what is intended

- `docker compose exec -e DB_HOST=database api python manage.py test onadata.apps.main.tests.test_org_account_login --settings=onadata.settings.github_actions_test --noinput --verbosity=2`
- `docker compose exec api isort --profile black onadata/apps/main/oidc_viewsets.py onadata/apps/main/tests/test_org_account_login.py`
- `docker compose exec api black onadata/apps/main/oidc_viewsets.py onadata/apps/main/tests/test_org_account_login.py`
- `git diff --check`

### Side effects of implementing this change

- Digest/basic/token authentication remains unchanged for API endpoints.
- Only the OIDC login, callback, and logout browser redirect endpoints skip DRF authentication.


**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  - [ ] Updated documentation

Closes #

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/onaio/codesmith/onadata/pr/3094"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782509313&installation_id=135786473&pr_number=3094&repository=onaio%2Fonadata&return_to=https%3A%2F%2Fgithub.com%2Fonaio%2Fonadata%2Fpull%2F3094&signature=6990234d889b3b91501785203b400ae1efd1f00989b8daafa5535ad6f3a81102"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->