### PR TITLE
chore: clean up v2 project endpoints and star/unstar handling

### DIFF
--- a/onadata/apps/api/tests/viewsets/v2/test_project_viewset.py
+++ b/onadata/apps/api/tests/viewsets/v2/test_project_viewset.py
@@ -286,46 +286,103 @@ class RetrieveProjectTestCase(TestAbstractViewSet):
         )
         ShareProject(self.project, "alice", "readonly").save()
 
+        # Project owner who starred the project
+        self.project.refresh_from_db()
         request = self.factory.get("/", **self.extra)
         response = self.view(request, pk=self.project.pk)
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(response.data["starred"])
-        self.assertIn("owner", response.data)
-        self.assertIn("current_user_role", response.data)
-        full_cache = cache.get(f"{PROJ_V2_OWNER_CACHE}{self.project.pk}")
-        self.assertIsNotNone(full_cache)
-        self.assertIn("owner", full_cache)
-        self.assertNotIn("starred", full_cache)
-        self.assertNotIn("current_user_role", full_cache)
 
+        expected = {
+            "url": f"http://testserver/api/v2/projects/{self.project.pk}",
+            "projectid": self.project.pk,
+            "name": "Tree Monitoring",
+            "owner": (
+                f"http://testserver/api/v1/users/{self.organization.user.username}"
+            ),
+            "created_by": f"http://testserver/api/v1/users/{self.user.username}",
+            "metadata": {
+                "description": "Some description",
+                "location": "Naivasha, Kenya",
+                "category": "governance",
+            },
+            "starred": True,
+            "forms": [],
+            "public": True,
+            "tags": ["Agriculture", "Environment"],
+            "num_datasets": 0,
+            "current_user_role": "owner",
+            "last_submission_date": None,
+            "data_views": [],
+            "date_created": self.project.date_created.isoformat().replace(
+                "+00:00", "Z"
+            ),
+            "date_modified": self.project.date_modified.isoformat().replace(
+                "+00:00", "Z"
+            ),
+        }
+        actual = response.data.copy()
+        actual["tags"] = sorted(actual["tags"])
+        expected["tags"] = sorted(expected["tags"])
+        self.assertEqual(actual, expected)
+
+        # Cache holds the shared base data without user-specific fields
+        expected_cache = {
+            key: value
+            for key, value in expected.items()
+            if key not in ("starred", "current_user_role")
+        }
+        full_cache = cache.get(f"{PROJ_V2_OWNER_CACHE}{self.project.pk}")
+        actual_cache = full_cache.copy()
+        actual_cache["tags"] = sorted(actual_cache["tags"])
+        self.assertEqual(actual_cache, expected_cache)
+
+        # Alice with readonly who did not star the project
         request = self.factory.get(
             "/",
             **{"HTTP_AUTHORIZATION": f"Token {alice_profile.user.auth_token}"},
         )
         response = self.view(request, pk=self.project.pk)
         self.assertEqual(response.status_code, 200)
-        self.assertFalse(response.data["starred"])
-        self.assertIn("owner", response.data)
-        self.assertEqual(response.data["current_user_role"], "readonly")
+        expected_alice = {
+            **expected,
+            "starred": False,
+            "current_user_role": "readonly",
+        }
+        actual = response.data.copy()
+        actual["tags"] = sorted(actual["tags"])
+        expected_alice["tags"] = sorted(expected_alice["tags"])
+        self.assertEqual(actual, expected_alice)
 
+        # Anonymous user: public variant, admin and user-specific fields omitted
         request = self.factory.get("/")
         response = self.view(request, pk=self.project.pk)
         self.assertEqual(response.status_code, 200)
