### PR TITLE
Fix public project response caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,5 @@ sonar-project.properties
 *.er
 .env
 *.csv
+# roborev snapshots
+/.roborev/

--- a/docs/projects.rst
+++ b/docs/projects.rst
@@ -282,6 +282,19 @@ Response
             "deleted_at":null
         }
 
+Public project responses
+------------------------
+
+Unauthenticated requests, and authenticated users who can see a project only
+because it is public, receive a reduced project response. The public response
+keeps public project and form summary fields such as ``url``, ``projectid``,
+``name``, ``forms``, ``public``, ``tags``, ``num_datasets``,
+``last_submission_date``, ``date_created`` and ``date_modified``.
+
+The public response omits internal administration fields: ``owner``,
+``created_by``, ``users``, ``teams`` and ``metadata``. In the version 2 API,
+``current_user_role`` is also omitted for public-only access.
+
 List users with access to a project (v2)
 ----------------------------------------
 

--- a/onadata/apps/api/tests/viewsets/test_project_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_project_viewset.py
@@ -61,10 +61,15 @@ from onadata.libs.permissions import (
 )
 from onadata.libs.serializers.metadata_serializer import MetaDataSerializer
 from onadata.libs.serializers.project_serializer import (
+    PROJECT_PUBLIC_EXCLUDED_FIELDS,
     BaseProjectSerializer,
     ProjectSerializer,
 )
-from onadata.libs.utils.cache_tools import PROJ_OWNER_CACHE, safe_key
+from onadata.libs.utils.cache_tools import (
+    PROJ_OWNER_CACHE,
+    PROJ_PUBLIC_OWNER_CACHE,
+    safe_key,
+)
 from onadata.libs.utils.user_auth import get_user_default_project
 
 User = get_user_model()
@@ -1762,6 +1767,7 @@ class TestProjectViewSet(TestAbstractViewSet):
         response = self.view(request)
         self.assertEqual(response.status_code, 200)
         self.assertIn(alice_project_data, response.data)
+        self.assertFalse(PROJECT_PUBLIC_EXCLUDED_FIELDS & set(response.data[0]))
 
         # should show deleted project public project when filtered by owner
         self.project.soft_delete()
@@ -1805,23 +1811,31 @@ class TestProjectViewSet(TestAbstractViewSet):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(False, response.data.get("public"))
         cached_project = cache.get(f"{PROJ_OWNER_CACHE}{self.project.pk}")
-        self.assertEqual(cached_project, response.data)
+        expected_cache = {**response.data}
+        expected_cache.pop("starred")
+        self.assertEqual(cached_project, expected_cache)
 
         projectid = self.project.pk
+        cache.set(f"{PROJ_PUBLIC_OWNER_CACHE}{projectid}", {"public": False})
         data = {"public": True}
         request = self.factory.patch("/", data=data, **self.extra)
         response = view(request, pk=projectid)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(True, response.data.get("public"))
         cached_project = cache.get(f"{PROJ_OWNER_CACHE}{self.project.pk}")
-        self.assertEqual(cached_project, response.data)
+        expected_cache = {**response.data}
+        expected_cache.pop("starred")
+        self.assertEqual(cached_project, expected_cache)
+        self.assertIsNone(cache.get(f"{PROJ_PUBLIC_OWNER_CACHE}{projectid}"))
 
         request = self.factory.get("/", **self.extra)
         response = view(request, pk=self.project.pk)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(True, response.data.get("public"))
         cached_project = cache.get(f"{PROJ_OWNER_CACHE}{self.project.pk}")
-        self.assertEqual(cached_project, response.data)
+        expected_cache = {**response.data}
+        expected_cache.pop("starred")
+        self.assertEqual(cached_project, expected_cache)
 
     def test_project_put_updates(self):
         self._project_create()
@@ -1961,8 +1975,6 @@ class TestProjectViewSet(TestAbstractViewSet):
             organization=self.user,
         )
         public_project.save()
-        alice_data = {"username": "alice", "email": "alice@localhost.com"}
-        self._login_user_and_profile(alice_data)
 
         view = ProjectViewSet.as_view({"get": "retrieve"})
         request = self.factory.get("/", **self.extra)
@@ -1971,6 +1983,89 @@ class TestProjectViewSet(TestAbstractViewSet):
         self.assertEqual(response.data["public"], True)
         self.assertEqual(response.data["projectid"], public_project.pk)
         self.assertEqual(response.data["name"], "demo")
+        for field in PROJECT_PUBLIC_EXCLUDED_FIELDS:
+            self.assertIn(field, response.data)
+
+        list_view = ProjectViewSet.as_view({"get": "list"})
+        alice_data = {"username": "alice", "email": "alice@localhost.com"}
+        self._login_user_and_profile(alice_data)
+        request = self.factory.get("/", **self.extra)
+        response = view(request, pk=public_project.pk)
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(PROJECT_PUBLIC_EXCLUDED_FIELDS & set(response.data))
+
+        request = self.factory.get("/")
+        response = view(request, pk=public_project.pk)
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(PROJECT_PUBLIC_EXCLUDED_FIELDS & set(response.data))
+
+        request = self.factory.get("/")
+        response = list_view(request)
+        self.assertEqual(response.status_code, 200)
+        project_data = next(
+            item for item in response.data if item["projectid"] == public_project.pk
+        )
+        self.assertFalse(PROJECT_PUBLIC_EXCLUDED_FIELDS & set(project_data))
+
+    def test_public_project_detail_cache_uses_public_and_full_variants(self):
+        public_project = Project.objects.create(
+            name="public demo",
+            shared=True,
+            metadata={"description": "public metadata"},
+            created_by=self.user,
+            organization=self.user,
+        )
+        public_project.user_stars.add(self.user)
+        alice_profile = self._create_user_profile(
+            {"username": "alice", "email": "alice@localhost.com"}
+        )
+        ShareProject(public_project, "alice", "readonly").save()
+
+        view = ProjectViewSet.as_view({"get": "retrieve"})
+        request = self.factory.get("/", **self.extra)
+        response = view(request, pk=public_project.pk)
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.data["starred"])
+        self.assertTrue(PROJECT_PUBLIC_EXCLUDED_FIELDS <= set(response.data))
+        full_cache = cache.get(f"{PROJ_OWNER_CACHE}{public_project.pk}")
+        self.assertNotIn("starred", full_cache)
+        self.assertTrue(PROJECT_PUBLIC_EXCLUDED_FIELDS <= set(full_cache))
+
+        request = self.factory.get(
+            "/",
+            **{"HTTP_AUTHORIZATION": f"Token {alice_profile.user.auth_token}"},
+        )
+        response = view(request, pk=public_project.pk)
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(response.data["starred"])
+        self.assertTrue(PROJECT_PUBLIC_EXCLUDED_FIELDS <= set(response.data))
+
+        request = self.factory.get("/")
+        response = view(request, pk=public_project.pk)
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(response.data["starred"])
+        self.assertFalse(PROJECT_PUBLIC_EXCLUDED_FIELDS & set(response.data))
+        public_cache = cache.get(f"{PROJ_PUBLIC_OWNER_CACHE}{public_project.pk}")
+        self.assertIsNotNone(public_cache)
+        self.assertNotIn("starred", public_cache)
+        self.assertFalse(PROJECT_PUBLIC_EXCLUDED_FIELDS & set(public_cache))
+
+        cache.clear()
+
+        request = self.factory.get("/")
+        response = view(request, pk=public_project.pk)
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(response.data["starred"])
+        self.assertFalse(PROJECT_PUBLIC_EXCLUDED_FIELDS & set(response.data))
+
+        request = self.factory.get("/", **self.extra)
+        response = view(request, pk=public_project.pk)
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.data["starred"])
+        self.assertTrue(PROJECT_PUBLIC_EXCLUDED_FIELDS <= set(response.data))
+        full_cache = cache.get(f"{PROJ_OWNER_CACHE}{public_project.pk}")
+        self.assertNotIn("starred", full_cache)
+        self.assertTrue(PROJECT_PUBLIC_EXCLUDED_FIELDS <= set(full_cache))
 
     def test_projects_same_name_diff_case(self):
         data1 = {

--- a/onadata/apps/api/tests/viewsets/v2/test_project_viewset.py
+++ b/onadata/apps/api/tests/viewsets/v2/test_project_viewset.py
@@ -4,9 +4,18 @@ from django.core.cache import cache
 from django.test import override_settings
 
 from onadata.apps.api.tests.viewsets.test_abstract_viewset import TestAbstractViewSet
+from onadata.apps.api.viewsets.project_viewset import (
+    ProjectViewSet as ProjectViewSetV1,
+)
 from onadata.apps.api.viewsets.v2.project_viewset import ProjectViewSet
 from onadata.apps.logger.models import EntityList, Project
 from onadata.libs.models.share_project import ShareProject
+from onadata.libs.serializers.project_serializer import PROJECT_PUBLIC_EXCLUDED_FIELDS
+from onadata.libs.utils.cache_tools import (
+    PROJ_OWNER_CACHE,
+    PROJ_V2_OWNER_CACHE,
+    PROJ_V2_PUBLIC_OWNER_CACHE,
+)
 
 
 @override_settings(TIME_ZONE="UTC")
@@ -65,6 +74,17 @@ class GetProjectListTestCase(TestAbstractViewSet):
             }
         ]
         self.assertEqual(response.data, expected_data)
