### PR TITLE
fix: don't mark __enketo_meta_username cookie HttpOnly

### DIFF
--- a/onadata/apps/api/tests/viewsets/test_xform_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_xform_viewset.py
@@ -2172,10 +2172,25 @@ class TestXFormViewSet(XFormViewSetBaseTestCase):
             ):
                 morsel = cookies[cookie_name]
                 self.assertTrue(morsel["secure"], f"{cookie_name} missing Secure flag")
-                self.assertTrue(
-                    morsel["httponly"], f"{cookie_name} missing HttpOnly flag"
-                )
                 self.assertEqual(morsel["samesite"], "Lax")
+
+            # The auth token and uid cookies are server-only, so HttpOnly.
+            for cookie_name in (
+                settings.ENKETO_META_UID_COOKIE,
+                settings.ENKETO_AUTH_COOKIE,
+            ):
+                self.assertTrue(
+                    cookies[cookie_name]["httponly"],
+                    f"{cookie_name} missing HttpOnly flag",
+                )
+
+            # __enketo_meta_username is read client-side by enketo-core
+            # (document.cookie) to populate the `username` form session
+            # metadata, so it must NOT be HttpOnly.
+            self.assertFalse(
+                cookies[settings.ENKETO_META_USERNAME_COOKIE]["httponly"],
+                "username cookie must not be HttpOnly",
+            )
 
     @patch("onadata.apps.api.viewsets.xform_viewset.XFormViewSet.list")
     def test_return_400_on_xlsform_error_on_list_action(self, mock_set_title):

--- a/onadata/apps/api/tools.py
+++ b/onadata/apps/api/tools.py
@@ -776,8 +776,16 @@ def set_enketo_signed_cookies(resp, username=None, json_web_token=None):
         enketo_meta_uid["domain"] = settings.ENKETO_AUTH_COOKIE_DOMAIN
         enketo["domain"] = settings.ENKETO_AUTH_COOKIE_DOMAIN
 
+    # The username cookie is read by client-side JS (enketo-core reads
+    # document.cookie) to populate the `username` form session metadata,
+    # so it must NOT be HttpOnly -- otherwise submissions record
+    # "username not found". It inherits max_age/domain from the uid cookie.
+    enketo_meta_username = {**enketo_meta_uid, "httponly": False}
+
     resp.set_signed_cookie(ENKETO_META_UID_COOKIE, username, **enketo_meta_uid)
-    resp.set_signed_cookie(ENKETO_META_USERNAME_COOKIE, username, **enketo_meta_uid)
+    resp.set_signed_cookie(
+        ENKETO_META_USERNAME_COOKIE, username, **enketo_meta_username
+    )
     resp.set_signed_cookie(ENKETO_AUTH_COOKIE, json_web_token, **enketo)
 
     return resp


### PR DESCRIPTION
## Problem

`set_enketo_signed_cookies()` set the `__enketo_meta_username` cookie using the same kwargs as the uid cookie, whose `httponly` comes from `SESSION_COOKIE_HTTPONLY` (default `True`).

That cookie is **meant to be read by client-side JavaScript**: enketo-core's `readCookie()` parses `document.cookie` (in `form-model.js` `createSession`) to populate the `username` form **session metadata** written into submissions. `HttpOnly` hides it from `document.cookie`, so the read returns nothing and enketo-core falls back to the literal string `username not found`.

This matches upstream enketo-express, which sets this cookie **without** `HttpOnly`; only the auth token is `HttpOnly`.

## Change

- `onadata/apps/api/tools.py` — give `__enketo_meta_username` its own kwargs with `httponly=False` (inheriting `max_age`/`domain` from the uid cookie). The auth token and uid cookies are unchanged and stay `HttpOnly`.
- `onadata/apps/api/tests/viewsets/test_xform_viewset.py` — `test_login_enketo_online_url_using_jwt` now asserts the auth/uid cookies are `HttpOnly` and the username cookie is **not**.

## Test plan

- [x] Updated `test_login_enketo_online_url_using_jwt` assertions
- [ ] CI: `test_login_enketo_online_url_using_jwt` (full Django test env/DB required; not run locally)

## Related PRs (same fix in sibling services)

- onaio/zebra — Clojure `add-cookies`
- the web frontend — Node `set-cookie` route

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/onaio/codesmith/onadata/pr/3165"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786103199&installation_id=135786473&pr_number=3165&repository=onaio%2Fonadata&return_to=https%3A%2F%2Fgithub.com%2Fonaio%2Fonadata%2Fpull%2F3165&signature=b291eee3e5df14cf85e61827bd52f3ed87900230012c47db1e57dc97dc9f3c74"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
