### PR TITLE
feat: case-insensitive partial username search on /users

### DIFF
--- a/onadata/apps/api/tests/viewsets/test_user_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_user_viewset.py
@@ -145,6 +145,45 @@ class TestUserViewSet(TestAbstractViewSet):
         # empty results
         self.assertEqual(response.data, [])
 
+    def test_search_by_username(self):
+        """Search filters the users list by username"""
+        self._create_user_profile({"username": "alice", "email": "alice@localhost.com"})
+
+        view = UserViewSet.as_view({"get": "list"})
+        request = self.factory.get("/", data={"search": "alice"}, **self.extra)
+        response = view(request)
+
+        self.assertEqual(response.status_code, 200)
+        usernames = [user["username"] for user in response.data]
+        self.assertIn("alice", usernames)
+        self.assertNotIn("bob", usernames)
+
+    def test_search_by_username_case_insensitive(self):
+        """Username search ignores case"""
+        self._create_user_profile({"username": "alice", "email": "alice@localhost.com"})
+
+        view = UserViewSet.as_view({"get": "list"})
+        request = self.factory.get("/", data={"search": "ALICE"}, **self.extra)
+        response = view(request)
+
+        self.assertEqual(response.status_code, 200)
+        usernames = [user["username"] for user in response.data]
+        self.assertIn("alice", usernames)
+
+    def test_search_by_username_partial(self):
+        """Username search matches on a substring, not only a prefix"""
+        self._create_user_profile({"username": "alice", "email": "alice@localhost.com"})
+
+        view = UserViewSet.as_view({"get": "list"})
+        # "lic" is in the middle of "alice"
+        request = self.factory.get("/", data={"search": "lic"}, **self.extra)
+        response = view(request)
+
+        self.assertEqual(response.status_code, 200)
+        usernames = [user["username"] for user in response.data]
+        self.assertIn("alice", usernames)
+        self.assertNotIn("bob", usernames)
+
     def test_get_non_org_users(self):
         self._org_create()
 

--- a/onadata/apps/api/viewsets/user_viewset.py
+++ b/onadata/apps/api/viewsets/user_viewset.py
@@ -46,7 +46,9 @@ class UserViewSet(
         filters.SearchFilter,
         UserNoOrganizationsFilter,
     )
-    search_fields = ("=email",)
+    # `=email`   -> case-insensitive exact match (iexact)
+    # `username` -> case-insensitive partial match (icontains)
+    search_fields = ("=email", "username")
 
     def get_object(self):
         """Lookup a  username by pk else use lookup_field"""


### PR DESCRIPTION
### Changes / Features implemented

Add `username` to `UserViewSet.search_fields` so `GET /api/v1/users` can search users by username via the `search` query parameter. The match is **case-insensitive** and **partial** (`icontains`) — e.g. both `?search=ali` and `?search=ALI` return `alice`. The existing exact email match (`=email`) is preserved, and the `orgs=false` filter still composes with `search`.

### Steps taken to verify this change does what is intended

- [x] Added tests

### Side effects of implementing this change

The `search` parameter now matches usernames in addition to exact emails, so a query that previously returned no results may now return username matches. No schema or migration changes.

**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  - [ ] Updated documentation

Closes #

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/onaio/codesmith/onadata/pr/3133"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784804158&installation_id=135786473&pr_number=3133&repository=onaio%2Fonadata&return_to=https%3A%2F%2Fgithub.com%2Fonaio%2Fonadata%2Fpull%2F3133&signature=3a6b1c7849265b156fe059f4c0916163cd32e629b1ded907fc2b136307c2d31c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->