### PR TITLE
Include filenames in upload validation errors

### DIFF
--- a/onadata/apps/api/tests/viewsets/test_metadata_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_metadata_viewset.py
@@ -700,6 +700,13 @@ class TestMetaDataViewSet(TestAbstractViewSet):
         request = self.factory.post("/", data=data, **self.extra)
         return view(request)
 
+    def assert_upload_validation_error(self, response, filename):
+        """Assert the API returns a generic file validation error."""
+        self.assertEqual(
+            response.data["data_file"][0],
+            f"The uploaded file '{filename}' could not be validated.",
+        )
+
     def test_media_upload_rejects_double_extension(self):
         """A `putty.exe.png` filename is rejected and no MetaData row remains."""
         before = MetaData.objects.count()
@@ -707,6 +714,7 @@ class TestMetaDataViewSet(TestAbstractViewSet):
         response = self._post_media_upload("putty.exe.png", b"MZpayload", "image/png")
 
         self.assertEqual(response.status_code, 400)
+        self.assert_upload_validation_error(response, "putty.exe.png")
         self.assertEqual(MetaData.objects.count(), before)
 
     def test_media_upload_rejects_signature_mismatch(self):
@@ -719,6 +727,7 @@ class TestMetaDataViewSet(TestAbstractViewSet):
         )
 
         self.assertEqual(response.status_code, 400)
+        self.assert_upload_validation_error(response, "putty.png")
         self.assertEqual(MetaData.objects.count(), before)
         self.assertEqual(MetaData.objects.exclude(data_file="").count(), before_files)
 
@@ -731,6 +740,7 @@ class TestMetaDataViewSet(TestAbstractViewSet):
         response = self._post_media_upload("data.csv", png_bytes, "text/csv")
 
         self.assertEqual(response.status_code, 400)
+        self.assert_upload_validation_error(response, "data.csv")
         self.assertEqual(MetaData.objects.count(), before)
 
     def test_media_upload_stores_uuid_filename(self):
@@ -794,6 +804,7 @@ class TestMetaDataViewSet(TestAbstractViewSet):
         )
 
         self.assertEqual(response.status_code, 400, response.data)
+        self.assert_upload_validation_error(response, "report.pdf.html")
         self.assertEqual(MetaData.objects.count(), before)
 
     def test_supporting_doc_upload_rejects_content_type_spoof(self):
@@ -805,6 +816,7 @@ class TestMetaDataViewSet(TestAbstractViewSet):
         )
 
         self.assertEqual(response.status_code, 400, response.data)
+        self.assert_upload_validation_error(response, "report.pdf")
         self.assertEqual(MetaData.objects.count(), before)
 
     def test_supporting_doc_upload_rejects_svg(self):
@@ -816,6 +828,7 @@ class TestMetaDataViewSet(TestAbstractViewSet):
         )
 
         self.assertEqual(response.status_code, 400, response.data)
+        self.assert_upload_validation_error(response, "icon.svg")
         self.assertEqual(MetaData.objects.count(), before)
 
     def test_supporting_doc_upload_rejects_zip(self):
@@ -829,6 +842,7 @@ class TestMetaDataViewSet(TestAbstractViewSet):
         )
 
         self.assertEqual(response.status_code, 400, response.data)
+        self.assert_upload_validation_error(response, "archive.zip")
         self.assertEqual(MetaData.objects.count(), before)
 
     def test_supporting_doc_upload_rejects_legacy_doc(self):
@@ -842,6 +856,7 @@ class TestMetaDataViewSet(TestAbstractViewSet):
         )
 
         self.assertEqual(response.status_code, 400, response.data)
+        self.assert_upload_validation_error(response, "report.doc")
         self.assertEqual(MetaData.objects.count(), before)
 
     def test_supporting_doc_upload_stores_uuid_filename(self):
@@ -872,4 +887,5 @@ class TestMetaDataViewSet(TestAbstractViewSet):
         )
 
         self.assertEqual(response.status_code, 400, response.data)
+        self.assert_upload_validation_error(response, "report.pdf")
         self.assertEqual(MetaData.objects.count(), before)

--- a/onadata/apps/api/tests/viewsets/test_xform_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_xform_viewset.py
@@ -3781,6 +3781,15 @@ nhMo+jI88L3qfm4/rtWKuQ9/a268phlNj34uQeoDDHuRViQo00L5meE/pFptm
         response = view(request)
 
         self.assertEqual(response.status_code, 400, getattr(response, "data", None))
+        self.assertEqual(
+            response.data,
+            {
+                "message": (
+                    "The uploaded file 'transportation.exe.xlsx' "
+                    "could not be validated."
+                )
+            },
+        )
         self.assertEqual(count, XForm.objects.count())
 
     @override_settings(CELERY_TASK_ALWAYS_EAGER=True)
@@ -3808,6 +3817,14 @@ nhMo+jI88L3qfm4/rtWKuQ9/a268phlNj34uQeoDDHuRViQo00L5meE/pFptm
         response = view(request)
 
         self.assertEqual(response.status_code, 400, getattr(response, "data", None))
