### PR TITLE
fix: project permission propagation to KPI

### DIFF
--- a/onadata/libs/tests/utils/test_project_utils.py
+++ b/onadata/libs/tests/utils/test_project_utils.py
@@ -196,14 +196,14 @@ class TestProjectUtils(TestBase):
 
     @override_settings(KPI_INTERNAL_SERVICE_URL="http://kpi.example.com")
     @patch("onadata.libs.utils.project_utils.requests.session")
-    def test_propagate_project_permissions_full_collaborator_set(self, mock_session):
+    def test_propagate_project_permissions_full_admin_set(self, mock_session):
         """
-        `propagate_project_permissions` sends the complete set of
-        manager/owner collaborators to the KPI bulk permission-assignments
-        endpoint, including collaborators already assigned on KPI
+        `propagate_project_permissions` sends the complete set of project
+        admins (managers/owners) to the KPI bulk permission-assignments
+        endpoint, including admins already assigned on KPI
 
         The bulk endpoint replaces the asset's assignments with the posted
-        set; a collaborator left out of the payload loses their permissions.
+        set; an admin left out of the payload loses their permissions.
         """
         self._publish_transportation_form()
         MetaData.published_by_formbuilder(self.xform, "True")

--- a/onadata/libs/tests/utils/test_project_utils.py
+++ b/onadata/libs/tests/utils/test_project_utils.py
@@ -3,15 +3,17 @@
 Test onadata.libs.utils.project_utils
 """
 
-from unittest.mock import call, MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 from django.test.utils import override_settings
+
+from guardian.shortcuts import get_perms
 from kombu.exceptions import OperationalError
 from requests import Response
-from guardian.shortcuts import get_perms
 
 from onadata.apps.api.models import Team
 from onadata.apps.logger.models import Project
+from onadata.apps.main.models import MetaData
 from onadata.apps.main.tests.test_base import TestBase
 from onadata.libs.permissions import (
     DataEntryRole,
@@ -20,7 +22,10 @@ from onadata.libs.permissions import (
     set_project_perms_to_object,
 )
 from onadata.libs.utils.project_utils import (
+    ExternalServiceRequestError,
     assign_change_asset_permission,
+    propagate_project_permissions,
+    propagate_project_permissions_async,
     retrieve_asset_permissions,
 )
 from onadata.libs.utils.xform_utils import (
@@ -152,6 +157,118 @@ class TestProjectUtils(TestBase):
         self.assertEqual(
             ret, {"bob": ["http://example.com/api/v2/permission-assignments/some_uuid"]}
         )
+
+    def test_retrieve_asset_permission_special_usernames(self):
+        """
+        `retrieve_asset_permissions` returns full usernames for users
+        whose names contain characters such as ., -, + and @
+        """
+        session_mock = MagicMock()
+        asset_id = "some_id"
+        service_url = "http://example.com"
+        resp = Response()
+        resp.status_code = 200
+        # pylint: disable=protected-access
+        resp._content = (
+            b'[{"user": "http://example.com/api/v2/users/john.doe/", "url": '
+            b'"http://example.com/api/v2/permission-assignments/uuid1/"},'
+            b'{"user": "http://example.com/api/v2/users/mary-jane/", "url": '
+            b'"http://example.com/api/v2/permission-assignments/uuid2/"},'
+            b'{"user": "http://example.com/api/v2/users/user+1@example.com/", "url": '
+            b'"http://example.com/api/v2/permission-assignments/uuid3/"}]'
+        )
+        session_mock.get.return_value = resp
+
+        ret = retrieve_asset_permissions(service_url, asset_id, session_mock)
+
+        self.assertEqual(
+            ret,
+            {
+                "john.doe": ["http://example.com/api/v2/permission-assignments/uuid1/"],
+                "mary-jane": [
+                    "http://example.com/api/v2/permission-assignments/uuid2/"
+                ],
+                "user+1@example.com": [
+                    "http://example.com/api/v2/permission-assignments/uuid3/"
+                ],
+            },
+        )
+
+    @override_settings(KPI_INTERNAL_SERVICE_URL="http://kpi.example.com")
+    @patch("onadata.libs.utils.project_utils.requests.session")
+    def test_propagate_project_permissions_full_collaborator_set(self, mock_session):
+        """
+        `propagate_project_permissions` sends the complete set of
+        manager/owner collaborators to the KPI bulk permission-assignments
+        endpoint, including collaborators already assigned on KPI
+
+        The bulk endpoint replaces the asset's assignments with the posted
+        set; a collaborator left out of the payload loses their permissions.
+        """
+        self._publish_transportation_form()
+        MetaData.published_by_formbuilder(self.xform, "True")
+        alice = self._create_user("alice", "alice", create_profile=True)
+        carol = self._create_user("carol", "carol", create_profile=True)
+        ManagerRole.add(alice, self.project)
+        ManagerRole.add(carol, self.project)
+
+        session_mock = mock_session.return_value
+        # On KPI, the asset owner and alice are already assigned
+        get_resp = Response()
+        get_resp.status_code = 200
+        # pylint: disable=protected-access
+        get_resp._content = (
+            b'[{"user": "http://kpi.example.com/api/v2/users/bob/", "url": '
+            b'"http://kpi.example.com/api/v2/permission-assignments/uuid1/"},'
+            b'{"user": "http://kpi.example.com/api/v2/users/alice/", "url": '
+            b'"http://kpi.example.com/api/v2/permission-assignments/uuid2/"}]'
+        )
+        session_mock.get.return_value = get_resp
+        post_resp = Response()
+        post_resp.status_code = 200
+        session_mock.post.return_value = post_resp
+
+        propagate_project_permissions(self.project)
+
+        session_mock.post.assert_called_once()
+        args, kwargs = session_mock.post.call_args
+        self.assertEqual(
+            args[0],
+            f"http://kpi.example.com/api/v2/assets/{self.xform.id_string}"
+            "/permission-assignments/bulk/",
+        )
+        self.assertCountEqual(
+            kwargs["json"],
+            [
+                {
+                    "user": "http://kpi.example.com/api/v2/users/alice/",
+                    "permission": (
+                        "http://kpi.example.com/api/v2/permissions/change_asset/"
+                    ),
+                },
+                {
+                    "user": "http://kpi.example.com/api/v2/users/carol/",
+                    "permission": (
+                        "http://kpi.example.com/api/v2/permissions/change_asset/"
+                    ),
+                },
+            ],
+        )
+
+    @patch("onadata.libs.utils.project_utils.propagate_project_permissions")
+    def test_propagate_project_permissions_async_retry(self, mock_propagate):
+        """
+        `propagate_project_permissions_async` retries when the KPI request
+        fails with an `ExternalServiceRequestError`
+        """
+        self._publish_transportation_form()
+        error = ExternalServiceRequestError("KPI is unreachable")
+        mock_propagate.side_effect = error
+
+        with patch.object(propagate_project_permissions_async, "retry") as mock_retry:
+            propagate_project_permissions_async(self.project.pk)
+
+        mock_retry.assert_called_once_with(exc=error, countdown=0)
 
     @override_settings(CELERY_TASK_ALWAYS_EAGER=True)
     @patch(

--- a/onadata/libs/utils/project_utils.py
+++ b/onadata/libs/utils/project_utils.py
@@ -20,14 +20,8 @@ from requests.sessions import HTTPAdapter
 from onadata.apps.api.models.team import Team
 from onadata.apps.logger.models.project import Project
 from onadata.celeryapp import app
-from onadata.libs.permissions import (
-    get_role,
-    is_organization,
-)
-from onadata.libs.utils.common_tags import (
-    API_TOKEN,
-    ONADATA_KOBOCAT_AUTH_HEADER,
-)
+from onadata.libs.permissions import get_role, is_organization
+from onadata.libs.utils.common_tags import API_TOKEN, ONADATA_KOBOCAT_AUTH_HEADER
 from onadata.libs.utils.common_tools import report_exception
 from onadata.libs.utils.model_tools import queryset_iterator
 
@@ -82,7 +76,7 @@ def retrieve_asset_permissions(
     data = resp.json()
     for permission in data:
         user = permission.get("user")
-        user = re.findall(r"\S\/api\/v2\/users\/(\w+)", user)[0]
+        user = re.search(r"/api/v2/users/([^/]+)", user).group(1)
 
         if user not in ret:
             ret[user] = []
@@ -128,7 +122,7 @@ def propagate_project_permissions_async(self, project_id: int):
             if self.request.retries > 3:
                 msg = f"Failed to propagate permissions for Project {project.pk}"
                 report_exception(msg, exc, sys.exc_info())
-            self.retry(exc=exc, countdown=60 * self.requests.retries)
+            self.retry(exc=exc, countdown=60 * self.request.retries)
 
 
 def propagate_project_permissions(
@@ -198,32 +192,18 @@ def propagate_project_permissions(
                     }
                 )
 
-            assigned_permissions = retrieve_asset_permissions(
-                service_url, asset.id_string, session
+            # The bulk endpoint is declarative: KPI replaces the asset's
+            # assignments with the posted set, removing users left out of
+            # the payload. Always send the complete desired state. The
+            # asset owner is excluded because KPI rejects payloads that
+            # assign permissions to the owner.
+            assign_change_asset_permission(
+                service_url,
+                asset.id_string,
+                [
+                    username
+                    for username in collaborators
+                    if username != asset.created_by.username
+                ],
+                session,
             )
-            new_users = [
-                username
-                for username in collaborators
-                if username not in assigned_permissions
-            ]
-            removed_permissions = [
-                (username, permissions)
-                for username, permissions in assigned_permissions.items()
-                if username not in collaborators
-            ]
-
-            # Unassign permissions granted to users who no longer have permissions
-            for _, permission_assignments in removed_permissions:
-                _ = [
-                    session.delete(permission_assignment)
-                    for permission_assignment in permission_assignments
-                ]
-
-            # Assign permissions to the new users
-            if new_users:
-                assign_change_asset_permission(
-                    service_url,
-                    asset.id_string,
-                    new_users,
-                    session,
-                )

--- a/onadata/libs/utils/project_utils.py
+++ b/onadata/libs/utils/project_utils.py
@@ -194,9 +194,13 @@ def propagate_project_permissions(
 
             # The bulk endpoint is declarative: KPI replaces the asset's
             # assignments with the posted set, removing users left out of
-            # the payload. Always send the complete desired state. The
-            # asset owner is excluded because KPI rejects payloads that
-            # assign permissions to the owner.
+            # the payload. Always send the complete desired state.
+            # `created_by` is the user who deployed the form from the
+            # Formbuilder and is therefore the asset owner on KPI — unlike
+            # `xform.user`, which is the form owner on Onadata and may be
+            # an organization. The KPI asset owner is excluded because KPI
+            # rejects payloads that assign permissions to the owner; owners
+            # hold all permissions implicitly.
             assign_change_asset_permission(
                 service_url,
                 asset.id_string,

--- a/onadata/libs/utils/project_utils.py
+++ b/onadata/libs/utils/project_utils.py
@@ -151,8 +151,8 @@ def propagate_project_permissions(
         if headers:
             session.headers.update(headers)
 
-        # Retrieve users who have access to the project
-        collaborators: List[str] = [
+        # Retrieve users who administer the project
+        admins: List[str] = [
             username
             for username, data in get_project_users(project).items()
             if not data.get("is_org") and data.get("role") in ["manager", "owner"]
@@ -167,8 +167,8 @@ def propagate_project_permissions(
                     ~Q(username=project.organization.username)
                 ).values_list("username", flat=True)
             )
-            collaborators += owners_team
-            collaborators = list(set(collaborators))
+            admins += owners_team
+            admins = list(set(admins))
 
         # Propagate permissions for XForms that were published by
         # Formbuilder
@@ -202,7 +202,7 @@ def propagate_project_permissions(
                 asset.id_string,
                 [
                     username
-                    for username in collaborators
+                    for username in admins
                     if username != asset.created_by.username
                 ],
                 session,


### PR DESCRIPTION
### Changes / Features implemented

- `propagate_project_permissions` now sends the complete desired collaborator set (all manager/owner collaborators except the asset owner) to the KPI bulk permission-assignments endpoint on every sync. The endpoint is declarative — KPI replaces the asset's assignments with the posted set — so the previous delta-only payload caused already-assigned collaborators to lose access on each propagation. Stale users are now removed by KPI itself, so the manual `GET` + per-assignment `DELETE` loop is gone.
- Fixed username parsing in `retrieve_asset_permissions`: the `\w+` pattern truncated usernames containing `.`, `-`, `+` or `@` (e.g. `john.doe` → `john`), which made those collaborators look stale and got their assignments deleted. The full URL path segment is now captured.
- Fixed `AttributeError` in `propagate_project_permissions_async`'s retry path (`self.requests.retries` → `self.request.retries`), so failed propagations are actually retried.

### Steps taken to verify this change does what is intended

- [x] Added tests

### Side effects of implementing this change

None

**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  - [ ] Updated documentation

Closes #3160

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/onaio/codesmith/onadata/pr/3161"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785939202&installation_id=135786473&pr_number=3161&repository=onaio%2Fonadata&return_to=https%3A%2F%2Fgithub.com%2Fonaio%2Fonadata%2Fpull%2F3161&signature=6b5a7292d7e9c5f807f041d8421c90ab8cf9371219a8e88568512dbd27545e22"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->