### PR TITLE
chore: bump cryptography, valigetta, and lxml

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -9,5 +9,5 @@ git+https://github.com/onaio/floip-py.git@3c980eb184069ae7c3c9136b18441978237cd4
 git+https://github.com/onaio/python-json2xlsclient.git@62b4645f7b4f2684421a13ce98da0331a9dd66a0#egg=python-json2xlsclient
 git+https://github.com/onaio/ona-oidc.git@8f39ec029a3ac07a3f4d565c8f3d30e0061f318d#egg=ona-oidc
 -e git+https://github.com/onaio/savreaderwriter.git@fix-pep-440-issues#egg=savreaderwriter
-git+https://git@github.com/onaio/valigetta.git@v0.2.1#egg=valigetta
+git+https://git@github.com/onaio/valigetta.git@v0.2.2#egg=valigetta
 codetiming

--- a/requirements/base.pip
+++ b/requirements/base.pip
@@ -66,7 +66,7 @@ click-repl==0.3.0
     # via celery
 codetiming==1.4.0
     # via -r requirements/base.in
-cryptography==44.0.3
+cryptography==46.0.5
     # via
     #   google-auth
     #   jwcrypto
@@ -226,7 +226,7 @@ lark==1.3.1
     # via pyxform
 linear-tsv==1.1.0
     # via dataflows-tabulator
-lxml==6.0.2
+lxml==6.1.1
     # via onadata
 markdown==3.10.2
     # via onadata
@@ -380,7 +380,7 @@ urllib3==2.6.3
     #   sentry-sdk
 uwsgi==2.0.31
     # via onadata
-valigetta @ git+https://git@github.com/onaio/valigetta.git@v0.2.1
+valigetta @ git+https://git@github.com/onaio/valigetta.git@v0.2.2
     # via -r requirements/base.in
 vine==5.1.0
     # via

--- a/requirements/dev.pip
+++ b/requirements/dev.pip
@@ -77,7 +77,7 @@ click-repl==0.3.0
     # via celery
 codetiming==1.4.0
     # via -r requirements/base.in
-cryptography==44.0.3
+cryptography==46.0.5
     # via
     #   google-auth
     #   jwcrypto
@@ -281,7 +281,7 @@ lark==1.3.1
     # via pyxform
 linear-tsv==1.1.0
     # via dataflows-tabulator
-lxml==6.0.2
+lxml==6.1.1
     # via onadata
 markdown==3.10.2
     # via onadata
@@ -542,7 +542,7 @@ urllib3==2.6.3
     #   sentry-sdk
 uwsgi==2.0.31
     # via onadata
-valigetta @ git+https://git@github.com/onaio/valigetta.git@v0.2.1
+valigetta @ git+https://git@github.com/onaio/valigetta.git@v0.2.2
     # via -r requirements/base.in
 vine==5.1.0
     # via


### PR DESCRIPTION
### Changes / Features implemented

Ports the genuine **forward** dependency updates from #3044 to `main`, without dragging in that branch's unrelated changes (decryption fixes, CSV-injection work, Docker/Trivy, etc.).

| Package | main | This PR | Notes |
|---------|------|---------|-------|
| `cryptography` | 44.0.3 | **46.0.5** | Major bump (44 → 46) |
| `valigetta` | v0.2.1 | **v0.2.2** | Required by `cryptography>=46` — v0.2.1 pins `cryptography<45`, so the two are coupled |
| `lxml` | 6.0.2 | **6.1.1** | Independent |

Files touched: `requirements/base.in`, `requirements/base.pip`, `requirements/dev.pip`.

### Why a surgical edit instead of copying #3044's requirement files

PR #3044 was branched from an older base (`v5.10.0-*`) and its `requirements/*.pip` files were `pip-compile`d at that earlier point. Relative to `main`, **most** of its requirement deltas are actually *downgrades* (e.g. `boto3` 1.42.86→1.42.72, `celery` 5.6.3→5.6.2, `numpy` 2.4.4→2.2.6, `sentry-sdk` 2.57.0→2.55.0). Copying the files wholesale would regress `main`. This PR therefore applies only the three lines where #3044 is genuinely *ahead* of `main`.

`azure.pip` already pins `cryptography==46.0.7` (newer), and `s3.pip`/`ses.pip`/`docs.pip` don't pin any of these three — so no other requirement files need changing.

### Steps taken to verify this change does what is intended

- Diffed every `requirements/*.pip` between `main` and #3044 and classified each version delta as forward vs. backward; confirmed these three are the only forward updates.
- Confirmed `valigetta` v0.2.2 supports `cryptography>=46`, resolving the `<45` pin that v0.2.1 carried.

### Side effects of implementing this change

- `cryptography` 44 → 46 is a major version jump. CI test run should confirm no API-compatibility regressions.

**Before submitting this PR for review, please make sure you have:**

  - [ ] Included tests
  - [ ] Updated documentation

Closes #

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/onaio/codesmith/onadata/pr/3119"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783167410&installation_id=135786473&pr_number=3119&repository=onaio%2Fonadata&return_to=https%3A%2F%2Fgithub.com%2Fonaio%2Fonadata%2Fpull%2F3119&signature=ad4d89867c5b6da8cc4b1a1cdf4bc6bf8fe68168cffb28fbdf523ed84e32a2ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->