### PR TITLE
feat(security): enforce failed-login lockout on /accounts/login

### DIFF
--- a/onadata/apps/main/forms.py
+++ b/onadata/apps/main/forms.py
@@ -3,6 +3,7 @@
 forms module.
 """
 
+import importlib
 import ipaddress
 import os
 import re
@@ -674,18 +675,14 @@ class LoginLockoutAuthenticationForm(AuthenticationForm):
 
     def clean(self):
         # Avoid circular import
-        from onadata.libs.authentication import (
-            add_login_attempt,
-            assert_not_locked_out,
-            get_client_ip,
-        )
+        authentication = importlib.import_module("onadata.libs.authentication")
 
         username = self.cleaned_data.get("username")
         password = self.cleaned_data.get("password")
-        ip_address = get_client_ip(self.request)
+        ip_address = authentication.get_client_ip(self.request)
 
         try:
-            assert_not_locked_out(ip_address, username)
+            authentication.assert_not_locked_out(ip_address, username)
         except AuthenticationFailed as exc:
             raise self._lockout_error() from exc
 
@@ -695,7 +692,7 @@ class LoginLockoutAuthenticationForm(AuthenticationForm):
             )
             if self.user_cache is None:
                 try:
-                    add_login_attempt(ip_address, username)
+                    authentication.add_login_attempt(ip_address, username)
                 except AuthenticationFailed as exc:
                     raise self._lockout_error() from exc
                 raise forms.ValidationError(

--- a/onadata/apps/main/forms.py
+++ b/onadata/apps/main/forms.py
@@ -674,55 +674,40 @@ class LoginLockoutAuthenticationForm(AuthenticationForm):
 
     def clean(self):
         # Avoid circular import
-        from onadata.libs.authentication import get_client_ip
+        from onadata.libs.authentication import (
+            add_login_attempt,
+            assert_not_locked_out,
+            get_client_ip,
+        )
 
         username = self.cleaned_data.get("username")
         password = self.cleaned_data.get("password")
         ip_address = get_client_ip(self.request)
 
-        self._raise_if_locked_out(ip_address, username)
+        try:
+            assert_not_locked_out(ip_address, username)
+        except AuthenticationFailed as exc:
+            raise self._lockout_error() from exc
 
         if username is not None and password:
             self.user_cache = authenticate(
                 self.request, username=username, password=password
             )
             if self.user_cache is None:
-                attempts = self._record_failed_attempt(ip_address, username)
-                raise self._invalid_login_error(attempts)
+                try:
+                    add_login_attempt(ip_address, username)
+                except AuthenticationFailed as exc:
+                    raise self._lockout_error() from exc
+                raise forms.ValidationError(
+                    _("Invalid username/password."), code="invalid_login"
+                )
             self.confirm_login_allowed(self.user_cache)
 
         return self.cleaned_data
 
     @staticmethod
-    def _invalid_login_error(attempts):
-        remaining_attempts = getattr(settings, "MAX_LOGIN_ATTEMPTS", 10) - attempts
-        lockout_time = getattr(settings, "LOCKOUT_TIME", 1800) // 60
+    def _lockout_error():
         return forms.ValidationError(
-            _(
-                "Invalid username/password. "
-                f"For security reasons, after {remaining_attempts} more failed "
-                f"login attempts you'll have to wait {lockout_time} minutes "
-                "before trying again."
-            ),
-            code="invalid_login",
+            _("Maximum login attempts exceeded. Please try again later."),
+            code="locked_out",
         )
-
-    @staticmethod
-    def _raise_if_locked_out(ip_address, username):
-        # Avoid circular import
-        from onadata.libs.authentication import assert_not_locked_out
-
-        try:
-            assert_not_locked_out(ip_address, username)
-        except AuthenticationFailed as exc:
-            raise forms.ValidationError(str(exc.detail), code="locked_out") from exc
-
-    @staticmethod
-    def _record_failed_attempt(ip_address, username):
-        # Avoid circular import
-        from onadata.libs.authentication import add_login_attempt
-
-        try:
-            return add_login_attempt(ip_address, username)
-        except AuthenticationFailed as exc:
-            raise forms.ValidationError(str(exc.detail), code="locked_out") from exc

--- a/onadata/apps/main/forms.py
+++ b/onadata/apps/main/forms.py
@@ -699,7 +699,7 @@ class LoginLockoutAuthenticationForm(AuthenticationForm):
                 except AuthenticationFailed as exc:
                     raise self._lockout_error() from exc
                 raise forms.ValidationError(
-                    _("Invalid username/password."), code="invalid_login"
+                    _("Invalid username or password"), code="invalid_login"
                 )
             self.confirm_login_allowed(self.user_cache)
 

--- a/onadata/apps/main/forms.py
+++ b/onadata/apps/main/forms.py
@@ -10,7 +10,8 @@ import socket
 
 from django import forms
 from django.conf import settings
-from django.contrib.auth import get_user_model
+from django.contrib.auth import authenticate, get_user_model
+from django.contrib.auth.forms import AuthenticationForm
 from django.core.files.base import ContentFile
 from django.core.files.storage import default_storage
 from django.core.validators import URLValidator
@@ -21,6 +22,7 @@ from django.utils.translation import gettext_lazy
 import requests
 from registration.forms import RegistrationFormUniqueEmail
 from requests.exceptions import RequestException
+from rest_framework.exceptions import AuthenticationFailed
 from six.moves.urllib.parse import urljoin, urlparse
 
 # pylint: disable=ungrouped-imports
@@ -659,3 +661,68 @@ class ExternalExportForm(forms.Form):
 
 # Deprecated
 ActivateSMSSupportFom = ActivateSMSSupportForm
+
+
+class LoginLockoutAuthenticationForm(AuthenticationForm):
+    """Authentication form that enforces the failed-login lockout.
+
+    Mirrors the lockout enforced by the digest authentication flow
+    (``onadata.libs.authentication``): blocks all logins while locked out,
+    counts failed attempts and triggers a lockout (and lockout email) once
+    ``MAX_LOGIN_ATTEMPTS`` is reached, keyed on IP + username.
+    """
+
+    def clean(self):
+        # Avoid circular import
+        from onadata.libs.authentication import get_client_ip
+
+        username = self.cleaned_data.get("username")
+        password = self.cleaned_data.get("password")
+        ip_address = get_client_ip(self.request)
+
+        self._raise_if_locked_out(ip_address, username)
+
+        if username is not None and password:
+            self.user_cache = authenticate(
+                self.request, username=username, password=password
+            )
+            if self.user_cache is None:
+                attempts = self._record_failed_attempt(ip_address, username)
+                raise self._invalid_login_error(attempts)
+            self.confirm_login_allowed(self.user_cache)
+
+        return self.cleaned_data
+
+    @staticmethod
+    def _invalid_login_error(attempts):
+        remaining_attempts = getattr(settings, "MAX_LOGIN_ATTEMPTS", 10) - attempts
+        lockout_time = getattr(settings, "LOCKOUT_TIME", 1800) // 60
+        return forms.ValidationError(
+            _(
+                "Invalid username/password. "
+                f"For security reasons, after {remaining_attempts} more failed "
+                f"login attempts you'll have to wait {lockout_time} minutes "
+                "before trying again."
+            ),
+            code="invalid_login",
+        )
+
+    @staticmethod
+    def _raise_if_locked_out(ip_address, username):
+        # Avoid circular import
+        from onadata.libs.authentication import assert_not_locked_out
+
+        try:
+            assert_not_locked_out(ip_address, username)
+        except AuthenticationFailed as exc:
+            raise forms.ValidationError(str(exc.detail), code="locked_out") from exc
+
+    @staticmethod
+    def _record_failed_attempt(ip_address, username):
+        # Avoid circular import
+        from onadata.libs.authentication import add_login_attempt
+
+        try:
+            return add_login_attempt(ip_address, username)
+        except AuthenticationFailed as exc:
+            raise forms.ValidationError(str(exc.detail), code="locked_out") from exc

--- a/onadata/apps/main/registration_urls.py
+++ b/onadata/apps/main/registration_urls.py
@@ -7,13 +7,17 @@ URLConf to include this URLConf for any URL beginning with
 
 """
 
