### PR TITLE
fix(exports): sanitize SPSS-invalid characters in SAV export variable names

### DIFF
--- a/onadata/libs/tests/utils/test_export_builder.py
+++ b/onadata/libs/tests/utils/test_export_builder.py
@@ -799,6 +799,48 @@ class TestExportBuilder(TestBase):
         shutil.rmtree(temp_dir)
 
     # pylint: disable=invalid-name
+    def test_zipped_sav_export_select_multiple_choice_name_with_ampersand(self):
+        """SAV export sanitizes SPSS-invalid characters in variable names.
+
+        A select_multiple choice name is the realistic path through which an
+        invalid character (here "&") reaches an SPSS variable name, since the
+        column is named "<question>.<choice>" and the choice name is free-form.
+        The export must replace the invalid character instead of raising
+        SPSSIOError (SPSS_NAME_BADCHAR).
+        """
+        md = """
+        | survey |
+        |        | type                  | name           | label |
+        |        | select_multiple food  | food_available | Food  |
+
+        | choices |
+        |         | list name | name      | label |
+        |         | food      | green&red | GR    |
+        |         | food      | 2         | Two   |
+        """
+        survey = self.md_to_pyxform_survey(md, {"name": "exp"})
+        data = [{"food_available": "green&red"}]
+        export_builder = ExportBuilder()
+        export_builder.set_survey(survey)
+        with NamedTemporaryFile(suffix=".zip") as temp_zip_file:
+            export_builder.to_zipped_sav(temp_zip_file.name, data)
+            temp_zip_file.seek(0)
+            temp_dir = tempfile.mkdtemp()
+            with zipfile.ZipFile(temp_zip_file.name, "r") as zip_file:
+                zip_file.extractall(temp_dir)
+
+        self.assertTrue(os.path.exists(os.path.join(temp_dir, "exp.sav")))
+
+        with SavReader(os.path.join(temp_dir, "exp.sav"), returnHeader=True) as reader:
+            rows = list(reader)
+            header = list(map(_str_if_bytes, rows[0]))
+            # The "&" must be sanitized out of the SPSS variable name.
+            self.assertNotIn("food_available.green&red", header)
+            self.assertIn("food_available.green_red", header)
+
+        shutil.rmtree(temp_dir)
+
+    # pylint: disable=invalid-name
     def test_zipped_sav_export_dynamic_select_multiple(self):
         md = """
         | survey |

--- a/onadata/libs/utils/export_builder.py
+++ b/onadata/libs/utils/export_builder.py
@@ -275,13 +275,11 @@ def _get_var_name(title, var_names):
     @param var_names - list of existing var_names
     @return valid varName and list of var_names with new var name appended
     """
-    var_name = (
-        title.replace("/", ".")
-        .replace("-", "_")
-        .replace(":", "_")
-        .replace("{", "")
-        .replace("}", "")
-    )
+    var_name = title.replace("/", ".").replace("{", "").replace("}", "")
+    # Replace any character that is invalid in an SPSS variable name (e.g.
+    # "&", "-", ":", embedded blanks) so the SAV writer does not raise
+    # SPSS_NAME_BADCHAR. SPSS only allows letters, digits and . _ $ # @.
+    var_name = re.sub(r"[^0-9A-Za-z._$#@]", "_", var_name)
     var_name = _check_sav_column(var_name, var_names)
     var_name = "@" + var_name if var_name.startswith("_") else var_name
     var_names.append(var_name)


### PR DESCRIPTION
### Changes / Features implemented

SAV/SPSS exports raised `SPSSIOError` (`SPSS_NAME_BADCHAR`) when a generated SPSS variable name contained a character that is invalid in SPSS variable names, such as `&` or an embedded blank, e.g.:

```
b'Preference_assistance_snack_item.Lentil_Cakes_with_Spinach_&_Bee' is an invalid variable name ['SPSS_NAME_BADCHAR: Invalid character or embedded blank']
```

`_get_var_name` in `onadata/libs/utils/export_builder.py` only replaced `/ - : { }`, so any other invalid character passed straight through to `SavWriter`. This replaces any character outside SPSS's allowed set (letters, digits and `. _ $ # @`) with `_`. The realistic trigger is a `select_multiple` choice: split columns are named `<question>.<choice>` and the choice `name` is free-form.

### Steps taken to verify this change does what is intended

- [x] Added tests

### Side effects of implementing this change

- SAV variable names that previously contained an invalid character (and would have failed the export) now have that character replaced with `_`. Names that were already valid are unchanged. Existing `_check_sav_column` length/duplicate handling is unaffected.

**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  - [ ] Updated documentation

Closes #3145

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/onaio/codesmith/onadata/pr/3146"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785320097&installation_id=135786473&pr_number=3146&repository=onaio%2Fonadata&return_to=https%3A%2F%2Fgithub.com%2Fonaio%2Fonadata%2Fpull%2F3146&signature=759c3f1cc8e0650575fc796b16d8daa55274c284b0e6f1e599c2b3e691e77b2c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->