+        self.assertEqual(
+            response.data,
+            {
+                "message": (
+                    "The uploaded file 'transportation.csv' could not be validated."
+                )
+            },
+        )
         self.assertEqual(count, XForm.objects.count())
 
     @override_settings(CELERY_TASK_ALWAYS_EAGER=True)
@@ -5592,7 +5609,10 @@ nhMo+jI88L3qfm4/rtWKuQ9/a268phlNj34uQeoDDHuRViQo00L5meE/pFptm
             response = view(request, pk=self.xform.id)
 
             self.assertEqual(response.status_code, 400, response.data)
-            self.assertIn("error", response.data)
+            self.assertEqual(
+                response.data["error"],
+                "The uploaded file 'evil.xlsx' could not be validated.",
+            )
 
     def test_csv_import_rejects_extension_spoofing(self):
         """csv_import rejects PNG bytes renamed with .csv extension."""
@@ -5628,7 +5648,10 @@ nhMo+jI88L3qfm4/rtWKuQ9/a268phlNj34uQeoDDHuRViQo00L5meE/pFptm
             response = view(request, pk=self.xform.id)
 
             self.assertEqual(response.status_code, 400, response.data)
-            self.assertIn("error", response.data)
+            self.assertEqual(
+                response.data["error"],
+                "The uploaded file 'evil.csv' could not be validated.",
+            )
 
     def test_csv_xls_import_errors(self):
         with HTTMock(enketo_mock):
@@ -5652,7 +5675,7 @@ nhMo+jI88L3qfm4/rtWKuQ9/a268phlNj34uQeoDDHuRViQo00L5meE/pFptm
             self.assertEqual(response.status_code, 400)
             self.assertEqual(
                 response.data.get("error"),
-                "The uploaded file could not be validated.",
+                "The uploaded file 'good.csv' could not be validated.",
             )
 
             post_data = {"csv_file": xls_import}
@@ -5661,7 +5684,7 @@ nhMo+jI88L3qfm4/rtWKuQ9/a268phlNj34uQeoDDHuRViQo00L5meE/pFptm
             self.assertEqual(response.status_code, 400)
             self.assertEqual(
                 response.data.get("error"),
-                "The uploaded file could not be validated.",
+                "The uploaded file 'good.xlsx' could not be validated.",
             )
 
     @override_settings(TIME_ZONE="UTC")

