### PR TITLE
fix: don't classify version numbers in form titles as URLs

### DIFF
--- a/onadata/apps/logger/models/xform.py
+++ b/onadata/apps/logger/models/xform.py
@@ -86,9 +86,14 @@ XFORM_TITLE_LENGTH = 255
 TITLE_PATTERN = re.compile(r"<h:title>(.*?)</h:title>")
 
 
+# A title is treated as a URL when it either uses an explicit http(s) scheme
+# (any host, including IP addresses) or is a scheme-less bare domain. Requiring
+# an alphabetic TLD for scheme-less matches keeps version suffixes such as
+# "1.0" from being misread as URLs (see issue #3138).
 URL_PATTERN = (
-    r"(?:https?://)?(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\."
-    r"[a-zA-Z0-9()]{1,6}\b(?::[0-9]{1,5})?(?:[-a-zA-Z0-9()@:%_\+.~#?&/=]*)"
+    r"(?:https?://(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}"
+    r"|(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z][a-zA-Z0-9()]{0,5})"
+    r"\b(?::[0-9]{1,5})?(?:[-a-zA-Z0-9()@:%_\+.~#?&/=]*)"
 )
 
 

--- a/onadata/apps/logger/tests/models/test_xform.py
+++ b/onadata/apps/logger/tests/models/test_xform.py
@@ -78,6 +78,27 @@ class TestXForm(TestBase):
         self.xform._set_title()  # pylint: disable=W0212
         self.assertIn(self.xform.title, self.xform.xml)
 
+    def test_version_number_title_not_treated_as_url(self):
+        """A version number like '1.0' anywhere in a title is not a URL."""
+        self._publish_transportation_form()
+
+        # A version number is allowed wherever it appears in the title.
+        for valid_title in ("Transport 1.0", "1.0 Transport", "Transport 1.0 Survey"):
+            xform = XForm.objects.get(pk=self.xform.pk)
+            xform.title = valid_title
+            xform.save()
+            self.assertEqual(XForm.objects.get(pk=xform.pk).title, valid_title)
+
+        # A real URL anywhere in the title is still rejected.
+        for url_title in ("deno.com", "Survey deno.com data"):
+            xform = XForm.objects.get(pk=self.xform.pk)
+            xform.title = url_title
+            with self.assertRaises(XLSFormError) as err:
+                xform.save()
+            self.assertEqual(
+                "Invalid title value; value shouldn't match a URL", str(err.exception)
+            )
+
     def test_version_length(self):
         """Test Xform.version can store more than 12 chars"""
         self._publish_transportation_form_and_submit_instance()


### PR DESCRIPTION
### Changes / Features implemented

Saving an `XForm` whose title contains a version number such as `1.0` failed with `Invalid title value; value shouldn't match a URL`.

`URL_PATTERN` had an optional scheme and a TLD group that accepted an all-numeric TLD, so a bare `1.0` matched as a URL (`1` read as the domain, `0` as the TLD). Because `XForm.save()` re-validates the title, this trapped legacy forms titled e.g. `Household Survey 1.0` — any edit (including toggling `downloadable` active/inactive) was rejected.

`URL_PATTERN` is now split into two branches:

- **With** an `http(s)://` scheme — match any host, so IP-address URLs are still detected.
- **Scheme-less** — require the TLD to start with a letter, so version numbers like `1.0` are no longer misread as URLs while bare domains (e.g. `deno.com`) are still caught.

### Steps taken to verify this change does what is intended

- [x] Added tests

### Side effects of implementing this change

A scheme-less title is now only treated as a URL when its TLD starts with a letter. A bare host with an all-numeric TLD (not a valid TLD) is no longer flagged; `http(s)://` and IP-address URLs are unaffected.


**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  - [ ] Updated documentation

Closes #3138
