### PR TITLE
fix: register XForm with django-reversion

### DIFF
--- a/onadata/apps/logger/admin.py
+++ b/onadata/apps/logger/admin.py
@@ -25,7 +25,7 @@ class FilterByUserMixin:  # pylint: disable=too-few-public-methods
         return queryset.filter(**{self.user_lookup_field: request.user})
 
 
-class XFormAdmin(FilterByUserMixin, admin.ModelAdmin):
+class XFormAdmin(FilterByUserMixin, VersionAdmin, admin.ModelAdmin):
     """Customise the XForm admin view."""
 
     exclude = ("user",)

--- a/onadata/apps/logger/models/xform.py
+++ b/onadata/apps/logger/models/xform.py
@@ -27,6 +27,7 @@ from django.utils.html import conditional_escape
 from django.utils.translation import gettext as _
 from django.utils.translation import gettext_lazy
 
+import reversion
 from guardian.models import GroupObjectPermissionBase, UserObjectPermissionBase
 from pyxform import SurveyElementBuilder, constants
 from pyxform.errors import PyXFormError
@@ -1546,6 +1547,11 @@ def xform_post_delete_callback(sender, instance, **kwargs):
 post_delete.connect(
     xform_post_delete_callback, sender=XForm, dispatch_uid="xform_post_delete_callback"
 )
+
+# DataDictionary is a proxy of XForm whose versions are stored under XForm's
+# content type, so reversion must be able to resolve XForm when saving or
+# reverting them.
+reversion.register(XForm)
 
 
 # pylint: disable=too-few-public-methods

--- a/onadata/apps/logger/models/xform.py
+++ b/onadata/apps/logger/models/xform.py
@@ -1548,9 +1548,7 @@ post_delete.connect(
     xform_post_delete_callback, sender=XForm, dispatch_uid="xform_post_delete_callback"
 )
 
-# DataDictionary is a proxy of XForm whose versions are stored under XForm's
-# content type, so reversion must be able to resolve XForm when saving or
-# reverting them.
+# Register XForm in django-reversion
 reversion.register(XForm)
 
 

--- a/onadata/apps/logger/tests/models/test_xform.py
+++ b/onadata/apps/logger/tests/models/test_xform.py
@@ -12,8 +12,11 @@ from django.contrib.contenttypes.models import ContentType
 from django.core.cache import cache
 from django.utils import timezone
 
+import reversion
 from pyxform.builder import SurveyElementBuilder as RealBuilder
 from pyxform.errors import PyXFormError
+from reversion import revisions
+from reversion.models import Version
 
 from onadata.apps.logger.models import DataView, Instance, KMSKey, XForm
 from onadata.apps.logger.models.kms import XFormKey
@@ -24,6 +27,7 @@ from onadata.apps.logger.models.xform import (
 )
 from onadata.apps.logger.xform_instance_parser import XLSFormError
 from onadata.apps.main.tests.test_base import TestBase
+from onadata.apps.viewer.models.data_dictionary import DataDictionary
 from onadata.libs.utils.common_tools import get_abbreviated_xpath
 
 
@@ -625,3 +629,40 @@ class TestXForm(TestBase):
         )
 
         self.assertTrue(self.xform.is_was_managed)
+
+
+class XFormReversionRegistrationTestCase(TestBase):
+    """Test XForm is registered with django-reversion."""
+
+    def setUp(self):
+        super().setUp()
+        # Mirror production, where django.contrib.admin is installed and
+        # DataDictionaryAdmin(VersionAdmin) auto-registers DataDictionary
+        # with default options on startup.
+        if not reversion.is_registered(DataDictionary):
+            reversion.register(DataDictionary)
+            self.addCleanup(reversion.unregister, DataDictionary)
+
+    def test_xform_is_registered(self):
+        """XForm is registered with django-reversion."""
+        self.assertTrue(reversion.is_registered(XForm))
+
+    def test_data_dictionary_revision_committed_and_read(self):
+        """A revision containing a DataDictionary is committed and readable.
+
+        DataDictionary is a proxy of XForm, so its versions are stored
+        under XForm's content type. Committing the revision
+        (e.g. publishing a form via /projects/{pk}/forms, which
+        RevisionMixin wraps in a revision) and reading it back (e.g. the
+        admin history and recover views) both resolve XForm from the
+        stored content type.
+        """
+        self._publish_transportation_form()
+        data_dictionary = DataDictionary.objects.get(pk=self.xform.pk)
+
+        with revisions.create_revision():
+            revisions.add_to_revision(data_dictionary)
+
+        version = Version.objects.get_for_object(data_dictionary).first()
+        self.assertIsNotNone(version)
+        self.assertEqual(version.field_dict["id_string"], self.xform.id_string)

