### PR TITLE
feat(messaging): group by verb, user in messaging endpoint

### DIFF
--- a/docs/messaging.rst
+++ b/docs/messaging.rst
@@ -162,37 +162,50 @@ GET Grouped activity counts
 
 Passing one or more ``group_by`` parameters returns activity counts instead of
 individual event messages, grouped by the requested dimension(s). The supported
-dimensions are ``user`` and ``verb``; repeat the parameter to group by both.
-The same ``target_type``, ``target_id`` and optional ``user`` filters apply.
-The results are paginated and ordered by most recent activity first. Any other
-``group_by`` value returns an HTTP 400 response.
+dimensions are ``user``, ``verb`` and a time bucket (one of ``hour``, ``day``,
+``week``, ``month`` or ``year``); repeat the parameter to combine them. At most
+one time bucket may be combined per request. The same ``target_type``,
+``target_id`` and optional ``user`` filters apply. The results are paginated and
+ordered by most recent activity first. Any other ``group_by`` value, or more
+than one time bucket, returns an HTTP 400 response.
 
 - ``group_by=verb`` - Counts per verb, aggregated across users.
 - ``group_by=user`` - Counts per user, aggregated across verbs.
 - ``group_by=user&group_by=verb`` - Counts per ``(user, verb)``.
+- ``group_by=day`` - Counts per UTC day, aggregated across users and verbs.
+- ``group_by=day&group_by=user&group_by=verb`` - Counts per
+  ``(day, user, verb)``.
 
 Each row always contains:
 
 - ``count`` - The number of events in the group.
+- ``earliest_timestamp`` - The timestamp of the oldest event in the group.
 - ``latest_timestamp`` - The timestamp of the most recent event in the group.
 
 The requested dimensions are also included in each row:
 
+- ``period_start`` - The UTC start of the time bucket. Only present when a time
+  bucket was requested. Time bucket boundaries are computed in UTC.
 - ``user`` - The username of the acting user. This is ``null`` when the actor
   id no longer resolves to a user.
 - ``verb`` - The action that occurred on the target.
 
+All timestamps in grouped responses are rendered in UTC. Because a time bucket
+also reports ``earliest_timestamp`` and ``latest_timestamp``, a client can
+render an event range (e.g. "15 submissions from 09:00 to 10:00") by merging
+adjacent buckets; the endpoint does not collapse bursts on the server.
+
 .. raw:: html
 
   <pre class="prettyprint">
-  <b>GET</b> /api/v1/messaging?target_type=<code>{type}</code>&target_id=<code>{form_id}</code>&group_by=<code>user</code>&group_by=<code>verb</code>
+  <b>GET</b> /api/v1/messaging?target_type=<code>{type}</code>&target_id=<code>{form_id}</code>&group_by=<code>day</code>&group_by=<code>user</code>&group_by=<code>verb</code>
   </pre>
 
 Example
 ^^^^^^^^
 ::
 
-    curl -X GET https://api.ona.io/api/v1/messaging?target_type=xform&target_id=1&group_by=user&group_by=verb
+    curl -X GET https://api.ona.io/api/v1/messaging?target_type=xform&target_id=1&group_by=day&group_by=user&group_by=verb
 
 
 Response
@@ -201,16 +214,20 @@ Response
 
     [
         {
+            "period_start": "2026-03-15T00:00:00Z",
             "user": "bob",
             "verb": "submission_created",
             "count": 14,
-            "latest_timestamp": "2021-02-26T03:32:57.799647-05:00"
+            "earliest_timestamp": "2026-03-15T06:10:00Z",
+            "latest_timestamp": "2026-03-15T18:22:57Z"
         },
         {
+            "period_start": "2026-03-14T00:00:00Z",
             "user": "bob",
             "verb": "submission_edited",
             "count": 2,
-            "latest_timestamp": "2020-12-14T02:57:23.264655-05:00"
+            "earliest_timestamp": "2026-03-14T02:57:23Z",
+            "latest_timestamp": "2026-03-14T09:41:05Z"
         }
     ]
 

--- a/docs/messaging.rst
+++ b/docs/messaging.rst
@@ -157,6 +157,63 @@ Sample response with link header
           }
       ]
 
