### PR TITLE
fix: case-insensitive username uniqueness + hyphenated username URL support

### DIFF
--- a/onadata/apps/api/constants.py
+++ b/onadata/apps/api/constants.py
@@ -26,10 +26,3 @@ USERNAME_VALIDATION_REGEX = (
     r"^(?!.*\.(?:json|csv|xls|xlsx|kml)$)"
     r"(?:[\w.-]+|\+?[\d.\-]+|[\w.%+-]+@[\w.-]+\.[a-zA-Z]{2,})$"
 )
-
-# Organization username validation regex
-# Stricter than the user regex: only alphanumeric characters and underscores
-# are allowed (no hyphens, dots, emails, or phone numbers).
-# Note: Uses ^ and $ anchors since we use match() on the full value.
-# Note: \w in Python 3 matches Unicode word characters (letters, digits, underscore)
-ORGANIZATION_USERNAME_VALIDATION_REGEX = r"^\w+$"

--- a/onadata/apps/api/constants.py
+++ b/onadata/apps/api/constants.py
@@ -26,3 +26,10 @@ USERNAME_VALIDATION_REGEX = (
     r"^(?!.*\.(?:json|csv|xls|xlsx|kml)$)"
     r"(?:[\w.-]+|\+?[\d.\-]+|[\w.%+-]+@[\w.-]+\.[a-zA-Z]{2,})$"
 )
+
+# Organization username validation regex
+# Stricter than the user regex: only alphanumeric characters and underscores
+# are allowed (no hyphens, dots, emails, or phone numbers).
+# Note: Uses ^ and $ anchors since we use match() on the full value.
+# Note: \w in Python 3 matches Unicode word characters (letters, digits, underscore)
+ORGANIZATION_USERNAME_VALIDATION_REGEX = r"^\w+$"

--- a/onadata/apps/api/tests/viewsets/test_organization_profile_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_organization_profile_viewset.py
@@ -643,6 +643,7 @@ class TestOrganizationProfileViewSet(TestAbstractViewSet):
         )
 
     def test_orgs_create_with_hyphen_rejected(self):
+        """An organization username containing a hyphen is rejected."""
         data = {
             "name": "deno inc",
             "org": "deno-inc",
@@ -667,6 +668,7 @@ class TestOrganizationProfileViewSet(TestAbstractViewSet):
         )
 
     def test_orgs_create_with_underscore_allowed(self):
+        """An organization username containing an underscore is accepted."""
         data = {
             "name": "deno inc",
             "org": "deno_inc",
@@ -688,6 +690,8 @@ class TestOrganizationProfileViewSet(TestAbstractViewSet):
         self.assertEqual(response.data["org"], "deno_inc")
 
     def test_orgs_create_existing_username_case_insensitive(self):
+        """An organization is rejected when a username already exists in a
+        different case."""
         # a username stored with mixed case (e.g. legacy/external data)
         User.objects.create(username="MixedOrg")
         data = {

--- a/onadata/apps/api/tests/viewsets/test_organization_profile_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_organization_profile_viewset.py
@@ -687,6 +687,29 @@ class TestOrganizationProfileViewSet(TestAbstractViewSet):
         self.assertEqual(response.status_code, 201)
         self.assertEqual(response.data["org"], "deno_inc")
 
+    def test_orgs_create_existing_username_case_insensitive(self):
+        # a username stored with mixed case (e.g. legacy/external data)
+        User.objects.create(username="MixedOrg")
+        data = {
+            "name": "mixed org",
+            "org": "mixedorg",
+            "city": "Denoville",
+            "country": "US",
+            "home_page": "deno.com",
+            "twitter": "denoinc",
+            "description": "",
+            "email": "user@mail.com",
+            "address": "",
+            "phonenumber": "",
+            "require_auth": False,
+        }
+        request = self.factory.post(
+            "/", data=json.dumps(data), content_type="application/json", **self.extra
+        )
+        response = self.view(request)
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("Organization mixedorg already exists.", response.data["org"])
+
     def test_publish_xls_form_to_organization_project(self):
         self._org_create()
         project_data = {"owner": self.company_data["user"]}

--- a/onadata/apps/api/tests/viewsets/test_organization_profile_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_organization_profile_viewset.py
@@ -642,6 +642,51 @@ class TestOrganizationProfileViewSet(TestAbstractViewSet):
             "Organization %s already exists." % data["org"], response.data["org"]
         )
 
+    def test_orgs_create_with_hyphen_rejected(self):
+        data = {
+            "name": "deno inc",
+            "org": "deno-inc",
+            "city": "Denoville",
+            "country": "US",
+            "home_page": "deno.com",
+            "twitter": "denoinc",
+            "description": "",
+            "email": "user@mail.com",
+            "address": "",
+            "phonenumber": "",
+            "require_auth": False,
+        }
+        request = self.factory.post(
+            "/", data=json.dumps(data), content_type="application/json", **self.extra
+        )
+        response = self.view(request)
+        self.assertEqual(response.status_code, 400)
+        self.assertIn(
+            "Organization may only contain alpha-numeric characters and underscores",
+            response.data["org"],
+        )
+
+    def test_orgs_create_with_underscore_allowed(self):
+        data = {
+            "name": "deno inc",
+            "org": "deno_inc",
+            "city": "Denoville",
+            "country": "US",
+            "home_page": "deno.com",
+            "twitter": "denoinc",
+            "description": "",
+            "email": "user@mail.com",
+            "address": "",
+            "phonenumber": "",
+            "require_auth": False,
+        }
+        request = self.factory.post(
+            "/", data=json.dumps(data), content_type="application/json", **self.extra
+        )
+        response = self.view(request)
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.data["org"], "deno_inc")
+
     def test_publish_xls_form_to_organization_project(self):
         self._org_create()
         project_data = {"owner": self.company_data["user"]}

--- a/onadata/apps/api/tests/viewsets/test_organization_profile_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_organization_profile_viewset.py
@@ -642,8 +642,8 @@ class TestOrganizationProfileViewSet(TestAbstractViewSet):
             "Organization %s already exists." % data["org"], response.data["org"]
         )
 
-    def test_orgs_create_with_hyphen_rejected(self):
-        """An organization username containing a hyphen is rejected."""
+    def test_orgs_create_with_hyphen_allowed(self):
+        """An organization username containing a hyphen is accepted."""
         data = {
             "name": "deno inc",
             "org": "deno-inc",
@@ -661,11 +661,8 @@ class TestOrganizationProfileViewSet(TestAbstractViewSet):
             "/", data=json.dumps(data), content_type="application/json", **self.extra
         )
         response = self.view(request)