-
+from django.contrib.auth.views import LoginView
 from django.urls import include, path, re_path
 from django.views.generic import TemplateView
+
 from registration.backends.default.views import ActivationView
 
+from onadata.apps.main.forms import (
+    LoginLockoutAuthenticationForm,
+    RegistrationFormUserProfile,
+)
 from onadata.apps.main.registration_views import FHRegistrationView
-from onadata.apps.main.forms import RegistrationFormUserProfile
 
 urlpatterns = [
     path(
@@ -39,6 +43,17 @@ urlpatterns = [
         "register/complete/",
         TemplateView.as_view(template_name="registration/registration_complete.html"),
         name="registration_complete",
+    ),
+    # Override the login view (defined in registration.auth_urls below) to use
+    # a form that enforces the failed-login lockout. Declared first so it takes
+    # precedence over the include's ``login/`` route.
+    path(
+        "login/",
+        LoginView.as_view(
+            template_name="registration/login.html",
+            authentication_form=LoginLockoutAuthenticationForm,
+        ),
+        name="auth_login",
     ),
     re_path(r"", include("registration.auth_urls")),
 ]

--- a/onadata/apps/main/tests/test_accounts_login_lockout.py
+++ b/onadata/apps/main/tests/test_accounts_login_lockout.py
@@ -1,0 +1,80 @@
+"""Tests for failed-login lockout on the /accounts/login/ endpoint.
+
+The lockout must mirror the behaviour already enforced by the digest
+authentication flow (onadata.libs.authentication): lock out after
+MAX_LOGIN_ATTEMPTS failed attempts for LOCKOUT_TIME, block all logins
+(even with the correct password) while locked, send a lockout email when
+the threshold is hit, and key the lockout on IP + username.
+"""
+
+from django.core import mail
+from django.core.cache import cache
+from django.test import Client, override_settings
+from django.urls import reverse
+
+from onadata.apps.main.tests.test_base import TestBase
+
+
+@override_settings(MAX_LOGIN_ATTEMPTS=3, LOCKOUT_TIME=1800)
+class AccountsLoginLockoutTestCase(TestBase):
+    """Lockout behaviour for POST /accounts/login/."""
+
+    def setUp(self):
+        super().setUp()
+        cache.clear()
+        self.url = reverse("auth_login")
+        self.client = Client()
+
+    def tearDown(self):
+        cache.clear()
+        super().tearDown()
+
+    def _attempt(self, password):
+        return self.client.post(
+            self.url, {"username": self.user.username, "password": password}
+        )
+
+    def test_locks_out_after_max_attempts(self):
+        """Correct password is blocked once MAX_LOGIN_ATTEMPTS is reached."""
+        for _ in range(3):
+            self._attempt("wrong-password")
+
+        response = self._attempt(self.login_password)
+
+        # Locked out: the form is re-rendered (not a login redirect) and
+        # shows the lockout message.
+        self.assertNotEqual(response.status_code, 302)
+        self.assertContains(response, "Locked out")
+
+    def test_failed_attempt_shows_remaining_attempts(self):
+        """A failed attempt below the threshold reports remaining attempts."""
+        response = self._attempt("wrong-password")
+
+        # MAX_LOGIN_ATTEMPTS=3, one attempt used -> 2 remaining.
+        self.assertNotEqual(response.status_code, 302)
+        self.assertContains(response, "2 more failed")
+
+    def test_lockout_email_sent_at_threshold(self):
+        """A lockout email is sent when the lockout threshold is reached."""
+        self.user.email = "bob@example.com"
+        self.user.save()
+        mail.outbox = []
+
+        for _ in range(3):
+            self._attempt("wrong-password")
+
+        self.assertTrue(mail.outbox)
+        self.assertIn("bob@example.com", mail.outbox[0].to)
+
+    def test_lockout_is_keyed_per_username(self):
+        """Locking out one user does not lock out another from the same IP."""
+        self._create_user("alice", "alicepass", create_profile=True)
+
+        for _ in range(3):
+            self._attempt("wrong-password")  # locks out bob
+
+        response = self.client.post(
+            self.url, {"username": "alice", "password": "alicepass"}
+        )
+
+        self.assertEqual(response.status_code, 302)

--- a/onadata/apps/main/tests/test_accounts_login_lockout.py
+++ b/onadata/apps/main/tests/test_accounts_login_lockout.py
@@ -44,15 +44,16 @@ class AccountsLoginLockoutTestCase(TestBase):
         # Locked out: the form is re-rendered (not a login redirect) and
         # shows the lockout message.
         self.assertNotEqual(response.status_code, 302)
-        self.assertContains(response, "Locked out")
+        self.assertContains(response, "Maximum login attempts exceeded")
 
-    def test_failed_attempt_shows_remaining_attempts(self):
-        """A failed attempt below the threshold reports remaining attempts."""
+    def test_failed_attempt_shows_generic_error(self):
+        """A failed attempt below the threshold shows a generic error and
+        does not disclose the number of remaining attempts."""
         response = self._attempt("wrong-password")
 
-        # MAX_LOGIN_ATTEMPTS=3, one attempt used -> 2 remaining.
         self.assertNotEqual(response.status_code, 302)
-        self.assertContains(response, "2 more failed")
+        self.assertContains(response, "Invalid username/password")
+        self.assertNotContains(response, "more failed")
 
     def test_lockout_email_sent_at_threshold(self):
         """A lockout email is sent when the lockout threshold is reached."""

--- a/onadata/apps/main/tests/test_accounts_login_lockout.py
+++ b/onadata/apps/main/tests/test_accounts_login_lockout.py
@@ -1,10 +1,8 @@
 """Tests for failed-login lockout on the /accounts/login/ endpoint.
 
-The lockout must mirror the behaviour already enforced by the digest
-authentication flow (onadata.libs.authentication): lock out after
-MAX_LOGIN_ATTEMPTS failed attempts for LOCKOUT_TIME, block all logins
-(even with the correct password) while locked, send a lockout email when
-the threshold is hit, and key the lockout on IP + username.
+Covers locking out after MAX_LOGIN_ATTEMPTS failed attempts for LOCKOUT_TIME,
+blocking all logins (even with the correct password) while locked, sending a
+lockout email when the threshold is hit, and keying the lockout on IP + username.
 """
 
 from django.core import mail

--- a/onadata/apps/main/tests/test_accounts_login_lockout.py
+++ b/onadata/apps/main/tests/test_accounts_login_lockout.py
@@ -52,7 +52,7 @@ class AccountsLoginLockoutTestCase(TestBase):
         response = self._attempt("wrong-password")
 
         self.assertNotEqual(response.status_code, 302)
-        self.assertContains(response, "Invalid username/password")
+        self.assertContains(response, "Invalid username or password")
         self.assertNotContains(response, "more failed")
 
     def test_lockout_email_sent_at_threshold(self):

--- a/onadata/libs/authentication.py
+++ b/onadata/libs/authentication.py
@@ -248,16 +248,18 @@ class SSOHeaderAuthentication(BaseAuthentication):
         return authenticate_sso(request)
 
 
+def get_client_ip(request) -> Optional[str]:
+    """Return the originating IP address of a HTTP request."""
+    if request.headers.get("X-Real-Ip"):
+        return request.headers["X-Real-Ip"].split(",")[0]
+    return request.META.get("REMOTE_ADDR")
+
+
 def retrieve_user_identification(request) -> Tuple[Optional[str], Optional[str]]:
     """
     Retrieve user information from a HTTP request.
     """
-    ip_address = None
-
-    if request.headers.get("X-Real-Ip"):
-        ip_address = request.headers["X-Real-Ip"].split(",")[0]
-    else:
-        ip_address = request.META.get("REMOTE_ADDR")
+    ip_address = get_client_ip(request)
 
     try:
         if isinstance(request.headers["Authorization"], bytes):
@@ -275,43 +277,35 @@ def retrieve_user_identification(request) -> Tuple[Optional[str], Optional[str]]
     return None, None
 
 
-def check_lockout(request) -> Tuple[Optional[str], Optional[str]]:
-    """Check request user is not locked out on authentication.
+def assert_not_locked_out(ip_address, username):
+    """Raise AuthenticationFailed if the IP + username pair is locked out.
 
-    Returns the username if not locked out, None if request path is in
-    LOCKOUT_EXCLUDED_PATHS.
-    Raises AuthenticationFailed on lockout.
+    Does nothing when either identifier is missing.
     """
-    uri_path = request.get_full_path()
-    if not any(part in LOCKOUT_EXCLUDED_PATHS for part in uri_path.split("/")):
-        ip_address, username = retrieve_user_identification(request)
-
-        if ip_address and username:
-            lockout = safe_cache_get(safe_key(f"{LOCKOUT_IP}{ip_address}-{username}"))
-            if lockout:
-                time_locked_out = datetime.now() - datetime.strptime(
-                    lockout, "%Y-%m-%dT%H:%M:%S"
+    if ip_address and username:
+        lockout = safe_cache_get(safe_key(f"{LOCKOUT_IP}{ip_address}-{username}"))
+        if lockout:
+            time_locked_out = datetime.now() - datetime.strptime(
+                lockout, "%Y-%m-%dT%H:%M:%S"
+            )
+            remaining_time = round(
+                (getattr(settings, "LOCKOUT_TIME", 1800) - time_locked_out.seconds) / 60
+            )
+            raise AuthenticationFailed(
+                _(
+                    "Locked out. Too many wrong username/password attempts. "
+                    f"Try again in {remaining_time} minutes."
                 )
-                remaining_time = round(
-                    (getattr(settings, "LOCKOUT_TIME", 1800) - time_locked_out.seconds)
-                    / 60
-                )
-                raise AuthenticationFailed(
-                    _(
-                        "Locked out. Too many wrong username/password attempts. "
-                        f"Try again in {remaining_time} minutes."
-                    )
-                )
-            return ip_address, username
-    return None, None
+            )
 
 
-def login_attempts(request):
+def add_login_attempt(ip_address, username):
+    """Track a failed login attempt for an IP + username pair.
+
+    Increments the attempt counter and, once MAX_LOGIN_ATTEMPTS is reached,
+    starts a lockout and sends the lockout email. Returns the number of
+    attempts. Raises AuthenticationFailed when the attempt triggers a lockout.
     """
-    Track number of login attempts made by a specific IP within
-    a specified amount of time
-    """
-    ip_address, username = check_lockout(request)
     attempts_key = safe_key(f"{LOGIN_ATTEMPTS}{ip_address}-{username}")
     attempts = safe_cache_get(attempts_key)
 
@@ -328,13 +322,37 @@ def login_attempts(request):
                     datetime.now().strftime("%Y-%m-%dT%H:%M:%S"),
                     getattr(settings, "LOCKOUT_TIME", 1800),
                 )
