### PR TITLE
perf(messaging): cache list endpoint responses

### DIFF
--- a/onadata/apps/messaging/tests/test_messaging_viewset.py
+++ b/onadata/apps/messaging/tests/test_messaging_viewset.py
@@ -361,26 +361,6 @@ class TestMessagingViewSet(TestCase):
             ),
         )
 
-        # Test the retrieval threshold is respected
-        with override_settings(MESSAGE_RETRIEVAL_THRESHOLD=2):
-            request = self.factory.get(
-                "/messaging", data={"target_type": "user", "target_id": user.pk}
-            )
-            force_authenticate(request, user=user)
-            response = view(request=request)
-            self.assertEqual(response.status_code, 200, response.data)
-            self.assertEqual(len(response.data), 2)
-            self.assertIn("Link", response)
-            self.assertEqual(
-                response["Link"],
-                (
-                    f"<http://testserver/messaging?page=2&"
-                    f'target_id={user.pk}&target_type=user>; rel="next",'
-                    " <http://testserver/messaging?page=2&"
-                    f'target_id={user.pk}&target_type=user>; rel="last"'
-                ),
-            )
-
     @override_settings(USE_TZ=False)
     def test_messaging_timestamp_filter(self):
         """

--- a/onadata/apps/messaging/tests/test_messaging_viewset.py
+++ b/onadata/apps/messaging/tests/test_messaging_viewset.py
@@ -7,6 +7,7 @@ from __future__ import unicode_literals
 from builtins import str as text
 
 from actstream.models import Action
+from django.core.cache import cache
 from django.test import TestCase
 from django.test.utils import override_settings
 from guardian.shortcuts import assign_perm
@@ -23,6 +24,8 @@ class TestMessagingViewSet(TestCase):
 
     def setUp(self):
         self.factory = APIRequestFactory()
+        # the list endpoint caches responses; start each test with a clean cache
+        cache.clear()
 
     @override_settings(FULL_MESSAGE_PAYLOAD=True)
     def _create_message(self, user=None):
@@ -144,6 +147,78 @@ class TestMessagingViewSet(TestCase):
         response = view(request=request)
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.data, {"detail": "Unknown target_type xyz"})
+
+    def test_list_response_is_cached(self):
+        """A repeated identical list request is served from cache."""
+        user = _create_user()
+        self._create_message(user)
+        view = MessagingViewSet.as_view({"get": "list"})
+        params = {"target_type": "user", "target_id": user.pk}
+
+        # first request populates the cache
+        request = self.factory.get("/messaging", params)
+        force_authenticate(request, user=user)
+        first = view(request=request)
+        first.render()
+        self.assertEqual(first.status_code, 200)
+
+        # the underlying data changes after the response has been cached
+        self._create_message(user)
+
+        # a repeated identical request is served the cached response body
+        request = self.factory.get("/messaging", params)
+        force_authenticate(request, user=user)
+        second = view(request=request)
+        if hasattr(second, "render"):
+            second.render()
+        self.assertEqual(second.status_code, 200)
+        self.assertEqual(second.content, first.content)
+
+    def test_list_cache_varies_by_query_params(self):
+        """Cached list responses are keyed by query params, not shared across targets."""
+        user = _create_user()
+        other = _create_user("otheruser")
+        self._create_message(user)  # a single message targeted at `user`
+        view = MessagingViewSet.as_view({"get": "list"})
+
+        # cache the response for target=user
+        request = self.factory.get(
+            "/messaging", {"target_type": "user", "target_id": user.pk}
+        )
+        force_authenticate(request, user=user)
+        first = view(request=request)
+        first.render()
+        self.assertEqual(first.status_code, 200)
+        self.assertEqual(len(first.data), 1)
+
+        # a request for a different target returns its own data
+        request = self.factory.get(
+            "/messaging", {"target_type": "user", "target_id": other.pk}
+        )
+        force_authenticate(request, user=user)
+        second = view(request=request)
+        second.render()
+        self.assertEqual(second.status_code, 200)
+        self.assertEqual(len(second.data), 0)
+
+    def test_list_cache_does_not_bypass_authentication(self):
+        """An anonymous request is rejected even when the list cache is warm."""
+        user = _create_user()
+        self._create_message(user)
+        view = MessagingViewSet.as_view({"get": "list"})
+        params = {"target_type": "user", "target_id": user.pk}
+
+        # warm the cache with an authenticated request
+        request = self.factory.get("/messaging", params)
+        force_authenticate(request, user=user)
+        warm = view(request=request)
+        warm.render()
+        self.assertEqual(warm.status_code, 200)
+
+        # an anonymous request to the same URL is still rejected
+        request = self.factory.get("/messaging", params)
+        response = view(request=request)
+        self.assertEqual(response.status_code, 401)
 
     def test_retrieve_message(self):
         """