-        self.assertEqual(response.status_code, 400)
-        self.assertIn(
-            "Organization may only contain alpha-numeric characters and underscores",
-            response.data["org"],
-        )
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.data["org"], "deno-inc")
 
     def test_orgs_create_with_underscore_allowed(self):
         """An organization username containing an underscore is accepted."""

--- a/onadata/apps/api/tests/viewsets/test_user_profile_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_user_profile_viewset.py
@@ -1228,6 +1228,29 @@ class TestUserProfileViewSet(TestAbstractViewSet):
         # Username should be normalized to lowercase
         self.assertEqual(response.data["username"], "user@example.com")
 
+    def test_profile_create_existing_username_case_insensitive(self):
+        """A profile cannot be created when the username already exists in a
+        different case."""
+        User.objects.create(username="MixedUser")
+        data = {
+            "username": "mixeduser",
+            "name": "Mixed User",
+            "email": "mixed@example.com",
+            "city": "TestCity",
+            "country": "US",
+            "password": "testpass123",
+            "is_org": False,
+        }
+        request = self.factory.post(
+            "/api/v1/profiles",
+            data=json.dumps(data),
+            content_type="application/json",
+            **self.extra,
+        )
+        response = self.view(request)
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("mixeduser already exists", response.data["username"])
+
     def test_username_boundary_cases(self):
         """Test boundary cases for username validation"""
         # Username ending with .tx (not blocked)

--- a/onadata/apps/main/forms.py
+++ b/onadata/apps/main/forms.py
@@ -391,12 +391,10 @@ class RegistrationFormUserProfile(RegistrationFormUniqueEmail, UserProfileFormRe
                     ".json, .csv, .xls, .xlsx, or .kml"
                 )
             )
-        try:
-            User.objects.get(username=username)
-        except User.DoesNotExist:
-            return username
+        if User.objects.filter(username__iexact=username).exists():
+            raise forms.ValidationError(_("%s already exists") % username)
 
-        raise forms.ValidationError(_("%s already exists") % username)
+        return username
 
 
 class SourceForm(forms.Form):

--- a/onadata/apps/main/tests/test_forms.py
+++ b/onadata/apps/main/tests/test_forms.py
@@ -6,11 +6,18 @@ Tests for onadata.apps.main.forms helpers.
 from unittest.mock import patch
 
 from django import forms
-from django.test import SimpleTestCase, override_settings
+from django.contrib.auth import get_user_model
+from django.test import SimpleTestCase, TestCase, override_settings
 
 import requests
 
-from onadata.apps.main.forms import _assert_url_not_internal, _get_with_ssrf_guard
+from onadata.apps.main.forms import (
+    RegistrationFormUserProfile,
+    _assert_url_not_internal,
+    _get_with_ssrf_guard,
+)
+
+User = get_user_model()
 
 
 def _redirect_to(location):
@@ -87,3 +94,15 @@ class GetWithSsrfGuardTestCase(SimpleTestCase):
 
         self.assertIs(_get_with_ssrf_guard("https://8.8.8.8/form.xlsx"), ok_response)
         self.assertEqual(mock_get.call_count, 1)
+
+
+class RegistrationFormUserProfileTestCase(TestCase):
+    """Tests for RegistrationFormUserProfile username validation."""
+
+    def test_existing_username_case_insensitive(self):
+        """Registration is rejected when the username already exists in a
+        different case."""
+        User.objects.create(username="MixedUser")
+        form = RegistrationFormUserProfile(data={"username": "mixeduser"})
+        self.assertFalse(form.is_valid())
+        self.assertIn("mixeduser already exists", form.errors["username"][0])

--- a/onadata/apps/main/tests/test_urls_without_admin.py
+++ b/onadata/apps/main/tests/test_urls_without_admin.py
@@ -4,7 +4,13 @@ import importlib
 
 from django.conf import settings
 from django.test import SimpleTestCase, override_settings
-from django.urls import NoReverseMatch, clear_url_caches, resolve, reverse
+from django.urls import (
+    NoReverseMatch,
+    Resolver404,
+    clear_url_caches,
+    resolve,
+    reverse,
+)
 
 from onadata.apps.api.urls import v1_urls as api_v1_urls_module
 from onadata.apps.main import urls as main_urls_module
@@ -77,3 +83,58 @@ class TestUrlsAdminToggle(SimpleTestCase):
             self._reload_urlconfs()
             # Should not raise.
             reverse("admin:index")
+
+
+class TestHyphenatedUsernameUrls(SimpleTestCase):
+    """Username-scoped URLs must reverse for usernames containing a hyphen."""
+
+    def test_download_xform_reverse_with_hyphenated_username(self):
+        """download_xform reverses for a hyphenated username (id_string and pk)."""
+        url = reverse(
+            "download_xform",
+            kwargs={"username": "alpha-project", "id_string": "myform"},
+        )
+        self.assertIn("alpha-project", url)
+
+        url_pk = reverse(
+            "download_xform",
+            kwargs={"username": "alpha-project", "pk": 885480},
+        )
+        self.assertIn("alpha-project", url_pk)
+
+    def test_username_scoped_urls_reverse_with_hyphenated_username(self):
+        """A representative set of username-scoped URLs reverse with a hyphen."""
+        username = "alpha-project"
+        cases = [
+            ("form-list", {"username": username}),
+            ("submissions", {"username": username}),
+            ("download_xlsform", {"username": username, "id_string": "myform"}),
+            ("download_jsonform", {"username": username, "id_string": "myform"}),
+            ("enter_data", {"username": username, "id_string": "myform"}),
+            ("data-view", {"username": username, "id_string": "myform"}),
+            ("manifest-url", {"username": username, "pk": 885480}),
+            (
+                "export-download",
+                {
+                    "username": username,
+                    "id_string": "myform",
+                    "export_type": "csv",
+                    "filename": "data.csv",
+                },
+            ),
+        ]
+        for name, kwargs in cases:
+            with self.subTest(url=name):
+                self.assertIn(username, reverse(name, kwargs=kwargs))
+
+    def test_metacharacter_username_does_not_match_routes(self):
+        """Usernames with HTML metacharacters do not match username routes.
+
+        The username group uses USERNAME_LOOKUP_REGEX (not the looser
+        ``[^/]+``), so characters such as ``<>"'`` that cannot appear in a
+        valid username never reach the underlying views.
+        """
+        for path in ("/<script>/formList", "/a\"b/submission", "/a'b/formUpload"):
+            with self.subTest(path=path):
+                with self.assertRaises(Resolver404):
+                    resolve(path)

