### PR TITLE
fix: exclude inactive users from project users list

### DIFF
--- a/onadata/apps/api/tests/viewsets/test_project_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_project_viewset.py
@@ -2517,6 +2517,42 @@ class TestProjectViewSet(TestAbstractViewSet):
         self.assertFalse(ReadOnlyRole.user_has_role(alice_profile.user, self.project))
         self.assertFalse(ReadOnlyRole.user_has_role(alice_profile.user, self.xform))
 
+    def test_project_users_excludes_inactive_users(self):
+        """Inactive users are not listed among the project users"""
+        # create project and publish form to project
+        self._publish_xls_form_to_project()
+        alice_data = {"username": "alice", "email": "alice@localhost.com"}
+        alice_profile = self._create_user_profile(alice_data)
+
+        projectid = self.project.pk
+
+        # share the project with alice while she is still active
+        data = {"username": "alice", "role": ReadOnlyRole.name}
+        request = self.factory.put("/", data=data, **self.extra)
+        view = ProjectViewSet.as_view({"put": "share", "get": "retrieve"})
+        response = view(request, pk=projectid)
+        self.assertEqual(response.status_code, 204)
+
+        # alice is listed while active
+        request = self.factory.get("/", **self.extra)
+        response = view(request, pk=projectid)
+        usernames = [user.get("user") for user in response.data.get("users")]
+        self.assertIn("alice", usernames)
+
+        # deactivate alice
+        alice_profile.user.is_active = False
+        alice_profile.user.save()
+
+        # simulate a fresh fetch (cached project detail/permissions expire)
+        cache.clear()
+
+        # alice is no longer listed once inactive
+        request = self.factory.get("/", **self.extra)
+        response = view(request, pk=projectid)
+        usernames = [user.get("user") for user in response.data.get("users")]
+        self.assertNotIn("alice", usernames)
+        self.assertIn("bob", usernames)
+
     def test_project_share_readonly_no_downloads(self):
         # create project and publish form to project
         self._publish_xls_form_to_project()

--- a/onadata/apps/api/tests/viewsets/v2/test_project_viewset.py
+++ b/onadata/apps/api/tests/viewsets/v2/test_project_viewset.py
@@ -409,6 +409,32 @@ class GetProjectUsersTestCase(TestAbstractViewSet):
         usernames = sorted(entry["user"] for entry in response.data)
         self.assertEqual(usernames, ["alice", self.user.username])
 
+    def test_inactive_users_excluded(self):
+        """Inactive users are not listed among the project users"""
+        alice_profile = self._create_user_profile(
+            {"username": "alice", "email": "alice@localhost.com"}
+        )
+        ShareProject(self.project, "alice", "readonly").save()
+
+        # alice is listed while active
+        request = self.factory.get("/", **self.extra)
+        response = self.view(request, pk=self.project.pk)
+        usernames = sorted(entry["user"] for entry in response.data)
+        self.assertEqual(usernames, ["alice", self.user.username])
+
+        # deactivate alice
+        alice_profile.user.is_active = False
+        alice_profile.user.save()
+
+        # simulate the cached permissions list expiring
+        cache.clear()
+
+        request = self.factory.get("/", **self.extra)
+        response = self.view(request, pk=self.project.pk)
+        usernames = [entry["user"] for entry in response.data]
+        self.assertNotIn("alice", usernames)
+        self.assertEqual(usernames, [self.user.username])
+
     def test_non_member_denied(self):
         """A user with no role on the project cannot view the users"""
         alice_profile = self._create_user_profile(

--- a/onadata/libs/serializers/project_serializer.py
+++ b/onadata/libs/serializers/project_serializer.py
@@ -162,7 +162,7 @@ def get_users(project, context, all_perms=True):
     else:
         request_user_is_admin = False
 
-    for perm in project.projectuserobjectpermission_set.all():
+    for perm in project.projectuserobjectpermission_set.filter(user__is_active=True):
         if perm.user_id not in data:
             user = perm.user
 


### PR DESCRIPTION
## Problem

Removing an inactive user from a project failed with `Failed to remove share` / `The following user(s) is/are not active`. The inactive user still appeared in the project's users list, so a project admin would try to remove them and hit the validation that rejects inactive users.

## Fix

Filter inactive users out of the shared `get_users()` helper in `project_serializer.py`. Since this helper backs both the **v1** project retrieve endpoint and the **v2** `/projects/{pk}/users` endpoint, inactive users are now excluded from the users list everywhere, so admins no longer see (or attempt to remove) them.

The users list is cached under `PROJ_PERM_CACHE` (default TTL 300s), so the change takes effect on the next fresh computation / cache expiry.

## Tests

- `TestProjectViewSet.test_project_users_excludes_inactive_users` (v1) — shares with an active user (asserts listed), deactivates them, asserts they're excluded from the retrieve `users` array.
- `GetProjectUsersTestCase.test_inactive_users_excluded` (v2) — same behavior through the `/projects/{pk}/users` endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/onaio/codesmith/onadata/pr/3131"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784280936&installation_id=135786473&pr_number=3131&repository=onaio%2Fonadata&return_to=https%3A%2F%2Fgithub.com%2Fonaio%2Fonadata%2Fpull%2F3131&signature=6fabad49155ab26ae4322ea15f0914e355beca4481b3be4f0b81fef88ca74299"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->