### PR TITLE
fix(oidc): clear stale auth cookies on login entry

### DIFF
--- a/onadata/apps/main/oidc_viewsets.py
+++ b/onadata/apps/main/oidc_viewsets.py
@@ -8,9 +8,11 @@ username claim coming from the IdP and calls ``django.contrib.auth.login``
 directly, bypassing ``onadata.apps.main.backends.ModelBackend``. Guarding only
 the backend is therefore not enough; the rejection must also happen here.
 """
+
+from django.conf import settings
 from django.utils.translation import gettext as _
 
-from oidc.viewsets import UserModelOpenIDConnectViewset
+from oidc.viewsets import SSO_COOKIE_NAME, UserModelOpenIDConnectViewset
 from rest_framework import status
 from rest_framework.response import Response
 
@@ -23,6 +25,30 @@ class OnaOpenIDConnectViewset(  # pylint: disable=too-few-public-methods
     """OpenID Connect viewset that refuses login for organization accounts."""
 
     authentication_classes = []
+
+    def login(self, request, **kwargs):
+        # Evict stale auth cookies a partly-logged-out browser may still
+        # be sending; without this, a 401 from the downstream callback
+        # carries a WWW-Authenticate challenge and pops the browser's
+        # native sign-in dialog mid-OIDC-flow. ``csrftoken`` is cleared
+        # by the base.
+        response = super().login(request, **kwargs)
+        current_host = request.get_host().split(":")[0]
+        response.delete_cookie(
+            "sessionid",
+            domain=getattr(settings, "SESSION_COOKIE_DOMAIN", None) or current_host,
+            path=getattr(settings, "SESSION_COOKIE_PATH", "/"),
+            samesite=getattr(settings, "SESSION_COOKIE_SAMESITE", "Lax"),
+        )
+        # Attrs must mirror the success path's set_cookie or the delete won't match.
+        response.delete_cookie(
+            SSO_COOKIE_NAME,
+            domain=self.cookie_domain,
+            path=self.cookie_path,
+            samesite=self.cookie_samesite,
+        )
+        response.delete_cookie("messages")
+        return response
 
     def generate_successful_response(self, request, user, *args, **kwargs):
         # Signature kept permissive (*args/**kwargs) to track the ona-oidc base

--- a/onadata/apps/main/oidc_viewsets.py
+++ b/onadata/apps/main/oidc_viewsets.py
@@ -22,6 +22,8 @@ class OnaOpenIDConnectViewset(  # pylint: disable=too-few-public-methods
 ):
     """OpenID Connect viewset that refuses login for organization accounts."""
 
+    authentication_classes = []
+
     def generate_successful_response(self, request, user, *args, **kwargs):
         # Signature kept permissive (*args/**kwargs) to track the ona-oidc base
         # across versions; only ``user`` is needed for the organization check.

--- a/onadata/apps/main/tests/test_org_account_login.py
+++ b/onadata/apps/main/tests/test_org_account_login.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
 """Tests that organization accounts cannot establish a login session."""
 from unittest.mock import MagicMock, patch
+from urllib.parse import parse_qs, urlparse
 
 from django.contrib.auth import get_user_model
 from django.http import HttpRequest, HttpResponseRedirect
-from django.test import RequestFactory, TestCase
+from django.test import RequestFactory, TestCase, override_settings
 
 from rest_framework import status
 
@@ -21,6 +22,22 @@ User = get_user_model()
 # hardcoded passwords.
 TEST_CREDENTIAL = "login-value"
 BEARER_VALUE = "bearer-value"
+OIDC_AUTHORIZATION_ENDPOINT = "https://login.example.com/oauth2/v2.0/authorize"
+OIDC_AUTH_SERVERS = {
+    "microsoft": {
+        "AUTHORIZATION_ENDPOINT": OIDC_AUTHORIZATION_ENDPOINT,
+        "CLIENT_ID": "test-client-id",
+        "JWKS_ENDPOINT": "https://login.example.com/discovery/keys",
+        "SCOPE": "openid profile",
+        "TOKEN_ENDPOINT": "https://login.example.com/oauth2/v2.0/token",
+        "END_SESSION_ENDPOINT": "https://login.example.com/logout",
+        "REDIRECT_URI": "http://testserver/oidc/microsoft/callback",
+        "RESPONSE_TYPE": "id_token",
+        "RESPONSE_MODE": "form_post",
+        "USE_NONCES": False,
+        "LOGIN_QUERY_PARAM_ALLOWLIST": ["kc_idp_hint"],
+    }
+}
 
 
 class TestBlockOrgAccountLogin(TestCase):
@@ -82,6 +99,23 @@ class TestBlockOrgAccountLogin(TestCase):
         )
 
     # -- OIDC SSO path ------------------------------------------------------
+
+    @override_settings(OPENID_CONNECT_AUTH_SERVERS=OIDC_AUTH_SERVERS)
+    def test_oidc_login_ignores_digest_auth_challenge_headers(self):
+        response = self.client.get(
+            "/oidc/microsoft/login?kc_idp_hint=onadata",
+            HTTP_AUTHORIZATION='Digest username="stale", realm="api", nonce="bad"',
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_302_FOUND)
+        self.assertFalse(response.has_header("WWW-Authenticate"))
+
+        redirect = urlparse(response["Location"])
+        self.assertEqual(
+            f"{redirect.scheme}://{redirect.netloc}{redirect.path}",
+            OIDC_AUTHORIZATION_ENDPOINT,
+        )
+        self.assertEqual(parse_qs(redirect.query)["kc_idp_hint"], ["onadata"])
 
     @patch("oidc.viewsets.login")
     def test_oidc_rejects_org_user(self, mock_login):

--- a/onadata/apps/main/tests/test_org_account_login.py
+++ b/onadata/apps/main/tests/test_org_account_login.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Tests that organization accounts cannot establish a login session."""
+
 from unittest.mock import MagicMock, patch
 from urllib.parse import parse_qs, urlparse
 
