### PR TITLE
feat(projects): add v2 project users endpoint

### DIFF
--- a/docs/projects.rst
+++ b/docs/projects.rst
@@ -282,6 +282,45 @@ Response
             "deleted_at":null
         }
 
+List users with access to a project (v2)
+----------------------------------------
+
+.. note::
+
+   In the version 2 API the project detail endpoint ``GET /api/v2/projects/{pk}``
+   no longer includes the ``users`` field. Use the dedicated endpoint below to
+   retrieve the users and organizations that have access to a project.
+
+.. raw:: html
+
+	<pre class="prettyprint">
+	<b>GET</b> /api/v2/projects/<code>{pk}</code>/users</pre>
+
+Only members of the project (users with a role on the project, e.g. ``owner``,
+``manager``, ``editor`` or ``readonly``) can access this endpoint. Requests from
+users who are not members of the project return ``HTTP 404 Not Found``.
+
+Example
+^^^^^^^^
+::
+
+       curl -X GET https://api.ona.io/api/v2/projects/1/users
+
+Response
+^^^^^^^^
+::
+
+        [
+            {
+                "is_org": false,
+                "metadata": {},
+                "first_name": "Ona",
+                "last_name": "",
+                "user": "ona",
+                "role": "owner"
+            }
+        ]
+
 Update Project Information
 ------------------------------
 .. raw:: html

--- a/onadata/apps/api/permissions.py
+++ b/onadata/apps/api/permissions.py
@@ -8,6 +8,7 @@ from django.contrib.auth import get_user_model
 from django.http import Http404
 from django.shortcuts import get_object_or_404
 
+from guardian.shortcuts import get_perms
 from rest_framework import exceptions
 from rest_framework.permissions import (
     BasePermission,
@@ -30,6 +31,7 @@ from onadata.libs.permissions import (
     ManagerRole,
     OwnerRole,
     ReadOnlyRoleNoDownload,
+    get_role,
 )
 
 SAFE_METHODS = ("GET", "HEAD", "OPTIONS")
@@ -291,6 +293,10 @@ class ProjectPermissions(DjangoObjectPermissions):
             or OwnerRole.user_has_role(request.user, obj)
         ):
             return False
+
+        if view.action == "users":
+            # Any member of the project may view the list of users
+            return get_role(get_perms(request.user, obj), obj) is not None
 
         return super().has_object_permission(request, view, obj)
 

--- a/onadata/apps/api/tests/viewsets/v2/test_project_viewset.py
+++ b/onadata/apps/api/tests/viewsets/v2/test_project_viewset.py
@@ -6,6 +6,7 @@ from django.test import override_settings
 from onadata.apps.api.tests.viewsets.test_abstract_viewset import TestAbstractViewSet
 from onadata.apps.api.viewsets.v2.project_viewset import ProjectViewSet
 from onadata.apps.logger.models import EntityList, Project
+from onadata.libs.models.share_project import ShareProject
 
 
 @override_settings(TIME_ZONE="UTC")
@@ -116,24 +117,6 @@ class RetrieveProjectTestCase(TestAbstractViewSet):
                 "category": "governance",
             },
             "starred": False,
-            "users": [
-                {
-                    "is_org": True,
-                    "metadata": {},
-                    "first_name": self.organization.user.first_name,
-                    "last_name": self.organization.user.last_name,
-                    "user": self.organization.user.username,
-                    "role": "owner",
-                },
-                {
-                    "is_org": False,
-                    "metadata": {},
-                    "first_name": self.user.first_name,
-                    "last_name": self.user.last_name,
-                    "user": self.user.username,
-                    "role": "owner",
-                },
-            ],
             "forms": [
                 {
                     "name": "Trees registration",
@@ -187,10 +170,6 @@ class RetrieveProjectTestCase(TestAbstractViewSet):
         }
         actual = response.data.copy()
 
-        # users: unique by `user`
-        actual["users"] = self.sort_by_keys(actual["users"], "user")
-        expected["users"] = self.sort_by_keys(expected["users"], "user")
-
         # forms: unique by `formid`
         actual["forms"] = self.sort_by_keys(actual["forms"], "formid")
         expected["forms"] = self.sort_by_keys(expected["forms"], "formid")
@@ -236,3 +215,112 @@ class RetrieveProjectTestCase(TestAbstractViewSet):
 
         self.assertEqual(response.status_code, 200)
         self.assertIsNone(response.data["current_user_role"])
+
+
+@override_settings(TIME_ZONE="UTC")
+class GetProjectUsersTestCase(TestAbstractViewSet):
+    """Tests for GET project users"""
+
+    def setUp(self):
+        super().setUp()
+
+        self.project = Project.objects.create(
+            name="Tree Monitoring",
+            organization=self.user,
+            created_by=self.user,
+            shared=False,
+        )
+        self.view = ProjectViewSet.as_view({"get": "users"})
+
+    def tearDown(self):
+        cache.clear()
+
+        super().tearDown()
+
+    def test_owner_can_view_users(self):
+        """Project owner can view the list of users with access"""
+        request = self.factory.get("/", **self.extra)
+        response = self.view(request, pk=self.project.pk)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.data,
+            [
+                {
+                    "is_org": False,
+                    "metadata": {},
+                    "first_name": self.user.first_name,
+                    "last_name": self.user.last_name,
+                    "user": self.user.username,
+                    "role": "owner",
+                },
+            ],
+        )
+
+    def test_manager_can_view_users(self):
+        """A project manager can view the list of users with access"""
+        alice_profile = self._create_user_profile(
+            {"username": "alice", "email": "alice@localhost.com"}
+        )
+        ShareProject(self.project, "alice", "manager").save()
+        extra = {"HTTP_AUTHORIZATION": f"Token {alice_profile.user.auth_token}"}
+
+        request = self.factory.get("/", **extra)
+        response = self.view(request, pk=self.project.pk)
+
+        self.assertEqual(response.status_code, 200)
+        usernames = sorted(entry["user"] for entry in response.data)
+        self.assertEqual(usernames, ["alice", self.user.username])
+
+    def test_member_can_view_users(self):
+        """A read-only member can view the list of users with access"""
+        alice_profile = self._create_user_profile(
+            {"username": "alice", "email": "alice@localhost.com"}
+        )
+        ShareProject(self.project, "alice", "readonly").save()
+        extra = {"HTTP_AUTHORIZATION": f"Token {alice_profile.user.auth_token}"}
+
+        request = self.factory.get("/", **extra)
+        response = self.view(request, pk=self.project.pk)
+
+        self.assertEqual(response.status_code, 200)
+        usernames = sorted(entry["user"] for entry in response.data)
+        self.assertEqual(usernames, ["alice", self.user.username])
+
+    def test_non_member_denied(self):
+        """A user with no role on the project cannot view the users"""
+        alice_profile = self._create_user_profile(
+            {"username": "alice", "email": "alice@localhost.com"}
+        )
+        extra = {"HTTP_AUTHORIZATION": f"Token {alice_profile.user.auth_token}"}
+
+        request = self.factory.get("/", **extra)
+        response = self.view(request, pk=self.project.pk)
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_anonymous_denied(self):
+        """An anonymous user cannot view the list of users"""
+        request = self.factory.get("/")
+        response = self.view(request, pk=self.project.pk)
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_non_member_denied_public_project(self):
+        """A non-member cannot view the users of a public project
+
+        A public project is returned by the project filter backend regardless
+        of membership, so the explicit member check in ProjectPermissions is
+        what keeps the users list members-only here.
+        """
+        self.project.shared = True
+        self.project.save()
+        alice_profile = self._create_user_profile(
+            {"username": "alice", "email": "alice@localhost.com"}
+        )
+        extra = {"HTTP_AUTHORIZATION": f"Token {alice_profile.user.auth_token}"}
+
+        request = self.factory.get("/", **extra)
+        response = self.view(request, pk=self.project.pk)
+
+        self.assertEqual(response.status_code, 403)