+
+        self.project.shared = True
+        self.project.save()
+
+        request = self.factory.get("/")
+        response = self.view(request)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 1)
+        public_excluded_fields = PROJECT_PUBLIC_EXCLUDED_FIELDS | {"current_user_role"}
+        self.assertFalse(public_excluded_fields & set(response.data[0]))
 
 
 @override_settings(TIME_ZONE="UTC")
@@ -171,26 +191,69 @@ class RetrieveProjectTestCase(TestAbstractViewSet):
         # Project data is cached
         expected_cache = {**response.data}
         del expected_cache["current_user_role"]
+        del expected_cache["starred"]
 
         self.assertEqual(
-            cache.get(f"ps-project_owner-{self.project.pk}"), expected_cache
+            cache.get(f"{PROJ_V2_OWNER_CACHE}{self.project.pk}"), expected_cache
         )
 
     def test_cache_hit(self):
         """Cached data is returned if it exists"""
         # Simulate cached data
-        cache.set(f"ps-project_owner-{self.project.pk}", {"name": "Tree Monitoring"})
+        cache.set(f"{PROJ_OWNER_CACHE}{self.project.pk}", {"name": "v1 data"})
+        cache.set(
+            f"{PROJ_V2_OWNER_CACHE}{self.project.pk}", {"name": "Tree Monitoring"}
+        )
 
         request = self.factory.get("/", **self.extra)
         response = self.view(request, pk=self.project.pk)
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
-            response.data, {"name": "Tree Monitoring", "current_user_role": "owner"}
+            response.data,
+            {
+                "name": "Tree Monitoring",
+                "starred": False,
+                "current_user_role": "owner",
+            },
         )
 
-    def test_anon_user_current_user_role(self):
-        """Anonymous user has no current user role"""
+    def test_v2_update_does_not_populate_v1_detail_cache(self):
+        """A v2 update cannot cache the v2 response under the v1 detail key."""
+        update_view = ProjectViewSet.as_view({"patch": "partial_update"})
+        request = self.factory.patch(
+            "/", data={"name": "Canopy Monitoring"}, **self.extra
+        )
+        response = update_view(request, pk=self.project.pk)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.data["url"], f"http://testserver/api/v2/projects/{self.project.pk}"
+        )
+        self.assertNotIn("teams", response.data)
+        self.assertIsNone(cache.get(f"{PROJ_OWNER_CACHE}{self.project.pk}"))
+        self.assertEqual(
+            cache.get(f"{PROJ_V2_OWNER_CACHE}{self.project.pk}")["url"],
+            f"http://testserver/api/v2/projects/{self.project.pk}",
+        )
+
+        retrieve_v1 = ProjectViewSetV1.as_view({"get": "retrieve"})
+        request = self.factory.get("/", **self.extra)
+        response = retrieve_v1(request, pk=self.project.pk)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.data["url"], f"http://testserver/api/v1/projects/{self.project.pk}"
+        )
+        self.assertEqual(response.data["name"], "Canopy Monitoring")
+        self.assertIn("teams", response.data)
+        self.assertEqual(
+            cache.get(f"{PROJ_OWNER_CACHE}{self.project.pk}")["url"],
+            f"http://testserver/api/v1/projects/{self.project.pk}",
+        )
+
+    def test_anon_user_public_project_fields(self):
+        """Anonymous user gets the public-safe project shape."""
         self.project.shared = True
         self.project.save()
 
@@ -198,7 +261,82 @@ class RetrieveProjectTestCase(TestAbstractViewSet):
         response = self.view(request, pk=self.project.pk)
 
         self.assertEqual(response.status_code, 200)
-        self.assertIsNone(response.data["current_user_role"])
+        public_excluded_fields = PROJECT_PUBLIC_EXCLUDED_FIELDS | {"current_user_role"}
+        self.assertFalse(public_excluded_fields & set(response.data))
+
+        alice_profile = self._create_user_profile(
+            {"username": "alice", "email": "alice@localhost.com"}
+        )
+        extra = {"HTTP_AUTHORIZATION": f"Token {alice_profile.user.auth_token}"}
+
+        request = self.factory.get("/", **extra)
+        response = self.view(request, pk=self.project.pk)
+
+        self.assertEqual(response.status_code, 200)
+        public_excluded_fields = PROJECT_PUBLIC_EXCLUDED_FIELDS | {"current_user_role"}
+        self.assertFalse(public_excluded_fields & set(response.data))
+
+    def test_public_project_detail_cache_uses_public_and_full_variants(self):
+        """Public and full project detail responses use separate cache variants."""
+        self.project.shared = True
+        self.project.save()
+        self.project.user_stars.add(self.user)
+        alice_profile = self._create_user_profile(
+            {"username": "alice", "email": "alice@localhost.com"}
+        )
+        ShareProject(self.project, "alice", "readonly").save()
+
+        request = self.factory.get("/", **self.extra)
+        response = self.view(request, pk=self.project.pk)
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.data["starred"])
+        self.assertIn("owner", response.data)
+        self.assertIn("current_user_role", response.data)
+        full_cache = cache.get(f"{PROJ_V2_OWNER_CACHE}{self.project.pk}")
+        self.assertIsNotNone(full_cache)
+        self.assertIn("owner", full_cache)
+        self.assertNotIn("starred", full_cache)
+        self.assertNotIn("current_user_role", full_cache)
+
+        request = self.factory.get(
+            "/",
+            **{"HTTP_AUTHORIZATION": f"Token {alice_profile.user.auth_token}"},
+        )
+        response = self.view(request, pk=self.project.pk)
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(response.data["starred"])
+        self.assertIn("owner", response.data)
+        self.assertEqual(response.data["current_user_role"], "readonly")
+
+        request = self.factory.get("/")
+        response = self.view(request, pk=self.project.pk)
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(response.data["starred"])
+        public_excluded_fields = PROJECT_PUBLIC_EXCLUDED_FIELDS | {"current_user_role"}
+        self.assertFalse(public_excluded_fields & set(response.data))
+        public_cache = cache.get(f"{PROJ_V2_PUBLIC_OWNER_CACHE}{self.project.pk}")
+        self.assertIsNotNone(public_cache)
+        self.assertNotIn("starred", public_cache)
+        self.assertFalse(public_excluded_fields & set(public_cache))
+
+        cache.clear()
+
+        request = self.factory.get("/")
+        response = self.view(request, pk=self.project.pk)
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(response.data["starred"])
+        self.assertFalse(public_excluded_fields & set(response.data))
+
+        request = self.factory.get("/", **self.extra)
+        response = self.view(request, pk=self.project.pk)
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.data["starred"])
+        self.assertIn("owner", response.data)
+        self.assertIn("current_user_role", response.data)
+        full_cache = cache.get(f"{PROJ_V2_OWNER_CACHE}{self.project.pk}")
+        self.assertIsNotNone(full_cache)
+        self.assertIn("owner", full_cache)
+        self.assertNotIn("starred", full_cache)
 
 
 @override_settings(TIME_ZONE="UTC")