-            check_lockout(request)
+            assert_not_locked_out(ip_address, username)
             return attempts
         return attempts
 
     safe_cache_set(attempts_key, 1)
 
     return safe_cache_get(attempts_key)
+
+
+def check_lockout(request) -> Tuple[Optional[str], Optional[str]]:
+    """Check request user is not locked out on authentication.
+
+    Returns the username if not locked out, None if request path is in
+    LOCKOUT_EXCLUDED_PATHS.
+    Raises AuthenticationFailed on lockout.
+    """
+    uri_path = request.get_full_path()
+    if not any(part in LOCKOUT_EXCLUDED_PATHS for part in uri_path.split("/")):
+        ip_address, username = retrieve_user_identification(request)
+        assert_not_locked_out(ip_address, username)
+        return ip_address, username
+    return None, None
+
+
+def login_attempts(request):
+    """
+    Track number of login attempts made by a specific IP within
+    a specified amount of time
+    """
+    ip_address, username = check_lockout(request)
+    return add_login_attempt(ip_address, username)
 
 
 def send_lockout_email(username, ip_address):

--- a/onadata/libs/tests/test_authentication.py
+++ b/onadata/libs/tests/test_authentication.py
@@ -1,8 +1,9 @@
-from datetime import timedelta
+from datetime import datetime, timedelta
 from unittest.mock import MagicMock, patch
 
 from django.conf import settings
 from django.contrib.auth.models import User
