### PR TITLE
feat: report auto-bumped version on form replace

### DIFF
--- a/onadata/apps/api/tests/viewsets/test_xform_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_xform_viewset.py
@@ -4234,8 +4234,12 @@ nhMo+jI88L3qfm4/rtWKuQ9/a268phlNj34uQeoDDHuRViQo00L5meE/pFptm
                 )
                 response = view(request, pk=self.xform.pk)
                 self.assertEqual(response.status_code, 200)
+                # the response carries the bumped version and flags the change
+                self.assertEqual(response.data["version"], f"{initial_version}-2")
+                self.assertTrue(response.data["has_version_changed"])
 
             self.xform.refresh_from_db()
+            self.assertEqual(response.data["version"], self.xform.version)
             self.assertEqual(
                 XFormVersion.objects.filter(xform=self.xform).count(),
                 initial_count + 1,
@@ -4283,6 +4287,43 @@ nhMo+jI88L3qfm4/rtWKuQ9/a268phlNj34uQeoDDHuRViQo00L5meE/pFptm
                     _xml_data_node_version(self.xform.xml, self.xform.id_string),
                     expected_version,
                 )
+
+    def test_replace_form_new_version_not_flagged(self):
+        """Replacing with a form whose version is not already used keeps the
+        submitted version and reports has_version_changed as False."""
+        with HTTMock(enketo_mock):
+            self._publish_xls_form_to_project()
+
+            view = XFormViewSet.as_view({"patch": "partial_update"})
+            path = os.path.join(
+                settings.PROJECT_ROOT,
+                "apps",
+                "main",
+                "tests",
+                "fixtures",
+                "transportation",
+                "transportation_version.xlsx",
+            )
+            with open(path, "rb") as xls_file:
+                request = self.factory.patch(
+                    "/", data={"xls_file": xls_file}, **self.extra
+                )
+                response = view(request, pk=self.xform.pk)
+                self.assertEqual(response.status_code, 200)
+                # version "212121211" is new, so it is used as-is, no flag
+                self.assertEqual(response.data["version"], "212121211")
+                self.assertFalse(response.data["has_version_changed"])
+
+    def test_has_version_changed_absent_on_form_retrieve(self):
+        """has_version_changed is scoped to the replace response; a plain
+        form retrieve does not include it."""
+        with HTTMock(enketo_mock):
+            self._publish_xls_form_to_project()
+            view = XFormViewSet.as_view({"get": "retrieve"})
+            request = self.factory.get("/", **self.extra)
+            response = view(request, pk=self.xform.pk)
+            self.assertEqual(response.status_code, 200)
+            self.assertNotIn("has_version_changed", response.data)
 
     def test_versions_endpoint(self):
         """

--- a/onadata/apps/api/viewsets/xform_viewset.py
+++ b/onadata/apps/api/viewsets/xform_viewset.py
@@ -75,6 +75,7 @@ from onadata.libs.serializers.xform_serializer import (
     XFormBaseSerializer,
     XFormCreateSerializer,
     XFormSerializer,
+    XFormUpdateSerializer,
     XFormVersionListSerializer,
 )
 from onadata.libs.utils.api_export_tools import (
@@ -260,7 +261,7 @@ def _try_update_xlsform(request, xform, owner):
     survey = utils.publish_xlsform(request, owner, xform.id_string, xform.project)
 
     if isinstance(survey, XForm):
-        serializer = XFormSerializer(xform, context={"request": request})
+        serializer = XFormUpdateSerializer(survey, context={"request": request})
 
         # send form update notification
         send_message(

--- a/onadata/apps/logger/models/xform.py
+++ b/onadata/apps/logger/models/xform.py
@@ -407,6 +407,11 @@ class XFormMixin:
         """Returns the boolean value of `_id_string_changed`."""
         return getattr(self, "_id_string_changed", False)
 
+    @property
+    def has_version_changed(self):
+        """Whether the version was auto-bumped during a form replace."""
+        return getattr(self, "_version_changed", False)
+
     def add_instances(self):
         """Returns all instances as a list of python objects."""
         _get_observation_from_dict = DictOrganizer().get_observation_from_dict

--- a/onadata/apps/viewer/models/data_dictionary.py
+++ b/onadata/apps/viewer/models/data_dictionary.py
@@ -150,6 +150,7 @@ class DataDictionary(XForm):  # pylint: disable=too-many-instance-attributes
         self.instances_for_export = lambda d: d.instances.all()
         self.has_external_choices = False
         self._id_string_changed = False
+        self._version_changed = False
         super().__init__(*args, **kwargs)
 
     def __str__(self):
@@ -167,7 +168,9 @@ class DataDictionary(XForm):  # pylint: disable=too-many-instance-attributes
                 self.has_external_choices = True
             survey = check_version_set(survey)
             if self.pk is not None:
-                survey.version = self.get_unique_version(survey.get("version"))
+                new_version = self.get_unique_version(survey.get("version"))
+                self._version_changed = new_version != survey.get("version")
+                survey.version = new_version
             workbook_json["version"] = survey.get("version")
             if get_columns_with_hxl(survey.get("children")):
                 self.has_hxl_support = True

--- a/onadata/libs/serializers/xform_serializer.py
+++ b/onadata/libs/serializers/xform_serializer.py
@@ -673,6 +673,24 @@ class XFormCreateSerializer(XFormSerializer):
         fields = XFormSerializer.Meta.fields + ("has_id_string_changed",)
 
 
+# pylint: disable=abstract-method,too-many-ancestors
+class XFormUpdateSerializer(XFormSerializer):
+    """
+    XForm serializer used when replacing/updating an existing form.
+    """
+
+    has_version_changed = serializers.SerializerMethodField()
+
+    def get_has_version_changed(self, obj):
+        """
+        Returns the value of ``obj.has_version_changed``
+        """
+        return obj.has_version_changed
+
+    class Meta(XFormSerializer.Meta):
+        fields = XFormSerializer.Meta.fields + ("has_version_changed",)
+
+
 # pylint: disable=abstract-method
 class XFormListSerializer(serializers.Serializer):
     """