+GET Grouped activity counts
+---------------------------
+
+Passing one or more ``group_by`` parameters returns activity counts instead of
+individual event messages, grouped by the requested dimension(s). The supported
+dimensions are ``user`` and ``verb``; repeat the parameter to group by both.
+The same ``target_type``, ``target_id`` and optional ``user`` filters apply.
+The results are paginated and ordered by most recent activity first. Any other
+``group_by`` value returns an HTTP 400 response.
+
+- ``group_by=verb`` - Counts per verb, aggregated across users.
+- ``group_by=user`` - Counts per user, aggregated across verbs.
+- ``group_by=user&group_by=verb`` - Counts per ``(user, verb)``.
+
+Each row always contains:
+
+- ``count`` - The number of events in the group.
+- ``latest_timestamp`` - The timestamp of the most recent event in the group.
+
+The requested dimensions are also included in each row:
+
+- ``user`` - The username of the acting user. This is ``null`` when the actor
+  id no longer resolves to a user.
+- ``verb`` - The action that occurred on the target.
+
+.. raw:: html
+
+  <pre class="prettyprint">
+  <b>GET</b> /api/v1/messaging?target_type=<code>{type}</code>&target_id=<code>{form_id}</code>&group_by=<code>user</code>&group_by=<code>verb</code>
+  </pre>
+
+Example
+^^^^^^^^
+::
+
+    curl -X GET https://api.ona.io/api/v1/messaging?target_type=xform&target_id=1&group_by=user&group_by=verb
+
+
+Response
+^^^^^^^^^
+::
+
+    [
+        {
+            "user": "bob",
+            "verb": "submission_created",
+            "count": 14,
+            "latest_timestamp": "2021-02-26T03:32:57.799647-05:00"
+        },
+        {
+            "user": "bob",
+            "verb": "submission_edited",
+            "count": 2,
+            "latest_timestamp": "2020-12-14T02:57:23.264655-05:00"
+        }
+    ]
+
 Query events of a target using timestamp
 ----------------------------------------
 

--- a/onadata/apps/messaging/README.md
+++ b/onadata/apps/messaging/README.md
@@ -26,6 +26,45 @@ Returns an empty list, will return a list of messages given `target_type` and `t
 curl -X GET https://api.ona.io/api/v1/messaging?target_type=xform&target_id=1337
 ```
 
+#### Grouping activity counts
+
+Passing one or more `group_by` parameters returns activity counts instead of
+individual messages, grouped by the requested dimension(s). The supported
+dimensions are `user` and `verb`; repeat the parameter to group by both. The
+same `target_type`/`target_id` (and optional `user`) filters apply. Any other
+`group_by` value returns `400`. Each row always carries `count` and
+`latest_timestamp`, and rows are ordered by most recent activity first and
+paginated.
+
+- `group_by=verb` — counts per verb (aggregated across users).
+- `group_by=user` — counts per user (aggregated across verbs).
+- `group_by=user&group_by=verb` — counts per `(user, verb)`.
+
+```console
+curl -X GET "https://api.ona.io/api/v1/messaging?target_type=xform&target_id=1337&group_by=user&group_by=verb"
+```
+
+```json
+[
+    {
+        "user": "joe",
+        "verb": "export_created",
+        "count": 3,
+        "latest_timestamp": "2026-06-12T12:00:00+00:00"
+    },
+    {
+        "user": "joe",
+        "verb": "submission_created",
+        "count": 14,
+        "latest_timestamp": "2025-10-03T10:04:00+00:00"
+    }
+]
+```
+
+Only the requested dimensions appear in each row (e.g. `group_by=verb` omits
+`user`). When `user` is a grouping dimension, it is `null` if the actor id no
+longer resolves to a user.
+
 ### GET /api/messaging/[pk]
 
 Returns a specific message with matching pk.

--- a/onadata/apps/messaging/README.md
+++ b/onadata/apps/messaging/README.md
@@ -30,40 +30,51 @@ curl -X GET https://api.ona.io/api/v1/messaging?target_type=xform&target_id=1337
 
 Passing one or more `group_by` parameters returns activity counts instead of
 individual messages, grouped by the requested dimension(s). The supported
-dimensions are `user` and `verb`; repeat the parameter to group by both. The
-same `target_type`/`target_id` (and optional `user`) filters apply. Any other
-`group_by` value returns `400`. Each row always carries `count` and
-`latest_timestamp`, and rows are ordered by most recent activity first and
-paginated.
+dimensions are `user`, `verb` and a time bucket (one of `hour`, `day`, `week`,
+`month` or `year`); repeat the parameter to combine them. At most one time
+bucket may be combined per request. The same `target_type`/`target_id` (and
+optional `user`) filters apply. Any other `group_by` value, or more than one
+time bucket, returns `400`. Each row always carries `count`,
+`earliest_timestamp` and `latest_timestamp`, and rows are ordered by most recent
+activity first and paginated. All timestamps are rendered in UTC.
 
 - `group_by=verb` — counts per verb (aggregated across users).
 - `group_by=user` — counts per user (aggregated across verbs).
 - `group_by=user&group_by=verb` — counts per `(user, verb)`.