--- a/onadata/apps/logger/tests/models/test_xform.py
+++ b/onadata/apps/logger/tests/models/test_xform.py
@@ -27,7 +27,6 @@ from onadata.apps.logger.models.xform import (
 )
 from onadata.apps.logger.xform_instance_parser import XLSFormError
 from onadata.apps.main.tests.test_base import TestBase
-from onadata.apps.viewer.models.data_dictionary import DataDictionary
 from onadata.libs.utils.common_tools import get_abbreviated_xpath
 
 
@@ -638,22 +637,13 @@ class XFormReversionRegistrationTestCase(TestBase):
         """XForm is registered with django-reversion."""
         self.assertTrue(reversion.is_registered(XForm))
 
-    def test_data_dictionary_revision_committed_and_read(self):
-        """A revision containing a DataDictionary is committed and readable.
-
-        DataDictionary is a proxy of XForm, so its versions are stored
-        under XForm's content type. Committing the revision
-        (e.g. publishing a form via /projects/{pk}/forms, which
-        RevisionMixin wraps in a revision) and reading it back (e.g. the
-        admin history and recover views) both resolve XForm from the
-        stored content type.
-        """
+    def test_revision_recorded_and_read(self):
+        """An XForm saved in a revision is recorded and readable."""
         self._publish_transportation_form()
-        data_dictionary = DataDictionary.objects.get(pk=self.xform.pk)
 
         with revisions.create_revision():
-            revisions.add_to_revision(data_dictionary)
+            revisions.add_to_revision(self.xform)
 
-        version = Version.objects.get_for_object(data_dictionary).first()
+        version = Version.objects.get_for_object(self.xform).first()
         self.assertIsNotNone(version)
         self.assertEqual(version.field_dict["id_string"], self.xform.id_string)

--- a/onadata/apps/logger/tests/models/test_xform.py
+++ b/onadata/apps/logger/tests/models/test_xform.py
@@ -634,15 +634,6 @@ class TestXForm(TestBase):
 class XFormReversionRegistrationTestCase(TestBase):
     """Test XForm is registered with django-reversion."""
 
-    def setUp(self):
-        super().setUp()
-        # Mirror production, where django.contrib.admin is installed and
-        # DataDictionaryAdmin(VersionAdmin) auto-registers DataDictionary
-        # with default options on startup.
-        if not reversion.is_registered(DataDictionary):
-            reversion.register(DataDictionary)
-            self.addCleanup(reversion.unregister, DataDictionary)
-
     def test_xform_is_registered(self):
         """XForm is registered with django-reversion."""
         self.assertTrue(reversion.is_registered(XForm))

--- a/onadata/apps/viewer/models/data_dictionary.py
+++ b/onadata/apps/viewer/models/data_dictionary.py
@@ -572,8 +572,6 @@ post_save.connect(
     dispatch_uid="auto_encrypt_xform",
 )
 
-# Register explicitly so DataDictionary saves are versioned regardless of
-# whether the admin app (whose DataDictionaryAdmin would auto-register it)
-# is installed. Django dispatches post_save with the proxy as sender, so
-# XForm's registration does not cover DataDictionary saves.
+# Register DataDictionary in django-reversion, XForm's registration
+# does not cover DataDictionary
 reversion.register(DataDictionary)

--- a/onadata/apps/viewer/models/data_dictionary.py
+++ b/onadata/apps/viewer/models/data_dictionary.py
@@ -17,6 +17,7 @@ from django.utils import timezone
 from django.utils.translation import gettext as _
 
 import openpyxl
+import reversion
 import unicodecsv as csv
 from floip import FloipSurvey
 from kombu.exceptions import OperationalError
