### PR TITLE
fix(kpi): resolve asset uid from source metadata when propagating permissions

### DIFF
--- a/onadata/libs/tests/utils/test_project_utils.py
+++ b/onadata/libs/tests/utils/test_project_utils.py
@@ -24,6 +24,7 @@ from onadata.libs.permissions import (
 from onadata.libs.utils.project_utils import (
     ExternalServiceRequestError,
     assign_change_asset_permission,
+    get_kpi_asset_uid,
     propagate_project_permissions,
     propagate_project_permissions_async,
     retrieve_asset_permissions,
@@ -255,6 +256,50 @@ class TestProjectUtils(TestBase):
             ],
         )
 
+    @override_settings(KPI_INTERNAL_SERVICE_URL="http://kpi.example.com")
+    @patch("onadata.libs.utils.project_utils.requests.session")
+    def test_propagate_project_permissions_source_metadata(self, mock_session):
+        """
+        `propagate_project_permissions` propagates permissions for a form
+        published on Onadata then edited on the Formbuilder
+
+        Such forms have no `published_by_formbuilder` metadata; the link to
+        the KPI asset is the `source` metadata and the asset uid is parsed
+        from its URL instead of using the XForm `id_string`.
+        """
+        self._publish_transportation_form()
+        MetaData.source(
+            self.xform, "http://kpi.example.com/assets/aTestAssetUid123.json"
+        )
+        alice = self._create_user("alice", "alice", create_profile=True)
+        ManagerRole.add(alice, self.project)
+
+        session_mock = mock_session.return_value
+        post_resp = Response()
+        post_resp.status_code = 200
+        session_mock.post.return_value = post_resp
+
+        propagate_project_permissions(self.project)
+
+        session_mock.post.assert_called_once()
+        args, kwargs = session_mock.post.call_args
+        self.assertEqual(
+            args[0],
+            "http://kpi.example.com/api/v2/assets/aTestAssetUid123"
+            "/permission-assignments/bulk/",
+        )
+        self.assertCountEqual(
+            kwargs["json"],
+            [
+                {
+                    "user": "http://kpi.example.com/api/v2/users/alice/",
+                    "permission": (
+                        "http://kpi.example.com/api/v2/permissions/change_asset/"
+                    ),
+                },
+            ],
+        )
+
     @patch("onadata.libs.utils.project_utils.propagate_project_permissions")
     def test_propagate_project_permissions_async_retry(self, mock_propagate):
         """
@@ -326,3 +371,62 @@ class SetProjectPermsToObjectTestCase(TestBase):
         set_project_perms_to_object(self.xform, self.project)
 
         self.assertTrue(OwnerRole.user_has_role(self.alice, self.xform))
+
+
+class GetKpiAssetUidTestCase(TestBase):
+    """Tests for get_kpi_asset_uid"""
+
+    def setUp(self):
+        super().setUp()
+        self._publish_transportation_form()
+
+    def test_source_metadata(self):
+        """Asset uid is parsed from the `source` metadata URL
+
+        A form published on Onadata then edited on the Formbuilder keeps
+        its original `id_string`; the KPI asset uid is only recorded in
+        the URL of its `source` metadata.
+        """
+        MetaData.source(
+            self.xform, "http://kpi.example.com/assets/aTestAssetUid123.json"
+        )
+
+        self.assertEqual(get_kpi_asset_uid(self.xform), "aTestAssetUid123")
+
+    def test_published_by_formbuilder(self):
+        """XForm `id_string` is returned for a form authored on the Formbuilder
+
+        Such forms are marked with `published_by_formbuilder` metadata and
+        their `id_string` matches the KPI asset uid.
+        """
+        MetaData.published_by_formbuilder(self.xform, "True")
+
+        self.assertEqual(get_kpi_asset_uid(self.xform), self.xform.id_string)
+
+    def test_source_metadata_priority(self):
+        """Asset uid from the `source` metadata takes priority over the
+        XForm `id_string` when a form has both `source` and
+        `published_by_formbuilder` metadata
+        """
+        MetaData.source(
+            self.xform, "http://kpi.example.com/assets/aTestAssetUid123.json"
+        )
+        MetaData.published_by_formbuilder(self.xform, "True")
+
+        self.assertEqual(get_kpi_asset_uid(self.xform), "aTestAssetUid123")
+
+    def test_source_metadata_not_kpi_asset_url(self):
+        """XForm `id_string` is returned when the `source` metadata is not
+        a KPI asset URL
+
+        The `source` data_type is also used for source documents attached
+        to a form; only a URL referencing a KPI asset records the uid.
+        """
+        MetaData.source(self.xform, "http://docs.example.com/manual.pdf")
+        MetaData.published_by_formbuilder(self.xform, "True")
+
+        self.assertEqual(get_kpi_asset_uid(self.xform), self.xform.id_string)
+
+    def test_no_formbuilder_counterpart(self):
+        """None is returned for a form that has no Formbuilder counterpart"""
+        self.assertIsNone(get_kpi_asset_uid(self.xform))

--- a/onadata/libs/utils/project_utils.py
+++ b/onadata/libs/utils/project_utils.py
@@ -57,6 +57,33 @@ def get_project_users(project):
     return ret
 
 
+def get_kpi_asset_uid(xform) -> Optional[str]:
+    """
+    Return the KPI asset uid for an XForm, or None if the form has no
+    Formbuilder counterpart
+
+    A form published on Onadata then edited on the Formbuilder keeps its
+    original `id_string`; the KPI asset uid is only recorded in the URL of
+    its `source` metadata. A form originally authored on the Formbuilder
+    has no `source` metadata, but its `id_string` matches the asset uid
+    and it is marked with `published_by_formbuilder` metadata.
+    """
+    source = xform.metadata_set.filter(data_type="source").first()
+
+    if source is not None:
+        match = re.search(r"/assets/([a-zA-Z0-9]+)", source.data_value or "")
+
+        if match is not None:
+            return match.group(1)
+
+    if xform.metadata_set.filter(
+        data_type="published_by_formbuilder", data_value=True
+    ).exists():
+        return xform.id_string
+
+    return None
+
+
 def retrieve_asset_permissions(
     service_url: str, asset_id: str, session: requests.Session
 ) -> Dict[str, List[str]]:
@@ -170,15 +197,11 @@ def propagate_project_permissions(
             admins += owners_team
             admins = list(set(admins))
 
-        # Propagate permissions for XForms that were published by
-        # Formbuilder
+        # Propagate permissions for XForms that exist on the Formbuilder
         for asset in project.xform_set.filter(deleted_at__isnull=True).iterator():
-            if (
-                asset.metadata_set.filter(
-                    data_type="published_by_formbuilder", data_value=True
-                ).count()
-                == 0
-            ):
+            asset_uid = get_kpi_asset_uid(asset)
+
+            if asset_uid is None:
                 continue
 
             if use_asset_owner_auth:
@@ -195,15 +218,15 @@ def propagate_project_permissions(
             # The bulk endpoint is declarative: KPI replaces the asset's
             # assignments with the posted set, removing users left out of
             # the payload. Always send the complete desired state.
-            # `created_by` is the user who deployed the form from the
-            # Formbuilder and is therefore the asset owner on KPI — unlike
-            # `xform.user`, which is the form owner on Onadata and may be
-            # an organization. The KPI asset owner is excluded because KPI
-            # rejects payloads that assign permissions to the owner; owners
-            # hold all permissions implicitly.
+            # For forms authored on the Formbuilder, `created_by` is the
+            # user who deployed the form and is therefore the asset owner
+            # on KPI — unlike `xform.user`, which is the form owner on
+            # Onadata and may be an organization. The KPI asset owner is
+            # excluded because KPI rejects payloads that assign permissions
+            # to the owner; owners hold all permissions implicitly.
             assign_change_asset_permission(
                 service_url,
-                asset.id_string,
+                asset_uid,
                 [
                     username
                     for username in admins


### PR DESCRIPTION
### Changes / Features implemented

Forms published on Onadata then edited on the KPI keep their original `id_string` and carry the asset link only in their source metadata — the permission request was previously made with the id_string as the asset uid, which does not resolve to the KPI asset. The request is now made with the uid parsed from their source metadata.

### Steps taken to verify this change does what is intended

- [x] Added tests

### Side effects of implementing this change

None

**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  - [ ] Updated documentation

Closes #3163