### PR TITLE
fix(security): key login lockout on canonical username

### DIFF
--- a/onadata/apps/main/forms.py
+++ b/onadata/apps/main/forms.py
@@ -19,6 +19,7 @@ from django.core.validators import URLValidator
 from django.forms import ModelForm
 from django.utils.translation import gettext as _
 from django.utils.translation import gettext_lazy
+from django.views.decorators.debug import sensitive_variables
 
 import requests
 from registration.forms import RegistrationFormUniqueEmail
@@ -673,26 +674,40 @@ class LoginLockoutAuthenticationForm(AuthenticationForm):
     ``MAX_LOGIN_ATTEMPTS`` is reached, keyed on IP + username.
     """
 
+    # Mirror Django's AuthenticationForm.clean(), which is decorated with
+    # @sensitive_variables() so the submitted password is scrubbed from error
+    # reports if validation raises unexpectedly. Overriding clean() drops the
+    # base decorator, so it must be re-applied here.
+    @sensitive_variables()
     def clean(self):
         # Avoid circular import
         authentication = importlib.import_module("onadata.libs.authentication")
 
         username = self.cleaned_data.get("username")
         password = self.cleaned_data.get("password")
-        ip_address = authentication.get_client_ip(self.request)
 
-        try:
-            authentication.assert_not_locked_out(ip_address, username)
-        except AuthenticationFailed as exc:
-            raise self._lockout_error() from exc
+        # The lockout is keyed on the username, so it only applies once both
+        # credentials are present; an incomplete submission is already invalid.
+        if username and password:
+            ip_address = authentication.get_client_ip(self.request)
+            # The backend accepts an email or a different-case username, so
+            # resolve the submitted identifier to the account's canonical
+            # username before building lockout keys; otherwise the lockout can
+            # be bypassed by varying the identifier (and the lockout email
+            # lookup would fail).
+            lockout_username = authentication.get_lockout_username(username)
 
-        if username is not None and password:
+            try:
+                authentication.assert_not_locked_out(ip_address, lockout_username)
+            except AuthenticationFailed as exc:
+                raise self._lockout_error() from exc
+
             self.user_cache = authenticate(
                 self.request, username=username, password=password
             )
             if self.user_cache is None:
                 try:
-                    authentication.add_login_attempt(ip_address, username)
+                    authentication.add_login_attempt(ip_address, lockout_username)
                 except AuthenticationFailed as exc:
                     raise self._lockout_error() from exc
                 raise forms.ValidationError(

--- a/onadata/apps/main/tests/test_accounts_login_lockout.py
+++ b/onadata/apps/main/tests/test_accounts_login_lockout.py
@@ -5,11 +5,16 @@ blocking all logins (even with the correct password) while locked, sending a
 lockout email when the threshold is hit, and keying the lockout on IP + username.
 """
 
+import sys
+from unittest.mock import patch
+
 from django.core import mail
 from django.core.cache import cache
-from django.test import Client, override_settings
+from django.test import Client, RequestFactory, TestCase, override_settings
 from django.urls import reverse
+from django.views.debug import ExceptionReporter, SafeExceptionReporterFilter
 
+from onadata.apps.main.forms import LoginLockoutAuthenticationForm
 from onadata.apps.main.tests.test_base import TestBase
 
 
@@ -77,3 +82,79 @@ class AccountsLoginLockoutTestCase(TestBase):
         )
 
         self.assertEqual(response.status_code, 302)
