### PR TITLE
feat(projects): add v2 project teams endpoint

### DIFF
--- a/docs/projects.rst
+++ b/docs/projects.rst
@@ -321,6 +321,42 @@ Response
             }
         ]
 
+List teams with access to a project (v2)
+----------------------------------------
+
+.. note::
+
+   In the version 2 API the project detail endpoint ``GET /api/v2/projects/{pk}``
+   no longer includes the ``teams`` field. Use the dedicated endpoint below to
+   retrieve the teams that have access to a project.
+
+.. raw:: html
+
+	<pre class="prettyprint">
+	<b>GET</b> /api/v2/projects/<code>{pk}</code>/teams</pre>
+
+Only members of the project (users with a role on the project, e.g. ``owner``,
+``manager``, ``editor`` or ``readonly``) can access this endpoint. Requests from
+users who are not members of the project return ``HTTP 404 Not Found``.
+
+Example
+^^^^^^^^
+::
+
+       curl -X GET https://api.ona.io/api/v2/projects/1/teams
+
+Response
+^^^^^^^^
+::
+
+        [
+            {
+                "name": "ona#Owners",
+                "role": "owner",
+                "users": ["ona"]
+            }
+        ]
+
 Update Project Information
 ------------------------------
 .. raw:: html

--- a/onadata/apps/api/permissions.py
+++ b/onadata/apps/api/permissions.py
@@ -294,8 +294,8 @@ class ProjectPermissions(DjangoObjectPermissions):
         ):
             return False
 
-        if view.action == "users":
-            # Any member of the project may view the list of users
+        if view.action in ["users", "teams"]:
+            # Any member of the project may view the list of users or teams
             return get_role(get_perms(request.user, obj), obj) is not None
 
         return super().has_object_permission(request, view, obj)

--- a/onadata/apps/api/tests/viewsets/v2/test_project_viewset.py
+++ b/onadata/apps/api/tests/viewsets/v2/test_project_viewset.py
@@ -148,18 +148,6 @@ class RetrieveProjectTestCase(TestAbstractViewSet):
             "num_datasets": 1,
             "current_user_role": "owner",
             "last_submission_date": None,
-            "teams": [
-                {
-                    "name": "denoinc#Owners",
-                    "role": "owner",
-                    "users": [self.user.username],
-                },
-                {
-                    "name": "denoinc#members",
-                    "role": None,
-                    "users": [self.organization.user.username],
-                },
-            ],
             "data_views": [],
             "date_created": self.project.date_created.isoformat().replace(
                 "+00:00", "Z"
@@ -170,13 +158,12 @@ class RetrieveProjectTestCase(TestAbstractViewSet):
         }
         actual = response.data.copy()
 
+        # `teams` is no longer part of the project detail response
+        self.assertNotIn("teams", actual)
+
         # forms: unique by `formid`
         actual["forms"] = self.sort_by_keys(actual["forms"], "formid")
         expected["forms"] = self.sort_by_keys(expected["forms"], "formid")
-
-        # teams unique by `name`
-        actual["teams"] = self.sort_by_keys(actual["teams"], "name")
-        expected["teams"] = self.sort_by_keys(expected["teams"], "name")
 
         # tags simple list
         actual["tags"] = sorted(actual["tags"])
@@ -312,6 +299,118 @@ class GetProjectUsersTestCase(TestAbstractViewSet):
         A public project is returned by the project filter backend regardless
         of membership, so the explicit member check in ProjectPermissions is
         what keeps the users list members-only here.