@@ -570,3 +571,9 @@ post_save.connect(
     sender=DataDictionary,
     dispatch_uid="auto_encrypt_xform",
 )
+
+# Register explicitly so DataDictionary saves are versioned regardless of
+# whether the admin app (whose DataDictionaryAdmin would auto-register it)
+# is installed. Django dispatches post_save with the proxy as sender, so
+# XForm's registration does not cover DataDictionary saves.
+reversion.register(DataDictionary)

--- a/onadata/apps/viewer/tests/test_data_dictionary.py
+++ b/onadata/apps/viewer/tests/test_data_dictionary.py
@@ -539,12 +539,7 @@ class DataDictionaryReversionRegistrationTestCase(TestBase):
         self.assertTrue(reversion.is_registered(DataDictionary))
 
     def test_revision_recorded_and_read(self):
-        """A DataDictionary saved in a revision is recorded and readable.
-
-        Publishing a form via /projects/{pk}/forms saves a DataDictionary
-        inside the revision opened by RevisionMixin; the snapshot must be
-        recorded on commit and deserializable when read back.
-        """
+        """A DataDictionary saved in a revision is recorded and readable."""
         self._publish_transportation_form()
         data_dictionary = DataDictionary.objects.get(pk=self.xform.pk)
 

--- a/onadata/apps/viewer/tests/test_data_dictionary.py
+++ b/onadata/apps/viewer/tests/test_data_dictionary.py
@@ -1,10 +1,12 @@
 """Tests for onadata.apps.viewer.models.data_dictionary"""
 
-import json
-
 from django.contrib.contenttypes.models import ContentType
 from django.core.cache import cache
 from django.test import override_settings
+
+import reversion
+from reversion import revisions
+from reversion.models import Version
 
 from onadata.apps.logger.models.entity_list import EntityList
 from onadata.apps.logger.models.follow_up_form import FollowUpForm
@@ -13,6 +15,7 @@ from onadata.apps.logger.models.registration_form import RegistrationForm
 from onadata.apps.logger.models.xform import XForm
 from onadata.apps.main.models.meta_data import MetaData
 from onadata.apps.main.tests.test_base import TestBase
+from onadata.apps.viewer.models.data_dictionary import DataDictionary
 from onadata.libs.permissions import ROLES
 from onadata.libs.utils.user_auth import get_user_default_project
 
@@ -526,3 +529,28 @@ class DataDictionaryTestCase(TestBase):
             xform.refresh_from_db()
 
             self.assertFalse(xform.encrypted)
+
+
+class DataDictionaryReversionRegistrationTestCase(TestBase):
+    """Test DataDictionary is registered with django-reversion."""
+
+    def test_data_dictionary_is_registered(self):
+        """DataDictionary is registered with django-reversion."""
+        self.assertTrue(reversion.is_registered(DataDictionary))
+
+    def test_revision_recorded_and_read(self):
+        """A DataDictionary saved in a revision is recorded and readable.
+
+        Publishing a form via /projects/{pk}/forms saves a DataDictionary
+        inside the revision opened by RevisionMixin; the snapshot must be
+        recorded on commit and deserializable when read back.
+        """
+        self._publish_transportation_form()
+        data_dictionary = DataDictionary.objects.get(pk=self.xform.pk)
+
+        with revisions.create_revision():
+            revisions.add_to_revision(data_dictionary)
+
+        version = Version.objects.get_for_object(data_dictionary).first()
+        self.assertIsNotNone(version)
+        self.assertEqual(version.field_dict["id_string"], self.xform.id_string)


### PR DESCRIPTION
### Changes / Features implemented

-  Re-register `XForm` with django-reversion. Fixes the `RegistrationError` crashing form publishes on django-reversion 6.3.0 caused by the missing `XForm` registration that had been previously removed.
- Explicitly register `XForm` and `DataDictionary` to avoid implicit registration by `VersionAdmin` and avoid unforseen side effects in future
- Re-add `VersionAdmin` to `XFormAdmin`, restoring versioning of admin edits and the history UI

### Steps taken to verify this change does what is intended

- [x] Add tests
- [x]  QA

### Side effects of implementing this change

- None

**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  - [ ] Updated documentation

Closes #3169