+from django.core.cache import cache
 from django.http.request import HttpRequest
 from django.test import TestCase
 
@@ -17,9 +18,12 @@ from onadata.libs.authentication import (
     MasterReplicaOAuth2Validator,
     TempTokenAuthentication,
     TempTokenURLParameterAuthentication,
+    assert_not_locked_out,
     check_lockout,
     get_api_token,
+    get_client_ip,
 )
+from onadata.libs.utils.cache_tools import LOCKOUT_IP, safe_cache_set, safe_key
 from onadata.libs.utils.common_tags import API_TOKEN
 
 JWT_SECRET_KEY = getattr(settings, "JWT_SECRET_KEY", "jwt")
@@ -172,6 +176,72 @@ class TestLockout(TestCase):
         # passed as a username
         with self.assertRaises(AuthenticationFailed):
             check_lockout(request)
+
+
+class TestGetClientIp(TestCase):
+    """Test get_client_ip() function."""
+
+    def setUp(self):
+        self.factory = APIRequestFactory()
+
+    def test_uses_remote_addr_by_default(self):
+        """REMOTE_ADDR is used when no X-Real-Ip header is present."""
+        request = self.factory.get("/")
+        self.assertNotIn("HTTP_X_REAL_IP", request.META)
+        self.assertEqual(get_client_ip(request), request.META.get("REMOTE_ADDR"))
+
+    def test_prefers_x_real_ip(self):
+        """The X-Real-Ip header takes precedence over REMOTE_ADDR."""
+        request = self.factory.get("/", HTTP_X_REAL_IP="1.2.3.4")
+        self.assertEqual(get_client_ip(request), "1.2.3.4")
+
+    def test_returns_first_of_comma_separated_x_real_ip(self):
+        """Only the first address in a comma-separated X-Real-Ip is returned."""
+        request = self.factory.get("/", HTTP_X_REAL_IP="1.2.3.4, 5.6.7.8")
+        self.assertEqual(get_client_ip(request), "1.2.3.4")
+
+
+class TestAssertNotLockedOut(TestCase):
+    """Test assert_not_locked_out() function."""
+
+    def setUp(self):
+        cache.clear()
+
+    def tearDown(self):
+        cache.clear()
+
+    @staticmethod
+    def _lock_out(ip_address, username):
+        safe_cache_set(
+            safe_key(f"{LOCKOUT_IP}{ip_address}-{username}"),
+            datetime.now().strftime("%Y-%m-%dT%H:%M:%S"),
+            getattr(settings, "LOCKOUT_TIME", 1800),
+        )
+
+    def test_does_nothing_when_not_locked_out(self):
+        """No exception is raised when the IP + username is not locked out."""
+        self.assertIsNone(assert_not_locked_out("1.2.3.4", "bob"))
+
+    def test_does_nothing_when_identifier_missing(self):
+        """No lockout is checked when either identifier is missing."""
+        self._lock_out("1.2.3.4", "bob")
+        self.assertIsNone(assert_not_locked_out("1.2.3.4", None))
+        self.assertIsNone(assert_not_locked_out(None, "bob"))
+        self.assertIsNone(assert_not_locked_out(None, None))
+
+    def test_raises_when_locked_out(self):
+        """AuthenticationFailed is raised when the IP + username is locked out."""
+        self._lock_out("1.2.3.4", "bob")
+        with self.assertRaises(AuthenticationFailed):
+            assert_not_locked_out("1.2.3.4", "bob")
+
+    def test_lockout_is_keyed_per_ip_and_username(self):
+        """A lockout for one IP + username does not affect another."""
+        self._lock_out("1.2.3.4", "bob")
+        # Different username, same IP -> not locked out
+        self.assertIsNone(assert_not_locked_out("1.2.3.4", "alice"))
+        # Different IP, same username -> not locked out
+        self.assertIsNone(assert_not_locked_out("5.6.7.8", "bob"))
 
 
 class TestMasterReplicaOAuth2Validator(TestCase):