+- `group_by=day` — counts per UTC day (aggregated across users and verbs).
+- `group_by=day&group_by=user&group_by=verb` — counts per `(day, user, verb)`.
 
 ```console
-curl -X GET "https://api.ona.io/api/v1/messaging?target_type=xform&target_id=1337&group_by=user&group_by=verb"
+curl -X GET "https://api.ona.io/api/v1/messaging?target_type=xform&target_id=1337&group_by=day&group_by=user&group_by=verb"
 ```
 
 ```json
 [
     {
+        "period_start": "2026-06-12T00:00:00Z",
         "user": "joe",
         "verb": "export_created",
         "count": 3,
-        "latest_timestamp": "2026-06-12T12:00:00+00:00"
+        "earliest_timestamp": "2026-06-12T08:15:00Z",
+        "latest_timestamp": "2026-06-12T12:00:00Z"
     },
     {
+        "period_start": "2025-10-03T00:00:00Z",
         "user": "joe",
         "verb": "submission_created",
         "count": 14,
-        "latest_timestamp": "2025-10-03T10:04:00+00:00"
+        "earliest_timestamp": "2025-10-03T06:22:00Z",
+        "latest_timestamp": "2025-10-03T10:04:00Z"
     }
 ]
 ```
 
 Only the requested dimensions appear in each row (e.g. `group_by=verb` omits
-`user`). When `user` is a grouping dimension, it is `null` if the actor id no
-longer resolves to a user.
+`user`, and `period_start` is present only when a time bucket is requested).
+When `user` is a grouping dimension, it is `null` if the actor id no longer
+resolves to a user. Time bucket boundaries are computed in UTC; a client can
+render an event range by merging adjacent buckets using `earliest_timestamp`
+and `latest_timestamp`.
 
 ### GET /api/messaging/[pk]
 

--- a/onadata/apps/messaging/serializers.py
+++ b/onadata/apps/messaging/serializers.py
@@ -5,6 +5,7 @@ Message serializers
 
 import json
 import sys
+from datetime import timezone as dt_timezone
 from typing import Optional, Union
 
 from django.conf import settings
@@ -143,14 +144,20 @@ class GroupedActivitySerializer(serializers.Serializer):
     """Serializer for grouped activity counts.
 
     ``user`` and ``verb`` are grouping dimensions and are only included when
-    requested via the ``dimensions`` context; ``count`` and
-    ``latest_timestamp`` are always present.
+    requested via the ``dimensions`` context. ``period_start`` is the UTC start
+    of the time bucket and is only included when a time bucket was requested via
+    the ``time_bucket`` context. ``count``, ``earliest_timestamp`` and
+    ``latest_timestamp`` are always present. Timestamps are rendered in UTC.
     """
 
+    period_start = serializers.DateTimeField(
+        default_timezone=dt_timezone.utc, required=False
+    )
     user = serializers.CharField(allow_null=True, required=False)
     verb = serializers.CharField(required=False)
     count = serializers.IntegerField()
-    latest_timestamp = serializers.DateTimeField()
+    earliest_timestamp = serializers.DateTimeField(default_timezone=dt_timezone.utc)
+    latest_timestamp = serializers.DateTimeField(default_timezone=dt_timezone.utc)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -159,6 +166,8 @@ class GroupedActivitySerializer(serializers.Serializer):
             for field in ("user", "verb"):
                 if field not in dimensions:
                     self.fields.pop(field, None)
+        if not self.context.get("time_bucket"):
+            self.fields.pop("period_start", None)
 
 
 # pylint: disable=too-many-arguments,too-many-positional-arguments

--- a/onadata/apps/messaging/serializers.py
+++ b/onadata/apps/messaging/serializers.py
@@ -138,6 +138,7 @@ class MessageSerializer(serializers.ModelSerializer):
         return instance
 
 
