### PR TITLE
fix(forms): exclude inactive users from form gallery

### DIFF
--- a/onadata/apps/main/tests/test_form_show.py
+++ b/onadata/apps/main/tests/test_form_show.py
@@ -73,6 +73,25 @@ class TestFormShow(TestBase):
         response = self.anon.get(self.url)
         self.assertEqual(response.status_code, 200)
 
+    def test_form_gallery_excludes_inactive_user_forms(self):
+        """Inactive users' shared forms are not listed in the form gallery."""
+        inactive_user = self._create_user(
+            "orgsettings-deleted-at-1763193276", "password", create_profile=True
+        )
+        inactive_user.is_active = False
+        inactive_user.save(update_fields=["is_active"])
+        self.project = get_user_default_project(inactive_user)
+        self._publish_transportation_form()
+        self.xform.user = inactive_user
+        self.xform.project = self.project
+        self.xform.shared = True
+        self.xform.save(update_fields=["user", "project", "shared"])
+
+        response = self.client.get(reverse("forms_list"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, inactive_user.username)
+
     def test_dl_xlsx_xlsform(self):
         self._publish_xlsx_file()
         response = self.client.get(

--- a/onadata/apps/main/views.py
+++ b/onadata/apps/main/views.py
@@ -1019,7 +1019,9 @@ def form_gallery(request):
     data = {}
     if request.user.is_authenticated:
         data["loggedin_user"] = request.user
-    data["shared_forms"] = XForm.objects.filter(shared=True, deleted_at__isnull=True)
+    data["shared_forms"] = XForm.objects.filter(
+        shared=True, deleted_at__isnull=True, user__is_active=True
+    )
     # build list of shared forms with cloned suffix
     id_strings_with_cloned_suffix = [
         x.id_string + XForm.CLONED_SUFFIX for x in data["shared_forms"]


### PR DESCRIPTION
### Changes / Features implemented

- Updated the form gallery to exclude shared forms owned by inactive users.
- Added regression coverage for the case where an inactive/deleted-style user owns a shared form.
- Prevents the form gallery from attempting to render download links for inactive users such as `user-deleted-at-1763193276`, which can trigger `NoReverseMatch` for `download_xlsform`.

### Steps taken to verify this change does what is intended

- Confirmed the new regression test failed before the fix with a `NoReverseMatch` while rendering `/forms/`.
- Confirmed the regression test passes after excluding inactive users from the form gallery.
- Ran the related form view test class:

  ```bash
  python manage.py test onadata.apps.main.tests.test_form_show.TestFormShow \
    --settings=onadata.settings.github_actions_test
  ```

  Result:

  ```text
  Ran 42 tests

  OK (skipped=1)
  ```

### Side effects of implementing this change

- Shared forms owned by inactive users will no longer appear in the public form gallery.
- Active users' shared, non-deleted forms are still included.

**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  - [ ] Updated documentation

Closes #3104

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/onaio/codesmith/onadata/pr/3115"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783101906&installation_id=135786473&pr_number=3115&repository=onaio%2Fonadata&return_to=https%3A%2F%2Fgithub.com%2Fonaio%2Fonadata%2Fpull%2F3115&signature=889887ecb8e0208fd672c5d8dbb3ff4b00d5139558cabb92228eae1e586e99c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->