--- a/onadata/apps/main/urls.py
+++ b/onadata/apps/main/urls.py
@@ -34,6 +34,11 @@ from onadata.apps.sms_support import views as sms_support_views
 from onadata.apps.viewer import views as viewer_views
 from onadata.libs.utils.analytics import init_analytics
 
+# Username capture group shared by username-scoped routes. Built from
+# USERNAME_LOOKUP_REGEX so hyphenated/email/phone usernames match while
+# URL/HTML metacharacters stay excluded.
+_USERNAME = rf"(?P<username>{USERNAME_LOOKUP_REGEX})"
+
 TESTING = len(sys.argv) > 1 and sys.argv[1] == "test"
 ADMIN_URL_PATH = getattr(settings, "ADMIN_URL_PATH", "admin")
 
@@ -253,7 +258,7 @@ urlpatterns += [
     ),
     # briefcase api urls
     re_path(
-        rf"^(?P<username>{USERNAME_LOOKUP_REGEX})/view/submissionList$",
+        rf"^{_USERNAME}/view/submissionList$",
         BriefcaseViewset.as_view({"get": "list", "head": "list"}),
         name="view-submission-list",
     ),
@@ -268,7 +273,7 @@ urlpatterns += [
         name="view-submission-list",
     ),
     re_path(
-        rf"^(?P<username>{USERNAME_LOOKUP_REGEX})/view/downloadSubmission$",
+        rf"^{_USERNAME}/view/downloadSubmission$",
         BriefcaseViewset.as_view({"get": "retrieve", "head": "retrieve"}),
         name="view-download-submission",
     ),