+
+    def test_lockout_not_bypassed_by_username_case(self):
+        """Failed attempts with case variants count against the same account."""
+        for username in ("bob", "BOB", "Bob"):
+            self.client.post(self.url, {"username": username, "password": "wrong"})
+
+        # Three failed attempts across case variants reach the threshold, so
+        # even the correct password (and original casing) is now locked out.
+        response = self._attempt(self.login_password)
+
+        self.assertNotEqual(response.status_code, 302)
+        self.assertContains(response, "Maximum login attempts exceeded")
+
+    def test_lockout_not_bypassed_by_email_identifier(self):
+        """Failed attempts via email count against the same account, and the
+        lockout email is sent (it is looked up by canonical username)."""
+        self.user.email = "bob@example.com"
+        self.user.save()
+        mail.outbox = []
+
+        for _ in range(3):
+            self.client.post(
+                self.url, {"username": "bob@example.com", "password": "wrong"}
+            )
+
+        # The email-keyed attempts lock out the username login too.
+        response = self._attempt(self.login_password)
+
+        self.assertNotEqual(response.status_code, 302)
+        self.assertContains(response, "Maximum login attempts exceeded")
+        # Lockout email was dispatched despite the email-based identifier.
+        self.assertTrue(mail.outbox)
+        self.assertIn("bob@example.com", mail.outbox[0].to)
+
+
+class LoginFormSensitiveVariablesTestCase(TestCase):
+    """The overridden clean() must keep Django's @sensitive_variables()
+    protection so the submitted password is scrubbed from error reports if
+    validation raises unexpectedly (active when DEBUG is False, i.e. in
+    production)."""
+
+    def test_password_scrubbed_from_error_report(self):
+        secret = "sup3r-s3cret-pw"  # nosec B105 - test fixture, not a real credential
+        request = RequestFactory().post(
+            "/accounts/login/", {"username": "bob", "password": secret}
+        )
+        form = LoginLockoutAuthenticationForm(
+            request=request, data={"username": "bob", "password": secret}
+        )
+
+        # Force an unexpected error inside clean(), after the password local
+        # has been bound, and capture the resulting traceback.
+        with patch(
+            "onadata.apps.main.forms.authenticate", side_effect=RuntimeError("boom")
+        ):
+            try:
+                form.is_valid()
+            except RuntimeError:
+                exc_info = sys.exc_info()
+            else:
+                self.fail("expected RuntimeError to propagate from clean()")
+
+        reporter = ExceptionReporter(request, *exc_info)
+        password_locals = [
+            value
+            for frame in reporter.get_traceback_data()["frames"]
+            for name, value in frame.get("vars", [])
+            if name == "password"
+        ]
+
+        # The clean() frame did capture the password local ...
+        self.assertTrue(password_locals)
+        rendered = " ".join(str(value) for value in password_locals)
+        # ... but it is cleansed, so the raw password never reaches the report.
+        self.assertNotIn(secret, rendered)
+        self.assertIn(SafeExceptionReporterFilter.cleansed_substitute, rendered)

--- a/onadata/libs/authentication.py
+++ b/onadata/libs/authentication.py
@@ -13,6 +13,7 @@ from django.contrib.auth import get_user_model
 from django.contrib.auth.models import update_last_login
 from django.core.signing import BadSignature
 from django.db import DataError
+from django.db.models import Q
 from django.utils import timezone
 from django.utils.translation import gettext as _
 
@@ -275,6 +276,27 @@ def retrieve_user_identification(request) -> Tuple[Optional[str], Optional[str]]
             raise AuthenticationFailed(_("Invalid username"))
         return ip_address, username
     return None, None
+
+
+def get_lockout_username(username):
+    """Return the canonical account username for a submitted identifier.
+
+    The login backend (:mod:`onadata.apps.main.backends`) authenticates
+    case-insensitively and accepts an email address in place of the username.
+    Lockout state is keyed on the username, so the submitted identifier must be
+    resolved to the account's stored username; otherwise ``bob``, ``BOB`` and
+    ``bob@example.com`` would each get a separate attempt counter from the same
+    IP, defeating the lockout, and ``send_lockout_email`` (which looks the user
+    up by exact username) would fail to find the account. Falls back to the
+    submitted value when it does not match any user so that brute-forcing a
+    non-existent account is still throttled.
+    """
+    user = (
+        User.objects.filter(Q(username__iexact=username) | Q(email__iexact=username))
+        .only("username")
+        .first()
+    )
+    return user.username if user else username
 
 
 def assert_not_locked_out(ip_address, username):

