### PR TITLE
fix: surface upload validation reason in metadata API errors

### DIFF
--- a/onadata/apps/api/tests/viewsets/test_metadata_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_metadata_viewset.py
@@ -701,10 +701,16 @@ class TestMetaDataViewSet(TestAbstractViewSet):
         return view(request)
 
     def assert_upload_validation_error(self, response, filename):
-        """Assert the API returns a generic file validation error."""
-        self.assertEqual(
+        """Assert the API returns a file validation error identifying the file.
+
+        The message starts with the generic, file-identifying text and may be
+        followed by the specific reason the upload failed.
+        """
+        self.assertTrue(
+            response.data["data_file"][0].startswith(
+                f"The uploaded file '{filename}' could not be validated."
+            ),
             response.data["data_file"][0],
-            f"The uploaded file '{filename}' could not be validated.",
         )
 
     def test_media_upload_rejects_double_extension(self):

--- a/onadata/libs/serializers/metadata_serializer.py
+++ b/onadata/libs/serializers/metadata_serializer.py
@@ -206,7 +206,7 @@ class MetaDataSerializer(serializers.HyperlinkedModelSerializer):
         except UploadValidationError as error:
             logger.warning("Metadata file upload validation failed: %s", error)
             raise serializers.ValidationError(
-                {"data_file": generic_upload_validation_error_message(data_file)}
+                {"data_file": generic_upload_validation_error_message(data_file, error)}
             ) from error
 
         data_file.name = upload.storage_basename

--- a/onadata/libs/tests/serializers/test_metadata_serializer.py
+++ b/onadata/libs/tests/serializers/test_metadata_serializer.py
@@ -3,6 +3,7 @@
 Test onadata.libs.serializers.metadata_serializer
 """
 
+import io
 import os
 
 from django.core.files.uploadedfile import InMemoryUploadedFile
@@ -68,9 +69,11 @@ class TestMetaDataViewSerializer(TestAbstractViewSet):
             }
             serializer = MetaDataSerializer(data=data)
             self.assertFalse(serializer.is_valid())
-            self.assertEqual(
+            self.assertTrue(
+                serializer.errors["data_file"][0].startswith(
+                    "The uploaded file 'sample.svg' could not be validated."
+                ),
                 serializer.errors["data_file"][0],
-                "The uploaded file 'sample.svg' could not be validated.",
             )
 
     def test_svg_media_files(self):
@@ -93,10 +96,50 @@ class TestMetaDataViewSerializer(TestAbstractViewSet):
             }
             serializer = MetaDataSerializer(data=data)
             self.assertFalse(serializer.is_valid())
-            self.assertEqual(
+            self.assertTrue(
+                serializer.errors["data_file"][0].startswith(
+                    "The uploaded file 'sample.svg' could not be validated."
+                ),
                 serializer.errors["data_file"][0],
-                "The uploaded file 'sample.svg' could not be validated.",
             )
+
+    def test_invalid_csv_surfaces_validation_reason(self):
+        """The specific validation reason is surfaced to API clients.
+
+        A CSV carrying a non-UTF-8 byte (0x92, a Windows-1252 smart quote)
+        must be rejected with an actionable message that explains *why* it
+        failed, not only the generic "could not be validated" text.
+        """
+        self._login_user_and_profile()
+        self._publish_form_with_hxl_support()
+        data_value = "delivery_partner_list.csv"
+        # Header row + one data cell whose middle byte (0x92) is not valid UTF-8.
+        content = b"h\r\na\x92b\r\n"
+        f = InMemoryUploadedFile(
+            io.BytesIO(content),
+            "media",
+            data_value,
+            "text/csv",
+            len(content),
+            None,
+        )
+        data = {
+            "data_value": data_value,
+            "data_file": f,
+            "data_type": "media",
+            "xform": self.xform.pk,
+        }
+        serializer = MetaDataSerializer(data=data)
+        self.assertFalse(serializer.is_valid())
+        error = serializer.errors["data_file"][0]
+        self.assertTrue(
+            error.startswith(
+                "The uploaded file 'delivery_partner_list.csv' "
+                "could not be validated."
+            ),
+            error,
+        )
+        self.assertIn("CSV files must be UTF-8 encoded.", error)
 
     def test_geojson_media_files(self):
         """

--- a/onadata/libs/tests/utils/test_upload_validation.py
+++ b/onadata/libs/tests/utils/test_upload_validation.py
@@ -168,6 +168,31 @@ class UploadValidationTestCase(SimpleTestCase):
             "The uploaded file could not be validated.",
         )
 