### PR DESCRIPTION
### Changes / Features implemented

The failed-login lockout was only wired into `DigestAuthentication`, so password logins through the web login form (`/accounts/login/`, Django's `LoginView` via `registration.auth_urls` → `ModelBackend`) were never rate-limited. An attacker could brute-force passwords through the web form with no lockout.

- **`onadata/libs/authentication.py`** — factor the digest lockout logic into reusable, identity-keyed helpers: `get_client_ip`, `assert_not_locked_out(ip, username)`, `add_login_attempt(ip, username)`. `check_lockout`/`login_attempts` now delegate to them, so the digest flow is behaviour-preserving.
- **`onadata/apps/main/forms.py`** — `LoginLockoutAuthenticationForm(AuthenticationForm)` reuses those helpers on the login view. Helpers are imported lazily (`# Avoid circular import`) since `authentication` is pulled in transitively during `forms` import.
- **`onadata/apps/main/registration_urls.py`** — point `accounts/login/` at `LoginView` with the new form, declared before the `registration.auth_urls` include so it takes precedence.

Lockout enforcement mirrors the digest flow: blocks all logins while locked, locks after `MAX_LOGIN_ATTEMPTS` for `LOCKOUT_TIME`, sends the start/end lockout emails, keyed on IP + username, and — like digest — does **not** reset the counter on success. User-facing messages are kept generic so they don't leak information:

- failed attempt below the threshold → `Invalid username or password` (no remaining-attempt count)
- once locked out → `Maximum login attempts exceeded. Please try again later.`

### Steps taken to verify this change does what is intended

New `onadata/apps/main/tests/test_accounts_login_lockout.py` (built TDD, red→green), driven through `POST /accounts/login/`:

- locks out after `MAX_LOGIN_ATTEMPTS` (correct password then blocked, shows the lockout message)
- failed attempt below threshold shows the generic error and does not disclose remaining attempts
- lockout email sent at threshold
- lockout keyed per username (locking one user doesn't lock another from the same IP)

All 4 pass. Existing `test_authentication` (digest `TestLockout` suite) still passes — the refactor is behaviour-preserving.

### Side effects of implementing this change

- The error message on `/accounts/login/` changes from Django's default ("Please enter a correct username and password…") to `Invalid username or password`, and a locked-out user now sees `Maximum login attempts exceeded. Please try again later.`
- The lockout shares the same cache keys, settings (`MAX_LOGIN_ATTEMPTS`, `LOCKOUT_TIME`), and counters as the digest flow, so attempts via either path accumulate against the same IP + username.


**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  - [ ] Updated documentation

Closes #