+# pylint: disable=abstract-method
 class GroupedActivitySerializer(serializers.Serializer):
     """Serializer for grouped activity counts.
 

--- a/onadata/apps/messaging/serializers.py
+++ b/onadata/apps/messaging/serializers.py
@@ -138,6 +138,28 @@ class MessageSerializer(serializers.ModelSerializer):
         return instance
 
 
+class GroupedActivitySerializer(serializers.Serializer):
+    """Serializer for grouped activity counts.
+
+    ``user`` and ``verb`` are grouping dimensions and are only included when
+    requested via the ``dimensions`` context; ``count`` and
+    ``latest_timestamp`` are always present.
+    """
+
+    user = serializers.CharField(allow_null=True, required=False)
+    verb = serializers.CharField(required=False)
+    count = serializers.IntegerField()
+    latest_timestamp = serializers.DateTimeField()
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        dimensions = self.context.get("dimensions")
+        if dimensions is not None:
+            for field in ("user", "verb"):
+                if field not in dimensions:
+                    self.fields.pop(field, None)
+
+
 # pylint: disable=too-many-arguments,too-many-positional-arguments
 def send_message(
     instance_id: Union[list, int],

--- a/onadata/apps/messaging/tests/test_messaging_viewset.py
+++ b/onadata/apps/messaging/tests/test_messaging_viewset.py
@@ -2,17 +2,24 @@
 """
 Tests Messaging app viewsets.
 """
+
 from __future__ import unicode_literals
 
 from builtins import str as text
+from datetime import timedelta
 
-from actstream.models import Action
 from django.core.cache import cache
 from django.test import TestCase
 from django.test.utils import override_settings
+from django.utils import timezone
+from django.utils.dateparse import parse_datetime
+
+from actstream.models import Action
+from actstream.signals import action
 from guardian.shortcuts import assign_perm
 from rest_framework.test import APIRequestFactory, force_authenticate
 
+from onadata.apps.messaging.constants import EXPORT_CREATED, SUBMISSION_CREATED
 from onadata.apps.messaging.tests.test_base import _create_user
 from onadata.apps.messaging.viewsets import MessagingViewSet
 
@@ -654,3 +661,210 @@ class TestMessagingViewSet(TestCase):
         response = view(request=request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 2)
+
+    def test_group_by_user_and_verb_returns_counts(self):
+        """
+        group_by=user&group_by=verb returns per-(user, verb) counts.
+        """
+        user = _create_user()
+        for _ in range(2):
+            action.send(user, verb=EXPORT_CREATED, target=user)
+        for _ in range(3):
+            action.send(user, verb=SUBMISSION_CREATED, target=user)
+
+        view = MessagingViewSet.as_view({"get": "list"})
+        request = self.factory.get(
+            "/messaging",
+            {
+                "target_type": "user",
+                "target_id": user.pk,
+                "group_by": ["user", "verb"],
+            },
+        )
+        force_authenticate(request, user=user)
+        response = view(request=request)
+        self.assertEqual(response.status_code, 200, response.data)
+
+        counts = {(row["user"], row["verb"]): row["count"] for row in response.data}
+        self.assertEqual(counts[(user.username, EXPORT_CREATED)], 2)
+        self.assertEqual(counts[(user.username, SUBMISSION_CREATED)], 3)
+        for row in response.data:
+            self.assertIn("latest_timestamp", row)
+
+    def test_group_by_verb_orders_by_recent_activity(self):
+        """
+        Grouped rows are ordered most-recent-activity first.
+        """
+        user = _create_user()
+        older = timezone.now() - timedelta(days=2)
+        newer = timezone.now()
+        action.send(user, verb=EXPORT_CREATED, target=user, timestamp=older)
+        action.send(user, verb=SUBMISSION_CREATED, target=user, timestamp=newer)
+
+        view = MessagingViewSet.as_view({"get": "list"})
+        request = self.factory.get(
+            "/messaging",
+            {"target_type": "user", "target_id": user.pk, "group_by": "verb"},
+        )
+        force_authenticate(request, user=user)
+        response = view(request=request)
+        self.assertEqual(response.status_code, 200, response.data)
+
+        verbs_in_order = [row["verb"] for row in response.data]
+        self.assertEqual(verbs_in_order, [SUBMISSION_CREATED, EXPORT_CREATED])
+
+    def test_group_by_verb_latest_timestamp_is_newest(self):
+        """
+        A group's latest_timestamp equals its newest action's timestamp.
+        """
+        user = _create_user()
+        older = timezone.now() - timedelta(days=1)
+        newest = timezone.now()
+        action.send(user, verb=EXPORT_CREATED, target=user, timestamp=older)
+        action.send(user, verb=EXPORT_CREATED, target=user, timestamp=newest)
+
+        view = MessagingViewSet.as_view({"get": "list"})
+        request = self.factory.get(
+            "/messaging",
+            {"target_type": "user", "target_id": user.pk, "group_by": "verb"},
+        )
+        force_authenticate(request, user=user)
+        response = view(request=request)
+        self.assertEqual(response.status_code, 200, response.data)
+
+        row = response.data[0]
+        self.assertEqual(row["count"], 2)
+        self.assertEqual(parse_datetime(row["latest_timestamp"]), newest)
+
+    def test_group_by_verb_null_user_for_unresolvable_actor(self):
+        """
+        A group whose actor id no longer resolves to a user is returned with
+        user null and the row is retained.
+        """
+        target_user = _create_user("target")
+        actor_user = _create_user("ghost")
+        action.send(actor_user, verb=SUBMISSION_CREATED, target=target_user)
+        # Simulate a dangling actor reference (e.g. data left behind by a raw
+        # delete) without triggering actstream's GenericRelation cascade, which
+        # deleting the user would otherwise use to remove the action too.
+        Action.objects.filter(actor_object_id=actor_user.pk).update(
+            actor_object_id=9999999
+        )
+
+        view = MessagingViewSet.as_view({"get": "list"})
+        request = self.factory.get(
+            "/messaging",
+            {
+                "target_type": "user",
+                "target_id": target_user.pk,
+                "group_by": ["user", "verb"],
+            },
+        )
+        force_authenticate(request, user=target_user)
+        response = view(request=request)
+        self.assertEqual(response.status_code, 200, response.data)
+
+        self.assertEqual(len(response.data), 1)
+        row = response.data[0]
+        self.assertEqual(row["verb"], SUBMISSION_CREATED)
+        self.assertEqual(row["count"], 1)
+        self.assertIsNone(row["user"])
+
+    def test_group_by_user_only(self):
+        """
+        group_by=user groups by actor only, aggregating across verbs, and the
+        rows carry no verb field.
+        """
+        target_user = _create_user("target")
+        alice = _create_user("alice")
+        bob = _create_user("bob")
+        action.send(alice, verb=SUBMISSION_CREATED, target=target_user)
+        action.send(bob, verb=SUBMISSION_CREATED, target=target_user)
+        action.send(bob, verb=EXPORT_CREATED, target=target_user)
+
+        view = MessagingViewSet.as_view({"get": "list"})
+        request = self.factory.get(
+            "/messaging",
+            {"target_type": "user", "target_id": target_user.pk, "group_by": "user"},
+        )
+        force_authenticate(request, user=target_user)
+        response = view(request=request)
+        self.assertEqual(response.status_code, 200, response.data)
+
+        counts = {row["user"]: row["count"] for row in response.data}
+        self.assertEqual(counts["alice"], 1)
+        self.assertEqual(counts["bob"], 2)
+        for row in response.data:
+            self.assertNotIn("verb", row)
+
+    def test_group_by_validation(self):
+        """
+        group_by rejects unsupported values and still requires a target.
+        """
+        user = _create_user()
+        action.send(user, verb=SUBMISSION_CREATED, target=user)
+        view = MessagingViewSet.as_view({"get": "list"})
+
+        # an unsupported group_by value is rejected
+        request = self.factory.get(
+            "/messaging",
+            {"target_type": "user", "target_id": user.pk, "group_by": "actor"},
+        )
+        force_authenticate(request, user=user)
+        response = view(request=request)
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.data, {"detail": "Unsupported group_by value 'actor'"}
+        )
+
+        # an unsupported value alongside a valid one is still rejected
+        request = self.factory.get(
+            "/messaging",
+            {
+                "target_type": "user",
+                "target_id": user.pk,
+                "group_by": ["verb", "actor"],
+            },
+        )
+        force_authenticate(request, user=user)
+        response = view(request=request)
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.data, {"detail": "Unsupported group_by value 'actor'"}
+        )
+
+        # grouped mode still requires a target (contract unchanged)
+        request = self.factory.get("/messaging", {"group_by": "verb"})
+        force_authenticate(request, user=user)
+        response = view(request=request)
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.data, {"detail": "Parameter 'target_type' is missing."}
+        )
+
+    def test_group_by_verb_only(self):
+        """
+        group_by=verb groups by verb only, aggregating across actors, and the
+        rows carry no user field.
+        """
+        target_user = _create_user("target")
+        alice = _create_user("alice")
+        bob = _create_user("bob")
+        action.send(alice, verb=SUBMISSION_CREATED, target=target_user)
+        action.send(bob, verb=SUBMISSION_CREATED, target=target_user)
+        action.send(bob, verb=EXPORT_CREATED, target=target_user)
+
+        view = MessagingViewSet.as_view({"get": "list"})
+        request = self.factory.get(
+            "/messaging",
+            {"target_type": "user", "target_id": target_user.pk, "group_by": "verb"},
+        )
+        force_authenticate(request, user=target_user)
+        response = view(request=request)
+        self.assertEqual(response.status_code, 200, response.data)
+
+        counts = {row["verb"]: row["count"] for row in response.data}
+        self.assertEqual(counts[SUBMISSION_CREATED], 2)
+        self.assertEqual(counts[EXPORT_CREATED], 1)
+        for row in response.data:
+            self.assertNotIn("user", row)

--- a/onadata/apps/messaging/tests/test_messaging_viewset.py
+++ b/onadata/apps/messaging/tests/test_messaging_viewset.py
@@ -6,7 +6,7 @@ Tests Messaging app viewsets.
 from __future__ import unicode_literals
 
 from builtins import str as text
-from datetime import timedelta
+from datetime import datetime, timedelta, timezone as dt_timezone
 
 from django.core.cache import cache
 from django.test import TestCase
@@ -868,3 +868,154 @@ class TestMessagingViewSet(TestCase):
         self.assertEqual(counts[EXPORT_CREATED], 1)
         for row in response.data:
             self.assertNotIn("user", row)
+
+    def test_group_by_day_returns_period_buckets(self):
+        """
+        group_by=day returns one row per UTC day carrying period_start,
+        earliest_timestamp and latest_timestamp, ordered most-recent day first.
+        """
+        user = _create_user()
+        day_one = datetime(2026, 3, 10, 12, 0, tzinfo=dt_timezone.utc)
+        day_two = datetime(2026, 3, 12, 9, 0, tzinfo=dt_timezone.utc)
+        action.send(user, verb=SUBMISSION_CREATED, target=user, timestamp=day_one)
+        action.send(
+            user,
+            verb=SUBMISSION_CREATED,
+            target=user,
+            timestamp=day_one + timedelta(hours=3),
+        )
+        action.send(user, verb=SUBMISSION_CREATED, target=user, timestamp=day_two)
+
+        view = MessagingViewSet.as_view({"get": "list"})
+        request = self.factory.get(
+            "/messaging",
+            {"target_type": "user", "target_id": user.pk, "group_by": "day"},
+        )
+        force_authenticate(request, user=user)
+        response = view(request=request)
+        self.assertEqual(response.status_code, 200, response.data)
+
+        self.assertEqual(len(response.data), 2)
+        periods = [parse_datetime(row["period_start"]) for row in response.data]
+        self.assertEqual(
+            periods,
+            [
+                datetime(2026, 3, 12, tzinfo=dt_timezone.utc),
+                datetime(2026, 3, 10, tzinfo=dt_timezone.utc),
+            ],
+        )
+
+        newest_day = response.data[0]
+        self.assertEqual(newest_day["count"], 1)
+        self.assertEqual(
+            parse_datetime(newest_day["latest_timestamp"]), day_two
+        )
+
+        oldest_day = response.data[1]
+        self.assertEqual(oldest_day["count"], 2)
+        self.assertEqual(
+            parse_datetime(oldest_day["earliest_timestamp"]), day_one
+        )
+        self.assertEqual(
+            parse_datetime(oldest_day["latest_timestamp"]),
+            day_one + timedelta(hours=3),
+        )
+
+    def test_group_by_day_buckets_boundaries_in_utc(self):
+        """
+        Day boundaries are computed in UTC, not the server timezone. Two events
+        on the same UTC day but different America/New_York days fall in one
+        bucket whose period_start is UTC midnight.
+        """
+        user = _create_user()
+        # Both on 2026-03-15 UTC; in America/New_York (EDT, UTC-4) the first is
+        # 2026-03-14 21:00 and the second is 2026-03-15 18:00 - different local
+        # days that must still collapse into a single UTC-day bucket.
+        early = datetime(2026, 3, 15, 1, 0, tzinfo=dt_timezone.utc)
+        late = datetime(2026, 3, 15, 22, 0, tzinfo=dt_timezone.utc)
+        action.send(user, verb=SUBMISSION_CREATED, target=user, timestamp=early)
+        action.send(user, verb=SUBMISSION_CREATED, target=user, timestamp=late)
+
+        view = MessagingViewSet.as_view({"get": "list"})
+        request = self.factory.get(
+            "/messaging",
+            {"target_type": "user", "target_id": user.pk, "group_by": "day"},
+        )
+        force_authenticate(request, user=user)
+        response = view(request=request)
+        self.assertEqual(response.status_code, 200, response.data)
+
+        self.assertEqual(len(response.data), 1)
+        row = response.data[0]
+        self.assertEqual(row["count"], 2)
+        self.assertEqual(
+            parse_datetime(row["period_start"]),
+            datetime(2026, 3, 15, tzinfo=dt_timezone.utc),
+        )
+
+    def test_group_by_rejects_multiple_time_buckets(self):
+        """
+        Combining more than one time bucket in a single request is rejected.
+        """
+        user = _create_user()
+        action.send(user, verb=SUBMISSION_CREATED, target=user)
+
+        view = MessagingViewSet.as_view({"get": "list"})
+        request = self.factory.get(
+            "/messaging",
+            {
+                "target_type": "user",
+                "target_id": user.pk,
+                "group_by": ["day", "hour"],
+            },
+        )
+        force_authenticate(request, user=user)
+        response = view(request=request)
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.data,
+            {"detail": "Only one time bucket may be combined per group_by request"},
+        )
+
+    def test_group_by_day_user_and_verb_composes(self):
+        """
+        A time bucket composes with user and verb: rows are per
+        (day, user, verb) and carry all requested dimensions.
+        """
+        target_user = _create_user("target")
+        bob = _create_user("bob")
+        sunday = datetime(2026, 3, 15, 10, 0, tzinfo=dt_timezone.utc)
+        monday = datetime(2026, 3, 16, 10, 0, tzinfo=dt_timezone.utc)
+        # Bob: two submissions on Sunday, one on Monday.
+        action.send(bob, verb=SUBMISSION_CREATED, target=target_user, timestamp=sunday)
+        action.send(
+            bob,
+            verb=SUBMISSION_CREATED,
+            target=target_user,
+            timestamp=sunday + timedelta(hours=2),
+        )
+        action.send(bob, verb=SUBMISSION_CREATED, target=target_user, timestamp=monday)
+
+        view = MessagingViewSet.as_view({"get": "list"})
+        request = self.factory.get(
+            "/messaging",
+            {
+                "target_type": "user",
+                "target_id": target_user.pk,
+                "group_by": ["day", "user", "verb"],
+            },
+        )
+        force_authenticate(request, user=target_user)
+        response = view(request=request)
+        self.assertEqual(response.status_code, 200, response.data)
+
+        counts = {
+            (parse_datetime(row["period_start"]), row["user"], row["verb"]): row[
+                "count"
+            ]
+            for row in response.data
+        }
+        sunday_bucket = datetime(2026, 3, 15, tzinfo=dt_timezone.utc)
+        monday_bucket = datetime(2026, 3, 16, tzinfo=dt_timezone.utc)
+        self.assertEqual(counts[(sunday_bucket, "bob", SUBMISSION_CREATED)], 2)
+        self.assertEqual(counts[(monday_bucket, "bob", SUBMISSION_CREATED)], 1)

--- a/onadata/apps/messaging/viewsets.py
+++ b/onadata/apps/messaging/viewsets.py
@@ -5,9 +5,18 @@ Messaging /messaging viewsets.
 
 from __future__ import unicode_literals
 
+from datetime import timezone
+
 from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
-from django.db.models import Count, Max
+from django.db.models import Count, Max, Min
+from django.db.models.functions import (
+    TruncDay,
+    TruncHour,
+    TruncMonth,
+    TruncWeek,
+    TruncYear,
+)
 from django.utils.decorators import method_decorator
 from django.views.decorators.cache import cache_page
 
@@ -62,6 +71,17 @@ class MessagingViewSet(
     # Action column they aggregate on.
     GROUP_BY_FIELDS = {"user": "actor_object_id", "verb": "verb"}
 
+    # Time buckets the ``group_by`` param accepts, mapped to the database
+    # function that truncates ``timestamp`` to the bucket boundary. At most one
+    # may be combined per request. Boundaries are computed in UTC.
+    TIME_BUCKETS = {
+        "hour": TruncHour,
+        "day": TruncDay,
+        "week": TruncWeek,
+        "month": TruncMonth,
+        "year": TruncYear,
+    }
+
     def list(self, request, *args, **kwargs):
         requested = request.query_params.getlist("group_by")
 
@@ -69,32 +89,53 @@ class MessagingViewSet(
             return super().list(request, *args, **kwargs)
 
         for value in requested:
-            if value not in self.GROUP_BY_FIELDS:
+            if value not in self.GROUP_BY_FIELDS and value not in self.TIME_BUCKETS:
                 raise exceptions.ParseError(f"Unsupported group_by value '{value}'")
+
+        time_buckets = [value for value in requested if value in self.TIME_BUCKETS]
+        if len(time_buckets) > 1:
+            raise exceptions.ParseError(
+                "Only one time bucket may be combined per group_by request"
+            )
+        time_bucket = time_buckets[0] if time_buckets else None
 
         # Canonical, de-duplicated dimension list (order is stable regardless
         # of the order the params were supplied in).
         dimensions = [dim for dim in self.GROUP_BY_FIELDS if dim in requested]
         db_fields = [self.GROUP_BY_FIELDS[dim] for dim in dimensions]
 
+        bucket_values = {}
+        if time_bucket:
+            # Truncate in UTC explicitly; the default would bucket in the
+            # server's TIME_ZONE, shifting day/hour boundaries.
+            bucket_values["period_start"] = self.TIME_BUCKETS[time_bucket](
+                "timestamp", tzinfo=timezone.utc
+            )
+
         user_content_type = ContentType.objects.get_for_model(User)
         queryset = (
             self.filter_queryset(self.get_queryset())
             .filter(actor_content_type=user_content_type)
-            .values(*db_fields)
-            .annotate(count=Count("id"), latest=Max("timestamp"))
+            .values(*db_fields, **bucket_values)
+            .annotate(
+                count=Count("id"),
+                earliest=Min("timestamp"),
+                latest=Max("timestamp"),
+            )
             .order_by("-latest")
         )
         page = self.paginate_queryset(queryset)
 
-        rows = self._build_grouped_rows(page, dimensions)
+        rows = self._build_grouped_rows(page, dimensions, time_bucket)
         serializer = GroupedActivitySerializer(
-            rows, many=True, context={"dimensions": dimensions}
+            rows,
+            many=True,
+            context={"dimensions": dimensions, "time_bucket": time_bucket},
         )
 
         return self.get_paginated_response(serializer.data)
 
-    def _build_grouped_rows(self, page, dimensions):
+    def _build_grouped_rows(self, page, dimensions, time_bucket):
         """Shape aggregate rows into the requested grouping dimensions."""
         usernames = {}
         if "user" in dimensions:
@@ -108,7 +149,13 @@ class MessagingViewSet(
 
         rows = []
         for row in page:
-            item = {"count": row["count"], "latest_timestamp": row["latest"]}
+            item = {
+                "count": row["count"],
+                "earliest_timestamp": row["earliest"],
+                "latest_timestamp": row["latest"],
+            }
+            if time_bucket:
+                item["period_start"] = row["period_start"]
             if "user" in dimensions:
                 item["user"] = usernames.get(int(row["actor_object_id"]))
             if "verb" in dimensions:

--- a/onadata/apps/messaging/viewsets.py
+++ b/onadata/apps/messaging/viewsets.py
@@ -5,12 +5,15 @@ Messaging /messaging viewsets.
 
 from __future__ import unicode_literals
 
+from django.contrib.auth import get_user_model
+from django.contrib.contenttypes.models import ContentType
+from django.db.models import Count, Max
 from django.utils.decorators import method_decorator
 from django.views.decorators.cache import cache_page
 
 from actstream.models import Action
 from django_filters.rest_framework import DjangoFilterBackend
-from rest_framework import mixins, viewsets
+from rest_framework import exceptions, mixins, viewsets
 from rest_framework.permissions import IsAuthenticated
 
 from onadata.apps.messaging.constants import MESSAGE_VERBS
@@ -21,8 +24,13 @@ from onadata.apps.messaging.filters import (
     UserFilterBackend,
 )
 from onadata.apps.messaging.permissions import TargetObjectPermissions
-from onadata.apps.messaging.serializers import MessageSerializer
+from onadata.apps.messaging.serializers import (
+    GroupedActivitySerializer,
+    MessageSerializer,
+)
 from onadata.libs.pagination import StandardPageNumberPagination
+
+User = get_user_model()
 
 
 # pylint: disable=too-many-ancestors
@@ -49,3 +57,62 @@ class MessagingViewSet(
     )
     filterset_class = ActionFilterSet
     pagination_class = StandardPageNumberPagination
+
+    # Grouping dimensions the ``group_by`` param accepts, mapped to the
+    # Action column they aggregate on.
+    GROUP_BY_FIELDS = {"user": "actor_object_id", "verb": "verb"}
+
+    def list(self, request, *args, **kwargs):
+        requested = request.query_params.getlist("group_by")
+
+        if not requested:
+            return super().list(request, *args, **kwargs)
+
+        for value in requested:
+            if value not in self.GROUP_BY_FIELDS:
+                raise exceptions.ParseError(f"Unsupported group_by value '{value}'")
+
+        # Canonical, de-duplicated dimension list (order is stable regardless
+        # of the order the params were supplied in).
+        dimensions = [dim for dim in self.GROUP_BY_FIELDS if dim in requested]
+        db_fields = [self.GROUP_BY_FIELDS[dim] for dim in dimensions]
+
+        user_content_type = ContentType.objects.get_for_model(User)
+        queryset = (
+            self.filter_queryset(self.get_queryset())
+            .filter(actor_content_type=user_content_type)
+            .values(*db_fields)
+            .annotate(count=Count("id"), latest=Max("timestamp"))
+            .order_by("-latest")
+        )
+        page = self.paginate_queryset(queryset)
+
+        rows = self._build_grouped_rows(page, dimensions)
+        serializer = GroupedActivitySerializer(
+            rows, many=True, context={"dimensions": dimensions}
+        )
+
+        return self.get_paginated_response(serializer.data)
+
+    def _build_grouped_rows(self, page, dimensions):
+        """Shape aggregate rows into the requested grouping dimensions."""
+        usernames = {}
+        if "user" in dimensions:
+            # Resolve actor ids to usernames for the current page in a single
+            # query; a row whose actor id no longer resolves to a user (e.g. a
+            # dangling reference) keeps a null user.
+            actor_ids = {row["actor_object_id"] for row in page}
+            usernames = dict(
+                User.objects.filter(pk__in=actor_ids).values_list("pk", "username")
+            )
+
+        rows = []
+        for row in page:
+            item = {"count": row["count"], "latest_timestamp": row["latest"]}
+            if "user" in dimensions:
+                item["user"] = usernames.get(int(row["actor_object_id"]))
+            if "verb" in dimensions:
+                item["verb"] = row["verb"]
+            rows.append(item)
+
+        return rows

--- a/onadata/apps/messaging/viewsets.py
+++ b/onadata/apps/messaging/viewsets.py
@@ -82,6 +82,7 @@ class MessagingViewSet(
         "year": TruncYear,
     }
 
+    # pylint: disable=too-many-locals
     def list(self, request, *args, **kwargs):
         requested = request.query_params.getlist("group_by")
 


### PR DESCRIPTION
### Changes / Features implemented

Add support for grouping by user or verb or both on endpoint GET /api/v1/messaging

### Steps taken to verify this change does what is intended

- [x] Added tests
- [x]  QA

### Side effects of implementing this change

None

**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  - [x] Updated documentation

Closes #

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/onaio/codesmith/onadata/pr/3159"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785592541&installation_id=135786473&pr_number=3159&repository=onaio%2Fonadata&return_to=https%3A%2F%2Fgithub.com%2Fonaio%2Fonadata%2Fpull%2F3159&signature=6db7e06db4778f06b98a52a533a6a2b0651ca55f5a8acceebe754bf1fbd5e118"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->