@@ -163,3 +164,36 @@ class TestBlockOrgAccountLogin(TestCase):
         if return_request:
             return request, result
         return result
+
+
+class TestOIDCLoginStaleCookieCleanup(TestCase):
+    """OIDC ``login`` must evict stale auth cookies on entry."""
+
+    @override_settings(OPENID_CONNECT_AUTH_SERVERS=OIDC_AUTH_SERVERS)
+    def test_login_redirect_carries_session_cookie_deletion(self):
+        response = self.client.get("/oidc/microsoft/login")
+        self.assertEqual(response.status_code, status.HTTP_302_FOUND)
+        cookie = response.cookies.get("sessionid")
+        self.assertIsNotNone(cookie)
+        self.assertEqual(cookie["max-age"], 0)
+
+    @override_settings(OPENID_CONNECT_AUTH_SERVERS=OIDC_AUTH_SERVERS)
+    def test_login_redirect_carries_sso_cookie_deletion(self):
+        response = self.client.get("/oidc/microsoft/login")
+        cookie = response.cookies.get("SSO")
+        self.assertIsNotNone(cookie)
+        self.assertEqual(cookie["max-age"], 0)
+
+    @override_settings(OPENID_CONNECT_AUTH_SERVERS=OIDC_AUTH_SERVERS)
+    def test_login_redirect_carries_messages_cookie_deletion(self):
+        response = self.client.get("/oidc/microsoft/login")
+        cookie = response.cookies.get("messages")
+        self.assertIsNotNone(cookie)
+        self.assertEqual(cookie["max-age"], 0)
+
+    @override_settings(OPENID_CONNECT_AUTH_SERVERS=OIDC_AUTH_SERVERS)
+    def test_login_still_deletes_csrftoken_from_base_viewset(self):
+        response = self.client.get("/oidc/microsoft/login")
+        cookie = response.cookies.get("csrftoken")
+        self.assertIsNotNone(cookie)
+        self.assertEqual(cookie["max-age"], 0)


### PR DESCRIPTION
### Changes / Features implemented

Stacks on top of #3094.

Override `OnaOpenIDConnectViewset.login` to evict the auth cookies a partly-logged-out browser may still be sending — `sessionid`, the `SSO` cookie this viewset issues itself on the success path, and the Django `messages` cookie — on entry to the OIDC flow. The ona-oidc base already clears `csrftoken`; this extends the same cleanup to the remaining cookies that can drag a stale identity into the callback.

#### Why

#3094 disables DRF's authentication challenge surface for the OIDC endpoints themselves, so a stale `Authorization: Digest ...` header on `/oidc/<server>/login` no longer triggers a native sign-in dialog. But the same dialog can still appear *after* the IdP round-trip if a stale `sessionid` or `SSO` cookie survives the redirect chain and lands on a downstream API endpoint that 401s — DRF will decorate that 401 with a `WWW-Authenticate` challenge from the first global authenticator (`DigestAuthentication`), and the browser pops the dialog mid-OIDC-flow.

Clearing the cookies on the way *out* (at `login` time) closes that second hole: any cookies that would still be sent after the round-trip are forced to be re-issued by the success path.

### Steps taken to verify this change does what is intended

- `docker compose exec -e DB_HOST=database api python manage.py test onadata.apps.main.tests.test_org_account_login.TestOIDCLoginStaleCookieCleanup --settings=onadata.settings.github_actions_test --noinput --verbosity=2`
- `docker compose exec api isort --profile black onadata/apps/main/oidc_viewsets.py onadata/apps/main/tests/test_org_account_login.py`
- `docker compose exec api black onadata/apps/main/oidc_viewsets.py onadata/apps/main/tests/test_org_account_login.py`

Four new tests in `TestOIDCLoginStaleCookieCleanup` verify deletion of `sessionid`, `SSO`, `messages`, plus a regression test for the base's existing `csrftoken` cleanup — all using the same Django-test-client + `override_settings(OPENID_CONNECT_AUTH_SERVERS=...)` pattern introduced in #3094.

### Side effects of implementing this change

- `OPENID_CONNECT_AUTH_SERVERS` deployments that rely on `sessionid` / `SSO` cookies surviving across a fresh OIDC login attempt would notice they're now cleared on every `/oidc/<server>/login` GET. That's the intended behavior — anyone visiting the login URL has signaled they want to start a fresh session.
- No change for API clients (curl, ODK Collect, etc.) — `delete_cookie` only affects clients that *had* those cookies set.

**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  - [ ] Updated documentation

Closes #

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/onaio/codesmith/onadata/pr/3096"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782550612&installation_id=135786473&pr_number=3096&repository=onaio%2Fonadata&return_to=https%3A%2F%2Fgithub.com%2Fonaio%2Fonadata%2Fpull%2F3096&signature=d0a5c3bc74acdc5ee11bfd776c70d1302de53d01c5e31fb9f14f45803888afea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->