--- a/onadata/apps/api/viewsets/v2/project_viewset.py
+++ b/onadata/apps/api/viewsets/v2/project_viewset.py
@@ -2,9 +2,11 @@
 Project viewset for v2 API
 """
 
+from rest_framework.decorators import action
 from rest_framework.response import Response
 
 from onadata.apps.api.viewsets.project_viewset import ProjectViewSet as ProjectViewSetV1
+from onadata.libs.serializers.project_serializer import get_users
 from onadata.libs.serializers.v2.project_serializer import (
     ProjectListSerializer,
     ProjectPrivateSerializer,
@@ -53,3 +55,14 @@ class ProjectViewSet(ProjectViewSetV1):
         ).data
 
         return Response({**base_data, **private_data})
+
+    @action(methods=["GET"], detail=True)
+    def users(self, request, *args, **kwargs):
+        """Return the users and organizations that have access to the project.
+
+        Accessible to any member of the project.
+        """
+        project = self.get_object()
+        data = get_users(project, {"request": request})
+
+        return Response(data)

--- a/onadata/apps/api/viewsets/v2/project_viewset.py
+++ b/onadata/apps/api/viewsets/v2/project_viewset.py
@@ -63,6 +63,11 @@ class ProjectViewSet(ProjectViewSetV1):
         Accessible to any member of the project.
         """
         project = self.get_object()
+        # No need for view level caching
+        # get_users caches the result under PROJ_PERM_CACHE
+        # (ps-project_permissions-<pk>) and is invalidated whenever a member is
+        # added, removed, or has their role changed (ShareProject.save in
+        # onadata/libs/models/share_project.py).
         data = get_users(project, {"request": request})
 
         return Response(data)

--- a/onadata/libs/serializers/v2/project_serializer.py
+++ b/onadata/libs/serializers/v2/project_serializer.py
@@ -125,3 +125,23 @@ class ProjectSerializer(ProjectSerializerV1):
     url = serializers.HyperlinkedIdentityField(
         view_name="project-v2-detail", lookup_field="pk"
     )
+
+    class Meta(ProjectSerializerV1.Meta):
+        fields = [
+            "url",
+            "projectid",
+            "name",
+            "owner",
+            "created_by",
+            "metadata",
+            "starred",
+            "forms",
+            "public",
+            "tags",
+            "num_datasets",
+            "last_submission_date",
+            "teams",
+            "data_views",
+            "date_created",
+            "date_modified",
+        ]


### PR DESCRIPTION
### Changes / Features implemented

Add `GET /api/v2/projects/<pk>/users` returning the users and organizations with access to a project, and remove the `users` field from the v2 project detail response (GET /`api/v2/projects/<pk>`).

### Steps taken to verify this change does what is intended

- [ ] QA

### Side effects of implementing this change

Improved security since project users aren't exposed
Faster loading times on enpoint `/v2/projects/<id>`

**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  - [x] Updated documentation

Closes #

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/onaio/codesmith/onadata/pr/3098"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782641443&installation_id=135786473&pr_number=3098&repository=onaio%2Fonadata&return_to=https%3A%2F%2Fgithub.com%2Fonaio%2Fonadata%2Fpull%2F3098&signature=c57db49578372c1aef0a93bba8e568e46b9069146352592e58cb7f825ba372ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->