### PR TITLE
chore: bump version to v5.21.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,19 @@ Changelog for Onadata
 
 ``* represents releases that introduce new migrations``
 
+v5.21.0(2026-06-24)*
+--------------------
+- Add last_edited_by to submissions
+  [@ukanga]
+  `PR #3128 https://github.com/onaio/onadata/pull/3128`
+- feat: case-insensitive partial username search on /users
+  [@kelvin-muchiri]
+  `PR #3133 https://github.com/onaio/onadata/pull/3133`
+- fix: invalidate team-users cache when a team's project role changes
+  [@FrankApiyo]
+  `PR #3134 https://github.com/onaio/onadata/pull/3134`
+
+
 v5.20.0(2026-06-17)
 -------------------
 - chore: bump cryptography, valigetta, and lxml

--- a/onadata/__init__.py
+++ b/onadata/__init__.py
@@ -7,7 +7,7 @@ visualization.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "5.20.0"
+__version__ = "5.21.0"
 
 
 # This will make sure the app is always imported when

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = onadata
-version = 5.20.0
+version = 5.21.0
 description = Collect Analyze and Share Data
 long_description = file: README.rst
 long_description_content_type = text/x-rst


### PR DESCRIPTION
### Changes

Bump version to v5.21.0

**Features**

- https://github.com/onaio/onadata/pull/3128
- https://github.com/onaio/onadata/pull/3133

**Bug fixes**
- https://github.com/onaio/onadata/pull/3134

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/onaio/codesmith/onadata/pr/3135"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784898297&installation_id=135786473&pr_number=3135&repository=onaio%2Fonadata&return_to=https%3A%2F%2Fgithub.com%2Fonaio%2Fonadata%2Fpull%2F3135&signature=dc22f1f9a745856edd04f81ec4dbb4582b9d609f3957aa5156ad8aa0cdca88e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->