### PR TITLE
fix(exports): convert bool values for SAV exports

### DIFF
--- a/onadata/libs/tests/utils/test_export_builder.py
+++ b/onadata/libs/tests/utils/test_export_builder.py
@@ -727,6 +727,75 @@ class TestExportBuilder(TestBase):
 
         shutil.rmtree(temp_dir)
 
+    def test_zipped_sav_export_with_bool_string_value(self):
+        """Boolean values in string fields are exported as strings."""
+        md = """
+        | survey |
+        |        | type              | name         | label        |
+        |        | text              | active       | Active       |
+
+        | choices |
+        |         | list name | name   | label  |
+        """
+        survey = self.md_to_pyxform_survey(md, {"name": "exp"})
+        data = [{"active": True}]
+        export_builder = ExportBuilder()
+        export_builder.set_survey(survey)
+        with NamedTemporaryFile(suffix=".zip") as temp_zip_file:
+            export_builder.to_zipped_sav(temp_zip_file.name, data)
+            temp_zip_file.seek(0)
+            temp_dir = tempfile.mkdtemp()
+            with zipfile.ZipFile(temp_zip_file.name, "r") as zip_file:
+                zip_file.extractall(temp_dir)
+
+        self.assertTrue(os.path.exists(os.path.join(temp_dir, "exp.sav")))
+
+        with SavReader(os.path.join(temp_dir, "exp.sav"), returnHeader=True) as reader:
+            rows = list(reader)
+            self.assertTrue(len(rows) > 1)
+            self.assertEqual(_str_if_bytes(rows[0][0]), "active")
+            self.assertEqual(_str_if_bytes(rows[1][0]), "True")
+
+        shutil.rmtree(temp_dir)
+
+    def test_zipped_sav_export_with_split_select_multiple_bool_values(self):
+        """Split select multiple bool values are exported correctly."""
+        md = """
+        | survey |
+        |        | type                  | name           | label |
+        |        | select_multiple food  | food_available | Food  |
+
+        | choices |
+        |         | list name | name | label |
+        |         | food      | 1    | One   |
+        |         | food      | 2    | Two   |
+        """
+        survey = self.md_to_pyxform_survey(md, {"name": "exp"})
+        data = [{"food_available": "1"}]
+        export_builder = ExportBuilder()
+        export_builder.set_survey(survey)
+        with NamedTemporaryFile(suffix=".zip") as temp_zip_file:
+            export_builder.to_zipped_sav(temp_zip_file.name, data)
+            temp_zip_file.seek(0)
+            temp_dir = tempfile.mkdtemp()
+            with zipfile.ZipFile(temp_zip_file.name, "r") as zip_file:
+                zip_file.extractall(temp_dir)
+
+        self.assertTrue(os.path.exists(os.path.join(temp_dir, "exp.sav")))
+
+        with SavReader(os.path.join(temp_dir, "exp.sav"), returnHeader=True) as reader:
+            rows = list(reader)
+            rows[0] = list(map(_str_if_bytes, rows[0]))
+            self.assertTrue(len(rows) > 1)
+            self.assertEqual(rows[0][0], "food_available")
+            self.assertEqual(_str_if_bytes(rows[1][0]), "1")
+            self.assertEqual(rows[0][1], "food_available.1")
+            self.assertEqual(rows[1][1], 1.0)
+            self.assertEqual(rows[0][2], "food_available.2")
+            self.assertEqual(rows[1][2], 0.0)
+
+        shutil.rmtree(temp_dir)
+
     # pylint: disable=invalid-name
     def test_zipped_sav_export_dynamic_select_multiple(self):
         md = """

--- a/onadata/libs/utils/export_builder.py
+++ b/onadata/libs/utils/export_builder.py
@@ -1440,9 +1440,16 @@ class ExportBuilder:
         def write_row(row, sav_writer, fields):
             # replace character for osm fields
             fields = [field.replace(":", "_") for field in fields]
-            sav_writer.writerow(
-                [encode_if_str(row, field, sav_writer=sav_writer) for field in fields]
-            )
+            record = []
+            for field, var_name in zip(fields, sav_writer.varNames):
+                value = encode_if_str(row, field, sav_writer=sav_writer)
+                if (
+                    isinstance(value, bool)
+                    and sav_writer.varTypes[var_name] != SAV_NUMERIC_TYPE
+                ):
+                    value = str(value)
+                record.append(value)
+            sav_writer.writerow(record)
 
         sav_defs = {}
 


### PR DESCRIPTION
### Changes / Features implemented

- Fixed SAV export generation when a string/text field contains a boolean value.
- Updated encodeifstr() so SAV export values are consistently converted to strings before being passed to savReaderWriter.
- Added regression coverage for boolean values in SAV exports.

### Steps taken to verify this change does what is intended

- Confirmed the regression test fails before the fix with:

  text
  AttributeError: 'bool' object has no attribute 'ljust'
  

- Confirmed the targeted tests pass after the fix:

  ```bash
  python manage.py test \
    onadata.libs.tests.utils.testexporttools.TestExportTools.testencodeifstr \
    onadata.libs.tests.utils.testexportbuilder.TestExportBuilder.testzippedsavexportwithboolstringvalue \
    --settings=onadata.settings.githubactionstest
  ```

### Side effects of implementing this change

- Boolean values in SAV string fields are now exported as "True" / "False" instead of being passed as raw Python booleans.
- No expected side effects for non-SAV exports.

Before submitting this PR for review, please make sure you have:

  - [x] Included tests
  - [ ] Updated documentation

Closes #3082

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/onaio/codesmith/onadata/pr/3102"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782974652&installation_id=135786473&pr_number=3102&repository=onaio%2Fonadata&return_to=https%3A%2F%2Fgithub.com%2Fonaio%2Fonadata%2Fpull%2F3102&signature=658e3a58e1156e7033191059b16af9cca5f00850fd2956acb70b892c15e88fb7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->