--- a/onadata/libs/utils/logger_tools.py
+++ b/onadata/libs/utils/logger_tools.py
@@ -1201,8 +1201,9 @@ def publish_xml_form(xml_file, user, project, id_string=None, created_by=None):
         new_version = xml_version
         if xml_version:
             new_version = dd.get_unique_version(xml_version)
-        dd._version_changed = new_version != xml_version
-        if new_version != xml_version:
+        version_changed = new_version != xml_version
+        dd._version_changed = version_changed  # pylint: disable=protected-access
+        if version_changed:
             xml = _set_version_in_xform_xml(xml, dd.id_string, new_version)
         dd.version = new_version
         dd.xml = xml

--- a/onadata/libs/utils/logger_tools.py
+++ b/onadata/libs/utils/logger_tools.py
@@ -1201,6 +1201,7 @@ def publish_xml_form(xml_file, user, project, id_string=None, created_by=None):
         new_version = xml_version
         if xml_version:
             new_version = dd.get_unique_version(xml_version)
+        dd._version_changed = new_version != xml_version
         if new_version != xml_version:
             xml = _set_version_in_xform_xml(xml, dd.id_string, new_version)
         dd.version = new_version


### PR DESCRIPTION
### Changes / Features implemented

Follow-up to #3075. When a form is replaced with an XLSForm that reuses an existing version string, onadata auto-bumps the version (`-2`, `-3`, …). Previously this happened silently — the client was never told. This surfaces it on the replace response (`PATCH /api/v1/forms/{pk}`), mirroring the existing `has_id_string_changed` pattern.

- Track the change via a transient `_version_changed` flag on `DataDictionary` (set in `save()` for the XLS path and in `publish_xml_form` for the XML path), exposed as the `XForm.has_version_changed` property.
- Add `XFormUpdateSerializer` (adds **only** `has_version_changed`, no `has_id_string_changed` coupling) and use it in `_try_update_xlsform`.
- Serialize the freshly-published form instead of the stale pre-replace object, so the returned `version` reflects the bump (also fixes a latent staleness bug where the replace response returned the old version).

The client reads both answers from the replace response: **"to what?"** via the existing `version` field (now accurate), and **"was it auto-bumped?"** via `has_version_changed`. `has_version_changed` is `True` only when the submitted version collided with an existing `XFormVersion`; it is scoped to the replace response and absent from form GET/list responses.

### Steps taken to verify this change does what is intended

Added/extended tests in `test_xform_viewset.py`, run via docker (no regressions against existing form-replacement tests):

- Same-version replace: response `version` is the bumped value and `has_version_changed` is `True`.
- New-version replace (`transportation_version.xlsx`): version used as-is, `has_version_changed` is `False`.
- Plain form retrieve: `has_version_changed` absent (confirms scoping).

### Side effects of implementing this change

- The `PATCH /api/v1/forms/{pk}` replace response now serializes the freshly-published form rather than the stale pre-replace object, and gains a `has_version_changed` boolean field. Both are additive; the previously-stale `version` field is now correct.

**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  - [ ] Updated documentation

Closes #