+    def test_generic_validation_error_message_appends_reason(self):
+        """A provided reason is appended after the generic text."""
+        uploaded_file = _CountingUpload("data.csv", b"x", "text/csv")
+
+        self.assertEqual(
+            generic_upload_validation_error_message(
+                uploaded_file, UploadValidationError("CSV files must be UTF-8 encoded.")
+            ),
+            "The uploaded file 'data.csv' could not be validated. "
+            "CSV files must be UTF-8 encoded.",
+        )
+
+    def test_generic_validation_error_message_sanitizes_reason(self):
+        """A multi-line/oversized reason is collapsed and length-capped."""
+        uploaded_file = _CountingUpload("data.csv", b"x", "text/csv")
+        noisy_reason = "line one\n\tline two   line three" + ("!" * 500)
+
+        message = generic_upload_validation_error_message(uploaded_file, noisy_reason)
+        surfaced = message.split("could not be validated. ", 1)[1]
+
+        self.assertNotIn("\n", surfaced)
+        self.assertNotIn("\t", surfaced)
+        self.assertLessEqual(len(surfaced), 200)
+        self.assertTrue(surfaced.startswith("line one line two line three"))
+
     def test_double_extension_is_rejected(self):
         """Filenames such as putty.exe.png are rejected before persistence."""
         uploaded_file = self._upload("putty.exe.png", b"MZpayload", "image/png")

--- a/onadata/libs/utils/upload_validation.py
+++ b/onadata/libs/utils/upload_validation.py
@@ -160,16 +160,29 @@ def sanitized_original_filename(name):
     return basename
 
 
-def generic_upload_validation_error_message(uploaded_file):
-    """Return a generic API validation error that identifies the upload."""
+def generic_upload_validation_error_message(uploaded_file, reason=None):
+    """Return an API validation error that identifies the upload.
+
+    When ``reason`` is provided (typically the :class:`UploadValidationError`
+    raised by the validators), it is appended so API clients learn *why* the
+    upload failed instead of only seeing the generic text. The validators
+    raise static, non-sensitive descriptions of the rule that was violated
+    (e.g. "CSV files must be UTF-8 encoded."), so surfacing them is safe.
+    """
     filename = sanitized_original_filename(getattr(uploaded_file, "name", ""))
 
     if filename:
-        return _("The uploaded file '%(filename)s' could not be validated.") % {
+        message = _("The uploaded file '%(filename)s' could not be validated.") % {
             "filename": filename
         }
+    else:
+        message = _("The uploaded file could not be validated.")
 
-    return _("The uploaded file could not be validated.")
+    reason_text = str(reason).strip() if reason is not None else ""
+    if reason_text:
+        return f"{message} {reason_text}"
+
+    return message
 
 
 DANGEROUS_PENULTIMATE_EXTENSIONS = frozenset(

--- a/onadata/libs/utils/upload_validation.py
+++ b/onadata/libs/utils/upload_validation.py
@@ -160,14 +160,32 @@ def sanitized_original_filename(name):
     return basename
 
 
+MAX_REASON_LENGTH = 200
+
+
+def _sanitize_reason(reason):
+    """Return a safe, single-line, length-capped reason string.
+
+    The validators raise static, non-sensitive descriptions of the rule that
+    was violated (e.g. "CSV files must be UTF-8 encoded."). Sanitizing here is
+    defence-in-depth: it guarantees that even if a future caller passes an
+    unexpected value, only a short single line of text can ever be surfaced —
+    never a multi-line traceback or internal detail.
+    """
+    if reason is None:
+        return ""
+    # Collapse all runs of whitespace (incl. newlines) to single spaces so a
+    # multi-line value cannot be surfaced, then cap the length.
+    return " ".join(str(reason).split())[:MAX_REASON_LENGTH]
+
+
 def generic_upload_validation_error_message(uploaded_file, reason=None):
     """Return an API validation error that identifies the upload.
 
     When ``reason`` is provided (typically the :class:`UploadValidationError`
-    raised by the validators), it is appended so API clients learn *why* the
-    upload failed instead of only seeing the generic text. The validators
-    raise static, non-sensitive descriptions of the rule that was violated
-    (e.g. "CSV files must be UTF-8 encoded."), so surfacing them is safe.
+    raised by the validators), a sanitized, single-line, length-capped form of
+    it is appended so API clients learn *why* the upload failed instead of only
+    seeing the generic text. See :func:`_sanitize_reason` for the guarantees.
     """
     filename = sanitized_original_filename(getattr(uploaded_file, "name", ""))
 
@@ -178,7 +196,7 @@ def generic_upload_validation_error_message(uploaded_file, reason=None):
     else:
         message = _("The uploaded file could not be validated.")
 
-    reason_text = str(reason).strip() if reason is not None else ""
+    reason_text = _sanitize_reason(reason)
     if reason_text:
         return f"{message} {reason_text}"
 


### PR DESCRIPTION
### Changes / Features implemented

Metadata media-file uploads that fail strict validation returned only a generic "could not be validated" message — the actual reason was logged server-side and discarded. The API error now includes the validation reason, sanitized before it is surfaced.

### Steps taken to verify this change does what is intended

- Unit tests across the upload validation helper, the metadata serializer and the metadata viewset

### Side effects of implementing this change

- None expected: only the error message content changes

**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  - [ ] Updated documentation

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/onaio/codesmith/onadata/pr/3154"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785415100&installation_id=135786473&pr_number=3154&repository=onaio%2Fonadata&return_to=https%3A%2F%2Fgithub.com%2Fonaio%2Fonadata%2Fpull%2F3154&signature=ff4d610cbf39eae4b5800a85541a774df7d5aa3fa33e499f68375a0995c97a3d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
