### PR TITLE
Is active session

### DIFF
--- a/onadata/apps/main/oidc_viewsets.py
+++ b/onadata/apps/main/oidc_viewsets.py
@@ -16,6 +16,7 @@ from oidc.viewsets import SSO_COOKIE_NAME, UserModelOpenIDConnectViewset
 from rest_framework import status
 from rest_framework.response import Response
 
+from onadata.apps.main.models.user_profile import UserProfile
 from onadata.libs.permissions import is_organization_user
 
 
@@ -66,3 +67,20 @@ class OnaOpenIDConnectViewset(  # pylint: disable=too-few-public-methods
                 template_name="oidc/oidc_unrecoverable_error.html",
             )
         return super().generate_successful_response(request, user, *args, **kwargs)
+
+    def is_session_allowed(self, user):
+        # Mirror the login org-rejection: an org account must not be able to
+        # restore a session via the challenge-free ``session`` probe either.
+        return not is_organization_user(user)
+
+    def get_session_data(self, user, request):
+        data = super().get_session_data(user, request)
+        profile, _created = UserProfile.objects.get_or_create(user=user)
+        data.update(
+            {
+                "name": profile.name,
+                "gravatar": profile.gravatar,
+                "require_auth": profile.require_auth,
+            }
+        )
+        return data

--- a/onadata/apps/main/tests/test_org_account_login.py
+++ b/onadata/apps/main/tests/test_org_account_login.py
@@ -8,6 +8,7 @@ from django.contrib.auth import get_user_model
 from django.http import HttpRequest, HttpResponseRedirect
 from django.test import RequestFactory, TestCase, override_settings
 
+import jwt
 from rest_framework import status
 
 from onadata.apps.api.tools import create_organization
@@ -164,6 +165,93 @@ class TestBlockOrgAccountLogin(TestCase):
         if return_request:
             return request, result
         return result
+
+
+SESSION_VIEWSET_CONFIG = {
+    "JWT_SECRET_KEY": "test-sso-secret-for-session-endpoint",
+    "JWT_ALGORITHM": "HS256",
+}
+
+
+@override_settings(OPENID_CONNECT_VIEWSET_CONFIG=SESSION_VIEWSET_CONFIG)
+class TestOIDCSessionEndpoint(TestCase):
+    """The challenge-free ``/oidc/<server>/session`` reload-restore probe."""
+
+    def setUp(self):
+        self.regular = User.objects.create_user(
+            username="bob", password=TEST_CREDENTIAL, email="bob@example.com"
+        )
+        self.profile = UserProfile.objects.create(
+            user=self.regular, name="Bob Tester", require_auth=True
+        )
+        self.org = create_organization("denoinc", self.regular)
+        self.org_user = self.org.user
+        self.org_user.email = "org@example.com"
+        self.org_user.save()
+
+    def _sso_cookie(self, email):
+        return jwt.encode(
+            {"email": email},
+            SESSION_VIEWSET_CONFIG["JWT_SECRET_KEY"],
+            algorithm="HS256",
+        )
+
+    def _get_session(self, email=None, **extra):
+        if email is not None:
+            self.client.cookies["SSO"] = self._sso_cookie(email)
+        return self.client.get("/oidc/microsoft/session", **extra)
+
+    def test_valid_session_returns_profile_without_secrets(self):
+        response = self._get_session("bob@example.com")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertEqual(data["username"], "bob")
+        self.assertEqual(data["name"], "Bob Tester")
+        self.assertEqual(data["require_auth"], True)
+        self.assertIn("gravatar", data)
+        # No PII / no token material leaves the endpoint.
+        self.assertNotIn("email", data)
+        self.assertNotIn("api_token", data)
+        self.assertNotIn("temp_token", data)
+        self.assertEqual(response["Cache-Control"], "no-store")
+        self.assertFalse(response.has_header("WWW-Authenticate"))
+
+    def test_anonymous_request_returns_plain_401(self):
+        response = self._get_session()
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertIn("detail", response.json())
+        self.assertEqual(response["Cache-Control"], "no-store")
+        self.assertFalse(response.has_header("WWW-Authenticate"))
+
+    def test_html_accept_header_cannot_negotiate_template_renderer(self):
+        response = self._get_session(HTTP_ACCEPT="text/html")
+        self.assertEqual(response.status_code, status.HTTP_406_NOT_ACCEPTABLE)
+        self.assertIn("detail", response.json())
+        self.assertEqual(response["Content-Type"], "application/json")
+        self.assertFalse(response.has_header("WWW-Authenticate"))
+
+    def test_invalid_sso_cookie_returns_plain_401(self):
+        self.client.cookies["SSO"] = "not-a-jwt"
+        response = self.client.get("/oidc/microsoft/session")
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertIn("detail", response.json())
+        self.assertEqual(response["Cache-Control"], "no-store")
+        self.assertFalse(response.has_header("WWW-Authenticate"))
+
+    def test_org_account_is_rejected(self):
+        response = self._get_session("org@example.com")
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(response["Cache-Control"], "no-store")
+        self.assertFalse(response.has_header("WWW-Authenticate"))
+
+    def test_digest_authorization_header_does_not_challenge(self):
+        response = self.client.get(
+            "/oidc/microsoft/session",
+            HTTP_AUTHORIZATION='Digest username="stale", realm="api", nonce="bad"',
+        )
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(response["Cache-Control"], "no-store")
+        self.assertFalse(response.has_header("WWW-Authenticate"))
 
 
 class TestOIDCLoginStaleCookieCleanup(TestCase):

