### PR TITLE
fix: invalidate team-users cache when a team's project role changes

### DIFF
--- a/onadata/libs/models/share_team_project.py
+++ b/onadata/libs/models/share_team_project.py
@@ -6,6 +6,7 @@ ShareTeamProject model - facilitate sharing a project to a team.
 from onadata.libs.permissions import ROLES
 from onadata.libs.utils.cache_tools import (
     PROJ_PERM_CACHE,
+    PROJ_TEAM_USERS_CACHE,
     clear_project_owner_cache,
     safe_cache_delete,
 )
@@ -47,6 +48,7 @@ class ShareTeamProject:
             # clear cache
             clear_project_owner_cache(self.project.pk)
             safe_cache_delete(f"{PROJ_PERM_CACHE}{self.project.pk}")
+            safe_cache_delete(f"{PROJ_TEAM_USERS_CACHE}{self.project.pk}")
 
     def remove_team(self):
         """Removes team permissions from a project."""
@@ -67,3 +69,4 @@ class ShareTeamProject:
             # clear cache
             clear_project_owner_cache(self.project.pk)
             safe_cache_delete(f"{PROJ_PERM_CACHE}{self.project.pk}")
+            safe_cache_delete(f"{PROJ_TEAM_USERS_CACHE}{self.project.pk}")

--- a/onadata/libs/tests/models/test_share_team_project.py
+++ b/onadata/libs/tests/models/test_share_team_project.py
@@ -9,6 +9,11 @@ from onadata.apps.logger.models.xform import XForm
 from onadata.apps.main.tests.test_base import TestBase
 from onadata.libs.models.share_team_project import ShareTeamProject
 from onadata.libs.permissions import ManagerRole
+from onadata.libs.utils.cache_tools import (
+    PROJ_TEAM_USERS_CACHE,
+    safe_cache_get,
+    safe_cache_set,
+)
 
 
 class ShareTeamProjectTestCase(TestBase):
@@ -50,6 +55,7 @@ class ShareTeamProjectTestCase(TestBase):
         mock_safe_cache_delete.assert_has_calls(
             [
                 call(f"ps-project_permissions-{self.project.pk}"),
+                call(f"{PROJ_TEAM_USERS_CACHE}{self.project.pk}"),
             ]
         )
 
@@ -79,5 +85,31 @@ class ShareTeamProjectTestCase(TestBase):
         mock_safe_cache_delete.assert_has_calls(
             [
                 call(f"ps-project_permissions-{self.project.pk}"),
+                call(f"{PROJ_TEAM_USERS_CACHE}{self.project.pk}"),
             ]
         )
+
+    def test_share_busts_team_users_cache(self):
+        """Sharing a project with a team busts the cached teams list.
+
+        Regression: get_teams() caches the team's role under
+        PROJ_TEAM_USERS_CACHE. If the role changes but the key is not
+        invalidated, the project endpoint keeps serving the stale role.
+        """
+        cache_key = f"{PROJ_TEAM_USERS_CACHE}{self.project.pk}"
+        safe_cache_set(
+            cache_key,
+            [{"name": self.team.name, "role": "dataentry", "users": []}],
+        )
+        ShareTeamProject(self.team, self.project, "editor").save()
+        self.assertIsNone(safe_cache_get(cache_key))
+
+    def test_remove_busts_team_users_cache(self):
+        """Removing a team from a project busts the cached teams list."""
+        cache_key = f"{PROJ_TEAM_USERS_CACHE}{self.project.pk}"
+        safe_cache_set(
+            cache_key,
+            [{"name": self.team.name, "role": "manager", "users": []}],
+        )
+        ShareTeamProject(self.team, self.project, "manager", remove=True).save()
+        self.assertIsNone(safe_cache_get(cache_key))


### PR DESCRIPTION
## Problem

After changing an organization team's role on a project (e.g. `dataentry` → `editor` via `POST /api/v1/teams/<pk>/share`), the project detail endpoint (`/api/v1/projects/<pk>.json`) kept reporting the **old** role in its `teams[]` array.

## Root cause

`get_teams()` in `onadata/libs/serializers/project_serializer.py` caches each team's `role` and `users` under `PROJ_TEAM_USERS_CACHE` (`ps-project-team-users<pk>`), and that result powers the `teams[]` field of the project endpoint.

`ShareTeamProject.save()` / `remove_team()` correctly reassign the guardian permissions and bust `PROJ_PERM_CACHE` and the project-detail caches (`clear_project_owner_cache`), but **never invalidated `PROJ_TEAM_USERS_CACHE`**. A grep confirms the key was written by `get_teams` but deleted nowhere in production code. So the stale role was served until the cache key expired on its own.

## Fix

Delete `PROJ_TEAM_USERS_CACHE` for the project in both the share and remove paths, alongside the existing cache invalidation.

## Tests

`onadata/libs/tests/models/test_share_team_project.py`:
- Extended the existing `test_share` / `test_remove` to assert the team-users key is busted.
- Added `test_share_busts_team_users_cache` / `test_remove_busts_team_users_cache` — behavioral regression tests that seed a stale `dataentry` entry, change the role, and assert the cache key is cleared.

All 4 tests fail before the fix (reproducing the prod symptom) and pass after.

```
Ran 4 tests in 3.942s
OK
```

## Notes / follow-up

The same `users` list inside `teams[]` can also go stale when members are added/removed via `add_user_to_team` / `remove_user_from_team` (`onadata/apps/api/tools.py`), which also don't bust `PROJ_TEAM_USERS_CACHE`. That path operates per-team across all org projects, so it's a larger change left as a follow-up.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/onaio/codesmith/onadata/pr/3134"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784890290&installation_id=135786473&pr_number=3134&repository=onaio%2Fonadata&return_to=https%3A%2F%2Fgithub.com%2Fonaio%2Fonadata%2Fpull%2F3134&signature=a5819ed08f85fad6871c6839de70e425f443b0baaf9089d9d16176803f5adb9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->