-        self.assertFalse(response.data["starred"])
-        public_excluded_fields = PROJECT_PUBLIC_EXCLUDED_FIELDS | {"current_user_role"}
-        self.assertFalse(public_excluded_fields & set(response.data))
+
+        excluded_fields = PROJECT_PUBLIC_EXCLUDED_FIELDS | {
+            "starred",
+            "current_user_role",
+        }
+        expected_public = {
+            key: value for key, value in expected.items() if key not in excluded_fields
+        }
+        actual = response.data.copy()
+        actual["tags"] = sorted(actual["tags"])
+        expected_public["tags"] = sorted(expected_public["tags"])
+        self.assertEqual(actual, expected_public)
+
         public_cache = cache.get(f"{PROJ_V2_PUBLIC_OWNER_CACHE}{self.project.pk}")
-        self.assertIsNotNone(public_cache)
-        self.assertNotIn("starred", public_cache)
-        self.assertFalse(public_excluded_fields & set(public_cache))
+        actual_public_cache = public_cache.copy()
+        actual_public_cache["tags"] = sorted(actual_public_cache["tags"])
+        self.assertEqual(actual_public_cache, expected_public)
 
         cache.clear()
 
         request = self.factory.get("/")
         response = self.view(request, pk=self.project.pk)
         self.assertEqual(response.status_code, 200)
-        self.assertFalse(response.data["starred"])
-        self.assertFalse(public_excluded_fields & set(response.data))
+        actual = response.data.copy()
+        actual["tags"] = sorted(actual["tags"])
+        self.assertEqual(actual, expected_public)
 
         request = self.factory.get("/", **self.extra)
         response = self.view(request, pk=self.project.pk)