+        """
+        self.project.shared = True
+        self.project.save()
+        alice_profile = self._create_user_profile(
+            {"username": "alice", "email": "alice@localhost.com"}
+        )
+        extra = {"HTTP_AUTHORIZATION": f"Token {alice_profile.user.auth_token}"}
+
+        request = self.factory.get("/", **extra)
+        response = self.view(request, pk=self.project.pk)
+
+        self.assertEqual(response.status_code, 403)
+
+
+@override_settings(TIME_ZONE="UTC")
+class GetProjectTeamsTestCase(TestAbstractViewSet):
+    """Tests for GET project teams"""
+
+    def setUp(self):
+        super().setUp()
+
+        self._org_create()
+        self.project = Project.objects.create(
+            name="Tree Monitoring",
+            organization=self.organization.user,
+            created_by=self.user,
+            shared=False,
+        )
+        self.view = ProjectViewSet.as_view({"get": "teams"})
+
+    def tearDown(self):
+        cache.clear()
+
+        super().tearDown()
+
+    def test_owner_can_view_teams(self):
+        """Project owner can view the list of teams with access"""
+        request = self.factory.get("/", **self.extra)
+        response = self.view(request, pk=self.project.pk)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            self.sort_by_keys(response.data, "name"),
+            [
+                {
+                    "name": "denoinc#Owners",
+                    "role": "owner",
+                    "users": [self.user.username],
+                },
+                {
+                    "name": "denoinc#members",
+                    "role": None,
+                    "users": [self.organization.user.username],
+                },
+            ],
+        )
+
+    def test_manager_can_view_teams(self):
+        """A project manager can view the list of teams with access"""
+        alice_profile = self._create_user_profile(
+            {"username": "alice", "email": "alice@localhost.com"}
+        )
+        ShareProject(self.project, "alice", "manager").save()
+        extra = {"HTTP_AUTHORIZATION": f"Token {alice_profile.user.auth_token}"}
+
+        request = self.factory.get("/", **extra)
+        response = self.view(request, pk=self.project.pk)
+
+        self.assertEqual(response.status_code, 200)
+        team_names = sorted(entry["name"] for entry in response.data)
+        self.assertEqual(team_names, ["denoinc#Owners", "denoinc#members"])
+
+    def test_member_can_view_teams(self):
+        """A read-only member can view the list of teams with access"""
+        alice_profile = self._create_user_profile(
+            {"username": "alice", "email": "alice@localhost.com"}
+        )
+        ShareProject(self.project, "alice", "readonly").save()
+        extra = {"HTTP_AUTHORIZATION": f"Token {alice_profile.user.auth_token}"}
+
+        request = self.factory.get("/", **extra)
+        response = self.view(request, pk=self.project.pk)
+
+        self.assertEqual(response.status_code, 200)
+        team_names = sorted(entry["name"] for entry in response.data)
+        self.assertEqual(team_names, ["denoinc#Owners", "denoinc#members"])
+
+    def test_non_member_denied(self):
+        """A user with no role on the project cannot view the teams"""
+        alice_profile = self._create_user_profile(
+            {"username": "alice", "email": "alice@localhost.com"}
+        )
+        extra = {"HTTP_AUTHORIZATION": f"Token {alice_profile.user.auth_token}"}
+
+        request = self.factory.get("/", **extra)
+        response = self.view(request, pk=self.project.pk)
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_anonymous_denied(self):
+        """An anonymous user cannot view the list of teams"""
+        request = self.factory.get("/")
+        response = self.view(request, pk=self.project.pk)
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_non_member_denied_public_project(self):
+        """A non-member cannot view the teams of a public project
+
+        A public project is returned by the project filter backend regardless
+        of membership, so the explicit member check in ProjectPermissions is
+        what keeps the teams list members-only here.
         """
         self.project.shared = True
         self.project.save()

--- a/onadata/apps/api/tests/viewsets/v2/test_project_viewset.py
+++ b/onadata/apps/api/tests/viewsets/v2/test_project_viewset.py
@@ -158,9 +158,6 @@ class RetrieveProjectTestCase(TestAbstractViewSet):
         }
         actual = response.data.copy()
 
-        # `teams` is no longer part of the project detail response
-        self.assertNotIn("teams", actual)
-
         # forms: unique by `formid`
         actual["forms"] = self.sort_by_keys(actual["forms"], "formid")
         expected["forms"] = self.sort_by_keys(expected["forms"], "formid")

--- a/onadata/apps/api/viewsets/v2/project_viewset.py
+++ b/onadata/apps/api/viewsets/v2/project_viewset.py
@@ -6,7 +6,7 @@ from rest_framework.decorators import action
 from rest_framework.response import Response
 
 from onadata.apps.api.viewsets.project_viewset import ProjectViewSet as ProjectViewSetV1
-from onadata.libs.serializers.project_serializer import get_users
+from onadata.libs.serializers.project_serializer import get_teams, get_users
 from onadata.libs.serializers.v2.project_serializer import (
     ProjectListSerializer,
     ProjectPrivateSerializer,
@@ -69,5 +69,19 @@ class ProjectViewSet(ProjectViewSetV1):
         # added, removed, or has their role changed (ShareProject.save in
         # onadata/libs/models/share_project.py).
         data = get_users(project, {"request": request})
+
+        return Response(data)
+
+    @action(methods=["GET"], detail=True)
+    def teams(self, request, *args, **kwargs):
+        """Return the teams that have access to the project.
+
+        Accessible to any member of the project.
+        """
+        project = self.get_object()
+        # No need for view level caching
+        # get_teams caches the result under PROJ_TEAM_USERS_CACHE
+        # (ps-project-team-users<pk>).
+        data = get_teams(project)
 
         return Response(data)

--- a/onadata/libs/serializers/v2/project_serializer.py
+++ b/onadata/libs/serializers/v2/project_serializer.py
@@ -140,7 +140,6 @@ class ProjectSerializer(ProjectSerializerV1):
             "tags",
             "num_datasets",
             "last_submission_date",
-            "teams",
             "data_views",
             "date_created",
             "date_modified",


### PR DESCRIPTION
### Changes / Features implemented

Add GET /api/v2/projects/<pk>/teams returning the teams with access to a project, and remove the `teams` field from the v2 project detail response (GET /api/v2/projects/<pk>).

The endpoint is restricted to project members via the existing member check in ProjectPermissions: non-members get a 404 for projects they cannot see, and a 403 for public projects (which the filter backend returns regardless of membership).

### Steps taken to verify this change does what is intended

- [ ] QA

### Side effects of implementing this change


**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  - [x] Updated documentation

Closes #

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/onaio/codesmith/onadata/pr/3099"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782649503&installation_id=135786473&pr_number=3099&repository=onaio%2Fonadata&return_to=https%3A%2F%2Fgithub.com%2Fonaio%2Fonadata%2Fpull%2F3099&signature=b63209469d2f26f6b4774895238e3032a5a5adf3f0e0f8d0d830aa095d4190aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->