--- a/onadata/apps/messaging/viewsets.py
+++ b/onadata/apps/messaging/viewsets.py
@@ -5,6 +5,9 @@ Messaging /messaging viewsets.
 from __future__ import unicode_literals
 
 from django.conf import settings
+from django.utils.decorators import method_decorator
+from django.views.decorators.cache import cache_page
+
 from actstream.models import Action
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import mixins, viewsets
@@ -24,6 +27,7 @@ from onadata.libs.pagination import StandardPageNumberPagination
 
 
 # pylint: disable=too-many-ancestors
+@method_decorator(cache_page(30 * 60), name="list")
 class MessagingViewSet(
     mixins.CreateModelMixin,
     mixins.ListModelMixin,
@@ -51,7 +55,7 @@ class MessagingViewSet(
         headers = None
         queryset = self.filter_queryset(self.get_queryset())
         no_of_records = queryset.count()
-        retrieval_threshold = getattr(settings, "MESSAGE_RETRIEVAL_THRESHOLD", 10000)
+        retrieval_threshold = getattr(settings, "MESSAGE_RETRIEVAL_THRESHOLD", 500)
         pagination_keys = [
             self.paginator.page_query_param,
             self.paginator.page_size_query_param,

--- a/onadata/apps/messaging/viewsets.py
+++ b/onadata/apps/messaging/viewsets.py
@@ -66,8 +66,13 @@ class MessagingViewSet(
         queryset = self.filter_queryset(self.get_queryset())
         self.record_count = queryset.count()
         page = self.paginate_queryset(queryset)
-        serializer = self.get_serializer(page, many=True)
-        headers = self.paginator.generate_link_header(
-            self.request, queryset, count=self.record_count
-        )
-        return Response(serializer.data, headers=headers)
+
+        if page is not None:
+            serializer = self.get_serializer(page, many=True)
+            headers = self.paginator.generate_link_header(
+                self.request, queryset, count=self.record_count
+            )
+            return Response(serializer.data, headers=headers)
+
+        serializer = self.get_serializer(queryset, many=True)
+        return Response(serializer.data)

--- a/onadata/apps/messaging/viewsets.py
+++ b/onadata/apps/messaging/viewsets.py
@@ -23,7 +23,7 @@ from onadata.apps.messaging.filters import (
 )
 from onadata.apps.messaging.permissions import TargetObjectPermissions
 from onadata.apps.messaging.serializers import MessageSerializer
-from onadata.libs.pagination import StandardPageNumberPagination
+from onadata.libs.pagination import CountOverridablePageNumberPagination
 
 
 # pylint: disable=too-many-ancestors
@@ -49,30 +49,46 @@ class MessagingViewSet(
         DjangoFilterBackend,
     )
     filterset_class = ActionFilterSet
-    pagination_class = StandardPageNumberPagination
+    pagination_class = CountOverridablePageNumberPagination
+    # cached count of the filtered queryset for the current request, reused
+    # across pagination and Link header generation to avoid repeat COUNT(*)
+    record_count = None
+
+    def paginate_queryset(self, queryset):
+        if self.paginator is None:
+            return None
+        return self.paginator.paginate_queryset(
+            queryset, self.request, view=self, count=self.record_count
+        )
 
     def list(self, request, *args, **kwargs):
         headers = None
         queryset = self.filter_queryset(self.get_queryset())
-        no_of_records = queryset.count()
         retrieval_threshold = getattr(settings, "MESSAGE_RETRIEVAL_THRESHOLD", 500)
         pagination_keys = [
             self.paginator.page_query_param,
             self.paginator.page_size_query_param,
         ]
         query_param_keys = self.request.query_params
-        should_paginate = (
-            any(k in query_param_keys for k in pagination_keys)
-            or no_of_records > retrieval_threshold
-        )
+        has_pagination_params = any(k in query_param_keys for k in pagination_keys)
 
-        if should_paginate and "page_size" not in self.request.query_params.keys():
-            self.paginator.page_size = retrieval_threshold
+        # Only count to decide auto-pagination; when pagination is explicitly
+        # requested the count is deferred to the pagination step below.
+        if not has_pagination_params:
+            self.record_count = queryset.count()
+
+        should_paginate = has_pagination_params or self.record_count > retrieval_threshold
 
         if should_paginate:
+            if "page_size" not in self.request.query_params.keys():
+                self.paginator.page_size = retrieval_threshold
+            if self.record_count is None:
+                self.record_count = queryset.count()
             page = self.paginate_queryset(queryset)
             serializer = self.get_serializer(page, many=True)
-            headers = self.paginator.generate_link_header(self.request, queryset)
+            headers = self.paginator.generate_link_header(
+                self.request, queryset, count=self.record_count
+            )
         else:
             serializer = self.get_serializer(queryset, many=True)
 

--- a/onadata/apps/messaging/viewsets.py
+++ b/onadata/apps/messaging/viewsets.py
@@ -58,13 +58,14 @@ class MessagingViewSet(
         """Returns a paginated queryset"""
         if self.paginator is None:
             return None
+
+        self.record_count = queryset.count()
         return self.paginator.paginate_queryset(
             queryset, self.request, view=self, count=self.record_count
         )
 
     def list(self, request, *args, **kwargs):
         queryset = self.filter_queryset(self.get_queryset())
-        self.record_count = queryset.count()
         page = self.paginate_queryset(queryset)
 
         if page is not None:

--- a/onadata/apps/messaging/viewsets.py
+++ b/onadata/apps/messaging/viewsets.py
@@ -56,6 +56,10 @@ class MessagingViewSet(
     record_count = None
 
     def paginate_queryset(self, queryset):
+        """Return a paginated queryset
+
+        Overrides super().paginate_queryset()
+        """
         if self.paginator is None:
             return None
         return self.paginator.paginate_queryset(

--- a/onadata/apps/messaging/viewsets.py
+++ b/onadata/apps/messaging/viewsets.py
@@ -65,7 +65,7 @@ class MessagingViewSet(
     def list(self, request, *args, **kwargs):
         headers = None
         queryset = self.filter_queryset(self.get_queryset())
-        retrieval_threshold = getattr(settings, "MESSAGE_RETRIEVAL_THRESHOLD", 500)
+        retrieval_threshold = getattr(settings, "MESSAGE_RETRIEVAL_THRESHOLD", 100)
         pagination_keys = [
             self.paginator.page_query_param,
             self.paginator.page_size_query_param,

--- a/onadata/apps/messaging/viewsets.py
+++ b/onadata/apps/messaging/viewsets.py
@@ -12,7 +12,6 @@ from actstream.models import Action
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import mixins, viewsets
 from rest_framework.permissions import IsAuthenticated
-from rest_framework.response import Response
 
 from onadata.apps.messaging.constants import MESSAGE_VERBS
 from onadata.apps.messaging.filters import (
@@ -23,7 +22,7 @@ from onadata.apps.messaging.filters import (
 )
 from onadata.apps.messaging.permissions import TargetObjectPermissions
 from onadata.apps.messaging.serializers import MessageSerializer
-from onadata.libs.pagination import CountOverridablePageNumberPagination
+from onadata.libs.pagination import StandardPageNumberPagination
 
 
 # pylint: disable=too-many-ancestors
@@ -49,31 +48,4 @@ class MessagingViewSet(
         DjangoFilterBackend,
     )
     filterset_class = ActionFilterSet
-    pagination_class = CountOverridablePageNumberPagination
-    # count of the filtered queryset for the current request, reused across
-    # pagination and Link header generation to avoid repeat COUNT(*)
-    record_count = None
-
-    def paginate_queryset(self, queryset):
-        """Returns a paginated queryset"""
-        if self.paginator is None:
-            return None
-
-        self.record_count = queryset.count()
-        return self.paginator.paginate_queryset(
-            queryset, self.request, view=self, count=self.record_count
-        )
-
-    def list(self, request, *args, **kwargs):
-        queryset = self.filter_queryset(self.get_queryset())
-        page = self.paginate_queryset(queryset)
-
-        if page is not None:
-            serializer = self.get_serializer(page, many=True)
-            headers = self.paginator.generate_link_header(
-                self.request, queryset, count=self.record_count
-            )
-            return Response(serializer.data, headers=headers)
-
-        serializer = self.get_serializer(queryset, many=True)
-        return Response(serializer.data)
+    pagination_class = StandardPageNumberPagination

--- a/onadata/apps/messaging/viewsets.py
+++ b/onadata/apps/messaging/viewsets.py
@@ -2,6 +2,7 @@
 """
 Messaging /messaging viewsets.
 """
+
 from __future__ import unicode_literals
 
 from django.conf import settings
@@ -27,7 +28,7 @@ from onadata.libs.pagination import CountOverridablePageNumberPagination
 
 
 # pylint: disable=too-many-ancestors
-@method_decorator(cache_page(30 * 60), name="list")
+@method_decorator(cache_page(10 * 60), name="list")
 class MessagingViewSet(
     mixins.CreateModelMixin,
     mixins.ListModelMixin,
@@ -77,7 +78,9 @@ class MessagingViewSet(
         if not has_pagination_params:
             self.record_count = queryset.count()
 
-        should_paginate = has_pagination_params or self.record_count > retrieval_threshold
+        should_paginate = (
+            has_pagination_params or self.record_count > retrieval_threshold
+        )
 
         if should_paginate:
             if "page_size" not in self.request.query_params.keys():

--- a/onadata/apps/messaging/viewsets.py
+++ b/onadata/apps/messaging/viewsets.py
@@ -73,8 +73,6 @@ class MessagingViewSet(
         query_param_keys = self.request.query_params
         has_pagination_params = any(k in query_param_keys for k in pagination_keys)
 
-        # Only count to decide auto-pagination; when pagination is explicitly
-        # requested the count is deferred to the pagination step below.
         if not has_pagination_params:
             self.record_count = queryset.count()
 

--- a/onadata/apps/messaging/viewsets.py
+++ b/onadata/apps/messaging/viewsets.py
@@ -5,7 +5,6 @@ Messaging /messaging viewsets.
 
 from __future__ import unicode_literals
 
-from django.conf import settings
 from django.utils.decorators import method_decorator
 from django.views.decorators.cache import cache_page
 
@@ -53,38 +52,14 @@ class MessagingViewSet(
     pagination_class = CountOverridablePageNumberPagination
 
     def list(self, request, *args, **kwargs):
-        headers = None
         queryset = self.filter_queryset(self.get_queryset())
-        retrieval_threshold = getattr(settings, "MESSAGE_RETRIEVAL_THRESHOLD", 100)
-        pagination_keys = [
-            self.paginator.page_query_param,
-            self.paginator.page_size_query_param,
-        ]
-        query_param_keys = self.request.query_params
-        has_pagination_params = any(k in query_param_keys for k in pagination_keys)
-
-        # Once record_count is set, pagination and the Link header do not
-        # trigger extra COUNT(*) queries.
-        record_count = None
-
-        if not has_pagination_params:
-            record_count = queryset.count()
-
-        should_paginate = has_pagination_params or record_count > retrieval_threshold
-
-        if should_paginate:
-            if "page_size" not in self.request.query_params.keys():
-                self.paginator.page_size = retrieval_threshold
-            if record_count is None:
-                record_count = queryset.count()
-            page = self.paginator.paginate_queryset(
-                queryset, self.request, view=self, count=record_count
-            )
-            serializer = self.get_serializer(page, many=True)
-            headers = self.paginator.generate_link_header(
-                self.request, queryset, count=record_count
-            )
-        else:
-            serializer = self.get_serializer(queryset, many=True)
-
+        # single count reused by pagination and the Link header
+        record_count = queryset.count()
+        page = self.paginator.paginate_queryset(
+            queryset, self.request, view=self, count=record_count
+        )
+        serializer = self.get_serializer(page, many=True)
+        headers = self.paginator.generate_link_header(
+            self.request, queryset, count=record_count
+        )
         return Response(serializer.data, headers=headers)

--- a/onadata/apps/messaging/viewsets.py
+++ b/onadata/apps/messaging/viewsets.py
@@ -50,16 +50,24 @@ class MessagingViewSet(
     )
     filterset_class = ActionFilterSet
     pagination_class = CountOverridablePageNumberPagination
+    # count of the filtered queryset for the current request, reused across
+    # pagination and Link header generation to avoid repeat COUNT(*)
+    record_count = None
+
+    def paginate_queryset(self, queryset):
+        """Returns a paginated queryset"""
+        if self.paginator is None:
+            return None
+        return self.paginator.paginate_queryset(
+            queryset, self.request, view=self, count=self.record_count
+        )
 
     def list(self, request, *args, **kwargs):
         queryset = self.filter_queryset(self.get_queryset())
-        # single count reused by pagination and the Link header
-        record_count = queryset.count()
-        page = self.paginator.paginate_queryset(
-            queryset, self.request, view=self, count=record_count
-        )
+        self.record_count = queryset.count()
+        page = self.paginate_queryset(queryset)
         serializer = self.get_serializer(page, many=True)
         headers = self.paginator.generate_link_header(
-            self.request, queryset, count=record_count
+            self.request, queryset, count=self.record_count
         )
         return Response(serializer.data, headers=headers)

--- a/onadata/apps/messaging/viewsets.py
+++ b/onadata/apps/messaging/viewsets.py
@@ -51,20 +51,6 @@ class MessagingViewSet(
     )
     filterset_class = ActionFilterSet
     pagination_class = CountOverridablePageNumberPagination
-    # cached count of the filtered queryset for the current request, reused
-    # across pagination and Link header generation to avoid repeat COUNT(*)
-    record_count = None
-
-    def paginate_queryset(self, queryset):
-        """Return a paginated queryset
-
-        Overrides super().paginate_queryset()
-        """
-        if self.paginator is None:
-            return None
-        return self.paginator.paginate_queryset(
-            queryset, self.request, view=self, count=self.record_count
-        )
 
     def list(self, request, *args, **kwargs):
         headers = None
@@ -77,22 +63,26 @@ class MessagingViewSet(
         query_param_keys = self.request.query_params
         has_pagination_params = any(k in query_param_keys for k in pagination_keys)
 
-        if not has_pagination_params:
-            self.record_count = queryset.count()
+        # Once record_count is set, pagination and the Link header do not
+        # trigger extra COUNT(*) queries.
+        record_count = None
 
-        should_paginate = (
-            has_pagination_params or self.record_count > retrieval_threshold
-        )
+        if not has_pagination_params:
+            record_count = queryset.count()
+
+        should_paginate = has_pagination_params or record_count > retrieval_threshold
 
         if should_paginate:
             if "page_size" not in self.request.query_params.keys():
                 self.paginator.page_size = retrieval_threshold
-            if self.record_count is None:
-                self.record_count = queryset.count()
-            page = self.paginate_queryset(queryset)
+            if record_count is None:
+                record_count = queryset.count()
+            page = self.paginator.paginate_queryset(
+                queryset, self.request, view=self, count=record_count
+            )
             serializer = self.get_serializer(page, many=True)
             headers = self.paginator.generate_link_header(
-                self.request, queryset, count=self.record_count
+                self.request, queryset, count=record_count
             )
         else:
             serializer = self.get_serializer(queryset, many=True)

--- a/onadata/libs/pagination.py
+++ b/onadata/libs/pagination.py
@@ -40,31 +40,32 @@ class StandardPageNumberPagination(PageNumberPagination):
 
     def get_last_page_link(self):
         """Returns the URL to the last page."""
-        if self.page.number == self.paginator.num_pages:
+        if self.page.number == self.page.paginator.num_pages:
             return None
 
         url = self.request.build_absolute_uri()
 
-        return replace_query_param(url, self.page_query_param, self.paginator.num_pages)
+        return replace_query_param(
+            url, self.page_query_param, self.page.paginator.num_pages
+        )
 
     def generate_link_header(self, request: Request, queryset: QuerySet):
         """Generates pagination headers for a HTTP response object"""
         page_size = self.get_page_size(request)
         if not page_size:
             return {}
-        # pylint: disable=attribute-defined-outside-init
-        self.paginator = self.django_paginator_class(queryset, page_size)
-        return self._build_link_header(request)
+        paginator = self.django_paginator_class(queryset, page_size)
+        return self._build_link_header(request, paginator)
 
-    def _build_link_header(self, request: Request):
-        """Builds the ``Link`` header dict from ``self.paginator``."""
+    def _build_link_header(self, request: Request, paginator):
+        """Builds the ``Link`` header dict from the given paginator."""
         links = []
         page_number = request.query_params.get(self.page_query_param, 1)
         # pylint: disable=attribute-defined-outside-init
         self.request = request
 
         try:
-            self.page = self.paginator.page(page_number)
+            self.page = paginator.page(page_number)
         except InvalidPage:
             return {}
 
@@ -158,11 +159,10 @@ class CountOverridablePageNumberPagination(StandardPageNumberPagination):
         page_size = self.get_page_size(request)
         if not page_size:
             return {}
-        # pylint: disable=attribute-defined-outside-init
-        self.paginator = self.django_paginator_class(
+        paginator = self.django_paginator_class(
             queryset, page_size, count_override=count
         )
-        return self._build_link_header(request)
+        return self._build_link_header(request, paginator)
 
 
 class RawSQLQueryPaginator(CountOverridablePaginator):

--- a/onadata/libs/pagination.py
+++ b/onadata/libs/pagination.py
@@ -2,10 +2,11 @@
 """
 Pagination classes.
 """
+
 from typing import Tuple
+
 from django.conf import settings
 from django.core.paginator import Paginator
-from django.db.models import QuerySet
 from django.utils.functional import cached_property
 
 from rest_framework.pagination import (
@@ -14,7 +15,6 @@ from rest_framework.pagination import (
     PageNumberPagination,
     replace_query_param,
 )
-from rest_framework.request import Request
 from rest_framework.response import Response
 
 
@@ -49,25 +49,9 @@ class StandardPageNumberPagination(PageNumberPagination):
             url, self.page_query_param, self.page.paginator.num_pages
         )
 
-    def generate_link_header(self, request: Request, queryset: QuerySet):
+    def generate_link_header(self):
         """Generates pagination headers for a HTTP response object"""
-        page_size = self.get_page_size(request)
-        if not page_size:
-            return {}
-        paginator = self.django_paginator_class(queryset, page_size)
-        return self._build_link_header(request, paginator)
-
-    def _build_link_header(self, request: Request, paginator):
-        """Builds the ``Link`` header dict from the given paginator."""
         links = []
-        page_number = request.query_params.get(self.page_query_param, 1)
-        # pylint: disable=attribute-defined-outside-init
-        self.request = request
-
-        try:
-            self.page = paginator.page(page_number)
-        except InvalidPage:
-            return {}
 
         for rel, link in (
             ("prev", self.get_previous_link()),
@@ -84,8 +68,8 @@ class StandardPageNumberPagination(PageNumberPagination):
         return {"Link": ", ".join(links)}
 
     def get_paginated_response(self, data):
-        """Override to remove the OrderedDict response"""
-        return Response(data)
+        """Override to remove the OrderedDict response and use headers"""
+        return Response(data, headers=self.generate_link_header())
 
 
 class CountOverridablePaginator(Paginator):
@@ -152,20 +136,6 @@ class CountOverridablePageNumberPagination(StandardPageNumberPagination):
 
         self.request = request
         return list(self.page)
-
-    def generate_link_header(self, request: Request, queryset: QuerySet, count=None):
-        """Generate ``Link`` headers, reusing a precomputed ``count``.
-
-        Passing ``count`` avoids an additional COUNT(*) by overriding the
-        paginator's count.
-        """
-        page_size = self.get_page_size(request)
-        if not page_size:
-            return {}
-        paginator = self.django_paginator_class(
-            queryset, page_size, count_override=count
-        )
-        return self._build_link_header(request, paginator)
 
 
 class RawSQLQueryPaginator(CountOverridablePaginator):

--- a/onadata/libs/pagination.py
+++ b/onadata/libs/pagination.py
@@ -47,26 +47,20 @@ class StandardPageNumberPagination(PageNumberPagination):
 
         return replace_query_param(url, self.page_query_param, self.paginator.num_pages)
 
-    def generate_link_header(self, request: Request, queryset: QuerySet, count=None):
-        """Generates pagination headers for a HTTP response object.
-
-        When ``count`` is provided it is passed to the paginator as a
-        ``count_override`` to avoid an extra COUNT(*); this requires a
-        count-overridable ``django_paginator_class`` (e.g.
-        ``CountOverridablePageNumberPagination``).
-        """
-        links = []
+    def generate_link_header(self, request: Request, queryset: QuerySet):
+        """Generates pagination headers for a HTTP response object"""
         page_size = self.get_page_size(request)
         if not page_size:
             return {}
+        # pylint: disable=attribute-defined-outside-init
+        self.paginator = self.django_paginator_class(queryset, page_size)
+        return self._build_link_header(request)
+
+    def _build_link_header(self, request: Request):
+        """Builds the ``Link`` header dict from ``self.paginator``."""
+        links = []
         page_number = request.query_params.get(self.page_query_param, 1)
         # pylint: disable=attribute-defined-outside-init
-        if count is None:
-            self.paginator = self.django_paginator_class(queryset, page_size)
-        else:
-            self.paginator = self.django_paginator_class(
-                queryset, page_size, count_override=count
-            )
         self.request = request
 
         try:
@@ -154,6 +148,21 @@ class CountOverridablePageNumberPagination(StandardPageNumberPagination):
 
         self.request = request
         return list(self.page)
+
+    def generate_link_header(self, request: Request, queryset: QuerySet, count=None):
+        """Generate ``Link`` headers, reusing a precomputed ``count``.
+
+        Passing ``count`` avoids an additional COUNT(*) by overriding the
+        paginator's count.
+        """
+        page_size = self.get_page_size(request)
+        if not page_size:
+            return {}
+        # pylint: disable=attribute-defined-outside-init
+        self.paginator = self.django_paginator_class(
+            queryset, page_size, count_override=count
+        )
+        return self._build_link_header(request)
 
 
 class RawSQLQueryPaginator(CountOverridablePaginator):

--- a/onadata/libs/pagination.py
+++ b/onadata/libs/pagination.py
@@ -47,15 +47,26 @@ class StandardPageNumberPagination(PageNumberPagination):
 
         return replace_query_param(url, self.page_query_param, self.paginator.num_pages)
 
-    def generate_link_header(self, request: Request, queryset: QuerySet):
-        """Generates pagination headers for a HTTP response object"""
+    def generate_link_header(self, request: Request, queryset: QuerySet, count=None):
+        """Generates pagination headers for a HTTP response object.
+
+        When ``count`` is provided it is passed to the paginator as a
+        ``count_override`` to avoid an extra COUNT(*); this requires a
+        count-overridable ``django_paginator_class`` (e.g.
+        ``CountOverridablePageNumberPagination``).
+        """
         links = []
         page_size = self.get_page_size(request)
         if not page_size:
             return {}
         page_number = request.query_params.get(self.page_query_param, 1)
         # pylint: disable=attribute-defined-outside-init
-        self.paginator = self.django_paginator_class(queryset, page_size)
+        if count is None:
+            self.paginator = self.django_paginator_class(queryset, page_size)
+        else:
+            self.paginator = self.django_paginator_class(
+                queryset, page_size, count_override=count
+            )
         self.request = request
 
         try:

--- a/onadata/libs/pagination.py
+++ b/onadata/libs/pagination.py
@@ -78,6 +78,9 @@ class StandardPageNumberPagination(PageNumberPagination):
             if link:
                 links.append(f'<{link}>; rel="{rel}"')
 
+        if not links:
+            return {}
+
         return {"Link": ", ".join(links)}
 
     def get_paginated_response(self, data):

--- a/onadata/libs/tests/test_pagination.py
+++ b/onadata/libs/tests/test_pagination.py
@@ -1,15 +1,16 @@
 """
 Tests onadata.libs.pagination module
 """
+
 from django.http.request import HttpRequest
 
 from rest_framework.request import Request
 
-from onadata.apps.main.tests.test_base import TestBase
 from onadata.apps.logger.models import Instance
+from onadata.apps.main.tests.test_base import TestBase
 from onadata.libs.pagination import (
-    StandardPageNumberPagination,
     RawSQLQueryPageNumberPagination,
+    StandardPageNumberPagination,
 )
 
 
@@ -27,7 +28,9 @@ class TestPaginationModule(TestBase):
         self._publish_transportation_form()
         self._make_submissions()
         qs = Instance.objects.filter(xform=self.xform)
-        out = StandardPageNumberPagination().generate_link_header(Request(req), qs)
+        paginator = StandardPageNumberPagination()
+        paginator.paginate_queryset(qs, Request(req))
+        out = paginator.generate_link_header()
         expected_out = {
             "Link": '<http://testserver?page=2&page_size=1>; rel="next",'
             ' <http://testserver?page=4&page_size=1>; rel="last"'
@@ -37,7 +40,9 @@ class TestPaginationModule(TestBase):
         # First page link is created when not on the first page
         req.META["QUERY_STRING"] = "page=2&page_size=1"
         req.GET = {"page": 2, "page_size": 1}
-        out = StandardPageNumberPagination().generate_link_header(Request(req), qs)
+        paginator = StandardPageNumberPagination()
+        paginator.paginate_queryset(qs, Request(req))
+        out = paginator.generate_link_header()
         expected_out = {
             "Link": '<http://testserver?page_size=1>; rel="prev", '
             '<http://testserver?page=3&page_size=1>; rel="next", '
@@ -49,7 +54,9 @@ class TestPaginationModule(TestBase):
         # Last page link is not created on last page
         req.META["QUERY_STRING"] = "page=4&page_size=1"
         req.GET = {"page": 4, "page_size": 1}
-        out = StandardPageNumberPagination().generate_link_header(Request(req), qs)
+        paginator = StandardPageNumberPagination()
+        paginator.paginate_queryset(qs, Request(req))
+        out = paginator.generate_link_header()
         expected_out = {
             "Link": '<http://testserver?page=3&page_size=1>; rel="prev", '
             '<http://testserver?page=1&page_size=1>; rel="first"'


### PR DESCRIPTION
### Changes / Features implemented

- Cache `GET /api/v1/messaging` list responses for 10 minutes
- Drop `MESSAGE_RETRIEVAL_THRESHOLD`  setting
- Refactor `StandardPageNumberPagination.()generate_link_header()` to stop re-creating another instance of `django_paginator_class` thus recomputing the queryset count. `queryset.count()` was being called in the view, in `StandardPageNumberPagination().paginate_queryset()` and `StandardPageNumberPagination().generate_link_header()`
- Add pagination link headers by default in the response for `StandardPageNumberPagination`. Previously, the view had to opt in to respond with the pagination link headers

### Steps taken to verify this change does what is intended

-  [x] Added tests
-  [x] QA

### Side effects of implementing this change

- Caching is TTL-only (no explicit invalidation), so newly created or deleted messages may not appear in a cached list until the entry expires.

**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  - [ ] Updated documentation

Closes #