--- a/onadata/apps/api/tools.py
+++ b/onadata/apps/api/tools.py
@@ -62,9 +62,9 @@ from onadata.libs.utils.cache_tools import (
     PROJ_BASE_FORMS_CACHE,
     PROJ_FORMS_CACHE,
     PROJ_NUM_DATASET_CACHE,
-    PROJ_OWNER_CACHE,
     PROJ_SUB_DATE_CACHE,
     XFORM_LIST_CACHE,
+    clear_project_owner_cache,
     reset_project_cache,
     safe_cache_delete,
 )
@@ -77,6 +77,10 @@ from onadata.libs.utils.model_tools import queryset_iterator
 from onadata.libs.utils.user_auth import (
     check_and_set_form_by_id,
     check_and_set_form_by_id_string,
+)
+from onadata.libs.utils.xform_utils import (
+    set_project_perms_to_xform,
+    set_project_perms_to_xform_async,
 )
 
 DECIMAL_PRECISION = 2
@@ -437,7 +441,7 @@ def publish_project_xform(request, project):
 
     if "formid" in request.data:
         xform = get_object_or_404(XForm, pk=request.data.get("formid"))
-        safe_cache_delete(f"{PROJ_OWNER_CACHE}{xform.project.pk}")
+        clear_project_owner_cache(xform.project.pk)
         safe_cache_delete(f"{PROJ_FORMS_CACHE}{xform.project.pk}")
         safe_cache_delete(f"{PROJ_BASE_FORMS_CACHE}{xform.project.pk}")
         safe_cache_delete(f"{PROJ_NUM_DATASET_CACHE}{xform.project.pk}")
@@ -464,15 +468,9 @@ def publish_project_xform(request, project):
         # First assign permissions to the person who uploaded the form
         OwnerRole.add(request.user, xform)
         try:
-            # pylint: disable=import-outside-toplevel,unused-import
-            from onadata.libs.utils.xform_utils import set_project_perms_to_xform_async
-
             # Next run async task to apply all other perms
             set_project_perms_to_xform_async.delay(xform.pk, project.pk)
         except OperationalError:
-            # pylint: disable=import-outside-toplevel,unused-import
-            from onadata.libs.utils.xform_utils import set_project_perms_to_xform
-
             # Apply permissions synchrounously
             set_project_perms_to_xform(xform, project)
     else:

--- a/onadata/apps/api/viewsets/dataview_viewset.py
+++ b/onadata/apps/api/viewsets/dataview_viewset.py
@@ -34,11 +34,12 @@ from onadata.libs.utils.api_export_tools import (
     process_async_export,
     response_for_format,
 )