@@ -283,117 +288,117 @@ urlpatterns += [
         name="view-download-submission",
     ),
     re_path(
-        rf"^(?P<username>{USERNAME_LOOKUP_REGEX})/formUpload$",
+        rf"^{_USERNAME}/formUpload$",
         BriefcaseViewset.as_view({"post": "create", "head": "create"}),
         name="form-upload",
     ),
     re_path(
-        rf"^(?P<username>{USERNAME_LOOKUP_REGEX})/upload$",
+        rf"^{_USERNAME}/upload$",
         BriefcaseViewset.as_view({"post": "create", "head": "create"}),
         name="upload",
     ),
     # exporting stuff
     re_path(
-        rf"^(?P<username>{USERNAME_LOOKUP_REGEX})/forms/(?P<id_string>[^/]+)/data\.csv$",
+        rf"^{_USERNAME}/forms/(?P<id_string>[^/]+)/data\.csv$",
         viewer_views.data_export,
         name="csv_export",
         kwargs={"export_type": "csv"},
     ),
     re_path(
-        rf"^(?P<username>{USERNAME_LOOKUP_REGEX})/forms/(?P<id_string>[^/]+)/data\.xls",
+        rf"^{_USERNAME}/forms/(?P<id_string>[^/]+)/data\.xls",
         viewer_views.data_export,
         name="xlsx_export",
         kwargs={"export_type": "xlsx"},
     ),
     re_path(
-        rf"^(?P<username>{USERNAME_LOOKUP_REGEX})/forms/(?P<id_string>[^/]+)/data\.csv.zip",
+        rf"^{_USERNAME}/forms/(?P<id_string>[^/]+)/data\.csv.zip",
         viewer_views.data_export,
         name="csv_zip_export",
         kwargs={"export_type": "csv_zip"},
     ),
     re_path(
-        rf"^(?P<username>{USERNAME_LOOKUP_REGEX})/forms/(?P<id_string>[^/]+)/data\.sav.zip",
+        rf"^{_USERNAME}/forms/(?P<id_string>[^/]+)/data\.sav.zip",
         viewer_views.data_export,
         name="sav_zip_export",
         kwargs={"export_type": "sav_zip"},
     ),
     re_path(
-        rf"^(?P<username>{USERNAME_LOOKUP_REGEX})/forms/(?P<id_string>[^/]+)/data\.kml$",
+        rf"^{_USERNAME}/forms/(?P<id_string>[^/]+)/data\.kml$",
         viewer_views.kml_export,
         name="kml-export",
     ),
     re_path(
-        rf"^(?P<username>{USERNAME_LOOKUP_REGEX})/forms/(?P<id_string>[^/]+)/data\.zip",
+        rf"^{_USERNAME}/forms/(?P<id_string>[^/]+)/data\.zip",
         viewer_views.zip_export,
     ),
     re_path(
-        rf"^(?P<username>{USERNAME_LOOKUP_REGEX})/forms/(?P<id_string>[^/]+)/gdocs$",
+        rf"^{_USERNAME}/forms/(?P<id_string>[^/]+)/gdocs$",
         viewer_views.google_xlsx_export,
     ),
     re_path(
-        rf"^(?P<username>{USERNAME_LOOKUP_REGEX})/forms/(?P<id_string>[^/]+)/map_embed",
+        rf"^{_USERNAME}/forms/(?P<id_string>[^/]+)/map_embed",
         viewer_views.map_embed_view,
     ),
     re_path(
-        rf"^(?P<username>{USERNAME_LOOKUP_REGEX})/forms/(?P<id_string>[^/]+)/map",
+        rf"^{_USERNAME}/forms/(?P<id_string>[^/]+)/map",
         viewer_views.map_view,
         name="map-view",
     ),
     re_path(
-        rf"^(?P<username>{USERNAME_LOOKUP_REGEX})/forms/(?P<id_string>[^/]+)/instance",
+        rf"^{_USERNAME}/forms/(?P<id_string>[^/]+)/instance",
         viewer_views.instance,
         name="submission-instance",
     ),
     re_path(
-        rf"^(?P<username>{USERNAME_LOOKUP_REGEX})/forms/(?P<id_string>[^/]+)/enter-data",
+        rf"^{_USERNAME}/forms/(?P<id_string>[^/]+)/enter-data",
         logger_views.enter_data,
         name="enter_data",
     ),
     re_path(
-        rf"^(?P<username>{USERNAME_LOOKUP_REGEX})/forms/(?P<id_string>[^/]+)/add-submission-with",  # noqa
+        rf"^{_USERNAME}/forms/(?P<id_string>[^/]+)/add-submission-with",  # noqa
         viewer_views.add_submission_with,
         name="add_submission_with",
     ),
     re_path(
-        rf"^(?P<username>{USERNAME_LOOKUP_REGEX})/forms/(?P<id_string>[^/]+)/thank_you_submission",  # noqa
+        rf"^{_USERNAME}/forms/(?P<id_string>[^/]+)/thank_you_submission",  # noqa
         viewer_views.thank_you_submission,
         name="thank_you_submission",
     ),
     re_path(
-        rf"^(?P<username>{USERNAME_LOOKUP_REGEX})/forms/(?P<id_string>[^/]+)/edit-data/(?P<data_id>\d+)$",  # noqa
+        rf"^{_USERNAME}/forms/(?P<id_string>[^/]+)/edit-data/(?P<data_id>\d+)$",  # noqa
         logger_views.edit_data,
         name="edit_data",
     ),
     re_path(
-        rf"^(?P<username>{USERNAME_LOOKUP_REGEX})/forms/(?P<id_string>[^/]+)/view-data",
+        rf"^{_USERNAME}/forms/(?P<id_string>[^/]+)/view-data",
         viewer_views.data_view,
         name="data-view",
     ),
     re_path(
-        rf"^(?P<username>{USERNAME_LOOKUP_REGEX})/exports/(?P<id_string>[^/]+)/(?P<export_type>\w+)/new$",  # noqa
+        rf"^{_USERNAME}/exports/(?P<id_string>[^/]+)/(?P<export_type>\w+)/new$",  # noqa
         viewer_views.create_export,
         name="new-export",
     ),
     re_path(
-        rf"^(?P<username>{USERNAME_LOOKUP_REGEX})/exports/(?P<id_string>[^/]+)/(?P<export_type>\w+)"  # noqa
+        rf"^{_USERNAME}/exports/(?P<id_string>[^/]+)/(?P<export_type>\w+)"  # noqa
         "/delete$",
         viewer_views.delete_export,
         name="delete-export",
     ),
     re_path(
-        rf"^(?P<username>{USERNAME_LOOKUP_REGEX})/exports/(?P<id_string>[^/]+)/(?P<export_type>\w+)"  # noqa
+        rf"^{_USERNAME}/exports/(?P<id_string>[^/]+)/(?P<export_type>\w+)"  # noqa
         "/progress$",
         viewer_views.export_progress,
         name="export-progress",
     ),
     re_path(
-        rf"^(?P<username>{USERNAME_LOOKUP_REGEX})/exports/(?P<id_string>[^/]+)/(?P<export_type>\w+)"  # noqa
+        rf"^{_USERNAME}/exports/(?P<id_string>[^/]+)/(?P<export_type>\w+)"  # noqa
         "/$",
         viewer_views.export_list,
         name="export-list",
     ),
     re_path(
-        rf"^(?P<username>{USERNAME_LOOKUP_REGEX})/exports/(?P<id_string>[^/]+)/(?P<export_type>\w+)"  # noqa
+        rf"^{_USERNAME}/exports/(?P<id_string>[^/]+)/(?P<export_type>\w+)"  # noqa
         "/(?P<filename>[^/]+)$",
         viewer_views.export_download,
         name="export-download",
@@ -422,7 +427,7 @@ urlpatterns += [
         name="form-list",
     ),
     re_path(
-        rf"^(?P<username>{USERNAME_LOOKUP_REGEX})/formList$",
+        rf"^{_USERNAME}/formList$",
         XFormListViewSet.as_view({"get": "list", "head": "list"}),
         name="form-list",
     ),
@@ -452,22 +457,22 @@ urlpatterns += [
         name="form-list",
     ),
     re_path(
-        rf"^(?P<username>{USERNAME_LOOKUP_REGEX})/(?P<xform_pk>\d+)/formList$",
+        rf"^{_USERNAME}/(?P<xform_pk>\d+)/formList$",
         XFormListViewSet.as_view({"get": "list", "head": "list"}),
         name="form-list",
     ),
     re_path(
-        rf"^preview/(?P<username>{USERNAME_LOOKUP_REGEX})/(?P<xform_pk>\d+)/formList$",
+        rf"^preview/{_USERNAME}/(?P<xform_pk>\d+)/formList$",
         PreviewXFormListViewSet.as_view({"get": "list", "head": "list"}),
         name="form-list",
     ),
     re_path(
-        rf"^preview/(?P<username>{USERNAME_LOOKUP_REGEX})/formList$",
+        rf"^preview/{_USERNAME}/formList$",
         PreviewXFormListViewSet.as_view({"get": "list", "head": "list"}),
         name="form-list",
     ),
     re_path(
-        rf"^(?P<username>{USERNAME_LOOKUP_REGEX})/xformsManifest/(?P<pk>[\d+^/]+)$",
+        rf"^{_USERNAME}/xformsManifest/(?P<pk>[\d+^/]+)$",
         XFormListViewSet.as_view({"get": "manifest", "head": "manifest"}),
         name="manifest-url",
     ),
@@ -477,13 +482,13 @@ urlpatterns += [
         name="manifest-url",
     ),
     re_path(
-        rf"^(?P<username>{USERNAME_LOOKUP_REGEX})/xformsMedia/(?P<pk>[\d+^/]+)/(?P<metadata>[\d+^/.]+)$",  # noqa
+        rf"^{_USERNAME}/xformsMedia/(?P<pk>[\d+^/]+)/(?P<metadata>[\d+^/.]+)$",  # noqa
         XFormListViewSet.as_view({"get": "media", "head": "media"}),
         name="xform-media",
     ),
     re_path(
         # pylint: disable=line-too-long
-        rf"^(?P<username>{USERNAME_LOOKUP_REGEX})/xformsMedia/(?P<pk>[\d+^/]+)/(?P<metadata>[\d+^/.]+)\.(?P<format>([a-z]|[0-9])*)$",  # noqa
+        rf"^{_USERNAME}/xformsMedia/(?P<pk>[\d+^/]+)/(?P<metadata>[\d+^/.]+)\.(?P<format>([a-z]|[0-9])*)$",  # noqa
         XFormListViewSet.as_view({"get": "media", "head": "media"}),
         name="xform-media",
     ),
@@ -499,7 +504,7 @@ urlpatterns += [
         name="xform-media",
     ),
     re_path(
-        rf"^(?P<username>{USERNAME_LOOKUP_REGEX})/submission$",
+        rf"^{_USERNAME}/submission$",
         XFormSubmissionViewSet.as_view({"post": "create", "head": "create"}),
         name="submissions",
     ),
@@ -524,41 +529,41 @@ urlpatterns += [
         name="submissions",
     ),
     re_path(
-        rf"^(?P<username>{USERNAME_LOOKUP_REGEX})/(?P<xform_pk>\d+)/submission$",
+        rf"^{_USERNAME}/(?P<xform_pk>\d+)/submission$",
         XFormSubmissionViewSet.as_view({"post": "create", "head": "create"}),
         name="submissions",
     ),
-    re_path(rf"^(?P<username>{USERNAME_LOOKUP_REGEX})/bulk-submission$", logger_views.bulksubmission),
+    re_path(rf"^{_USERNAME}/bulk-submission$", logger_views.bulksubmission),
     re_path(
-        rf"^(?P<username>{USERNAME_LOOKUP_REGEX})/bulk-submission-form$", logger_views.bulksubmission_form
+        rf"^{_USERNAME}/bulk-submission-form$", logger_views.bulksubmission_form
     ),
     re_path(
-        rf"^(?P<username>{USERNAME_LOOKUP_REGEX})/forms/(?P<pk>[\d+^/]+)/form\.xml$",
+        rf"^{_USERNAME}/forms/(?P<pk>[\d+^/]+)/form\.xml$",
         XFormListViewSet.as_view({"get": "retrieve", "head": "retrieve"}),
         name="download_xform",
     ),
     re_path(
-        rf"^(?P<username>{USERNAME_LOOKUP_REGEX})/forms/(?P<id_string>[^/]+)/form\.xml$",
+        rf"^{_USERNAME}/forms/(?P<id_string>[^/]+)/form\.xml$",
         logger_views.download_xform,
         name="download_xform",
     ),
     re_path(
-        rf"^(?P<username>{USERNAME_LOOKUP_REGEX})/forms/(?P<id_string>[^/]+)/form\.xls$",
+        rf"^{_USERNAME}/forms/(?P<id_string>[^/]+)/form\.xls$",
         logger_views.download_xlsform,
         name="download_xlsform",
     ),
     re_path(
-        rf"^(?P<username>{USERNAME_LOOKUP_REGEX})/forms/(?P<id_string>[^/]+)/form\.json",
+        rf"^{_USERNAME}/forms/(?P<id_string>[^/]+)/form\.json",
         logger_views.download_jsonform,
         name="download_jsonform",
     ),
     re_path(
-        rf"^(?P<username>{USERNAME_LOOKUP_REGEX})/delete/(?P<id_string>[^/]+)/$",
+        rf"^{_USERNAME}/delete/(?P<id_string>[^/]+)/$",
         logger_views.delete_xform,
         name="delete-xform",
     ),
     re_path(
-        rf"^(?P<username>{USERNAME_LOOKUP_REGEX})/(?P<id_string>[^/]+)/toggle_downloadable/$",
+        rf"^{_USERNAME}/(?P<id_string>[^/]+)/toggle_downloadable/$",
         logger_views.toggle_downloadable,
         name="toggle-downloadable",
     ),
@@ -596,7 +601,7 @@ urlpatterns += [
     ),
     # Stats tables
     re_path(
-        rf"^(?P<username>{USERNAME_LOOKUP_REGEX})/forms/(?P<id_string>[^/]+)/tables",
+        rf"^{_USERNAME}/forms/(?P<id_string>[^/]+)/tables",
         viewer_views.stats_tables,
         name="stats-tables",
     ),

--- a/onadata/apps/main/urls.py
+++ b/onadata/apps/main/urls.py
@@ -15,6 +15,7 @@ from django.views.generic import RedirectView
 from rest_framework.renderers import JSONRenderer
 
 from onadata.apps import sms_support
+from onadata.apps.api.constants import USERNAME_LOOKUP_REGEX
 from onadata.apps.api.urls.v1_urls import (
     BriefcaseViewset,
     XFormListViewSet,
@@ -252,7 +253,7 @@ urlpatterns += [
     ),
     # briefcase api urls
     re_path(
-        r"^(?P<username>\w+)/view/submissionList$",
+        rf"^(?P<username>{USERNAME_LOOKUP_REGEX})/view/submissionList$",
         BriefcaseViewset.as_view({"get": "list", "head": "list"}),
         name="view-submission-list",
     ),
@@ -267,7 +268,7 @@ urlpatterns += [
         name="view-submission-list",
     ),
     re_path(
-        r"^(?P<username>\w+)/view/downloadSubmission$",
+        rf"^(?P<username>{USERNAME_LOOKUP_REGEX})/view/downloadSubmission$",
         BriefcaseViewset.as_view({"get": "retrieve", "head": "retrieve"}),
         name="view-download-submission",
     ),
@@ -282,117 +283,117 @@ urlpatterns += [
         name="view-download-submission",
     ),
     re_path(
-        r"^(?P<username>\w+)/formUpload$",
+        rf"^(?P<username>{USERNAME_LOOKUP_REGEX})/formUpload$",
         BriefcaseViewset.as_view({"post": "create", "head": "create"}),
         name="form-upload",
     ),
     re_path(
-        r"^(?P<username>\w+)/upload$",
+        rf"^(?P<username>{USERNAME_LOOKUP_REGEX})/upload$",
         BriefcaseViewset.as_view({"post": "create", "head": "create"}),
         name="upload",
     ),
     # exporting stuff
     re_path(
-        r"^(?P<username>\w+)/forms/(?P<id_string>[^/]+)/data\.csv$",
+        rf"^(?P<username>{USERNAME_LOOKUP_REGEX})/forms/(?P<id_string>[^/]+)/data\.csv$",
         viewer_views.data_export,
         name="csv_export",
         kwargs={"export_type": "csv"},
     ),
     re_path(
-        r"^(?P<username>\w+)/forms/(?P<id_string>[^/]+)/data\.xls",
+        rf"^(?P<username>{USERNAME_LOOKUP_REGEX})/forms/(?P<id_string>[^/]+)/data\.xls",
         viewer_views.data_export,
         name="xlsx_export",
         kwargs={"export_type": "xlsx"},
     ),
     re_path(
-        r"^(?P<username>\w+)/forms/(?P<id_string>[^/]+)/data\.csv.zip",
+        rf"^(?P<username>{USERNAME_LOOKUP_REGEX})/forms/(?P<id_string>[^/]+)/data\.csv.zip",
         viewer_views.data_export,
         name="csv_zip_export",
         kwargs={"export_type": "csv_zip"},
     ),
     re_path(
-        r"^(?P<username>\w+)/forms/(?P<id_string>[^/]+)/data\.sav.zip",
+        rf"^(?P<username>{USERNAME_LOOKUP_REGEX})/forms/(?P<id_string>[^/]+)/data\.sav.zip",
         viewer_views.data_export,
         name="sav_zip_export",
         kwargs={"export_type": "sav_zip"},
     ),
     re_path(
-        r"^(?P<username>\w+)/forms/(?P<id_string>[^/]+)/data\.kml$",
+        rf"^(?P<username>{USERNAME_LOOKUP_REGEX})/forms/(?P<id_string>[^/]+)/data\.kml$",
         viewer_views.kml_export,
         name="kml-export",
     ),
     re_path(
-        r"^(?P<username>\w+)/forms/(?P<id_string>[^/]+)/data\.zip",
+        rf"^(?P<username>{USERNAME_LOOKUP_REGEX})/forms/(?P<id_string>[^/]+)/data\.zip",
         viewer_views.zip_export,
     ),
     re_path(
-        r"^(?P<username>\w+)/forms/(?P<id_string>[^/]+)/gdocs$",
+        rf"^(?P<username>{USERNAME_LOOKUP_REGEX})/forms/(?P<id_string>[^/]+)/gdocs$",
         viewer_views.google_xlsx_export,
     ),
     re_path(
-        r"^(?P<username>\w+)/forms/(?P<id_string>[^/]+)/map_embed",
+        rf"^(?P<username>{USERNAME_LOOKUP_REGEX})/forms/(?P<id_string>[^/]+)/map_embed",
         viewer_views.map_embed_view,
     ),
     re_path(
-        r"^(?P<username>\w+)/forms/(?P<id_string>[^/]+)/map",
+        rf"^(?P<username>{USERNAME_LOOKUP_REGEX})/forms/(?P<id_string>[^/]+)/map",
         viewer_views.map_view,
         name="map-view",
     ),
     re_path(
-        r"^(?P<username>\w+)/forms/(?P<id_string>[^/]+)/instance",
+        rf"^(?P<username>{USERNAME_LOOKUP_REGEX})/forms/(?P<id_string>[^/]+)/instance",
         viewer_views.instance,
         name="submission-instance",
     ),
     re_path(
-        r"^(?P<username>\w+)/forms/(?P<id_string>[^/]+)/enter-data",
+        rf"^(?P<username>{USERNAME_LOOKUP_REGEX})/forms/(?P<id_string>[^/]+)/enter-data",
         logger_views.enter_data,
         name="enter_data",
     ),
     re_path(
-        r"^(?P<username>\w+)/forms/(?P<id_string>[^/]+)/add-submission-with",  # noqa
+        rf"^(?P<username>{USERNAME_LOOKUP_REGEX})/forms/(?P<id_string>[^/]+)/add-submission-with",  # noqa
         viewer_views.add_submission_with,
         name="add_submission_with",
     ),
     re_path(
-        r"^(?P<username>\w+)/forms/(?P<id_string>[^/]+)/thank_you_submission",  # noqa
+        rf"^(?P<username>{USERNAME_LOOKUP_REGEX})/forms/(?P<id_string>[^/]+)/thank_you_submission",  # noqa
         viewer_views.thank_you_submission,
         name="thank_you_submission",
     ),
     re_path(
-        r"^(?P<username>\w+)/forms/(?P<id_string>[^/]+)/edit-data/(?P<data_id>\d+)$",  # noqa
+        rf"^(?P<username>{USERNAME_LOOKUP_REGEX})/forms/(?P<id_string>[^/]+)/edit-data/(?P<data_id>\d+)$",  # noqa
         logger_views.edit_data,
         name="edit_data",
     ),
     re_path(
-        r"^(?P<username>\w+)/forms/(?P<id_string>[^/]+)/view-data",
+        rf"^(?P<username>{USERNAME_LOOKUP_REGEX})/forms/(?P<id_string>[^/]+)/view-data",
         viewer_views.data_view,
         name="data-view",
     ),
     re_path(
-        r"^(?P<username>\w+)/exports/(?P<id_string>[^/]+)/(?P<export_type>\w+)/new$",  # noqa
+        rf"^(?P<username>{USERNAME_LOOKUP_REGEX})/exports/(?P<id_string>[^/]+)/(?P<export_type>\w+)/new$",  # noqa
         viewer_views.create_export,
         name="new-export",
     ),
     re_path(
-        r"^(?P<username>\w+)/exports/(?P<id_string>[^/]+)/(?P<export_type>\w+)"  # noqa
+        rf"^(?P<username>{USERNAME_LOOKUP_REGEX})/exports/(?P<id_string>[^/]+)/(?P<export_type>\w+)"  # noqa
         "/delete$",
         viewer_views.delete_export,
         name="delete-export",
     ),
     re_path(
-        r"^(?P<username>\w+)/exports/(?P<id_string>[^/]+)/(?P<export_type>\w+)"  # noqa
+        rf"^(?P<username>{USERNAME_LOOKUP_REGEX})/exports/(?P<id_string>[^/]+)/(?P<export_type>\w+)"  # noqa
         "/progress$",
         viewer_views.export_progress,
         name="export-progress",
     ),
     re_path(
-        r"^(?P<username>\w+)/exports/(?P<id_string>[^/]+)/(?P<export_type>\w+)"  # noqa
+        rf"^(?P<username>{USERNAME_LOOKUP_REGEX})/exports/(?P<id_string>[^/]+)/(?P<export_type>\w+)"  # noqa
         "/$",
         viewer_views.export_list,
         name="export-list",
     ),
     re_path(
-        r"^(?P<username>\w+)/exports/(?P<id_string>[^/]+)/(?P<export_type>\w+)"  # noqa
+        rf"^(?P<username>{USERNAME_LOOKUP_REGEX})/exports/(?P<id_string>[^/]+)/(?P<export_type>\w+)"  # noqa
         "/(?P<filename>[^/]+)$",
         viewer_views.export_download,
         name="export-download",
@@ -421,7 +422,7 @@ urlpatterns += [
         name="form-list",
     ),
     re_path(
-        r"^(?P<username>\w+)/formList$",
+        rf"^(?P<username>{USERNAME_LOOKUP_REGEX})/formList$",
         XFormListViewSet.as_view({"get": "list", "head": "list"}),
         name="form-list",
     ),
@@ -451,22 +452,22 @@ urlpatterns += [
         name="form-list",
     ),
     re_path(
-        r"^(?P<username>\w+)/(?P<xform_pk>\d+)/formList$",
+        rf"^(?P<username>{USERNAME_LOOKUP_REGEX})/(?P<xform_pk>\d+)/formList$",
         XFormListViewSet.as_view({"get": "list", "head": "list"}),
         name="form-list",
     ),
     re_path(
-        r"^preview/(?P<username>\w+)/(?P<xform_pk>\d+)/formList$",
+        rf"^preview/(?P<username>{USERNAME_LOOKUP_REGEX})/(?P<xform_pk>\d+)/formList$",
         PreviewXFormListViewSet.as_view({"get": "list", "head": "list"}),
         name="form-list",
     ),
     re_path(
-        r"^preview/(?P<username>\w+)/formList$",
+        rf"^preview/(?P<username>{USERNAME_LOOKUP_REGEX})/formList$",
         PreviewXFormListViewSet.as_view({"get": "list", "head": "list"}),
         name="form-list",
     ),
     re_path(
-        r"^(?P<username>\w+)/xformsManifest/(?P<pk>[\d+^/]+)$",
+        rf"^(?P<username>{USERNAME_LOOKUP_REGEX})/xformsManifest/(?P<pk>[\d+^/]+)$",
         XFormListViewSet.as_view({"get": "manifest", "head": "manifest"}),
         name="manifest-url",
     ),
@@ -476,13 +477,13 @@ urlpatterns += [
         name="manifest-url",
     ),
     re_path(
-        r"^(?P<username>\w+)/xformsMedia/(?P<pk>[\d+^/]+)/(?P<metadata>[\d+^/.]+)$",  # noqa
+        rf"^(?P<username>{USERNAME_LOOKUP_REGEX})/xformsMedia/(?P<pk>[\d+^/]+)/(?P<metadata>[\d+^/.]+)$",  # noqa
         XFormListViewSet.as_view({"get": "media", "head": "media"}),
         name="xform-media",
     ),
     re_path(
         # pylint: disable=line-too-long
-        r"^(?P<username>\w+)/xformsMedia/(?P<pk>[\d+^/]+)/(?P<metadata>[\d+^/.]+)\.(?P<format>([a-z]|[0-9])*)$",  # noqa
+        rf"^(?P<username>{USERNAME_LOOKUP_REGEX})/xformsMedia/(?P<pk>[\d+^/]+)/(?P<metadata>[\d+^/.]+)\.(?P<format>([a-z]|[0-9])*)$",  # noqa
         XFormListViewSet.as_view({"get": "media", "head": "media"}),
         name="xform-media",
     ),
@@ -498,7 +499,7 @@ urlpatterns += [
         name="xform-media",
     ),
     re_path(
-        r"^(?P<username>\w+)/submission$",
+        rf"^(?P<username>{USERNAME_LOOKUP_REGEX})/submission$",
         XFormSubmissionViewSet.as_view({"post": "create", "head": "create"}),
         name="submissions",
     ),
@@ -523,41 +524,41 @@ urlpatterns += [
         name="submissions",
     ),
     re_path(
-        r"^(?P<username>\w+)/(?P<xform_pk>\d+)/submission$",
+        rf"^(?P<username>{USERNAME_LOOKUP_REGEX})/(?P<xform_pk>\d+)/submission$",
         XFormSubmissionViewSet.as_view({"post": "create", "head": "create"}),
         name="submissions",
     ),
-    re_path(r"^(?P<username>\w+)/bulk-submission$", logger_views.bulksubmission),
+    re_path(rf"^(?P<username>{USERNAME_LOOKUP_REGEX})/bulk-submission$", logger_views.bulksubmission),
     re_path(
-        r"^(?P<username>\w+)/bulk-submission-form$", logger_views.bulksubmission_form
+        rf"^(?P<username>{USERNAME_LOOKUP_REGEX})/bulk-submission-form$", logger_views.bulksubmission_form
     ),
     re_path(
-        r"^(?P<username>\w+)/forms/(?P<pk>[\d+^/]+)/form\.xml$",
+        rf"^(?P<username>{USERNAME_LOOKUP_REGEX})/forms/(?P<pk>[\d+^/]+)/form\.xml$",
         XFormListViewSet.as_view({"get": "retrieve", "head": "retrieve"}),
         name="download_xform",
     ),
     re_path(
-        r"^(?P<username>\w+)/forms/(?P<id_string>[^/]+)/form\.xml$",
+        rf"^(?P<username>{USERNAME_LOOKUP_REGEX})/forms/(?P<id_string>[^/]+)/form\.xml$",
         logger_views.download_xform,
         name="download_xform",
     ),
     re_path(
-        r"^(?P<username>\w+)/forms/(?P<id_string>[^/]+)/form\.xls$",
+        rf"^(?P<username>{USERNAME_LOOKUP_REGEX})/forms/(?P<id_string>[^/]+)/form\.xls$",
         logger_views.download_xlsform,
         name="download_xlsform",
     ),
     re_path(
-        r"^(?P<username>\w+)/forms/(?P<id_string>[^/]+)/form\.json",
+        rf"^(?P<username>{USERNAME_LOOKUP_REGEX})/forms/(?P<id_string>[^/]+)/form\.json",
         logger_views.download_jsonform,
         name="download_jsonform",
     ),
     re_path(
-        r"^(?P<username>\w+)/delete/(?P<id_string>[^/]+)/$",
+        rf"^(?P<username>{USERNAME_LOOKUP_REGEX})/delete/(?P<id_string>[^/]+)/$",
         logger_views.delete_xform,
         name="delete-xform",
     ),
     re_path(
-        r"^(?P<username>\w+)/(?P<id_string>[^/]+)/toggle_downloadable/$",
+        rf"^(?P<username>{USERNAME_LOOKUP_REGEX})/(?P<id_string>[^/]+)/toggle_downloadable/$",
         logger_views.toggle_downloadable,
         name="toggle-downloadable",
     ),
@@ -595,7 +596,7 @@ urlpatterns += [
     ),
     # Stats tables
     re_path(
-        r"^(?P<username>\w+)/forms/(?P<id_string>[^/]+)/tables",
+        rf"^(?P<username>{USERNAME_LOOKUP_REGEX})/forms/(?P<id_string>[^/]+)/tables",
         viewer_views.stats_tables,
         name="stats-tables",
     ),

--- a/onadata/libs/serializers/organization_serializer.py
+++ b/onadata/libs/serializers/organization_serializer.py
@@ -3,6 +3,8 @@
 Organization Serializer
 """
 
+import re
+
 from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
 from django.db.models.query import QuerySet
@@ -11,6 +13,7 @@ from django.utils.translation import gettext as _
 from rest_framework import serializers
 
 from onadata.apps.api import tools
+from onadata.apps.api.constants import ORGANIZATION_USERNAME_VALIDATION_REGEX
 from onadata.apps.api.models import OrganizationProfile
 from onadata.apps.api.tools import (
     _get_first_last_names,
@@ -27,6 +30,8 @@ from onadata.libs.serializers.fields.json_field import JsonField
 
 # pylint: disable=invalid-name
 User = get_user_model()
+
+ORG_USERNAME_RE = re.compile(ORGANIZATION_USERNAME_VALIDATION_REGEX)
 
 
 class KMSKeyInlineSerializer(serializers.ModelSerializer):
@@ -148,7 +153,7 @@ class OrganizationSerializer(serializers.HyperlinkedModelSerializer):
             raise serializers.ValidationError(
                 _(f"{org} is a reserved name, please choose another")
             )
-        if not RegistrationFormUserProfile.legal_usernames_re.search(org):
+        if not ORG_USERNAME_RE.match(org):
             raise serializers.ValidationError(
                 _(
                     "Organization may only contain alpha-numeric characters and "

--- a/onadata/libs/serializers/organization_serializer.py
+++ b/onadata/libs/serializers/organization_serializer.py
@@ -3,8 +3,6 @@
 Organization Serializer
 """
 
-import re
-
 from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
 from django.db.models.query import QuerySet
@@ -13,7 +11,6 @@ from django.utils.translation import gettext as _
 from rest_framework import serializers
 
 from onadata.apps.api import tools
-from onadata.apps.api.constants import ORGANIZATION_USERNAME_VALIDATION_REGEX
 from onadata.apps.api.models import OrganizationProfile
 from onadata.apps.api.tools import (
     _get_first_last_names,
@@ -30,8 +27,6 @@ from onadata.libs.serializers.fields.json_field import JsonField
 
 # pylint: disable=invalid-name
 User = get_user_model()
-
-ORG_USERNAME_RE = re.compile(ORGANIZATION_USERNAME_VALIDATION_REGEX)
 
 
 class KMSKeyInlineSerializer(serializers.ModelSerializer):
@@ -153,7 +148,7 @@ class OrganizationSerializer(serializers.HyperlinkedModelSerializer):
             raise serializers.ValidationError(
                 _(f"{org} is a reserved name, please choose another")
             )
-        if not ORG_USERNAME_RE.match(org):
+        if not RegistrationFormUserProfile.legal_usernames_re.search(org):
             raise serializers.ValidationError(
                 _(
                     "Organization may only contain alpha-numeric characters and "

--- a/onadata/libs/serializers/organization_serializer.py
+++ b/onadata/libs/serializers/organization_serializer.py
@@ -160,12 +160,10 @@ class OrganizationSerializer(serializers.HyperlinkedModelSerializer):
                     "underscores"
                 )
             )
-        try:
-            User.objects.get(username=org)
-        except User.DoesNotExist:
-            return org
+        if User.objects.filter(username__iexact=org).exists():
+            raise serializers.ValidationError(_(f"Organization {org} already exists."))
 
-        raise serializers.ValidationError(_(f"Organization {org} already exists."))
+        return org
 
     def get_users(self, obj):
         """

--- a/onadata/libs/serializers/user_profile_serializer.py
+++ b/onadata/libs/serializers/user_profile_serializer.py
@@ -340,7 +340,7 @@ class UserProfileSerializer(serializers.HyperlinkedModelSerializer):
             raise serializers.ValidationError(
                 _("Username must have 3 or more characters")
             )
-        users = User.objects.filter(username=username)
+        users = User.objects.filter(username__iexact=username)
         if self.instance:
             users = users.exclude(pk=self.instance.user.pk)
         if users.exists():


### PR DESCRIPTION
### Changes / Features implemented

**Case-insensitive username uniqueness (orgs + users)**
The duplicate checks lowercased the input but did an exact-match lookup (`username=...`), so a username already stored in a different case (legacy/externally-created data) could be missed and a duplicate created. Switched to `username__iexact` in:
- `onadata/libs/serializers/organization_serializer.py` (`validate_org`)
- `onadata/libs/serializers/user_profile_serializer.py` (`validate_username`)
- `onadata/apps/main/forms.py` (`RegistrationFormUserProfile.clean_username`)

**Hyphenated (and email/phone) usernames now work in main URLs**
Many username-scoped patterns in `main/urls.py` captured the username with `(?P<username>\w+)`, which rejects hyphens, dots, `@`, `+`. This caused `NoReverseMatch` for valid usernames such as `alpha-project` (reported on `download_xform`) and for email/phone-format usernames. Switched the username group to the existing `USERNAME_LOOKUP_REGEX` (already used by the API viewsets' `lookup_value_regex`).
- Chosen over a blanket `[^/]+`: `USERNAME_LOOKUP_REGEX` permits the full valid username charset but still excludes URL/HTML metacharacters (`<>\"'`, whitespace), so it does **not** widen the reflected-input attack surface that `\w+` previously constrained.

### Steps taken to verify this change does what is intended

- URLs: `test_download_xform_reverse_with_hyphenated_username`, `test_username_scoped_urls_reverse_with_hyphenated_username` (representative set of ~8 named routes), and `test_metacharacter_username_does_not_match_routes` (security: `<script>`/quote usernames return `Resolver404`, never reaching views).
- Case-insensitive: `test_orgs_create_existing_username_case_insensitive`, `test_profile_create_existing_username_case_insensitive` (API), `RegistrationFormUserProfileTestCase.test_existing_username_case_insensitive` (form).
- Org revert: `test_orgs_create_with_hyphen_allowed` (hyphenated org → 201).
- Regression: org viewset, form-show, export-list, forms and user-profile viewset suites all pass (119 + 76 tests, no failures).

### Side effects of implementing this change

- ~42 username-scoped URL patterns now route a broader (but still validated) username charset. Metacharacters remain excluded by `USERNAME_LOOKUP_REGEX`.
- The ~29 pre-existing patterns that already used `[^/]+` are unchanged; tightening those to `USERNAME_LOOKUP_REGEX` could be a follow-up for consistency.
- `create_organization_object` in `onadata/apps/api/tools.py` still builds the `User` directly without the regex check (it already uses `username__iexact`), so internal/CLI org creation bypasses character validation. Out of scope; possible follow-up.

**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  - [ ] Updated documentation