### PR TITLE
feat(security): rate-limit HTTP Basic and OAuth2 password-grant logins

### DIFF
--- a/onadata/apps/api/viewsets/xform_submission_viewset.py
+++ b/onadata/apps/api/viewsets/xform_submission_viewset.py
@@ -9,7 +9,7 @@ from django.shortcuts import get_object_or_404
 from django.utils.translation import gettext as _
 
 from rest_framework import mixins, permissions, status, viewsets
-from rest_framework.authentication import BasicAuthentication, TokenAuthentication
+from rest_framework.authentication import TokenAuthentication
 from rest_framework.parsers import FormParser, JSONParser, MultiPartParser
 from rest_framework.renderers import BrowsableAPIRenderer, JSONRenderer
 from rest_framework.response import Response
@@ -18,7 +18,11 @@ from onadata.apps.api.permissions import IsAuthenticatedSubmission
 from onadata.apps.api.tools import get_baseviewset_class
 from onadata.apps.logger.models import Instance
 from onadata.libs import filters
-from onadata.libs.authentication import DigestAuthentication, EnketoTokenAuthentication
+from onadata.libs.authentication import (
+    DigestAuthentication,
+    EnketoTokenAuthentication,
+    LockoutBasicAuthentication,
+)
 from onadata.libs.mixins.authenticate_header_mixin import AuthenticateHeaderMixin
 from onadata.libs.mixins.openrosa_headers_mixin import OpenRosaHeadersMixin
 from onadata.libs.renderers.renderers import FLOIPRenderer, TemplateXMLRenderer