+from onadata.libs.utils.bbox_tools import compute_instance_bbox
 from onadata.libs.utils.cache_tools import (
     DATAVIEW_BBOX_CACHE,
-    get_bbox_cache_ttl,
-    PROJ_OWNER_CACHE,
     PROJECT_LINKED_DATAVIEWS,
+    clear_project_owner_cache,
+    get_bbox_cache_ttl,
     safe_cache_delete,
     safe_cache_get,
     safe_cache_set,
@@ -47,7 +48,6 @@ from onadata.libs.utils.chart_tools import (
     get_chart_data_for_field,
     get_field_from_field_name,
 )
-from onadata.libs.utils.bbox_tools import compute_instance_bbox
 from onadata.libs.utils.common_tools import get_abbreviated_xpath
 from onadata.libs.utils.dataview_filters import apply_filters
 from onadata.libs.utils.export_tools import parse_request_export_options, str_to_bool
@@ -180,9 +180,7 @@ class DataViewViewSet(
             return Response(cached)
 
         data = {
-            "bbox": compute_instance_bbox(
-                [self.object.xform_id], dataview=self.object
-            )
+            "bbox": compute_instance_bbox([self.object.xform_id], dataview=self.object)
         }
         safe_cache_set(cache_key, data, get_bbox_cache_ttl())
         return Response(data)
@@ -328,7 +326,7 @@ class DataViewViewSet(
         dataview = self.get_object()
         user = request.user
         dataview.soft_delete(user)
-        safe_cache_delete(f"{PROJ_OWNER_CACHE}{dataview.project.pk}")
+        clear_project_owner_cache(dataview.project.pk)
 
         return Response(status=status.HTTP_204_NO_CONTENT)
 

--- a/onadata/apps/api/viewsets/project_viewset.py
+++ b/onadata/apps/api/viewsets/project_viewset.py
@@ -37,6 +37,7 @@ from onadata.libs.serializers.project_invitation_serializer import (
 from onadata.libs.serializers.project_serializer import (
     BaseProjectSerializer,
     ProjectSerializer,
+    is_starred,
 )
 from onadata.libs.serializers.share_project_serializer import (
     RemoveUserFromProjectSerializer,
@@ -48,8 +49,9 @@ from onadata.libs.serializers.xform_serializer import (
     XFormSerializer,
 )
 from onadata.libs.utils.cache_tools import (
-    PROJ_OWNER_CACHE,
-    safe_cache_delete,
+    clear_project_owner_cache,
+    get_project_cache_key,
+    get_shared_project_detail_cache_data,
     safe_cache_get,
     safe_cache_set,
 )
@@ -91,6 +93,7 @@ class ProjectViewSet(
     permission_classes = [ProjectPermissions]
     filter_backends = (AnonUserProjectFilter, ProjectOwnerFilter, TagFilter)
     pagination_class = StandardPageNumberPagination
+    api_version = "v1"
 
     def get_serializer_class(self):
         """Override `get_serializer_class."""
@@ -121,19 +124,27 @@ class ProjectViewSet(
         """Updates project properties and set's cache with the updated records."""
         project_id = kwargs.get("pk")
         response = super().update(request, *args, **kwargs)
-        safe_cache_set(f"{PROJ_OWNER_CACHE}{project_id}", response.data)
+        clear_project_owner_cache(project_id)
+        safe_cache_set(
+            get_project_cache_key(project_id, request, api_version=self.api_version),
+            get_shared_project_detail_cache_data(response.data),
+        )
         return response
 
     def retrieve(self, request, *args, **kwargs):
         """Retrieve single project"""
-        project_id = kwargs.get("pk")
-        project = safe_cache_get(f"{PROJ_OWNER_CACHE}{project_id}")
-        if project:
-            return Response(project)
         # pylint: disable=attribute-defined-outside-init
         self.object = self.get_object()
-        serializer = ProjectSerializer(self.object, context={"request": request})
-        return Response(serializer.data)
+        cache_key = get_project_cache_key(self.object.pk, request, self.object)
+        project_data = safe_cache_get(cache_key)
+        if project_data is None:
+            serializer = ProjectSerializer(self.object, context={"request": request})
+            project_data = get_shared_project_detail_cache_data(serializer.data)
+            safe_cache_set(cache_key, project_data)
+        else:
+            project_data = get_shared_project_detail_cache_data(project_data)
+
+        return Response({**project_data, "starred": is_starred(self.object, request)})
 
     def list(self, request, *args, **kwargs):
         """Returns a list of projects"""
@@ -232,7 +243,7 @@ class ProjectViewSet(
             return Response(data=serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
         # clear cache
-        safe_cache_delete(f"{PROJ_OWNER_CACHE}{self.object.pk}")
+        clear_project_owner_cache(self.object.pk)
 
         return Response(status=status.HTTP_204_NO_CONTENT)
 

--- a/onadata/apps/api/viewsets/v2/project_viewset.py
+++ b/onadata/apps/api/viewsets/v2/project_viewset.py
@@ -6,14 +6,16 @@ from rest_framework.decorators import action
 from rest_framework.response import Response
 
 from onadata.apps.api.viewsets.project_viewset import ProjectViewSet as ProjectViewSetV1
-from onadata.libs.serializers.project_serializer import get_teams, get_users
+from onadata.libs.serializers.project_serializer import get_teams, get_users, is_starred
 from onadata.libs.serializers.v2.project_serializer import (
     ProjectListSerializer,
     ProjectPrivateSerializer,
     ProjectSerializer,
 )
 from onadata.libs.utils.cache_tools import (
-    PROJ_OWNER_CACHE,
+    get_project_cache_key,
+    get_shared_project_detail_cache_data,
+    is_public_project_access,
     safe_cache_get,
     safe_cache_set,
 )
@@ -24,6 +26,7 @@ class ProjectViewSet(ProjectViewSetV1):
     """List, Retrieve, Update, Create Project and Project Forms."""
 
     serializer_class = ProjectSerializer
+    api_version = "v2"
 
     def get_serializer_class(self):
         """Get serializer class based on action
@@ -41,13 +44,23 @@ class ProjectViewSet(ProjectViewSetV1):
         Overrides super().retrieve()
         """
         project = self.get_object()
-        base_data = safe_cache_get(f"{PROJ_OWNER_CACHE}{project.pk}")
+        cache_key = get_project_cache_key(
+            project.pk, request, project, api_version=self.api_version
+        )
+        base_data = safe_cache_get(cache_key)
 
         if base_data is None:
-            base_data = ProjectSerializer(project, context={"request": request}).data
+            base_data = get_shared_project_detail_cache_data(
+                ProjectSerializer(project, context={"request": request}).data
+            )
+            safe_cache_set(cache_key, base_data)
+        else:
+            base_data = get_shared_project_detail_cache_data(base_data)
 
-        # Cache data
-        safe_cache_set(f"{PROJ_OWNER_CACHE}{project.pk}", base_data)
+        base_data = {**base_data, "starred": is_starred(project, request)}
+
+        if is_public_project_access(request, project):
+            return Response(base_data)
 
         # Inject user specific fields
         private_data = ProjectPrivateSerializer(

--- a/onadata/apps/api/viewsets/xform_viewset.py
+++ b/onadata/apps/api/viewsets/xform_viewset.py
@@ -91,8 +91,8 @@ from onadata.libs.utils.cache_tools import (
     ENKETO_SINGLE_SUBMIT_URL_CACHE,
     ENKETO_URL_CACHE,
     ENKETO_URLS_CACHE,
-    PROJ_OWNER_CACHE,
     XFORM_BBOX_CACHE,
+    clear_project_owner_cache,
     get_bbox_cache_ttl,
     get_enketo_urls_cache_ttl,
     safe_cache_delete,
@@ -1023,7 +1023,7 @@ class XFormViewSet(
             }
 
             # clear project from cache
-            safe_cache_delete(f"{PROJ_OWNER_CACHE}{xform.project.pk}")
+            clear_project_owner_cache(xform.project.pk)
             resp_code = status.HTTP_202_ACCEPTED
 
         if request.method == "GET":

--- a/onadata/apps/logger/models/data_view.py
+++ b/onadata/apps/logger/models/data_view.py
@@ -23,8 +23,8 @@ from onadata.libs.models.sorting import (  # noqa pylint: disable=unused-import
 from onadata.libs.utils.cache_tools import (  # noqa pylint: disable=unused-import
     DATAVIEW_COUNT,
     DATAVIEW_LAST_SUBMISSION_TIME,
-    PROJ_OWNER_CACHE,
     XFORM_LINKED_DATAVIEWS,
+    clear_project_owner_cache,
     safe_cache_delete,
 )
 from onadata.libs.utils.common_tags import (
@@ -428,7 +428,7 @@ class DataView(models.Model):
     ):
         """Returns a list of records for the view based on the parameters passed in."""
 
-        (sql, columns, params) = cls.generate_query_string(
+        sql, columns, params = cls.generate_query_string(
             data_view,
             start_index,
             limit,
@@ -453,7 +453,7 @@ def clear_cache(sender, instance, **kwargs):  # pylint: disable=unused-argument
 
 def clear_dataview_cache(sender, instance, **kwargs):  # pylint: disable=unused-argument
     """Post Save handler for clearing dataview cache on serialized fields."""
-    safe_cache_delete(f"{PROJ_OWNER_CACHE}{instance.project.pk}")
+    clear_project_owner_cache(instance.project.pk)
     safe_cache_delete(f"{DATAVIEW_COUNT}{instance.xform.pk}")
     safe_cache_delete(f"{DATAVIEW_LAST_SUBMISSION_TIME}{instance.xform.pk}")
     safe_cache_delete(f"{XFORM_LINKED_DATAVIEWS}{instance.xform.pk}")

--- a/onadata/apps/logger/models/xform.py
+++ b/onadata/apps/logger/models/xform.py
@@ -14,6 +14,7 @@ from io import BytesIO
 from pathlib import Path
 from xml.dom import Node
 
+from django.apps import apps
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.fields import GenericRelation
@@ -47,12 +48,12 @@ from onadata.libs.utils.cache_tools import (
     PROJ_BASE_FORMS_CACHE,
     PROJ_FORMS_CACHE,
     PROJ_NUM_DATASET_CACHE,
-    PROJ_OWNER_CACHE,
     PROJ_SUB_DATE_CACHE,
     XFORM_COUNT,
     XFORM_DEC_SUBMISSION_COUNT,
     XFORM_SUBMISSION_COUNT_FOR_DAY,
     XFORM_SUBMISSION_COUNT_FOR_DAY_DATE,
+    clear_project_owner_cache,
     safe_cache_delete,
     safe_cache_get,
 )
@@ -891,12 +892,8 @@ class XFormMixin:
         header = self._headers[i]
 
         if not hasattr(self, "_variable_names"):
-            # pylint: disable=import-outside-toplevel
-            from onadata.apps.viewer.models.column_rename import (  # noqa: PLC0415
-                ColumnRename,
-            )
-
-            self._variable_names = ColumnRename.get_dict()
+            column_rename_model = apps.get_model("viewer", "ColumnRename")
+            self._variable_names = column_rename_model.get_dict()
 
         if header in self._variable_names and self._variable_names[header]:
             return self._variable_names[header]
@@ -1516,7 +1513,7 @@ post_delete.connect(
 
 def clear_project_cache(project_id):
     """Clear project cache"""
-    safe_cache_delete(f"{PROJ_OWNER_CACHE}{project_id}")
+    clear_project_owner_cache(project_id)
     safe_cache_delete(f"{PROJ_FORMS_CACHE}{project_id}")
     safe_cache_delete(f"{PROJ_BASE_FORMS_CACHE}{project_id}")
     safe_cache_delete(f"{PROJ_SUB_DATE_CACHE}{project_id}")

--- a/onadata/libs/models/share_project.py
+++ b/onadata/libs/models/share_project.py
@@ -13,8 +13,8 @@ from onadata.libs.permissions import (
     ReadOnlyRoleNoDownload,
 )
 from onadata.libs.utils.cache_tools import (
-    PROJ_OWNER_CACHE,
     PROJ_PERM_CACHE,
+    clear_project_owner_cache,
     safe_cache_delete,
 )
 from onadata.libs.utils.common_tags import XFORM_META_PERMS
@@ -76,7 +76,7 @@ class ShareProject:
     def save(self, **kwargs):
         """Assigns role permissions to a project for the user."""
         # pylint: disable=too-many-nested-blocks
-        safe_cache_delete(f"{PROJ_OWNER_CACHE}{self.project.pk}")
+        clear_project_owner_cache(self.project.pk)
         safe_cache_delete(f"{PROJ_PERM_CACHE}{self.project.pk}")
         if self.remove:
             self.__remove_user()
@@ -115,7 +115,7 @@ class ShareProject:
                     role.add(self.user, entity_list)
 
         # clear cache
-        safe_cache_delete(f"{PROJ_OWNER_CACHE}{self.project.pk}")
+        clear_project_owner_cache(self.project.pk)
         safe_cache_delete(f"{PROJ_PERM_CACHE}{self.project.pk}")
         # propagate KPI permissions
         propagate_project_permissions_async.apply_async(args=[self.project.pk])

--- a/onadata/libs/models/share_team_project.py
+++ b/onadata/libs/models/share_team_project.py
@@ -5,8 +5,8 @@ ShareTeamProject model - facilitate sharing a project to a team.
 
 from onadata.libs.permissions import ROLES
 from onadata.libs.utils.cache_tools import (
-    PROJ_OWNER_CACHE,
     PROJ_PERM_CACHE,
+    clear_project_owner_cache,
     safe_cache_delete,
 )
 from onadata.libs.utils.common_tags import XFORM_META_PERMS
@@ -45,7 +45,7 @@ class ShareTeamProject:
                         role.add(self.team, dataview.xform)
 
             # clear cache
-            safe_cache_delete(f"{PROJ_OWNER_CACHE}{self.project.pk}")
+            clear_project_owner_cache(self.project.pk)
             safe_cache_delete(f"{PROJ_PERM_CACHE}{self.project.pk}")
 
     def remove_team(self):
@@ -65,5 +65,5 @@ class ShareTeamProject:
                 role._remove_obj_permissions(self.team, dataview.xform)
 
             # clear cache
-            safe_cache_delete(f"{PROJ_OWNER_CACHE}{self.project.pk}")
+            clear_project_owner_cache(self.project.pk)
             safe_cache_delete(f"{PROJ_PERM_CACHE}{self.project.pk}")

--- a/onadata/libs/serializers/project_serializer.py
+++ b/onadata/libs/serializers/project_serializer.py
@@ -17,6 +17,7 @@ from onadata.apps.logger.models.project import Project
 from onadata.apps.logger.models.xform import XForm
 from onadata.apps.main.models.user_profile import UserProfile
 from onadata.libs.permissions import ManagerRole, OwnerRole, get_role, is_organization
+from onadata.libs.serializers.dataview_serializer import DataViewMinimalSerializer
 from onadata.libs.serializers.fields.json_field import JsonField
 from onadata.libs.serializers.tag_list_serializer import TagListSerializer
 from onadata.libs.utils.analytics import TrackObjectEvent
@@ -29,6 +30,8 @@ from onadata.libs.utils.cache_tools import (
     PROJ_SUB_DATE_CACHE,
     PROJ_TEAM_USERS_CACHE,
     PROJECT_LINKED_DATAVIEWS,
+    get_shared_project_detail_cache_data,
+    is_public_project_access,
     safe_cache_delete,
     safe_cache_get,
     safe_cache_set,
@@ -203,6 +206,52 @@ def set_owners_permission(user, project):
     OwnerRole.add(user, project)
 
 
+PROJECT_PUBLIC_EXCLUDED_FIELDS = {
+    "owner",
+    "created_by",
+    "users",
+    "teams",
+    "metadata",
+}
+
+
+# pylint: disable=too-few-public-methods
+class PublicProjectFieldsMixin:
+    """
+    Remove project administration fields when a requester only has access
+    because the project is public.
+    """
+
+    public_excluded_fields = PROJECT_PUBLIC_EXCLUDED_FIELDS
+
+    def get_fields(self):
+        """Return serializer fields, excluding internal fields for public access."""
+        fields = super().get_fields()
+
+        if self.is_public_access(self.instance):
+            for field in self.public_excluded_fields:
+                fields.pop(field, None)
+
+        return fields
+
+    def is_public_access(self, instance):
+        """Return True if the request should receive the public-safe shape."""
+        request = self.context.get("request")
+        project = instance if isinstance(instance, Project) else None
+
+        return is_public_project_access(request, project)
+
+    def to_representation(self, instance):
+        """Remove internal fields from public-only list items."""
+        data = super().to_representation(instance)
+
+        if self.is_public_access(instance):
+            for field in self.public_excluded_fields:
+                data.pop(field, None)
+
+        return data
+
+
 # pylint: disable=too-few-public-methods
 class BaseProjectXFormSerializer(serializers.HyperlinkedModelSerializer):
     """
@@ -302,7 +351,9 @@ class ProjectXFormSerializer(BaseProjectXFormSerializer):
         return metadata and hasattr(metadata, "data_value") and metadata.data_value
 
 
-class BaseProjectSerializer(serializers.HyperlinkedModelSerializer):
+class BaseProjectSerializer(
+    PublicProjectFieldsMixin, serializers.HyperlinkedModelSerializer
+):
     """
     BaseProjectSerializer class.
     """
@@ -424,7 +475,9 @@ def can_add_project_to_profile(user, organization):
     return True
 
 
-class ProjectSerializer(serializers.HyperlinkedModelSerializer):
+class ProjectSerializer(
+    PublicProjectFieldsMixin, serializers.HyperlinkedModelSerializer
+):
     """
     ProjectSerializer class - creates and updates a project.
     """
@@ -603,7 +656,10 @@ class ProjectSerializer(serializers.HyperlinkedModelSerializer):
         request = self.context.get("request")
         serializer = ProjectSerializer(project, context={"request": request})
         response = serializer.data
-        safe_cache_set(f"{PROJ_OWNER_CACHE}{project.pk}", response)
+        safe_cache_set(
+            f"{PROJ_OWNER_CACHE}{project.pk}",
+            get_shared_project_detail_cache_data(response),
+        )
         return project
 
     def get_users(self, obj):
@@ -670,11 +726,6 @@ class ProjectSerializer(serializers.HyperlinkedModelSerializer):
             obj.dataview_prefetch
             if hasattr(obj, "dataview_prefetch")
             else obj.dataview_set.filter(deleted_at__isnull=True)
-        )
-
-        # pylint: disable=import-outside-toplevel
-        from onadata.libs.serializers.dataview_serializer import (
-            DataViewMinimalSerializer,
         )
 
         serializer = DataViewMinimalSerializer(

--- a/onadata/libs/serializers/v2/project_serializer.py
+++ b/onadata/libs/serializers/v2/project_serializer.py
@@ -12,9 +12,13 @@ from onadata.apps.logger.models.project import Project
 from onadata.libs.permissions import get_role
 from onadata.libs.serializers.fields.json_field import JsonField
 from onadata.libs.serializers.project_serializer import (
+    PROJECT_PUBLIC_EXCLUDED_FIELDS,
+)
+from onadata.libs.serializers.project_serializer import (
     ProjectSerializer as ProjectSerializerV1,
 )
 from onadata.libs.serializers.project_serializer import (
+    PublicProjectFieldsMixin,
     get_last_submission_date,
     get_num_datasets,
     is_starred,
@@ -35,7 +39,9 @@ def get_current_user_role(project, request):
     return get_role(perms, project)
 
 
-class ProjectListSerializer(serializers.HyperlinkedModelSerializer):
+class ProjectListSerializer(
+    PublicProjectFieldsMixin, serializers.HyperlinkedModelSerializer
+):
     """Serializer for a list of Projects"""
 
     projectid = serializers.ReadOnlyField(source="id")
@@ -60,6 +66,7 @@ class ProjectListSerializer(serializers.HyperlinkedModelSerializer):
     num_datasets = serializers.SerializerMethodField()
     last_submission_date = serializers.SerializerMethodField()
     current_user_role = serializers.SerializerMethodField()
+    public_excluded_fields = PROJECT_PUBLIC_EXCLUDED_FIELDS | {"current_user_role"}
 
     class Meta:
         model = Project

--- a/onadata/libs/tests/models/test_share_project.py
+++ b/onadata/libs/tests/models/test_share_project.py
@@ -32,14 +32,18 @@ class ShareProjectTestCase(TestBase):
         self.entity_list = EntityList.objects.create(name="trees", project=self.project)
         self.alice = self._create_user("alice", "Yuao8(-)")
 
-    @patch("onadata.libs.models.share_project.safe_cache_delete")
-    def test_share(self, mock_safe_cache_delete, mock_propagate):
+    def test_share(self, mock_propagate):
         """A project is shared with a user
 
         Permissions assigned to project, xform, mergedxform and dataview
         """
         instance = ShareProject(self.project, self.alice, "manager")
-        instance.save()
+        with patch(
+            "onadata.libs.models.share_project.clear_project_owner_cache"
+        ) as mock_clear_project_owner_cache, patch(
+            "onadata.libs.models.share_project.safe_cache_delete"
+        ) as mock_safe_cache_delete:
+            instance.save()
         self.alice.refresh_from_db()
         self.assertTrue(ManagerRole.user_has_role(self.alice, self.project))
         self.assertTrue(ManagerRole.user_has_role(self.alice, self.xform))
@@ -49,15 +53,17 @@ class ShareProjectTestCase(TestBase):
         self.assertTrue(ManagerRole.user_has_role(self.alice, self.entity_list))
         mock_propagate.assert_called_once_with(args=[self.project.pk])
         # Cache is invalidated
+        mock_clear_project_owner_cache.assert_has_calls(
+            [call(self.project.pk), call(self.project.pk)]
+        )
         mock_safe_cache_delete.assert_has_calls(
             [
-                call(f"ps-project_owner-{self.project.pk}"),
+                call(f"ps-project_permissions-{self.project.pk}"),
                 call(f"ps-project_permissions-{self.project.pk}"),
             ]
         )
 
-    @patch("onadata.libs.models.share_project.safe_cache_delete")
-    def test_remove(self, mock_safe_cache_delete, mock_propagate):
+    def test_remove(self, mock_propagate):
         """A user is removed from a project
 
         Permissions removed from project, xform, mergedxform and dataview
@@ -78,7 +84,12 @@ class ShareProjectTestCase(TestBase):
         self.assertTrue(ManagerRole.user_has_role(self.alice, self.entity_list))
         # Remove user
         instance = ShareProject(self.project, self.alice, "manager", True)
-        instance.save()
+        with patch(
+            "onadata.libs.models.share_project.clear_project_owner_cache"
+        ) as mock_clear_project_owner_cache, patch(
+            "onadata.libs.models.share_project.safe_cache_delete"
+        ) as mock_safe_cache_delete:
+            instance.save()
         self.assertFalse(ManagerRole.user_has_role(self.alice, self.project))
         self.assertFalse(ManagerRole.user_has_role(self.alice, self.xform))
         self.assertFalse(ManagerRole.user_has_role(self.alice, self.dataview_form))
@@ -89,9 +100,12 @@ class ShareProjectTestCase(TestBase):
         self.assertFalse(ManagerRole.user_has_role(self.alice, self.entity_list))
         mock_propagate.assert_called_once_with(args=[self.project.pk])
         # Cache is invalidated
+        mock_clear_project_owner_cache.assert_has_calls(
+            [call(self.project.pk), call(self.project.pk)]
+        )
         mock_safe_cache_delete.assert_has_calls(
             [
-                call(f"ps-project_owner-{self.project.pk}"),
+                call(f"ps-project_permissions-{self.project.pk}"),
                 call(f"ps-project_permissions-{self.project.pk}"),
             ]
         )

--- a/onadata/libs/tests/models/test_share_team_project.py
+++ b/onadata/libs/tests/models/test_share_team_project.py
@@ -33,24 +33,27 @@ class ShareTeamProjectTestCase(TestBase):
         self.alice = self._create_user("alice", "Yuao8(-)")
         add_user_to_team(self.team, self.alice)
 
-    @patch("onadata.libs.models.share_team_project.safe_cache_delete")
-    def test_share(self, mock_safe_cache_delete):
+    def test_share(self):
         """Sharing a project with a team assigns permissions and clears cache"""
         instance = ShareTeamProject(self.team, self.project, "manager")
-        instance.save()
+        with patch(
+            "onadata.libs.models.share_team_project.clear_project_owner_cache"
+        ) as mock_clear_project_owner_cache, patch(
+            "onadata.libs.models.share_team_project.safe_cache_delete"
+        ) as mock_safe_cache_delete:
+            instance.save()
         self.assertTrue(ManagerRole.user_has_role(self.alice, self.project))
         self.assertTrue(ManagerRole.user_has_role(self.alice, self.xform))
         self.assertTrue(ManagerRole.user_has_role(self.alice, self.dataview_form))
         # Cache is invalidated
+        mock_clear_project_owner_cache.assert_called_once_with(self.project.pk)
         mock_safe_cache_delete.assert_has_calls(
             [
-                call(f"ps-project_owner-{self.project.pk}"),
                 call(f"ps-project_permissions-{self.project.pk}"),
             ]
         )
 
-    @patch("onadata.libs.models.share_team_project.safe_cache_delete")
-    def test_remove(self, mock_safe_cache_delete):
+    def test_remove(self):
         """Removing a team from a project removes permissions and clears cache"""
         # Simulate share project
         ManagerRole.add(self.team, self.project)
@@ -62,14 +65,19 @@ class ShareTeamProjectTestCase(TestBase):
         self.assertTrue(ManagerRole.user_has_role(self.alice, self.dataview_form))
         # Remove team
         instance = ShareTeamProject(self.team, self.project, "manager", remove=True)
-        instance.save()
+        with patch(
+            "onadata.libs.models.share_team_project.clear_project_owner_cache"
+        ) as mock_clear_project_owner_cache, patch(
+            "onadata.libs.models.share_team_project.safe_cache_delete"
+        ) as mock_safe_cache_delete:
+            instance.save()
         self.assertFalse(ManagerRole.user_has_role(self.alice, self.project))
         self.assertFalse(ManagerRole.user_has_role(self.alice, self.xform))
         self.assertFalse(ManagerRole.user_has_role(self.alice, self.dataview_form))
         # Cache is invalidated
+        mock_clear_project_owner_cache.assert_called_once_with(self.project.pk)
         mock_safe_cache_delete.assert_has_calls(
             [
-                call(f"ps-project_owner-{self.project.pk}"),
                 call(f"ps-project_permissions-{self.project.pk}"),
             ]
         )

--- a/onadata/libs/tests/serializers/test_project_serializer.py
+++ b/onadata/libs/tests/serializers/test_project_serializer.py
@@ -16,7 +16,11 @@ from onadata.libs.serializers.project_serializer import (
     BaseProjectSerializer,
     ProjectSerializer,
 )
-from onadata.libs.utils.cache_tools import PROJ_OWNER_CACHE, safe_key
+from onadata.libs.utils.cache_tools import (
+    PROJ_OWNER_CACHE,
+    get_shared_project_detail_cache_data,
+    safe_key,
+)
 
 
 class TestBaseProjectSerializer(TestAbstractViewSet):
@@ -167,7 +171,10 @@ class TestProjectSerializer(TestAbstractViewSet):
         request.user = self.user
 
         serializer = ProjectSerializer(self.project, context={"request": request}).data
-        self.assertEqual(cache.get(f"{PROJ_OWNER_CACHE}{self.project.pk}"), serializer)
+        self.assertEqual(
+            cache.get(f"{PROJ_OWNER_CACHE}{self.project.pk}"),
+            get_shared_project_detail_cache_data(serializer),
+        )
 
         # clear cache
         cache.delete(safe_key(f"{PROJ_OWNER_CACHE}{self.project.pk}"))

--- a/onadata/libs/tests/utils/test_cache_tools.py
+++ b/onadata/libs/tests/utils/test_cache_tools.py
@@ -7,6 +7,7 @@ import socket
 from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
+from django.contrib.auth.models import AnonymousUser
 from django.core.cache import cache
 from django.http.request import HttpRequest
 from django.test import TestCase
@@ -20,7 +21,14 @@ from onadata.libs.utils.cache_tools import (
     PROJ_NUM_DATASET_CACHE,
     PROJ_OWNER_CACHE,
     PROJ_PERM_CACHE,
+    PROJ_PUBLIC_OWNER_CACHE,
     PROJ_SUB_DATE_CACHE,
+    PROJ_V2_OWNER_CACHE,
+    PROJ_V2_PUBLIC_OWNER_CACHE,
+    clear_project_owner_cache,
+    get_project_cache_key,
+    get_project_cache_keys,
+    get_shared_project_detail_cache_data,
     project_cache_prefixes,
     reset_project_cache,
     safe_cache_add,
@@ -71,7 +79,6 @@ class TestCacheTools(TestCase):
             "owner": "http://testserver/api/v1/users/bob",
             "created_by": "http://testserver/api/v1/users/bob",
             "metadata": {},
-            "starred": False,
             "users": [
                 {
                     "is_org": False,
@@ -108,11 +115,72 @@ class TestCacheTools(TestCase):
             expected_project_cache["forms"],
         )
         self.assertEqual(cache.get(f"{PROJ_BASE_FORMS_CACHE}{project.pk}"), None)
+        self.assertEqual(cache.get(f"{PROJ_PUBLIC_OWNER_CACHE}{project.pk}"), None)
 
         project_cache = cache.get(f"{PROJ_OWNER_CACHE}{project.pk}")
         project_cache.pop("date_created")
         project_cache.pop("date_modified")
         self.assertEqual(project_cache, expected_project_cache)
+
+    def test_project_owner_cache_helpers(self):
+        """Project detail cache helpers separate public and full responses."""
+        bob = User.objects.create(username="bob", first_name="bob")
+        UserProfile.objects.create(user=bob)
+        project = Project.objects.create(
+            name="Some Project", created_by=bob, organization=bob, shared=True
+        )
+        request = HttpRequest()
+        request.user = bob
+        anonymous_request = HttpRequest()
+        anonymous_request.user = AnonymousUser()
+
+        self.assertEqual(
+            get_project_cache_keys(project.pk),
+            [
+                f"{PROJ_OWNER_CACHE}{project.pk}",
+                f"{PROJ_PUBLIC_OWNER_CACHE}{project.pk}",
+                f"{PROJ_V2_OWNER_CACHE}{project.pk}",
+                f"{PROJ_V2_PUBLIC_OWNER_CACHE}{project.pk}",
+            ],
+        )
+        self.assertEqual(
+            get_project_cache_key(project.pk, request, project),
+            f"{PROJ_OWNER_CACHE}{project.pk}",
+        )
+        self.assertEqual(
+            get_project_cache_key(project.pk, anonymous_request, project),
+            f"{PROJ_PUBLIC_OWNER_CACHE}{project.pk}",
+        )
+        self.assertEqual(
+            get_project_cache_key(project.pk, request, project, api_version="v2"),
+            f"{PROJ_V2_OWNER_CACHE}{project.pk}",
+        )
+        self.assertEqual(
+            get_project_cache_key(
+                project.pk, anonymous_request, project, api_version="v2"
+            ),
+            f"{PROJ_V2_PUBLIC_OWNER_CACHE}{project.pk}",
+        )
+        self.assertEqual(
+            get_shared_project_detail_cache_data(
+                {
+                    "name": "Some Project",
+                    "starred": True,
+                    "current_user_role": "owner",
+                }
+            ),
+            {"name": "Some Project"},
+        )
+
+        cache.set(f"{PROJ_OWNER_CACHE}{project.pk}", "full")
+        cache.set(f"{PROJ_PUBLIC_OWNER_CACHE}{project.pk}", "public")
+        cache.set(f"{PROJ_V2_OWNER_CACHE}{project.pk}", "v2-full")
+        cache.set(f"{PROJ_V2_PUBLIC_OWNER_CACHE}{project.pk}", "v2-public")
+        clear_project_owner_cache(project.pk)
+        self.assertIsNone(cache.get(f"{PROJ_OWNER_CACHE}{project.pk}"))
+        self.assertIsNone(cache.get(f"{PROJ_PUBLIC_OWNER_CACHE}{project.pk}"))
+        self.assertIsNone(cache.get(f"{PROJ_V2_OWNER_CACHE}{project.pk}"))
+        self.assertIsNone(cache.get(f"{PROJ_V2_PUBLIC_OWNER_CACHE}{project.pk}"))
 
     @patch("onadata.libs.utils.cache_tools.cache.set")
     def test_reset_project_cache_handles_oversized_data(self, mock_cache_set):

--- a/onadata/libs/utils/cache_tools.py
+++ b/onadata/libs/utils/cache_tools.py
@@ -22,7 +22,21 @@ PROJ_NUM_DATASET_CACHE = "ps-num_datasets-"
 PROJ_SUB_DATE_CACHE = "ps-last_submission_date-"
 PROJ_FORMS_CACHE = "ps-project_forms-"
 PROJ_BASE_FORMS_CACHE = "ps-project_base_forms-"
-PROJ_OWNER_CACHE = "ps-project_owner-"
+PROJ_OWNER_CACHE = "ps-project_owner-v1-"
+PROJ_PUBLIC_OWNER_CACHE = "ps-project_owner-v1-public-"
+PROJ_V2_OWNER_CACHE = "ps-project_owner-v2-"
+PROJ_V2_PUBLIC_OWNER_CACHE = "ps-project_owner-v2-public-"
+PROJECT_DETAIL_CACHE_PREFIXES = {
+    "v1": {
+        "full": PROJ_OWNER_CACHE,
+        "public": PROJ_PUBLIC_OWNER_CACHE,
+    },
+    "v2": {
+        "full": PROJ_V2_OWNER_CACHE,
+        "public": PROJ_V2_PUBLIC_OWNER_CACHE,
+    },
+}
+PROJECT_DETAIL_USER_FIELDS = {"starred", "current_user_role"}
 project_cache_prefixes = [
     PROJ_PERM_CACHE,
     PROJ_NUM_DATASET_CACHE,
@@ -30,6 +44,9 @@ project_cache_prefixes = [
     PROJ_FORMS_CACHE,
     PROJ_BASE_FORMS_CACHE,
     PROJ_OWNER_CACHE,
+    PROJ_PUBLIC_OWNER_CACHE,
+    PROJ_V2_OWNER_CACHE,
+    PROJ_V2_PUBLIC_OWNER_CACHE,
 ]
 
 # Cache names used in user_profile_serializer
@@ -134,6 +151,56 @@ def safe_key(key):
     return hashlib.sha256(force_bytes(key)).hexdigest()
 
 
+def get_project_cache_keys(project_id):
+    """Return all detail cache keys for a project."""
+    return [
+        f"{prefixes[access_type]}{project_id}"
+        for prefixes in PROJECT_DETAIL_CACHE_PREFIXES.values()
+        for access_type in ("full", "public")
+    ]
+
+
+def clear_project_owner_cache(project_id):
+    """Clear all project detail cache variants."""
+    for cache_key in get_project_cache_keys(project_id):
+        safe_cache_delete(cache_key)
+
+
+def is_public_project_access(request, project=None):
+    """Return True when the request should receive the public project shape."""
+    user = getattr(request, "user", None)
+
+    if user is None:
+        return False
+
+    if user.is_anonymous:
+        return True
+
+    if project is None:
+        return False
+
+    return not user.has_perm("view_project", project)
+
+
+def get_project_cache_key(project_id, request, project=None, api_version="v1"):
+    """Return the correct project detail cache key for a request."""
+    prefixes = PROJECT_DETAIL_CACHE_PREFIXES[api_version]
+    prefix = prefixes[
+        "public" if is_public_project_access(request, project) else "full"
+    ]
+
+    return f"{prefix}{project_id}"
+
+
+def get_shared_project_detail_cache_data(project_data):
+    """Return project detail data safe for a shared cache entry."""
+    return {
+        key: value
+        for key, value in project_data.items()
+        if key not in PROJECT_DETAIL_USER_FIELDS
+    }
+
+
 def reset_project_cache(project, request, project_serializer_class):
     """
     Clears and sets project cache
@@ -148,7 +215,10 @@ def reset_project_cache(project, request, project_serializer_class):
     project_cache_data = project_serializer_class(
         project, context={"request": request}
     ).data
-    safe_cache_set(f"{PROJ_OWNER_CACHE}{project.pk}", project_cache_data)
+    safe_cache_set(
+        f"{PROJ_OWNER_CACHE}{project.pk}",
+        get_shared_project_detail_cache_data(project_cache_data),
+    )
 
 
 def _safe_cache_operation(operation, default_return=None):

--- a/onadata/libs/utils/xform_utils.py
+++ b/onadata/libs/utils/xform_utils.py
@@ -29,10 +29,10 @@ from onadata.libs.permissions import (
     set_project_perms_to_object,
 )
 from onadata.libs.utils.cache_tools import (
-    PROJ_OWNER_CACHE,
     XFORM_DATA_VERSIONS,
     XFORM_METADATA_CACHE,
     XFORM_PERMISSIONS_CACHE,
+    clear_project_owner_cache,
     safe_cache_delete,
 )
 from onadata.libs.utils.common_tags import MEMBERS
@@ -147,7 +147,7 @@ def get_xform_users(xform):
 
 
 def clear_permissions_cache(xform):
-    safe_cache_delete(f"{PROJ_OWNER_CACHE}{xform.project.pk}")
+    clear_project_owner_cache(xform.project.pk)
     safe_cache_delete(f"{XFORM_METADATA_CACHE}{xform.pk}")
     safe_cache_delete(f"{XFORM_DATA_VERSIONS}{xform.pk}")
     safe_cache_delete(f"{XFORM_PERMISSIONS_CACHE}{xform.pk}")


### PR DESCRIPTION
### Changes / Features implemented

- Separates project detail cache entries by API version and by full vs public-only access.
- Removes administration-only fields from public-only project detail/list responses.
- Invalidates all project detail cache variants when project sharing, form, xform, or dataview state changes.
- Adds v1/v2 regression coverage for public response shapes, cache variants, and v2 update cache isolation.
- Updates project API docs and ignores roborev snapshot files.

### Steps taken to verify this change does what is intended

- `python manage.py test onadata.libs.tests.models.test_share_project onadata.libs.tests.models.test_share_team_project --settings=onadata.settings.github_actions_test --noinput`
- `python manage.py test onadata.libs.tests.models.test_share_project onadata.libs.tests.models.test_share_team_project onadata.apps.api.tests.viewsets.test_project_viewset.TestProjectViewSet onadata.apps.api.tests.viewsets.v2.test_project_viewset --settings=onadata.settings.github_actions_test --noinput`
- `git diff --check`
- `python -m flake8 onadata/libs/tests/models/test_share_project.py onadata/libs/tests/models/test_share_team_project.py`
- Roborev branch re-review passed with no issues.

### Side effects of implementing this change

Public-only project responses now omit internal administration fields: `owner`, `created_by`, `users`, `teams`, `metadata`, and `current_user_role` for v2 responses.

Existing project detail cache entries are split across v1/v2 and full/public prefixes and invalidated together.


**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  - [x] Updated documentation

Closes #

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/onaio/codesmith/onadata/pr/3120"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783354259&installation_id=135786473&pr_number=3120&repository=onaio%2Fonadata&return_to=https%3A%2F%2Fgithub.com%2Fonaio%2Fonadata%2Fpull%2F3120&signature=3fa8bdf9c67639df7ae868c992ae9f32181f75706d14b2514ce0c025d5dd0cfc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->