--- a/onadata/apps/main/urls.py
+++ b/onadata/apps/main/urls.py
@@ -12,6 +12,8 @@ from django.contrib.staticfiles import views as staticfiles_views
 from django.urls import include, re_path
 from django.views.generic import RedirectView
 
+from rest_framework.renderers import JSONRenderer
+
 from onadata.apps import sms_support
 from onadata.apps.api.urls.v1_urls import (
     BriefcaseViewset,
@@ -83,6 +85,15 @@ urlpatterns += [
                         r"^oidc/(?P<auth_server>\w+)/logout",
                         OnaOpenIDConnectViewset.as_view({"get": "logout"}),
                         name="openid_connect_logout",
+                    ),
+                    re_path(
+                        r"^oidc/(?P<auth_server>\w+)/session",
+                        OnaOpenIDConnectViewset.as_view(
+                            {"get": "session"},
+                            authentication_classes=[],
+                            renderer_classes=[JSONRenderer],
+                        ),
+                        name="openid_connect_session",
                     ),
                 ],
                 "oidc",

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -7,7 +7,7 @@ git+https://github.com/onaio/django-digest.git@6bf61ec08502fd3545d4f2c0838b6cb15
 git+https://github.com/onaio/django-multidb-router.git@f711368180d58eef87eda54fadfd5f8355623d52#egg=django-multidb-router
 git+https://github.com/onaio/floip-py.git@3c980eb184069ae7c3c9136b18441978237cd41d#egg=pyfloip
 git+https://github.com/onaio/python-json2xlsclient.git@62b4645f7b4f2684421a13ce98da0331a9dd66a0#egg=python-json2xlsclient
-git+https://github.com/onaio/ona-oidc.git@v2.9.0#egg=ona-oidc
+git+https://github.com/onaio/ona-oidc.git@8f39ec029a3ac07a3f4d565c8f3d30e0061f318d#egg=ona-oidc
 -e git+https://github.com/onaio/savreaderwriter.git@fix-pep-440-issues#egg=savreaderwriter
 git+https://git@github.com/onaio/valigetta.git@v0.2.1#egg=valigetta
 codetiming

--- a/requirements/base.pip
+++ b/requirements/base.pip
@@ -242,7 +242,7 @@ oauthlib==3.3.1
     # via
     #   django-oauth-toolkit
     #   requests-oauthlib
-ona-oidc @ git+https://github.com/onaio/ona-oidc.git@v2.9.0
+ona-oidc @ git+https://github.com/onaio/ona-oidc.git@8f39ec029a3ac07a3f4d565c8f3d30e0061f318d
     # via -r requirements/base.in
 openpyxl==3.1.5
     # via

--- a/requirements/dev.pip
+++ b/requirements/dev.pip
@@ -312,7 +312,7 @@ oauthlib==3.3.1
     # via
     #   django-oauth-toolkit
     #   requests-oauthlib
-ona-oidc @ git+https://github.com/onaio/ona-oidc.git@v2.9.0
+ona-oidc @ git+https://github.com/onaio/ona-oidc.git@8f39ec029a3ac07a3f4d565c8f3d30e0061f318d
     # via -r requirements/base.in
 openpyxl==3.1.5
     # via


### PR DESCRIPTION
### Changes / Features implemented

  Adds `GET /oidc/<auth_server>/session`, a challenge-free current-session endpoint for browser clients to silently restore an OIDC session from the SSO cookie.

  This endpoint:

  - returns non-secret session data: `username`, `name`, `gravatar`, `require_auth`
  - rejects anonymous, invalid-cookie, and organization-account requests with `401`
  - avoids `WWW-Authenticate` headers so browsers do not show native Basic/Digest dialogs
  - avoids returning `email`, `api_token`, or `temp_token`
  - sets `Cache-Control: no-store`
  - pins `ona-oidc` to PR commit `1eca9f65e91c202aac2b8b39279fd86590bb9fbb`

  ### Steps taken to verify this change does what is intended

  - `isort --profile black`
  - `black`
  - `isort --profile black --check-only`
  - `black --check`
  - `flake8`
  - `git diff --check`
  - `python manage.py check --settings=onadata.settings.github_actions_test`
  - `python manage.py test onadata.apps.main.tests.test_org_account_login --settings=onadata.settings.github_actions_test --keepdb -v2`

  Focused test result: `19 tests OK`.

  ### Side effects of implementing this change

  `ona-oidc` is pinned to an unreleased PR commit containing the session endpoint support and version bump to `2.10.0`. This should be updated to a release tag once available.

  The endpoint intentionally does not expose token material or email.

  **Before submitting this PR for review, please make sure you have:**

    - [x] Included tests
    - [ ] Updated documentation

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/onaio/codesmith/onadata/pr/3112"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783095886&installation_id=135786473&pr_number=3112&repository=onaio%2Fonadata&return_to=https%3A%2F%2Fgithub.com%2Fonaio%2Fonadata%2Fpull%2F3112&signature=cb291c41c78568b7835cdfdf93bee7b7f58c919998b67a233cc020c64c6771db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->