@@ -65,7 +69,7 @@ class XFormSubmissionViewSet(
 
     authentication_classes = (
         DigestAuthentication,
-        BasicAuthentication,
+        LockoutBasicAuthentication,
         TokenAuthentication,
         EnketoTokenAuthentication,
     )

--- a/onadata/apps/main/urls.py
+++ b/onadata/apps/main/urls.py
@@ -119,6 +119,11 @@ urlpatterns += [
         main_views.OnaAuthorizationView.as_view(),
         name="oauth2_provider_authorize",
     ),
+    re_path(
+        r"^o/token/$",
+        main_views.LockoutTokenView.as_view(),
+        name="oauth2_provider_token",
+    ),
     re_path(r"^o/", include("oauth2_provider.urls", namespace="oauth2_provider")),
     # main website views
     re_path(r"^$", main_views.home),
@@ -534,9 +539,7 @@ urlpatterns += [
         name="submissions",
     ),
     re_path(rf"^{_USERNAME}/bulk-submission$", logger_views.bulksubmission),
-    re_path(
-        rf"^{_USERNAME}/bulk-submission-form$", logger_views.bulksubmission_form
-    ),
+    re_path(rf"^{_USERNAME}/bulk-submission-form$", logger_views.bulksubmission_form),
     re_path(
         rf"^{_USERNAME}/forms/(?P<pk>[\d+^/]+)/form\.xml$",
         XFormListViewSet.as_view({"get": "retrieve", "head": "retrieve"}),

--- a/onadata/apps/main/views.py
+++ b/onadata/apps/main/views.py
@@ -35,8 +35,9 @@ from django.views.decorators.http import require_GET, require_http_methods, requ
 from bson import json_util
 from bson.objectid import ObjectId
 from guardian.shortcuts import assign_perm, remove_perm
-from oauth2_provider.views.base import AuthorizationView
+from oauth2_provider.views.base import AuthorizationView, TokenView
 from rest_framework.authtoken.models import Token
+from rest_framework.exceptions import AuthenticationFailed
 
 import onadata
 from onadata.apps.logger.models import Instance, XForm
@@ -72,6 +73,12 @@ from onadata.apps.viewer.models.parsed_instance import (
     query_fields_data,
 )
 from onadata.apps.viewer.views import attachment_url
+from onadata.libs.authentication import (
+    add_login_attempt,
+    assert_not_locked_out,
+    get_client_ip,
+    get_lockout_username,
+)
 from onadata.libs.exceptions import EnketoError
 from onadata.libs.utils.decorators import is_owner
 from onadata.libs.utils.export_tools import upload_template_for_external_export
@@ -1633,3 +1640,59 @@ class OnaAuthorizationView(AuthorizationView):
         context["user"] = self.request.user
         context["request_path"] = self.request.get_full_path()
         return context
+
+
+class LockoutTokenView(TokenView):
+    """OAuth2 token endpoint with failed-login lockout on the password grant.
+
+    The Resource Owner Password Credentials grant accepts a username +
+    password and is otherwise brute-forceable with no lockout. The lockout
+    reuses the same IP + username machinery as the other password flows
+    (digest, basic, the web login form), so attempts accumulate against a
+    single counter. Other grants (authorization_code, client_credentials,
+    refresh_token, device_code) do not submit a user password and pass
+    straight through.
+    """
+
+    @staticmethod
+    def _password_grant_identity(request):
+        """Return the (ip_address, username) for a password-grant request.
+
+        ``username`` is ``None`` for any other grant or when no username is
+        supplied, in which case no lockout is tracked.
+        """
+        if request.POST.get("grant_type") != "password":
+            return None, None
+        username = request.POST.get("username")
+        if not username:
+            return None, None
+        return get_client_ip(request), get_lockout_username(username)
+
+    @staticmethod
+    def _lockout_response(exc):
+        detail = exc.detail if isinstance(exc.detail, str) else str(exc.detail)
+        return JsonResponse(
+            {"error": "locked_out", "error_description": detail},
+            status=429,
+        )
+
+    def post(self, request, *args, **kwargs):
+        ip_address, username = self._password_grant_identity(request)
+
+        if username:
+            try:
+                assert_not_locked_out(ip_address, username)
+            except AuthenticationFailed as exc:
+                return self._lockout_response(exc)
+
+        response = super().post(request, *args, **kwargs)
+
+        # add_login_attempt raises AuthenticationFailed on the attempt that
+        # trips the lockout, so convert that to the lockout response too.
+        if username and response.status_code != 200:
+            try:
+                add_login_attempt(ip_address, username)
+            except AuthenticationFailed as exc:
+                return self._lockout_response(exc)
+
+        return response

--- a/onadata/libs/authentication.py
+++ b/onadata/libs/authentication.py
@@ -5,6 +5,8 @@ Authentication classes.
 
 from __future__ import unicode_literals
 
+import base64
+import binascii
 from datetime import datetime
 from typing import Optional, Tuple
 
@@ -27,6 +29,7 @@ from oidc.utils import authenticate_sso
 from rest_framework import exceptions
 from rest_framework.authentication import (
     BaseAuthentication,
+    BasicAuthentication,
     TokenAuthentication,
     get_authorization_header,
 )
@@ -139,6 +142,58 @@ class DigestAuthentication(BaseAuthentication):
         response = self.authenticator.build_challenge_response()
 
         return response["WWW-Authenticate"]
+
+
+class LockoutBasicAuthentication(BasicAuthentication):
+    """HTTP Basic authentication with failed-login lockout.
+
+    Stock ``BasicAuthentication`` returns ``401`` indefinitely on wrong
+    credentials, so basic auth on the API can be brute-forced at full speed.
+    This subclass rejects requests from a locked-out IP + username before
+    checking credentials, and records a failed attempt — locking out after
+    ``MAX_LOGIN_ATTEMPTS`` — whenever authentication fails.
+    """
+
+    def _lockout_identity(self, request):
+        """Return the (ip_address, username) the basic credentials key on.
+
+        ``username`` is ``None`` when there is no usable Basic username (the
+        header is malformed/absent), in which case no lockout is tracked and
+        the parent class surfaces the error.
+        """
+        ip_address = get_client_ip(request)
+        auth = get_authorization_header(request).split()
+        if len(auth) != 2 or auth[0].lower() != b"basic":
+            return ip_address, None
+        try:
+            decoded = base64.b64decode(auth[1]).decode("utf-8")
+            userid = decoded.split(":", 1)[0]
+        except (TypeError, ValueError, binascii.Error):
+            return ip_address, None
+        if not userid:
+            return ip_address, None
+        return ip_address, get_lockout_username(userid)
+
+    def authenticate(self, request):
+        auth = get_authorization_header(request).split()
+        if not auth or auth[0].lower() != b"basic":
+            return None
+
+        # Exempt high-frequency OpenRosa endpoints, mirroring check_lockout.
+        if is_lockout_excluded_path(request):
+            return super().authenticate(request)
+
+        ip_address, username = self._lockout_identity(request)
+        assert_not_locked_out(ip_address, username)
+
+        try:
+            return super().authenticate(request)
+        except AuthenticationFailed:
+            if username:
+                # Records the attempt and raises the lockout error itself once
+                # MAX_LOGIN_ATTEMPTS is reached.
+                add_login_attempt(ip_address, username)
+            raise
 
 
 class TempTokenAuthentication(TokenAuthentication):
@@ -353,6 +408,17 @@ def add_login_attempt(ip_address, username):
     return safe_cache_get(attempts_key)
 
 
+def is_lockout_excluded_path(request) -> bool:
+    """Return True when the request path is exempt from lockout.
+
+    OpenRosa/Briefcase endpoints (see LOCKOUT_EXCLUDED_PATHS) are hit
+    frequently by ODK clients, so they are not subject to failed-login
+    lockout.
+    """
+    uri_path = request.get_full_path()
+    return any(part in LOCKOUT_EXCLUDED_PATHS for part in uri_path.split("/"))
+
+
 def check_lockout(request) -> Tuple[Optional[str], Optional[str]]:
     """Check request user is not locked out on authentication.
 
@@ -360,8 +426,7 @@ def check_lockout(request) -> Tuple[Optional[str], Optional[str]]:
     LOCKOUT_EXCLUDED_PATHS.
     Raises AuthenticationFailed on lockout.
     """
-    uri_path = request.get_full_path()
-    if not any(part in LOCKOUT_EXCLUDED_PATHS for part in uri_path.split("/")):
+    if not is_lockout_excluded_path(request):
         ip_address, username = retrieve_user_identification(request)
         assert_not_locked_out(ip_address, username)
         return ip_address, username

--- a/onadata/libs/tests/test_authentication.py
+++ b/onadata/libs/tests/test_authentication.py
@@ -1,3 +1,4 @@
+import base64
 from datetime import datetime, timedelta
 from unittest.mock import MagicMock, patch
 
@@ -5,16 +6,17 @@ from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.cache import cache
 from django.http.request import HttpRequest
-from django.test import TestCase
+from django.test import TestCase, override_settings
 
 import jwt
-from oauth2_provider.models import AccessToken
+from oauth2_provider.models import AccessToken, get_application_model
 from rest_framework.exceptions import AuthenticationFailed
 from rest_framework.test import APIRequestFactory
 
 from onadata.apps.api.models.temp_token import TempToken
 from onadata.libs.authentication import (
     DigestAuthentication,
+    LockoutBasicAuthentication,
     MasterReplicaOAuth2Validator,
     TempTokenAuthentication,
     TempTokenURLParameterAuthentication,
@@ -23,6 +25,7 @@ from onadata.libs.authentication import (
     get_api_token,
     get_client_ip,
     get_lockout_username,
+    is_lockout_excluded_path,
 )
 from onadata.libs.utils.cache_tools import LOCKOUT_IP, safe_cache_set, safe_key
 from onadata.libs.utils.common_tags import API_TOKEN
@@ -179,6 +182,41 @@ class TestLockout(TestCase):
             check_lockout(request)
 
 
+class TestIsLockoutExcludedPath(TestCase):
+    """Test is_lockout_excluded_path() function."""
+
+    def setUp(self):
+        self.factory = APIRequestFactory()
+
+    def test_true_for_excluded_openrosa_paths(self):
+        """OpenRosa/Briefcase endpoints are exempt from lockout."""
+        for path in (
+            "/formList",
+            "/bob/formList",
+            "/submission",
+            "/bob/submission",
+            "/xformsManifest/123",
+            "/123/form.xml",
+            "/submissionList",
+            "/downloadSubmission",
+        ):
+            with self.subTest(path=path):
+                request = self.factory.get(path)
+                self.assertTrue(is_lockout_excluded_path(request))
+
+    def test_false_for_regular_paths(self):
+        """Regular API paths are subject to lockout."""
+        for path in ("/", "/api/v1/user.json", "/api/v1/forms"):
+            with self.subTest(path=path):
+                request = self.factory.get(path)
+                self.assertFalse(is_lockout_excluded_path(request))
+
+    def test_matches_excluded_segment_anywhere_in_path(self):
+        """The exemption matches an excluded segment in any path position."""
+        request = self.factory.get("/enketo/123/submission")
+        self.assertTrue(is_lockout_excluded_path(request))
+
+
 class TestGetClientIp(TestCase):
     """Test get_client_ip() function."""
 
@@ -296,3 +334,179 @@ class TestMasterReplicaOAuth2Validator(TestCase):
         )
         self.assertEqual(req.access_token, token)
         self.assertEqual(req.user, token.user)
+
+
+def _basic_header(username, password):
+    """Build an HTTP Basic ``Authorization`` header value for credentials."""
+    raw = f"{username}:{password}".encode("utf-8")
+    return b"Basic " + base64.b64encode(raw)
+
+
+MAX_LOGIN_ATTEMPTS = 3
+
+
+@override_settings(MAX_LOGIN_ATTEMPTS=MAX_LOGIN_ATTEMPTS)
+class TestLockoutBasicAuthentication(TestCase):
+    """Test failed-login lockout on HTTP Basic authentication (ONADATA-1304)."""
+
+    def setUp(self):
+        cache.clear()
+        self.factory = APIRequestFactory()
+        self.auth = LockoutBasicAuthentication()
+        self.user = User.objects.create_user(
+            username="bob", email="bob@example.com", password="secret"
+        )
+
+    def tearDown(self):
+        cache.clear()
+
+    def test_authenticates_with_valid_credentials(self):
+        """Valid Basic credentials return the authenticated user."""
+        request = self.factory.get(
+            "/", HTTP_AUTHORIZATION=_basic_header("bob", "secret")
+        )
+        user, _auth = self.auth.authenticate(request)
+        self.assertEqual(user, self.user)
+
+    def test_returns_none_without_basic_header(self):
+        """Non-Basic requests are ignored so other authenticators can run."""
+        request = self.factory.get("/", HTTP_AUTHORIZATION=b'Digest username="bob",')
+        self.assertIsNone(self.auth.authenticate(request))
+
+    def test_locks_out_after_max_failed_attempts(self):
+        """Repeated wrong passwords lock the IP + username out."""
+        header = _basic_header("bob", "wrong")
+        for _i in range(MAX_LOGIN_ATTEMPTS):
+            request = self.factory.get("/", HTTP_AUTHORIZATION=header)
+            with self.assertRaises(AuthenticationFailed):
+                self.auth.authenticate(request)
+
+        # The IP + username is now locked out: even the correct password fails.
+        request = self.factory.get(
+            "/", HTTP_AUTHORIZATION=_basic_header("bob", "secret")
+        )
+        with self.assertRaises(AuthenticationFailed) as ctx:
+            self.auth.authenticate(request)
+        self.assertIn("Locked out", str(ctx.exception))
+
+    def test_lockout_is_keyed_per_username(self):
+        """Locking one username does not lock another from the same IP."""
+        User.objects.create_user(username="alice", password="secret")
+        for _i in range(MAX_LOGIN_ATTEMPTS):
+            request = self.factory.get(
+                "/", HTTP_AUTHORIZATION=_basic_header("bob", "wrong")
+            )
+            with self.assertRaises(AuthenticationFailed):
+                self.auth.authenticate(request)
+
+        # alice, same IP, is unaffected and authenticates normally.
+        request = self.factory.get(
+            "/", HTTP_AUTHORIZATION=_basic_header("alice", "secret")
+        )
+        user, _auth = self.auth.authenticate(request)
+        self.assertEqual(user.username, "alice")
+
+    def test_excluded_paths_are_not_locked_out(self):
+        """OpenRosa endpoints (e.g. /submission) are exempt from lockout,
+        mirroring DigestAuthentication, so high-frequency clients aren't locked
+        out."""
+        for _i in range(MAX_LOGIN_ATTEMPTS + 5):
+            request = self.factory.post(
+                "/submission", HTTP_AUTHORIZATION=_basic_header("bob", "wrong")
+            )
+            with self.assertRaises(AuthenticationFailed) as ctx:
+                self.auth.authenticate(request)
+            # Always the plain credential error, never a lockout.
+            self.assertNotIn("Locked out", str(ctx.exception))
+
+        # The correct password still works on the excluded path.
+        request = self.factory.post(
+            "/submission", HTTP_AUTHORIZATION=_basic_header("bob", "secret")
+        )
+        user, _auth = self.auth.authenticate(request)
+        self.assertEqual(user, self.user)
+
+    def test_lockout_counter_canonicalises_identifier(self):
+        """Case/email variants of a username share one lockout counter."""
+        # Mix bare username, uppercase, and email forms — all resolve to "bob".
+        identifiers = (["BOB", "bob@example.com"] * MAX_LOGIN_ATTEMPTS)[
+            :MAX_LOGIN_ATTEMPTS
+        ]
+        for identifier in identifiers:
+            request = self.factory.get(
+                "/", HTTP_AUTHORIZATION=_basic_header(identifier, "wrong")
+            )
+            with self.assertRaises(AuthenticationFailed):
+                self.auth.authenticate(request)
+
+        # The canonical account is now locked out despite the varied inputs.
+        request = self.factory.get(
+            "/", HTTP_AUTHORIZATION=_basic_header("bob", "secret")
+        )
+        with self.assertRaises(AuthenticationFailed) as ctx:
+            self.auth.authenticate(request)
+        self.assertIn("Locked out", str(ctx.exception))
+
+
+@override_settings(MAX_LOGIN_ATTEMPTS=MAX_LOGIN_ATTEMPTS)
+class TestLockoutTokenView(TestCase):
+    """Test failed-login lockout on the OAuth2 password grant (/o/token/)."""
+
+    def setUp(self):
+        cache.clear()
+        self.user = User.objects.create_user(
+            username="bob", email="bob@example.com", password="secret"
+        )
+        application_model = get_application_model()
+        self.client_secret = "test-client-secret"
+        self.application = application_model(
+            name="password-grant-app",
+            user=self.user,
+            client_id="test-client-id",
+            client_secret=self.client_secret,
+            client_type=application_model.CLIENT_CONFIDENTIAL,
+            authorization_grant_type=application_model.GRANT_PASSWORD,
+        )
+        self.application.save()
+
+    def tearDown(self):
+        cache.clear()
+
+    def _token_request(self, password):
+        return self.client.post(
+            "/o/token/",
+            {
+                "grant_type": "password",
+                "username": "bob",
+                "password": password,
+                "client_id": "test-client-id",
+                "client_secret": self.client_secret,
+            },
+        )
+
+    def test_locks_out_after_max_failed_password_grants(self):
+        """Repeated wrong passwords lock the IP + username out of /o/token/."""
+        for _i in range(MAX_LOGIN_ATTEMPTS):
+            response = self._token_request("wrong")
+            self.assertNotEqual(response.status_code, 200)
+
+        # Even the correct password is now rejected with the lockout response.
+        response = self._token_request("secret")
+        self.assertEqual(response.status_code, 429)
+        self.assertEqual(response.json()["error"], "locked_out")
+
+    def test_valid_password_grant_issues_token(self):
+        """Valid credentials still return an access token through the view."""
+        response = self._token_request("secret")
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("access_token", response.json())
+
+    def test_failure_below_threshold_returns_oauth_error(self):
+        """A failed attempt below the threshold returns the normal OAuth error,
+        not the lockout response."""
+        response = self._token_request("wrong")
+        self.assertEqual(response.status_code, 400)
+        self.assertNotEqual(response.status_code, 429)
+        # The account is not yet locked: the correct password still works.
+        response = self._token_request("secret")
+        self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
### Changes / Features implemented

Stock `BasicAuthentication` and the OAuth2 token endpoint (`/o/token/`) returned errors indefinitely on wrong credentials, so both could be brute-forced at full network speed — no lockout, rate limiting, or CAPTCHA. Usernames are publicly enumerable (public projects endpoint) and a successful basic auth returns the persistent, non-expiring `api_token`, making this **high severity**.

This complements #3116, which added the same lockout to `DigestAuthentication` and the web login form but left the Basic-auth and OAuth2 password-grant paths unprotected. All password vectors (digest, basic, web form, `/o/token/`) now share one IP + username lockout counter, so an attacker can't reset by switching vector.

- **`onadata/libs/authentication.py`** — add `LockoutBasicAuthentication(BasicAuthentication)`. It reuses the existing IP + username lockout machinery (`assert_not_locked_out` / `add_login_attempt`): rejects a locked-out IP + username *before* checking credentials, and records a failed attempt — locking out after `MAX_LOGIN_ATTEMPTS` for `LOCKOUT_TIME` — whenever authentication fails. The submitted identifier is canonicalised via `get_lockout_username`, so case/email variants share one counter. Extracted `is_lockout_excluded_path()` and reused it in `check_lockout` so the OpenRosa/Briefcase exemptions stay DRY.
- **`onadata/apps/api/viewsets/xform_submission_viewset.py`** — replace stock `BasicAuthentication` with `LockoutBasicAuthentication` (the only in-code Basic-auth surface).
- **`onadata/apps/main/views.py`** — add `LockoutTokenView(TokenView)`. The Resource Owner Password Credentials grant accepts a username + password and was otherwise brute-forceable; this rejects a locked-out IP + username before the grant and records a failed attempt on any non-200 password-grant response, returning a `429 locked_out`. Only the password grant is throttled — `authorization_code`, `client_credentials`, `refresh_token`, and `device_code` pass straight through.
- **`onadata/apps/main/urls.py`** — route `o/token/` to `LockoutTokenView` ahead of the `oauth2_provider` include (same precedence pattern as the existing `OnaAuthorizationView` override).

Behaviour mirrors the digest flow: keyed on IP + username, does **not** reset the counter on success, sends the lockout email at the threshold, and exempts the high-frequency OpenRosa/Briefcase endpoints (`LOCKOUT_EXCLUDED_PATHS`) so legitimate ODK Collect/Briefcase clients aren't locked out.


### Steps taken to verify this change does what is intended

- Added tests

### Side effects of implementing this change

- Failed attempts via digest, the web login form, basic auth, and the OAuth2 password grant all accumulate against the same IP + username counter, settings (`MAX_LOGIN_ATTEMPTS`, `LOCKOUT_TIME`), and cache keys.
- On `XFormSubmissionViewSet`, Basic-auth submissions are now subject to lockout — but the OpenRosa submission paths are in `LOCKOUT_EXCLUDED_PATHS`, so legitimate ODK clients are unaffected (parity with digest).
- `/o/token/` is now served by a project view rather than the bundled `oauth2_provider` `TokenView`; behaviour is identical except for the password-grant lockout.

**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  - [ ] Updated documentation