### PR TITLE
fix(viewer): support uppercase export types

### DIFF
--- a/onadata/apps/viewer/tests/test_export_list.py
+++ b/onadata/apps/viewer/tests/test_export_list.py
@@ -116,6 +116,17 @@ class TestExportList(TestBase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
 
+    def test_uppercase_csv_export_list(self):
+        kwargs = {
+            "username": self.user.username.upper(),
+            "id_string": self.xform.id_string.upper(),
+            "export_type": Export.CSV_EXPORT.upper(),
+        }
+
+        url = reverse(export_list, kwargs=kwargs)
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+
     def test_xlsx_export_list(self):
         kwargs = {
             "username": self.user.username,

--- a/onadata/apps/viewer/views.py
+++ b/onadata/apps/viewer/views.py
@@ -486,6 +486,7 @@ def export_list(request, username, id_string, export_type):  # noqa C901
     Export list view.
     """
     credential = None
+    export_type = export_type.lower()
 
     if export_type not in Export.EXPORT_TYPE_DICT:
         return HttpResponseBadRequest(


### PR DESCRIPTION

### Changes / Features implemented

- Normalize export_type in the export list view so uppercase values like CSV are handled the same as lowercase csv.
- Added a regression test for uppercase CSV export list URLs.

### Steps taken to verify this change does what is intended

- Confirmed the new regression test failed before the fix with 400 != 200.
- Ran the targeted test after the fix:

  bash
  python manage.py test onadata.apps.viewer.tests.testexportlist.TestExportList.testuppercasecsvexportlist --settings=onadata.settings.githubactionstest --noinput --verbosity=1
  

  Result:

  text
  Ran 1 test in 2.141s

  OK
  

- Also ran the full export list test module successfully:

  text
  Ran 19 tests in 37.350s

  OK
  

### Side effects of implementing this change

- No expected negative side effects.
- Unsupported export types remain rejected after normalization.

Before submitting this PR for review, please make sure you have:

  - [x] Included tests
  - [ ] Updated documentation

Closes #2269

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/onaio/codesmith/onadata/pr/3100"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782929751&installation_id=135786473&pr_number=3100&repository=onaio%2Fonadata&return_to=https%3A%2F%2Fgithub.com%2Fonaio%2Fonadata%2Fpull%2F3100&signature=dcb23374e002aadb4139d1f83ddf2f711f626f2d6be564fb59098d5eb90ecbce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->