--- a/onadata/apps/api/viewsets/project_viewset.py
+++ b/onadata/apps/api/viewsets/project_viewset.py
@@ -137,6 +137,7 @@ class ProjectViewSet(
         self.object = self.get_object()
         cache_key = get_project_cache_key(self.object.pk, request, self.object)
         project_data = safe_cache_get(cache_key)
+
         if project_data is None:
             serializer = ProjectSerializer(self.object, context={"request": request})
             project_data = get_shared_project_detail_cache_data(serializer.data)
@@ -145,17 +146,6 @@ class ProjectViewSet(
             project_data = get_shared_project_detail_cache_data(project_data)
 
         return Response({**project_data, "starred": is_starred(self.object, request)})
-
-    def list(self, request, *args, **kwargs):
-        """Returns a list of projects"""
-        queryset = self.filter_queryset(self.get_queryset())
-        page = self.paginate_queryset(queryset)
-        if page:
-            serializer = self.get_serializer(page, many=True)
-        else:
-            serializer = self.get_serializer(queryset, many=True)
-
-        return Response(serializer.data)
 
     @action(methods=["POST", "GET"], detail=True)
     def forms(self, request, **kwargs):

--- a/onadata/apps/api/viewsets/project_viewset.py
+++ b/onadata/apps/api/viewsets/project_viewset.py
@@ -248,10 +248,8 @@ class ProjectViewSet(
 
         if request.method == "DELETE":
             project.user_stars.remove(user)
-            project.save()
         elif request.method == "POST":
             project.user_stars.add(user)
-            project.save()
         elif request.method == "GET":
             users = project.user_stars.values("pk")
             user_profiles = UserProfile.objects.filter(user__in=users)

--- a/onadata/apps/api/viewsets/v2/project_viewset.py
+++ b/onadata/apps/api/viewsets/v2/project_viewset.py
@@ -50,9 +50,8 @@ class ProjectViewSet(ProjectViewSetV1):
         base_data = safe_cache_get(cache_key)
 
         if base_data is None:
-            base_data = get_shared_project_detail_cache_data(
-                ProjectSerializer(project, context={"request": request}).data
-            )
+            serializer = ProjectSerializer(project, context={"request": request})
+            base_data = get_shared_project_detail_cache_data(serializer.data)
             safe_cache_set(cache_key, base_data)
         else:
             base_data = get_shared_project_detail_cache_data(base_data)

--- a/onadata/apps/api/viewsets/v2/project_viewset.py
+++ b/onadata/apps/api/viewsets/v2/project_viewset.py
@@ -6,7 +6,7 @@ from rest_framework.decorators import action
 from rest_framework.response import Response
 
 from onadata.apps.api.viewsets.project_viewset import ProjectViewSet as ProjectViewSetV1
-from onadata.libs.serializers.project_serializer import get_teams, get_users, is_starred
+from onadata.libs.serializers.project_serializer import get_teams, get_users
 from onadata.libs.serializers.v2.project_serializer import (
     ProjectListSerializer,
     ProjectPrivateSerializer,
@@ -57,9 +57,8 @@ class ProjectViewSet(ProjectViewSetV1):
         else:
             base_data = get_shared_project_detail_cache_data(base_data)
 
-        base_data = {**base_data, "starred": is_starred(project, request)}
-
         if is_public_project_access(request, project):
+            # Public shape omits user-specific fields such as starred
             return Response(base_data)
 
         # Inject user specific fields

--- a/onadata/libs/serializers/project_serializer.py
+++ b/onadata/libs/serializers/project_serializer.py
@@ -97,7 +97,7 @@ def is_starred(project, request):
     """
     Return True if the request.user has starred this project.
     """
-    return project.user_stars.filter(pk=request.user.pk).count() == 1
+    return project.user_stars.filter(pk=request.user.pk).exists()
 
 
 def get_team_permissions(team, project):

--- a/onadata/libs/serializers/v2/project_serializer.py
+++ b/onadata/libs/serializers/v2/project_serializer.py
@@ -116,14 +116,19 @@ class ProjectPrivateSerializer(serializers.ModelSerializer):
     """User specific fields for a Project"""
 
     current_user_role = serializers.SerializerMethodField()
+    starred = serializers.SerializerMethodField()
 
     def get_current_user_role(self, obj):
         """Return the role of the request user in the project."""
         return get_current_user_role(obj, self.context["request"])
 
+    def get_starred(self, obj):
+        """Return True if request user has starred this project."""
+        return is_starred(obj, self.context["request"])
+
     class Meta:
         model = Project
-        fields = ("current_user_role",)
+        fields = ("current_user_role", "starred")
 
 
 class ProjectSerializer(ProjectSerializerV1):

--- a/onadata/libs/serializers/v2/project_serializer.py
+++ b/onadata/libs/serializers/v2/project_serializer.py
@@ -146,7 +146,6 @@ class ProjectSerializer(ProjectSerializerV1):
             "owner",
             "created_by",
             "metadata",
-            "starred",
             "forms",
             "public",
             "tags",


### PR DESCRIPTION
### Changes / Features implemented

Project endpoint cleanups (the non-`created_by` changes originally from #3132):

- Remove the redundant `list()` override in the v1 `ProjectViewSet` — DRF's default `list()` plus the custom pagination's `get_paginated_response` already return the same unwrapped payload.
- Optimize the `is_starred` query (`.count() == 1` → `.exists()`).
- Add `starred` to `ProjectPrivateSerializer` so it is computed per request for authenticated users.
- Omit `starred` from the public-shape `GET /api/v2/projects/{id}` response served to anonymous users; authenticated users still receive it.
- Remove the redundant `starred` field from v2 `ProjectSerializer` — it is stripped from the cached detail payload and sourced from `ProjectPrivateSerializer`, and star state is managed via the dedicated `/api/v2/projects/<id>/star` endpoint. This also avoids a wasted `is_starred` query on every detail cache miss.
- Drop the unnecessary `project.save()` in the `star`/`unstar` action — an M2M `add()`/`remove()` writes the through table directly and never needs the parent saved.

### Steps taken to verify this change does what is intended

- [x] Added tests

### Side effects of implementing this change

- `star`/`unstar` no longer bumps the project's `date_modified` (it was previously bumped by the redundant `save()`). 


**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  - [ ] Updated documentation