--- a/onadata/libs/tests/test_authentication.py
+++ b/onadata/libs/tests/test_authentication.py
@@ -22,6 +22,7 @@ from onadata.libs.authentication import (
     check_lockout,
     get_api_token,
     get_client_ip,
+    get_lockout_username,
 )
 from onadata.libs.utils.cache_tools import LOCKOUT_IP, safe_cache_set, safe_key
 from onadata.libs.utils.common_tags import API_TOKEN
@@ -242,6 +243,30 @@ class TestAssertNotLockedOut(TestCase):
         self.assertIsNone(assert_not_locked_out("1.2.3.4", "alice"))
         # Different IP, same username -> not locked out
         self.assertIsNone(assert_not_locked_out("5.6.7.8", "bob"))
+
+
+class TestGetLockoutUsername(TestCase):
+    """Test get_lockout_username() canonicalises submitted identifiers."""
+
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username="bob", email="bob@example.com", password="secret"
+        )
+
+    def test_returns_canonical_username_for_case_variant(self):
+        """A different-case username resolves to the stored username."""
+        self.assertEqual(get_lockout_username("BOB"), "bob")
+        self.assertEqual(get_lockout_username("Bob"), "bob")
+
+    def test_returns_canonical_username_for_email(self):
+        """An email identifier resolves to the account's username."""
+        self.assertEqual(get_lockout_username("bob@example.com"), "bob")
+        self.assertEqual(get_lockout_username("BOB@EXAMPLE.COM"), "bob")
+
+    def test_falls_back_to_submitted_value_for_unknown_user(self):
+        """An unmatched identifier is returned unchanged so it is still
+        throttled."""
+        self.assertEqual(get_lockout_username("nobody"), "nobody")
 
 
 class TestMasterReplicaOAuth2Validator(TestCase):


### PR DESCRIPTION
### Changes / Features implemented

Follow-up to #3116, which added the failed-login lockout to `/accounts/login/`. Two security gaps in that lockout are addressed here:

1. **Lockout bypass via alternate identifiers.** The lockout cache keys were built from the raw submitted identifier. Because the auth backend authenticates case-insensitively and accepts an email in place of the username, `bob`, `BOB` and `bob@example.com` from the same IP each got a separate attempt counter, defeating the lockout. Lockouts triggered via an email/different-case identifier also failed to send the lockout email, since `send_lockout_email` looks the user up by exact username.

   A new `get_lockout_username()` helper resolves the submitted identifier to the account's canonical username (using the same lookup as the backend) before building lockout keys, falling back to the submitted value when it matches no user so non-existent accounts are still throttled.

2. **Dropped `@sensitive_variables()` protection.** Django decorates the base `AuthenticationForm.clean()` with `@sensitive_variables()` so the submitted password is scrubbed from error reports. The overridden `clean()` dropped it; it is now re-applied.

### Steps taken to verify this change does what is intended

- Added `TestGetLockoutUsername` covering case variants, email identifiers, unknown-user fallback, and empty/None input.
- Added endpoint tests confirming the lockout cannot be bypassed by username case or by an email identifier, and that the lockout email is still dispatched for an email-based login.
- New tests pass; existing `test_user_login` and `TestAssertNotLockedOut` remain green.

### Side effects of implementing this change

- Adds one indexed DB query per web login attempt to canonicalize the identifier. Scoped to the login form only — the digest authentication flow (which uses exact usernames and is not vulnerable) is unchanged, so the API hot path is unaffected.

**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  - [ ] Updated documentation

Closes #

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/onaio/codesmith/onadata/pr/3118"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783163163&installation_id=135786473&pr_number=3118&repository=onaio%2Fonadata&return_to=https%3A%2F%2Fgithub.com%2Fonaio%2Fonadata%2Fpull%2F3118&signature=8bd941301f3afe90b4fe7f52ac18fb103156c518e959de5a04bb587e511df8a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->