--- a/onadata/apps/api/viewsets/xform_viewset.py
+++ b/onadata/apps/api/viewsets/xform_viewset.py
@@ -113,6 +113,7 @@ from onadata.libs.utils.upload_validation import (
     DATA_IMPORT_UPLOAD_CONTEXT,
     XLSFORM_UPLOAD_CONTEXT,
     UploadValidationError,
+    generic_upload_validation_error_message,
     validate_uploaded_file,
 )
 from onadata.libs.utils.viewer_tools import (
@@ -144,6 +145,7 @@ def _prepare_import_csv(csv_file, xls_file):
     validation fails. An XLS upload is converted to CSV after validation.
     """
     xls_upload = None
+    uploaded_file = xls_file or csv_file
     try:
         if xls_file:
             xls_upload = _validate_api_upload(
@@ -153,7 +155,7 @@ def _prepare_import_csv(csv_file, xls_file):
             _validate_api_upload(csv_file, (CSV_EXTENSION,), DATA_IMPORT_UPLOAD_CONTEXT)
     except UploadValidationError as error:
         logger.warning("Data import upload validation failed: %s", error)
-        return None, _("The uploaded file could not be validated.")
+        return None, generic_upload_validation_error_message(uploaded_file)
 
     if xls_file:
         csv_file = submission_xls_to_csv(xls_file)
@@ -186,7 +188,7 @@ def _publish_xlsform_async(request):
     except UploadValidationError as error:
         logger.warning("XLSForm upload validation failed: %s", error)
         return Response(
-            {"message": _("The uploaded file could not be validated.")},
+            {"message": generic_upload_validation_error_message(xls_file)},
             status=status.HTTP_400_BAD_REQUEST,
         )
 
@@ -946,7 +948,9 @@ class XFormViewSet(
                 except UploadValidationError as error:
                     logger.warning("CSV import upload validation failed: %s", error)
                     return Response(
-                        data={"error": _("The uploaded file could not be validated.")},
+                        data={
+                            "error": generic_upload_validation_error_message(csv_file)
+                        },
                         status=status.HTTP_400_BAD_REQUEST,
                     )
 

--- a/onadata/libs/serializers/metadata_serializer.py
+++ b/onadata/libs/serializers/metadata_serializer.py
@@ -37,6 +37,7 @@ from onadata.libs.utils.upload_validation import (
     SUPPORTING_DOC_ALLOWED_EXTENSIONS,
     SUPPORTING_DOC_UPLOAD_CONTEXT,
     UploadValidationError,
+    generic_upload_validation_error_message,
     validate_uploaded_file,
 )
 from onadata.libs.utils.xform_utils import update_role_by_meta_xform_perms
@@ -205,7 +206,7 @@ class MetaDataSerializer(serializers.HyperlinkedModelSerializer):
         except UploadValidationError as error:
             logger.warning("Metadata file upload validation failed: %s", error)
             raise serializers.ValidationError(
-                {"data_file": _("The uploaded file could not be validated.")}
+                {"data_file": generic_upload_validation_error_message(data_file)}
             ) from error
 
         data_file.name = upload.storage_basename

--- a/onadata/libs/tests/serializers/test_metadata_serializer.py
+++ b/onadata/libs/tests/serializers/test_metadata_serializer.py
@@ -2,6 +2,7 @@
 """
 Test onadata.libs.serializers.metadata_serializer
 """
+
 import os
 
 from django.core.files.uploadedfile import InMemoryUploadedFile
@@ -67,9 +68,9 @@ class TestMetaDataViewSerializer(TestAbstractViewSet):
             }
             serializer = MetaDataSerializer(data=data)
             self.assertFalse(serializer.is_valid())
-            self.assertIn(
-                "The uploaded file could not be validated.",
+            self.assertEqual(
                 serializer.errors["data_file"][0],
+                "The uploaded file 'sample.svg' could not be validated.",
             )
 
     def test_svg_media_files(self):
@@ -92,9 +93,9 @@ class TestMetaDataViewSerializer(TestAbstractViewSet):
             }
             serializer = MetaDataSerializer(data=data)
             self.assertFalse(serializer.is_valid())
-            self.assertIn(
-                "The uploaded file could not be validated.",
+            self.assertEqual(
                 serializer.errors["data_file"][0],
+                "The uploaded file 'sample.svg' could not be validated.",
             )
 
     def test_geojson_media_files(self):

--- a/onadata/libs/tests/utils/test_upload_validation.py
+++ b/onadata/libs/tests/utils/test_upload_validation.py
@@ -21,6 +21,7 @@ from onadata.libs.utils.upload_validation import (
     XLSFORM_ALLOWED_EXTENSIONS,
     XLSFORM_UPLOAD_CONTEXT,
     UploadValidationError,
+    generic_upload_validation_error_message,
     validate_uploaded_file,
 )
 
@@ -146,6 +147,26 @@ class UploadValidationTestCase(SimpleTestCase):
                 self.assertTrue(
                     result.storage_basename.endswith(f".{result.extension}")
                 )
+
+    def test_generic_validation_error_message_sanitizes_filename(self):
+        """Generic API errors identify only the sanitized client filename."""
+        uploaded_file = _CountingUpload(
+            r"C:\fakepath\evil.svg", b"<svg/>", "image/svg+xml"
+        )
+
+        self.assertEqual(
+            generic_upload_validation_error_message(uploaded_file),
+            "The uploaded file 'evil.svg' could not be validated.",
+        )
+
+    def test_generic_validation_error_message_handles_missing_filename(self):
+        """Generic API errors retain the old text when no filename remains."""
+        uploaded_file = _CountingUpload("\x00\x1f", b"payload", "application/pdf")
+
+        self.assertEqual(
+            generic_upload_validation_error_message(uploaded_file),
+            "The uploaded file could not be validated.",
+        )
 
     def test_double_extension_is_rejected(self):
         """Filenames such as putty.exe.png are rejected before persistence."""

--- a/onadata/libs/utils/upload_validation.py
+++ b/onadata/libs/utils/upload_validation.py
@@ -160,6 +160,18 @@ def sanitized_original_filename(name):
     return basename
 
 
+def generic_upload_validation_error_message(uploaded_file):
+    """Return a generic API validation error that identifies the upload."""
+    filename = sanitized_original_filename(getattr(uploaded_file, "name", ""))
+
+    if filename:
+        return _("The uploaded file '%(filename)s' could not be validated.") % {
+            "filename": filename
+        }
+
+    return _("The uploaded file could not be validated.")
+
+
 DANGEROUS_PENULTIMATE_EXTENSIONS = frozenset(
     {
         ".asp",


### PR DESCRIPTION
### Changes / Features implemented

- Include sanitized client filenames in generic upload validation errors for metadata uploads, async XLSForm publishing, CSV import, and data import.
- Keep the existing generic validation message when filename sanitization leaves no usable name.
- Update tests to assert filename-aware validation errors across rejected upload paths.

### Steps taken to verify this change does what is intended

- isort --profile black on the changed Python files.
- black on the changed Python files.
- git diff --check.
- python manage.py test targeted upload validation tests --settings=onadata.settings.github_actions_test --keepdb --noinput; 18 tests passed.
- prospector on the changed Python files; it reports existing file-level E501, dodgy secret, and django-not-configured findings.

### Side effects of implementing this change

- API clients now receive the sanitized uploaded filename in generic validation errors when one is available.
- No intended change to upload storage, persistence, or accepted file behavior.


**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  - [x] Updated documentation (not applicable)

Closes #

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/onaio/codesmith/onadata/pr/3121"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783516603&installation_id=135786473&pr_number=3121&repository=onaio%2Fonadata&return_to=https%3A%2F%2Fgithub.com%2Fonaio%2Fonadata%2Fpull%2F3121&signature=e77ffc8efc03185a5f04a7e3ff4a907049f472ca392b639ac11ae517f29cbb31"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->