### PR TITLE
feat(v2): server-side project search, sort & role/starred/shared filters

### DIFF
--- a/docs/projects.rst
+++ b/docs/projects.rst
@@ -197,7 +197,7 @@ of projects the requesting user already has access to.
 - ``ordering`` - Sort the list by one of ``name``, ``date_created``, ``last_submission_date`` or ``metadata__category``. Prefix the value with ``-`` for descending order (for example ``-date_created``).
 - ``shared`` - ``true`` returns only public projects; ``false`` returns only private projects.
 - ``starred`` - ``true`` returns only the projects the requesting user has starred; ``false`` returns only those they have not.
-- ``role`` - Comma-separated list of role names (for example ``owner`` or ``owner,manager``). Returns projects where the requesting user's role is one of the listed roles.
+- ``role`` - Comma-separated list of role names (for example ``owner`` or ``owner,manager``). Returns projects where the requesting user holds the lowest-ranked listed role **or a higher one** — for example ``role=editor`` also returns projects where the user is a manager or owner. Unknown role names return an HTTP 400 error, as do values other than ``true``/``false`` for ``shared`` and ``starred``.
 
 .. raw:: html
 

--- a/docs/projects.rst
+++ b/docs/projects.rst
@@ -197,19 +197,19 @@ of projects the requesting user already has access to.
 - ``ordering`` - Sort the list by one of ``name``, ``date_created``, ``last_submission_date`` or ``metadata__category``. Prefix the value with ``-`` for descending order (for example ``-date_created``).
 - ``shared`` - ``true`` returns only public projects; ``false`` returns only private projects.
 - ``starred`` - ``true`` returns only the projects the requesting user has starred; ``false`` returns only those they have not.
-- ``role`` - Comma-separated list of role names (for example ``owner`` or ``owner,manager``). Returns projects where the requesting user holds the lowest-ranked listed role **or a higher one** — for example ``role=editor`` also returns projects where the user is a manager or owner. Unknown role names return an HTTP 400 error, as do values other than ``true``/``false`` for ``shared`` and ``starred``.
+- ``role`` - A single role name (for example ``owner`` or ``editor``). Returns projects where the requesting user holds that role **or a higher one** — for example ``role=editor`` also returns projects where the user is a manager or owner. Unknown role names return an HTTP 400 error, as do values other than ``true``/``false`` for ``shared`` and ``starred``.
 
 .. raw:: html
 
 	<pre class="prettyprint">
-	<b>GET</b> /api/v2/projects?<code>search</code>=<code>rainfall</code>&<code>ordering</code>=<code>-date_created</code>&<code>shared</code>=<code>true</code>&<code>starred</code>=<code>true</code>&<code>role</code>=<code>owner,manager</code>
+	<b>GET</b> /api/v2/projects?<code>search</code>=<code>rainfall</code>&<code>ordering</code>=<code>-date_created</code>&<code>shared</code>=<code>true</code>&<code>starred</code>=<code>true</code>&<code>role</code>=<code>manager</code>
 	</pre>
 
 Example
 ^^^^^^^^
 ::
 
-       curl -X GET "https://api.ona.io/api/v2/projects?search=rainfall&ordering=name&role=owner,manager"
+       curl -X GET "https://api.ona.io/api/v2/projects?search=rainfall&ordering=name&role=manager"
 
 Retrieve Project Information
 --------------------------------

--- a/docs/projects.rst
+++ b/docs/projects.rst
@@ -187,6 +187,30 @@ Example
 
        curl -X GET https://api.ona.io/api/v1/projects?owner=ona
 
+Search, sort, and filter the project list (v2)
+----------------------------------------------
+The version 2 project list endpoint ``GET /api/v2/projects`` accepts the
+following query parameters. They may be combined, and each one narrows the set
+of projects the requesting user already has access to.
+
+- ``search`` - Case-insensitive substring match on the project ``name`` and the owner's username.
+- ``ordering`` - Sort the list by one of ``name``, ``date_created``, ``last_submission_date`` or ``metadata__category``. Prefix the value with ``-`` for descending order (for example ``-date_created``).
+- ``shared`` - ``true`` returns only public projects; ``false`` returns only private projects.
+- ``starred`` - ``true`` returns only the projects the requesting user has starred; ``false`` returns only those they have not.
+- ``role`` - Comma-separated list of role names (for example ``owner`` or ``owner,manager``). Returns projects where the requesting user's role is one of the listed roles.
+
+.. raw:: html
+
+	<pre class="prettyprint">
+	<b>GET</b> /api/v2/projects?<code>search</code>=<code>rainfall</code>&<code>ordering</code>=<code>-date_created</code>&<code>shared</code>=<code>true</code>&<code>starred</code>=<code>true</code>&<code>role</code>=<code>owner,manager</code>
+	</pre>
+
+Example
+^^^^^^^^
+::
+
+       curl -X GET "https://api.ona.io/api/v2/projects?search=rainfall&ordering=name&role=owner,manager"
+
 Retrieve Project Information
 --------------------------------
 .. raw:: html

--- a/onadata/apps/api/tests/viewsets/v2/test_project_viewset.py
+++ b/onadata/apps/api/tests/viewsets/v2/test_project_viewset.py
@@ -678,3 +678,32 @@ class ProjectSearchTestCase(TestAbstractViewSet):
         response = self.view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data, [])
+
+
+@override_settings(TIME_ZONE="UTC")
+class ProjectOrderingTestCase(TestAbstractViewSet):
+    """?ordering= sorts by name / created."""
+
+    def setUp(self):
+        super().setUp()
+        # Created oldest → newest: Banana, Apple, Cherry
+        self.banana = Project.objects.create(
+            name="Banana", organization=self.user, created_by=self.user)
+        self.apple = Project.objects.create(
+            name="Apple", organization=self.user, created_by=self.user)
+        self.cherry = Project.objects.create(
+            name="Cherry", organization=self.user, created_by=self.user)
+        self.view = ProjectViewSet.as_view({"get": "list"})
+
+    def _names(self, response):
+        return [p["name"] for p in response.data]
+
+    def test_order_by_name_asc(self):
+        request = self.factory.get("/", {"ordering": "name"}, **self.extra)
+        response = self.view(request)
+        self.assertEqual(self._names(response), ["Apple", "Banana", "Cherry"])
+
+    def test_order_by_created_desc(self):
+        request = self.factory.get("/", {"ordering": "-created"}, **self.extra)
+        response = self.view(request)
+        self.assertEqual(self._names(response), ["Cherry", "Apple", "Banana"])

--- a/onadata/apps/api/tests/viewsets/v2/test_project_viewset.py
+++ b/onadata/apps/api/tests/viewsets/v2/test_project_viewset.py
@@ -878,7 +878,7 @@ class ProjectStarredFilterTestCase(ProjectListFilterTestBase):
 
 @override_settings(TIME_ZONE="UTC")
 class ProjectRoleFilterTestCase(ProjectListFilterTestBase):
-    """?role= returns projects where the requesting user's role is in the set."""
+    """?role= returns projects where the user holds that role or higher."""
 
     def setUp(self):
         super().setUp()
@@ -903,11 +903,6 @@ class ProjectRoleFilterTestCase(ProjectListFilterTestBase):
         """?role=owner returns only projects where the user is an owner."""
         response = self._list({"role": "owner"}, extra=self.member_extra)
         self.assertEqual(self._names(response), ["Owner Proj"])
-
-    def test_role_owner_or_manager(self):
-        """?role=owner,manager returns manager-and-above projects."""
-        response = self._list({"role": "owner,manager"}, extra=self.member_extra)
-        self.assertEqual(self._names(response), ["Manager Proj", "Owner Proj"])
 
     def test_role_editor_includes_higher_roles(self):
         """?role=editor means editor-and-above: manager and owner projects

--- a/onadata/apps/api/tests/viewsets/v2/test_project_viewset.py
+++ b/onadata/apps/api/tests/viewsets/v2/test_project_viewset.py
@@ -692,6 +692,17 @@ class ProjectSearchTestCase(ProjectListFilterTestBase):
         response = self._list({"search": self.user.username})
         self.assertEqual(self._names(response), ["Household Census", "Rainfall Survey"])
 
+    def test_search_by_owner_username_case_insensitive_substring(self):
+        """?search= matches a case-variant substring of the owner's username."""
+        response = self._list({"search": self.user.username[:-1].upper()})
+        self.assertEqual(self._names(response), ["Household Census", "Rainfall Survey"])
+
+    def test_search_no_match(self):
+        """?search= returns an empty list when nothing matches."""
+        response = self._list({"search": "no-such-project"})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data, [])
+
     def test_search_combines_with_ordering(self):
         """?search= and ?ordering= can be combined in a single request."""
         response = self._list({"search": self.user.username, "ordering": "-name"})
@@ -703,7 +714,14 @@ class ProjectSearchTestCase(ProjectListFilterTestBase):
 
 @override_settings(TIME_ZONE="UTC")
 class ProjectOrderingTestCase(ProjectListFilterTestBase):
-    """?ordering= sorts by name / created."""
+    """?ordering= sorts by name / created / category / last submission.
+
+    ``setUp`` only creates the three bare projects; tests that sort on
+    ``metadata__category`` or ``last_submission_date`` add those fixtures
+    via ``_set_categories`` / ``_make_forms``. The fixture orders are
+    chosen so no two sort fields agree — a test can't pass by falling
+    back to another ordering.
+    """
 
     def setUp(self):
         super().setUp()
@@ -716,6 +734,39 @@ class ProjectOrderingTestCase(ProjectListFilterTestBase):
         self.cherry = Project.objects.create(
             name="Cherry", organization=self.user, created_by=self.user
         )
+
+    def _set_categories(self):
+        """Give each project a metadata category (asc: Banana, Cherry, Apple)."""
+        for project, category in (
+            (self.apple, "governance"),
+            (self.banana, "agriculture"),
+            (self.cherry, "energy"),
+        ):
+            Project.objects.filter(pk=project.pk).update(
+                metadata={"category": category}
+            )
+
+    def _make_form(self, project, id_string, last_submission_time):
+        """Publish a minimal form on *project* with a fixed last submission time."""
+        md = """
+        | survey |
+        |        | type | name | label |
+        |        | text | city | City? |
+        """
+        data_dict = self._publish_markdown(
+            md, self.user, project=project, id_string=id_string
+        )
+        XForm.objects.filter(pk=data_dict.pk).update(
+            last_submission_time=last_submission_time
+        )
+        return data_dict
+
+    def _make_forms(self):
+        """Give each project a form (last submitted-to, asc: Apple, Cherry, Banana)."""
+        now = timezone.now()
+        self._make_form(self.apple, "apple_form", now - timedelta(days=3))
+        self._make_form(self.cherry, "cherry_form", now - timedelta(days=2))
+        self._make_form(self.banana, "banana_form", now - timedelta(days=1))
 
     def test_order_by_name_asc(self):
         """?ordering=name sorts projects alphabetically."""
@@ -738,73 +789,49 @@ class ProjectOrderingTestCase(ProjectListFilterTestBase):
             self._names(response, sort=False), ["Banana", "Apple", "Cherry"]
         )
 
-
-@override_settings(TIME_ZONE="UTC")
-class ProjectOrderingDerivedTestCase(ProjectListFilterTestBase):
-    """?ordering=last_submission and ?ordering=category."""
-
-    def setUp(self):
-        super().setUp()
-        self.p_agri = Project.objects.create(
-            name="Agri",
-            organization=self.user,
-            created_by=self.user,
-            metadata={"category": "agriculture"},
+    def test_order_by_created_desc(self):
+        """?ordering=-date_created sorts the newest-created project first."""
+        response = self._list({"ordering": "-date_created"})
+        self.assertEqual(
+            self._names(response, sort=False), ["Cherry", "Apple", "Banana"]
         )
-        self.p_gov = Project.objects.create(
-            name="Gov",
-            organization=self.user,
-            created_by=self.user,
-            metadata={"category": "governance"},
-        )
-
-    def _make_form(self, project, id_string, last_submission_time):
-        """Create a minimal XForm on *project* with a fixed last submission time."""
-        xml = (
-            '<?xml version="1.0"?><h:html xmlns="http://www.w3.org/2002/xforms" '
-            'xmlns:h="http://www.w3.org/1999/xhtml"><h:head>'
-            f"<h:title>{id_string}</h:title><model><instance>"
-            f'<data id="{id_string}"><name/></data>'
-            "</instance></model></h:head><h:body/></h:html>"
-        )
-        # sms_id_string is supplied so save() doesn't derive it from the
-        # pyxform JSON, which this minimal fixture doesn't carry.
-        xform = XForm.objects.create(
-            xml=xml,
-            user=self.user,
-            project=project,
-            json={},
-            sms_id_string=id_string,
-        )
-        XForm.objects.filter(pk=xform.pk).update(
-            last_submission_time=last_submission_time
-        )
-        return xform
 
     def test_order_by_category_asc(self):
         """?ordering=metadata__category sorts by the JSON category value."""
+        self._set_categories()
         response = self._list({"ordering": "metadata__category"})
-        self.assertEqual(self._names(response, sort=False), ["Agri", "Gov"])
+        self.assertEqual(
+            self._names(response, sort=False), ["Banana", "Cherry", "Apple"]
+        )
+
+    def test_order_by_category_desc(self):
+        """?ordering=-metadata__category sorts by the JSON category value,
+        descending."""
+        self._set_categories()
+        response = self._list({"ordering": "-metadata__category"})
+        self.assertEqual(
+            self._names(response, sort=False), ["Apple", "Cherry", "Banana"]
+        )
 
     def test_order_by_last_submission_asc(self):
         """?ordering=last_submission_date puts the least recently submitted-to
         project first."""
-        now = timezone.now()
-        self._make_form(self.p_agri, "agri_form", now - timedelta(days=2))
-        self._make_form(self.p_gov, "gov_form", now - timedelta(days=1))
+        self._make_forms()
         response = self._list({"ordering": "last_submission_date"})
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(self._names(response, sort=False), ["Agri", "Gov"])
+        self.assertEqual(
+            self._names(response, sort=False), ["Apple", "Cherry", "Banana"]
+        )
 
     def test_order_by_last_submission_desc(self):
         """?ordering=-last_submission_date puts the most recently submitted-to
         project first."""
-        now = timezone.now()
-        self._make_form(self.p_agri, "agri_form", now - timedelta(days=2))
-        self._make_form(self.p_gov, "gov_form", now - timedelta(days=1))
+        self._make_forms()
         response = self._list({"ordering": "-last_submission_date"})
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(self._names(response, sort=False), ["Gov", "Agri"])
+        self.assertEqual(
+            self._names(response, sort=False), ["Banana", "Cherry", "Apple"]
+        )
 
 
 @override_settings(TIME_ZONE="UTC")
@@ -832,6 +859,11 @@ class ProjectSharedFilterTestCase(ProjectListFilterTestBase):
         """?shared=false returns only private projects."""
         response = self._list({"shared": "false"})
         self.assertEqual(self._names(response), ["Private One"])
+
+    def test_filter_shared_invalid(self):
+        """?shared=invalid is a 400"""
+        response = self._list({"shared": "banana"})
+        self.assertEqual(response.status_code, 400)
 
 
 @override_settings(TIME_ZONE="UTC")

--- a/onadata/apps/api/tests/viewsets/v2/test_project_viewset.py
+++ b/onadata/apps/api/tests/viewsets/v2/test_project_viewset.py
@@ -755,3 +755,31 @@ class ProjectOrderingDerivedTestCase(TestAbstractViewSet):
         # No submissions on either → both null; assert the ordering param is
         # accepted (200) and returns both projects rather than erroring.
         self.assertEqual(sorted(self._names(response)), ["Agri", "Gov"])
+
+
+@override_settings(TIME_ZONE="UTC")
+class ProjectSharedFilterTestCase(TestAbstractViewSet):
+    """?shared= filters public/private projects."""
+
+    def setUp(self):
+        super().setUp()
+        self.public = Project.objects.create(
+            name="Public One", organization=self.user, created_by=self.user,
+            shared=True)
+        self.private = Project.objects.create(
+            name="Private One", organization=self.user, created_by=self.user,
+            shared=False)
+        self.view = ProjectViewSet.as_view({"get": "list"})
+
+    def _names(self, response):
+        return sorted(p["name"] for p in response.data)
+
+    def test_filter_shared_true(self):
+        request = self.factory.get("/", {"shared": "true"}, **self.extra)
+        response = self.view(request)
+        self.assertEqual(self._names(response), ["Public One"])
+
+    def test_filter_shared_false(self):
+        request = self.factory.get("/", {"shared": "false"}, **self.extra)
+        response = self.view(request)
+        self.assertEqual(self._names(response), ["Private One"])

--- a/onadata/apps/api/tests/viewsets/v2/test_project_viewset.py
+++ b/onadata/apps/api/tests/viewsets/v2/test_project_viewset.py
@@ -783,3 +783,30 @@ class ProjectSharedFilterTestCase(TestAbstractViewSet):
         request = self.factory.get("/", {"shared": "false"}, **self.extra)
         response = self.view(request)
         self.assertEqual(self._names(response), ["Private One"])
+
+
+@override_settings(TIME_ZONE="UTC")
+class ProjectStarredFilterTestCase(TestAbstractViewSet):
+    """?starred= filters by the requesting user's stars."""
+
+    def setUp(self):
+        super().setUp()
+        self.starred = Project.objects.create(
+            name="Starred One", organization=self.user, created_by=self.user)
+        self.plain = Project.objects.create(
+            name="Plain One", organization=self.user, created_by=self.user)
+        self.starred.user_stars.add(self.user)
+        self.view = ProjectViewSet.as_view({"get": "list"})
+
+    def _names(self, response):
+        return sorted(p["name"] for p in response.data)
+
+    def test_filter_starred_true(self):
+        request = self.factory.get("/", {"starred": "true"}, **self.extra)
+        response = self.view(request)
+        self.assertEqual(self._names(response), ["Starred One"])
+
+    def test_filter_starred_false(self):
+        request = self.factory.get("/", {"starred": "false"}, **self.extra)
+        response = self.view(request)
+        self.assertEqual(self._names(response), ["Plain One"])

--- a/onadata/apps/api/tests/viewsets/v2/test_project_viewset.py
+++ b/onadata/apps/api/tests/viewsets/v2/test_project_viewset.py
@@ -767,7 +767,15 @@ class ProjectOrderingDerivedTestCase(ProjectListFilterTestBase):
             f'<data id="{id_string}"><name/></data>'
             "</instance></model></h:head><h:body/></h:html>"
         )
-        xform = XForm.objects.create(xml=xml, user=self.user, project=project, json={})
+        # sms_id_string is supplied so save() doesn't derive it from the
+        # pyxform JSON, which this minimal fixture doesn't carry.
+        xform = XForm.objects.create(
+            xml=xml,
+            user=self.user,
+            project=project,
+            json={},
+            sms_id_string=id_string,
+        )
         XForm.objects.filter(pk=xform.pk).update(
             last_submission_time=last_submission_time
         )

--- a/onadata/apps/api/tests/viewsets/v2/test_project_viewset.py
+++ b/onadata/apps/api/tests/viewsets/v2/test_project_viewset.py
@@ -704,13 +704,13 @@ class ProjectOrderingTestCase(TestAbstractViewSet):
         self.assertEqual(self._names(response), ["Apple", "Banana", "Cherry"])
 
     def test_order_by_created_desc(self):
-        request = self.factory.get("/", {"ordering": "-created"}, **self.extra)
+        request = self.factory.get("/", {"ordering": "-date_created"}, **self.extra)
         response = self.view(request)
         self.assertEqual(self._names(response), ["Cherry", "Apple", "Banana"])
 
     def test_order_by_created_asc(self):
-        request = self.factory.get("/", {"ordering": "created"}, **self.extra)
+        request = self.factory.get("/", {"ordering": "date_created"}, **self.extra)
         response = self.view(request)
-        # Ascending created differs from the default -date_created order,
+        # Ascending date_created differs from the default -date_created order,
         # so this fails if OrderingFilter/ordering_fields is broken or dropped.
         self.assertEqual(self._names(response), ["Banana", "Apple", "Cherry"])

--- a/onadata/apps/api/tests/viewsets/v2/test_project_viewset.py
+++ b/onadata/apps/api/tests/viewsets/v2/test_project_viewset.py
@@ -1,12 +1,15 @@
 """Tests for onadata.apps.api.viewsets.v2.project_viewset"""
 
+from datetime import timedelta
+
 from django.core.cache import cache
 from django.test import override_settings
+from django.utils import timezone
 
 from onadata.apps.api.tests.viewsets.test_abstract_viewset import TestAbstractViewSet
 from onadata.apps.api.viewsets.project_viewset import ProjectViewSet as ProjectViewSetV1
 from onadata.apps.api.viewsets.v2.project_viewset import ProjectViewSet
-from onadata.apps.logger.models import EntityList, Project
+from onadata.apps.logger.models import EntityList, Project, XForm
 from onadata.libs.models.share_project import ShareProject
 from onadata.libs.serializers.project_serializer import PROJECT_PUBLIC_EXCLUDED_FIELDS
 from onadata.libs.utils.cache_tools import (
@@ -649,8 +652,13 @@ class ProjectListFilterTestBase(TestAbstractViewSet):
         self.view = ProjectViewSet.as_view({"get": "list"})
 
     def _list(self, params, extra=None):
-        """GET the project list with query params (defaults to self.extra auth)."""
-        return self.view(self.factory.get("/", params, **(extra or self.extra)))
+        """GET the project list with query params (defaults to self.extra auth).
+
+        Pass ``extra={}`` for an unauthenticated (anonymous) request.
+        """
+        if extra is None:
+            extra = self.extra
+        return self.view(self.factory.get("/", params, **extra))
 
     def _names(self, response, sort=True):
         names = [project["name"] for project in response.data]
@@ -675,12 +683,22 @@ class ProjectSearchTestCase(ProjectListFilterTestBase):
         )
 
     def test_search_by_name(self):
+        """?search= matches projects by name, case-insensitively."""
         response = self._list({"search": "rain"})
         self.assertEqual(self._names(response), ["Rainfall Survey"])
 
     def test_search_by_owner_username(self):
+        """?search= matches projects by the owner's username."""
         response = self._list({"search": self.user.username})
         self.assertEqual(self._names(response), ["Household Census", "Rainfall Survey"])
+
+    def test_search_combines_with_ordering(self):
+        """?search= and ?ordering= can be combined in a single request."""
+        response = self._list({"search": self.user.username, "ordering": "-name"})
+        self.assertEqual(
+            self._names(response, sort=False),
+            ["Rainfall Survey", "Household Census"],
+        )
 
 
 @override_settings(TIME_ZONE="UTC")
@@ -700,12 +718,21 @@ class ProjectOrderingTestCase(ProjectListFilterTestBase):
         )
 
     def test_order_by_name_asc(self):
+        """?ordering=name sorts projects alphabetically."""
         response = self._list({"ordering": "name"})
         self.assertEqual(
             self._names(response, sort=False), ["Apple", "Banana", "Cherry"]
         )
 
+    def test_order_by_name_desc(self):
+        """?ordering=-name sorts projects reverse-alphabetically."""
+        response = self._list({"ordering": "-name"})
+        self.assertEqual(
+            self._names(response, sort=False), ["Cherry", "Banana", "Apple"]
+        )
+
     def test_order_by_created_asc(self):
+        """?ordering=date_created sorts the oldest-created project first."""
         response = self._list({"ordering": "date_created"})
         self.assertEqual(
             self._names(response, sort=False), ["Banana", "Apple", "Cherry"]
@@ -731,14 +758,45 @@ class ProjectOrderingDerivedTestCase(ProjectListFilterTestBase):
             metadata={"category": "governance"},
         )
 
+    def _make_form(self, project, id_string, last_submission_time):
+        """Create a minimal XForm on *project* with a fixed last submission time."""
+        xml = (
+            '<?xml version="1.0"?><h:html xmlns="http://www.w3.org/2002/xforms" '
+            'xmlns:h="http://www.w3.org/1999/xhtml"><h:head>'
+            f"<h:title>{id_string}</h:title><model><instance>"
+            f'<data id="{id_string}"><name/></data>'
+            "</instance></model></h:head><h:body/></h:html>"
+        )
+        xform = XForm.objects.create(xml=xml, user=self.user, project=project, json={})
+        XForm.objects.filter(pk=xform.pk).update(
+            last_submission_time=last_submission_time
+        )
+        return xform
+
     def test_order_by_category_asc(self):
+        """?ordering=metadata__category sorts by the JSON category value."""
         response = self._list({"ordering": "metadata__category"})
         self.assertEqual(self._names(response, sort=False), ["Agri", "Gov"])
 
+    def test_order_by_last_submission_asc(self):
+        """?ordering=last_submission_date puts the least recently submitted-to
+        project first."""
+        now = timezone.now()
+        self._make_form(self.p_agri, "agri_form", now - timedelta(days=2))
+        self._make_form(self.p_gov, "gov_form", now - timedelta(days=1))
+        response = self._list({"ordering": "last_submission_date"})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(self._names(response, sort=False), ["Agri", "Gov"])
+
     def test_order_by_last_submission_desc(self):
+        """?ordering=-last_submission_date puts the most recently submitted-to
+        project first."""
+        now = timezone.now()
+        self._make_form(self.p_agri, "agri_form", now - timedelta(days=2))
+        self._make_form(self.p_gov, "gov_form", now - timedelta(days=1))
         response = self._list({"ordering": "-last_submission_date"})
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(self._names(response), ["Agri", "Gov"])
+        self.assertEqual(self._names(response, sort=False), ["Gov", "Agri"])
 
 
 @override_settings(TIME_ZONE="UTC")
@@ -758,10 +816,12 @@ class ProjectSharedFilterTestCase(ProjectListFilterTestBase):
         )
 
     def test_filter_shared_true(self):
+        """?shared=true returns only public projects."""
         response = self._list({"shared": "true"})
         self.assertEqual(self._names(response), ["Public One"])
 
     def test_filter_shared_false(self):
+        """?shared=false returns only private projects."""
         response = self._list({"shared": "false"})
         self.assertEqual(self._names(response), ["Private One"])
 
@@ -781,12 +841,31 @@ class ProjectStarredFilterTestCase(ProjectListFilterTestBase):
         self.starred.user_stars.add(self.user)
 
     def test_filter_starred_true(self):
+        """?starred=true returns only the requesting user's starred projects."""
         response = self._list({"starred": "true"})
         self.assertEqual(self._names(response), ["Starred One"])
 
     def test_filter_starred_false(self):
+        """?starred=false returns only projects the user has not starred."""
         response = self._list({"starred": "false"})
         self.assertEqual(self._names(response), ["Plain One"])
+
+    def test_filter_starred_anonymous(self):
+        """An anonymous ?starred= request is handled gracefully, not a 500."""
+        Project.objects.filter(pk__in=[self.starred.pk, self.plain.pk]).update(
+            shared=True
+        )
+        response = self._list({"starred": "true"}, extra={})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(self._names(response), [])
+        response = self._list({"starred": "false"}, extra={})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(self._names(response), ["Plain One", "Starred One"])
+
+    def test_filter_starred_invalid_value(self):
+        """A ?starred= value other than true/false is a 400, not silently false."""
+        response = self._list({"starred": "banana"})
+        self.assertEqual(response.status_code, 400)
 
 
 @override_settings(TIME_ZONE="UTC")
@@ -813,9 +892,24 @@ class ProjectRoleFilterTestCase(ProjectListFilterTestBase):
         return proj
 
     def test_role_owner_only(self):
+        """?role=owner returns only projects where the user is an owner."""
         response = self._list({"role": "owner"}, extra=self.member_extra)
         self.assertEqual(self._names(response), ["Owner Proj"])
 
     def test_role_owner_or_manager(self):
+        """?role=owner,manager returns manager-and-above projects."""
         response = self._list({"role": "owner,manager"}, extra=self.member_extra)
         self.assertEqual(self._names(response), ["Manager Proj", "Owner Proj"])
+
+    def test_role_editor_includes_higher_roles(self):
+        """?role=editor means editor-and-above: manager and owner projects
+        are included because those roles hold every editor permission."""
+        response = self._list({"role": "editor"}, extra=self.member_extra)
+        self.assertEqual(
+            self._names(response), ["Editor Proj", "Manager Proj", "Owner Proj"]
+        )
+
+    def test_role_unknown_is_rejected(self):
+        """An unknown role name is a 400, not a silent no-op."""
+        response = self._list({"role": "bogus"}, extra=self.member_extra)
+        self.assertEqual(response.status_code, 400)

--- a/onadata/apps/api/tests/viewsets/v2/test_project_viewset.py
+++ b/onadata/apps/api/tests/viewsets/v2/test_project_viewset.py
@@ -810,3 +810,48 @@ class ProjectStarredFilterTestCase(TestAbstractViewSet):
         request = self.factory.get("/", {"starred": "false"}, **self.extra)
         response = self.view(request)
         self.assertEqual(self._names(response), ["Plain One"])
+
+
+@override_settings(TIME_ZONE="UTC")
+class ProjectRoleFilterTestCase(TestAbstractViewSet):
+    """?role= returns projects where the requesting user's role is in the set."""
+
+    def setUp(self):
+        super().setUp()
+        # self.user (bob) owns everything; share each project to a second user
+        # (alice) at a distinct role, then query the list AS alice.
+        self.member = self._create_user_profile(
+            {"username": "alice", "email": "alice@localhost.com"}
+        ).user
+        self.member_extra = {
+            "HTTP_AUTHORIZATION": f"Token {self.member.auth_token}"
+        }
+
+        self.owner_p = self._make_shared_project("Owner Proj", "owner")
+        self.manager_p = self._make_shared_project("Manager Proj", "manager")
+        self.editor_p = self._make_shared_project("Editor Proj", "editor")
+        self.readonly_p = self._make_shared_project("Readonly Proj", "readonly")
+
+        self.view = ProjectViewSet.as_view({"get": "list"})
+
+    def _make_shared_project(self, name, role):
+        proj = Project.objects.create(
+            name=name, organization=self.user, created_by=self.user
+        )
+        ShareProject(proj, "alice", role).save()
+        return proj
+
+    def _names(self, response):
+        return sorted(p["name"] for p in response.data)
+
+    def test_role_owner_only(self):
+        request = self.factory.get("/", {"role": "owner"}, **self.member_extra)
+        response = self.view(request)
+        self.assertEqual(self._names(response), ["Owner Proj"])
+
+    def test_role_owner_or_manager(self):
+        request = self.factory.get(
+            "/", {"role": "owner,manager"}, **self.member_extra
+        )
+        response = self.view(request)
+        self.assertEqual(self._names(response), ["Manager Proj", "Owner Proj"])

--- a/onadata/apps/api/tests/viewsets/v2/test_project_viewset.py
+++ b/onadata/apps/api/tests/viewsets/v2/test_project_viewset.py
@@ -714,3 +714,40 @@ class ProjectOrderingTestCase(TestAbstractViewSet):
         # Ascending date_created differs from the default -date_created order,
         # so this fails if OrderingFilter/ordering_fields is broken or dropped.
         self.assertEqual(self._names(response), ["Banana", "Apple", "Cherry"])
+
+
+@override_settings(TIME_ZONE="UTC")
+class ProjectOrderingDerivedTestCase(TestAbstractViewSet):
+    """?ordering=last_submission and ?ordering=category."""
+
+    def setUp(self):
+        super().setUp()
+        # Create Agri before Gov (oldest -> newest) so the default queryset
+        # ordering (-date_created) puts Gov first. This decouples the
+        # ?ordering=metadata__category assertion below from the fallback
+        # ordering used when the field isn't recognised — without this,
+        # the test would pass even before ordering_fields is extended.
+        self.p_agri = Project.objects.create(
+            name="Agri", organization=self.user, created_by=self.user,
+            metadata={"category": "agriculture"})
+        self.p_gov = Project.objects.create(
+            name="Gov", organization=self.user, created_by=self.user,
+            metadata={"category": "governance"})
+        self.view = ProjectViewSet.as_view({"get": "list"})
+
+    def _names(self, response):
+        return [p["name"] for p in response.data]
+
+    def test_order_by_category_asc(self):
+        request = self.factory.get("/", {"ordering": "metadata__category"}, **self.extra)
+        response = self.view(request)
+        # agriculture < governance
+        self.assertEqual(self._names(response), ["Agri", "Gov"])
+
+    def test_order_by_last_submission_desc(self):
+        request = self.factory.get("/", {"ordering": "-last_submission_date"}, **self.extra)
+        response = self.view(request)
+        self.assertEqual(response.status_code, 200)
+        # No submissions on either → both null; assert the ordering param is
+        # accepted (200) and returns both projects rather than erroring.
+        self.assertEqual(sorted(self._names(response)), ["Agri", "Gov"])

--- a/onadata/apps/api/tests/viewsets/v2/test_project_viewset.py
+++ b/onadata/apps/api/tests/viewsets/v2/test_project_viewset.py
@@ -921,3 +921,15 @@ class ProjectRoleFilterTestCase(ProjectListFilterTestBase):
         """An unknown role name is a 400, not a silent no-op."""
         response = self._list({"role": "bogus"}, extra=self.member_extra)
         self.assertEqual(response.status_code, 400)
+
+    def test_user_not_shared_to_any_project(self):
+        """A user shared into no projects gets an empty list, not a 4xx."""
+        not_shared_user = self._create_user_profile(
+            {"username": "carol", "email": "carol@localhost.com"}
+        ).user
+        not_shared_user_extra = {
+            "HTTP_AUTHORIZATION": f"Token {not_shared_user.auth_token}"
+        }
+        response = self._list({"role": "owner"}, extra=not_shared_user_extra)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data, [])

--- a/onadata/apps/api/tests/viewsets/v2/test_project_viewset.py
+++ b/onadata/apps/api/tests/viewsets/v2/test_project_viewset.py
@@ -707,3 +707,10 @@ class ProjectOrderingTestCase(TestAbstractViewSet):
         request = self.factory.get("/", {"ordering": "-created"}, **self.extra)
         response = self.view(request)
         self.assertEqual(self._names(response), ["Cherry", "Apple", "Banana"])
+
+    def test_order_by_created_asc(self):
+        request = self.factory.get("/", {"ordering": "created"}, **self.extra)
+        response = self.view(request)
+        # Ascending created differs from the default -date_created order,
+        # so this fails if OrderingFilter/ordering_fields is broken or dropped.
+        self.assertEqual(self._names(response), ["Banana", "Apple", "Cherry"])

--- a/onadata/apps/api/tests/viewsets/v2/test_project_viewset.py
+++ b/onadata/apps/api/tests/viewsets/v2/test_project_viewset.py
@@ -739,13 +739,17 @@ class ProjectOrderingDerivedTestCase(TestAbstractViewSet):
         return [p["name"] for p in response.data]
 
     def test_order_by_category_asc(self):
-        request = self.factory.get("/", {"ordering": "metadata__category"}, **self.extra)
+        request = self.factory.get(
+            "/", {"ordering": "metadata__category"}, **self.extra
+        )
         response = self.view(request)
         # agriculture < governance
         self.assertEqual(self._names(response), ["Agri", "Gov"])
 
     def test_order_by_last_submission_desc(self):
-        request = self.factory.get("/", {"ordering": "-last_submission_date"}, **self.extra)
+        request = self.factory.get(
+            "/", {"ordering": "-last_submission_date"}, **self.extra
+        )
         response = self.view(request)
         self.assertEqual(response.status_code, 200)
         # No submissions on either → both null; assert the ordering param is

--- a/onadata/apps/api/tests/viewsets/v2/test_project_viewset.py
+++ b/onadata/apps/api/tests/viewsets/v2/test_project_viewset.py
@@ -4,9 +4,7 @@ from django.core.cache import cache
 from django.test import override_settings
 
 from onadata.apps.api.tests.viewsets.test_abstract_viewset import TestAbstractViewSet
-from onadata.apps.api.viewsets.project_viewset import (
-    ProjectViewSet as ProjectViewSetV1,
-)
+from onadata.apps.api.viewsets.project_viewset import ProjectViewSet as ProjectViewSetV1
 from onadata.apps.api.viewsets.v2.project_viewset import ProjectViewSet
 from onadata.apps.logger.models import EntityList, Project
 from onadata.libs.models.share_project import ShareProject
@@ -643,196 +641,169 @@ class GetProjectTeamsTestCase(TestAbstractViewSet):
         self.assertEqual(response.status_code, 403)
 
 
+class ProjectListFilterTestBase(TestAbstractViewSet):
+    """Shared helpers for the v2 project list filter/sort test cases."""
+
+    def setUp(self):
+        super().setUp()
+        self.view = ProjectViewSet.as_view({"get": "list"})
+
+    def _list(self, params, extra=None):
+        """GET the project list with query params (defaults to self.extra auth)."""
+        return self.view(self.factory.get("/", params, **(extra or self.extra)))
+
+    def _names(self, response, sort=True):
+        names = [project["name"] for project in response.data]
+        return sorted(names) if sort else names
+
+
 @override_settings(TIME_ZONE="UTC")
-class ProjectSearchTestCase(TestAbstractViewSet):
+class ProjectSearchTestCase(ProjectListFilterTestBase):
     """?search= matches project name and owner username."""
 
     def setUp(self):
         super().setUp()
         self.alpha = Project.objects.create(
-            name="Rainfall Survey", organization=self.user, created_by=self.user,
+            name="Rainfall Survey",
+            organization=self.user,
+            created_by=self.user,
         )
         self.beta = Project.objects.create(
-            name="Household Census", organization=self.user, created_by=self.user,
+            name="Household Census",
+            organization=self.user,
+            created_by=self.user,
         )
-        self.view = ProjectViewSet.as_view({"get": "list"})
-
-    def _names(self, response):
-        return sorted(p["name"] for p in response.data)
 
     def test_search_by_name(self):
-        request = self.factory.get("/", {"search": "rain"}, **self.extra)
-        response = self.view(request)
-        self.assertEqual(response.status_code, 200)
+        response = self._list({"search": "rain"})
         self.assertEqual(self._names(response), ["Rainfall Survey"])
 
     def test_search_by_owner_username(self):
-        # self.user.username is the owner of both projects.
-        request = self.factory.get("/", {"search": self.user.username}, **self.extra)
-        response = self.view(request)
-        self.assertEqual(response.status_code, 200)
+        response = self._list({"search": self.user.username})
         self.assertEqual(self._names(response), ["Household Census", "Rainfall Survey"])
-
-    def test_search_no_match_returns_empty(self):
-        request = self.factory.get("/", {"search": "zzznotreal"}, **self.extra)
-        response = self.view(request)
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.data, [])
 
 
 @override_settings(TIME_ZONE="UTC")
-class ProjectOrderingTestCase(TestAbstractViewSet):
+class ProjectOrderingTestCase(ProjectListFilterTestBase):
     """?ordering= sorts by name / created."""
 
     def setUp(self):
         super().setUp()
-        # Created oldest → newest: Banana, Apple, Cherry
         self.banana = Project.objects.create(
-            name="Banana", organization=self.user, created_by=self.user)
+            name="Banana", organization=self.user, created_by=self.user
+        )
         self.apple = Project.objects.create(
-            name="Apple", organization=self.user, created_by=self.user)
+            name="Apple", organization=self.user, created_by=self.user
+        )
         self.cherry = Project.objects.create(
-            name="Cherry", organization=self.user, created_by=self.user)
-        self.view = ProjectViewSet.as_view({"get": "list"})
-
-    def _names(self, response):
-        return [p["name"] for p in response.data]
+            name="Cherry", organization=self.user, created_by=self.user
+        )
 
     def test_order_by_name_asc(self):
-        request = self.factory.get("/", {"ordering": "name"}, **self.extra)
-        response = self.view(request)
-        self.assertEqual(self._names(response), ["Apple", "Banana", "Cherry"])
-
-    def test_order_by_created_desc(self):
-        request = self.factory.get("/", {"ordering": "-date_created"}, **self.extra)
-        response = self.view(request)
-        self.assertEqual(self._names(response), ["Cherry", "Apple", "Banana"])
+        response = self._list({"ordering": "name"})
+        self.assertEqual(
+            self._names(response, sort=False), ["Apple", "Banana", "Cherry"]
+        )
 
     def test_order_by_created_asc(self):
-        request = self.factory.get("/", {"ordering": "date_created"}, **self.extra)
-        response = self.view(request)
-        # Ascending date_created differs from the default -date_created order,
-        # so this fails if OrderingFilter/ordering_fields is broken or dropped.
-        self.assertEqual(self._names(response), ["Banana", "Apple", "Cherry"])
+        response = self._list({"ordering": "date_created"})
+        self.assertEqual(
+            self._names(response, sort=False), ["Banana", "Apple", "Cherry"]
+        )
 
 
 @override_settings(TIME_ZONE="UTC")
-class ProjectOrderingDerivedTestCase(TestAbstractViewSet):
+class ProjectOrderingDerivedTestCase(ProjectListFilterTestBase):
     """?ordering=last_submission and ?ordering=category."""
 
     def setUp(self):
         super().setUp()
-        # Create Agri before Gov (oldest -> newest) so the default queryset
-        # ordering (-date_created) puts Gov first. This decouples the
-        # ?ordering=metadata__category assertion below from the fallback
-        # ordering used when the field isn't recognised — without this,
-        # the test would pass even before ordering_fields is extended.
         self.p_agri = Project.objects.create(
-            name="Agri", organization=self.user, created_by=self.user,
-            metadata={"category": "agriculture"})
+            name="Agri",
+            organization=self.user,
+            created_by=self.user,
+            metadata={"category": "agriculture"},
+        )
         self.p_gov = Project.objects.create(
-            name="Gov", organization=self.user, created_by=self.user,
-            metadata={"category": "governance"})
-        self.view = ProjectViewSet.as_view({"get": "list"})
-
-    def _names(self, response):
-        return [p["name"] for p in response.data]
+            name="Gov",
+            organization=self.user,
+            created_by=self.user,
+            metadata={"category": "governance"},
+        )
 
     def test_order_by_category_asc(self):
-        request = self.factory.get(
-            "/", {"ordering": "metadata__category"}, **self.extra
-        )
-        response = self.view(request)
-        # agriculture < governance
-        self.assertEqual(self._names(response), ["Agri", "Gov"])
+        response = self._list({"ordering": "metadata__category"})
+        self.assertEqual(self._names(response, sort=False), ["Agri", "Gov"])
 
     def test_order_by_last_submission_desc(self):
-        request = self.factory.get(
-            "/", {"ordering": "-last_submission_date"}, **self.extra
-        )
-        response = self.view(request)
+        response = self._list({"ordering": "-last_submission_date"})
         self.assertEqual(response.status_code, 200)
-        # No submissions on either → both null; assert the ordering param is
-        # accepted (200) and returns both projects rather than erroring.
-        self.assertEqual(sorted(self._names(response)), ["Agri", "Gov"])
+        self.assertEqual(self._names(response), ["Agri", "Gov"])
 
 
 @override_settings(TIME_ZONE="UTC")
-class ProjectSharedFilterTestCase(TestAbstractViewSet):
+class ProjectSharedFilterTestCase(ProjectListFilterTestBase):
     """?shared= filters public/private projects."""
 
     def setUp(self):
         super().setUp()
         self.public = Project.objects.create(
-            name="Public One", organization=self.user, created_by=self.user,
-            shared=True)
+            name="Public One", organization=self.user, created_by=self.user, shared=True
+        )
         self.private = Project.objects.create(
-            name="Private One", organization=self.user, created_by=self.user,
-            shared=False)
-        self.view = ProjectViewSet.as_view({"get": "list"})
-
-    def _names(self, response):
-        return sorted(p["name"] for p in response.data)
+            name="Private One",
+            organization=self.user,
+            created_by=self.user,
+            shared=False,
+        )
 
     def test_filter_shared_true(self):
-        request = self.factory.get("/", {"shared": "true"}, **self.extra)
-        response = self.view(request)
+        response = self._list({"shared": "true"})
         self.assertEqual(self._names(response), ["Public One"])
 
     def test_filter_shared_false(self):
-        request = self.factory.get("/", {"shared": "false"}, **self.extra)
-        response = self.view(request)
+        response = self._list({"shared": "false"})
         self.assertEqual(self._names(response), ["Private One"])
 
 
 @override_settings(TIME_ZONE="UTC")
-class ProjectStarredFilterTestCase(TestAbstractViewSet):
+class ProjectStarredFilterTestCase(ProjectListFilterTestBase):
     """?starred= filters by the requesting user's stars."""
 
     def setUp(self):
         super().setUp()
         self.starred = Project.objects.create(
-            name="Starred One", organization=self.user, created_by=self.user)
+            name="Starred One", organization=self.user, created_by=self.user
+        )
         self.plain = Project.objects.create(
-            name="Plain One", organization=self.user, created_by=self.user)
+            name="Plain One", organization=self.user, created_by=self.user
+        )
         self.starred.user_stars.add(self.user)
-        self.view = ProjectViewSet.as_view({"get": "list"})
-
-    def _names(self, response):
-        return sorted(p["name"] for p in response.data)
 
     def test_filter_starred_true(self):
-        request = self.factory.get("/", {"starred": "true"}, **self.extra)
-        response = self.view(request)
+        response = self._list({"starred": "true"})
         self.assertEqual(self._names(response), ["Starred One"])
 
     def test_filter_starred_false(self):
-        request = self.factory.get("/", {"starred": "false"}, **self.extra)
-        response = self.view(request)
+        response = self._list({"starred": "false"})
         self.assertEqual(self._names(response), ["Plain One"])
 
 
 @override_settings(TIME_ZONE="UTC")
-class ProjectRoleFilterTestCase(TestAbstractViewSet):
+class ProjectRoleFilterTestCase(ProjectListFilterTestBase):
     """?role= returns projects where the requesting user's role is in the set."""
 
     def setUp(self):
         super().setUp()
-        # self.user (bob) owns everything; share each project to a second user
-        # (alice) at a distinct role, then query the list AS alice.
         self.member = self._create_user_profile(
             {"username": "alice", "email": "alice@localhost.com"}
         ).user
-        self.member_extra = {
-            "HTTP_AUTHORIZATION": f"Token {self.member.auth_token}"
-        }
+        self.member_extra = {"HTTP_AUTHORIZATION": f"Token {self.member.auth_token}"}
 
         self.owner_p = self._make_shared_project("Owner Proj", "owner")
         self.manager_p = self._make_shared_project("Manager Proj", "manager")
         self.editor_p = self._make_shared_project("Editor Proj", "editor")
         self.readonly_p = self._make_shared_project("Readonly Proj", "readonly")
-
-        self.view = ProjectViewSet.as_view({"get": "list"})
 
     def _make_shared_project(self, name, role):
         proj = Project.objects.create(
@@ -841,17 +812,10 @@ class ProjectRoleFilterTestCase(TestAbstractViewSet):
         ShareProject(proj, "alice", role).save()
         return proj
 
-    def _names(self, response):
-        return sorted(p["name"] for p in response.data)
-
     def test_role_owner_only(self):
-        request = self.factory.get("/", {"role": "owner"}, **self.member_extra)
-        response = self.view(request)
+        response = self._list({"role": "owner"}, extra=self.member_extra)
         self.assertEqual(self._names(response), ["Owner Proj"])
 
     def test_role_owner_or_manager(self):
-        request = self.factory.get(
-            "/", {"role": "owner,manager"}, **self.member_extra
-        )
-        response = self.view(request)
+        response = self._list({"role": "owner,manager"}, extra=self.member_extra)
         self.assertEqual(self._names(response), ["Manager Proj", "Owner Proj"])

--- a/onadata/apps/api/tests/viewsets/v2/test_project_viewset.py
+++ b/onadata/apps/api/tests/viewsets/v2/test_project_viewset.py
@@ -641,3 +641,40 @@ class GetProjectTeamsTestCase(TestAbstractViewSet):
         response = self.view(request, pk=self.project.pk)
 
         self.assertEqual(response.status_code, 403)
+
+
+@override_settings(TIME_ZONE="UTC")
+class ProjectSearchTestCase(TestAbstractViewSet):
+    """?search= matches project name and owner username."""
+
+    def setUp(self):
+        super().setUp()
+        self.alpha = Project.objects.create(
+            name="Rainfall Survey", organization=self.user, created_by=self.user,
+        )
+        self.beta = Project.objects.create(
+            name="Household Census", organization=self.user, created_by=self.user,
+        )
+        self.view = ProjectViewSet.as_view({"get": "list"})
+
+    def _names(self, response):
+        return sorted(p["name"] for p in response.data)
+
+    def test_search_by_name(self):
+        request = self.factory.get("/", {"search": "rain"}, **self.extra)
+        response = self.view(request)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(self._names(response), ["Rainfall Survey"])
+
+    def test_search_by_owner_username(self):
+        # self.user.username is the owner of both projects.
+        request = self.factory.get("/", {"search": self.user.username}, **self.extra)
+        response = self.view(request)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(self._names(response), ["Household Census", "Rainfall Survey"])
+
+    def test_search_no_match_returns_empty(self):
+        request = self.factory.get("/", {"search": "zzznotreal"}, **self.extra)
+        response = self.view(request)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data, [])

--- a/onadata/apps/api/viewsets/v2/project_viewset.py
+++ b/onadata/apps/api/viewsets/v2/project_viewset.py
@@ -3,7 +3,7 @@ Project viewset for v2 API
 """
 
 from rest_framework.decorators import action
-from rest_framework.filters import SearchFilter
+from rest_framework.filters import OrderingFilter, SearchFilter
 from rest_framework.response import Response
 
 from onadata.apps.api.viewsets.project_viewset import ProjectViewSet as ProjectViewSetV1
@@ -39,8 +39,13 @@ class ProjectViewSet(ProjectViewSetV1):
         ProjectOwnerFilter,  # ?owner=
         TagFilter,  # ?tags=
         SearchFilter,  # ?search=
+        OrderingFilter,  # ?ordering=
     )
     search_fields = ["name", "organization__username"]
+    ordering_fields = (
+        ("name", "name"),
+        ("date_created", "created"),
+    )
 
     def get_serializer_class(self):
         """Get serializer class based on action

--- a/onadata/apps/api/viewsets/v2/project_viewset.py
+++ b/onadata/apps/api/viewsets/v2/project_viewset.py
@@ -65,8 +65,8 @@ class ProjectViewSet(ProjectViewSetV1):
         """
         queryset = super().get_queryset()
         ordering = self.request.query_params.get("ordering", "")
-        requested = {field.strip() for field in ordering.split(",")}
-        if requested & {"last_submission_date", "-last_submission_date"}:
+        requested = {field.strip().removeprefix("-") for field in ordering.split(",")}
+        if "last_submission_date" in requested:
             # Annotation is only for ordering; the serializer still computes
             # last_submission_date itself. Exclude soft-deleted forms.
             queryset = queryset.annotate(

--- a/onadata/apps/api/viewsets/v2/project_viewset.py
+++ b/onadata/apps/api/viewsets/v2/project_viewset.py
@@ -12,8 +12,9 @@ from rest_framework.response import Response
 from onadata.apps.api.viewsets.project_viewset import ProjectViewSet as ProjectViewSetV1
 from onadata.libs.filters import (
     AnonUserProjectFilter,
-    ProjectFilterSet,
     ProjectOwnerFilter,
+    ProjectRoleFilter,
+    ProjectStarredFilter,
     TagFilter,
 )
 from onadata.libs.serializers.project_serializer import get_teams, get_users
@@ -39,14 +40,16 @@ class ProjectViewSet(ProjectViewSetV1):
     api_version = "v2"
 
     filter_backends = (
-        AnonUserProjectFilter,  # permission scoping — MUST stay first
-        ProjectOwnerFilter,  # ?owner=
-        TagFilter,  # ?tags=
-        DjangoFilterBackend,  # ?shared=
-        SearchFilter,  # ?search=
-        OrderingFilter,  # ?ordering=
+        AnonUserProjectFilter,
+        ProjectOwnerFilter,
+        TagFilter,
+        DjangoFilterBackend,
+        ProjectStarredFilter,
+        ProjectRoleFilter,
+        SearchFilter,
+        OrderingFilter,
     )
-    filterset_class = ProjectFilterSet
+    filterset_fields = ("shared",)
     search_fields = ["name", "organization__username"]
     ordering_fields = [
         "name",

--- a/onadata/apps/api/viewsets/v2/project_viewset.py
+++ b/onadata/apps/api/viewsets/v2/project_viewset.py
@@ -65,7 +65,8 @@ class ProjectViewSet(ProjectViewSetV1):
         """
         queryset = super().get_queryset()
         ordering = self.request.query_params.get("ordering", "")
-        if "last_submission" in ordering:
+        requested = {field.strip() for field in ordering.split(",")}
+        if requested & {"last_submission_date", "-last_submission_date"}:
             # Annotation is only for ordering; the serializer still computes
             # last_submission_date itself. Exclude soft-deleted forms.
             queryset = queryset.annotate(

--- a/onadata/apps/api/viewsets/v2/project_viewset.py
+++ b/onadata/apps/api/viewsets/v2/project_viewset.py
@@ -12,6 +12,7 @@ from rest_framework.response import Response
 from onadata.apps.api.viewsets.project_viewset import ProjectViewSet as ProjectViewSetV1
 from onadata.libs.filters import (
     AnonUserProjectFilter,
+    ProjectFilterSet,
     ProjectOwnerFilter,
     ProjectRoleFilter,
     ProjectStarredFilter,
@@ -49,7 +50,7 @@ class ProjectViewSet(ProjectViewSetV1):
         SearchFilter,
         OrderingFilter,
     )
-    filterset_fields = ("shared",)
+    filterset_class = ProjectFilterSet
     search_fields = ["name", "organization__username"]
     ordering_fields = [
         "name",

--- a/onadata/apps/api/viewsets/v2/project_viewset.py
+++ b/onadata/apps/api/viewsets/v2/project_viewset.py
@@ -4,6 +4,7 @@ Project viewset for v2 API
 
 from django.db.models import Max, Q
 
+from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework.decorators import action
 from rest_framework.filters import OrderingFilter, SearchFilter
 from rest_framework.response import Response
@@ -11,6 +12,7 @@ from rest_framework.response import Response
 from onadata.apps.api.viewsets.project_viewset import ProjectViewSet as ProjectViewSetV1
 from onadata.libs.filters import (
     AnonUserProjectFilter,
+    ProjectFilterSet,
     ProjectOwnerFilter,
     TagFilter,
 )
@@ -40,9 +42,11 @@ class ProjectViewSet(ProjectViewSetV1):
         AnonUserProjectFilter,  # permission scoping — MUST stay first
         ProjectOwnerFilter,  # ?owner=
         TagFilter,  # ?tags=
+        DjangoFilterBackend,  # ?shared=
         SearchFilter,  # ?search=
         OrderingFilter,  # ?ordering=
     )
+    filterset_class = ProjectFilterSet
     search_fields = ["name", "organization__username"]
     ordering_fields = [
         "name",

--- a/onadata/apps/api/viewsets/v2/project_viewset.py
+++ b/onadata/apps/api/viewsets/v2/project_viewset.py
@@ -42,10 +42,7 @@ class ProjectViewSet(ProjectViewSetV1):
         OrderingFilter,  # ?ordering=
     )
     search_fields = ["name", "organization__username"]
-    ordering_fields = (
-        ("name", "name"),
-        ("date_created", "created"),
-    )
+    ordering_fields = ["name", "date_created"]
 
     def get_serializer_class(self):
         """Get serializer class based on action

--- a/onadata/apps/api/viewsets/v2/project_viewset.py
+++ b/onadata/apps/api/viewsets/v2/project_viewset.py
@@ -3,9 +3,15 @@ Project viewset for v2 API
 """
 
 from rest_framework.decorators import action
+from rest_framework.filters import SearchFilter
 from rest_framework.response import Response
 
 from onadata.apps.api.viewsets.project_viewset import ProjectViewSet as ProjectViewSetV1
+from onadata.libs.filters import (
+    AnonUserProjectFilter,
+    ProjectOwnerFilter,
+    TagFilter,
+)
 from onadata.libs.serializers.project_serializer import get_teams, get_users
 from onadata.libs.serializers.v2.project_serializer import (
     ProjectListSerializer,
@@ -27,6 +33,14 @@ class ProjectViewSet(ProjectViewSetV1):
 
     serializer_class = ProjectSerializer
     api_version = "v2"
+
+    filter_backends = (
+        AnonUserProjectFilter,  # permission scoping — MUST stay first
+        ProjectOwnerFilter,  # ?owner=
+        TagFilter,  # ?tags=
+        SearchFilter,  # ?search=
+    )
+    search_fields = ["name", "organization__username"]
 
     def get_serializer_class(self):
         """Get serializer class based on action

--- a/onadata/apps/api/viewsets/v2/project_viewset.py
+++ b/onadata/apps/api/viewsets/v2/project_viewset.py
@@ -2,6 +2,8 @@
 Project viewset for v2 API
 """
 
+from django.db.models import Max, Q
+
 from rest_framework.decorators import action
 from rest_framework.filters import OrderingFilter, SearchFilter
 from rest_framework.response import Response
@@ -42,7 +44,30 @@ class ProjectViewSet(ProjectViewSetV1):
         OrderingFilter,  # ?ordering=
     )
     search_fields = ["name", "organization__username"]
-    ordering_fields = ["name", "date_created"]
+    ordering_fields = [
+        "name",
+        "date_created",
+        "last_submission_date",
+        "metadata__category",
+    ]
+
+    def get_queryset(self):
+        """Annotate `last_submission_date` only when it is requested for ordering.
+
+        Overrides super().get_queryset()
+        """
+        queryset = super().get_queryset()
+        ordering = self.request.query_params.get("ordering", "")
+        if "last_submission" in ordering:
+            # Annotation is only for ordering; the serializer still computes
+            # last_submission_date itself. Exclude soft-deleted forms.
+            queryset = queryset.annotate(
+                last_submission_date=Max(
+                    "xform__last_submission_time",
+                    filter=Q(xform__deleted_at__isnull=True),
+                )
+            )
+        return queryset
 
     def get_serializer_class(self):
         """Get serializer class based on action

--- a/onadata/libs/filters.py
+++ b/onadata/libs/filters.py
@@ -151,6 +151,21 @@ class FormIDFilter(django_filter_filters.FilterSet):
         fields = ["formID"]
 
 
+class ProjectFilterSet(django_filter_filters.FilterSet):
+    """Project FilterSet; rejects unrecognized ``shared`` values with a 400."""
+
+    shared = django_filter_filters.TypedChoiceFilter(
+        choices=[(choice, choice) for choice in ("true", "false", "True", "False", "1", "0")],
+        coerce=str2bool,
+        error_messages={"invalid_choice": _("Select either true or false.")},
+    )
+
+    # pylint: disable=missing-class-docstring
+    class Meta:
+        model = Project
+        fields = ["shared"]
+
+
 # pylint: disable=too-few-public-methods
 class ProjectStarredFilter(filters.BaseFilterBackend):
     """Project `starred` filter using the `starred` query parameter."""

--- a/onadata/libs/filters.py
+++ b/onadata/libs/filters.py
@@ -32,7 +32,6 @@ from onadata.apps.logger.models import (
 from onadata.apps.viewer.models import Export
 from onadata.libs.permissions import (
     ROLES,
-    ROLES_ORDERED,
     exclude_items_from_queryset_using_xform_meta_perms,
 )
 from onadata.libs.utils.common_tags import MEDIA_FILE_TYPES
@@ -185,33 +184,29 @@ class ProjectRoleFilter(filters.BaseFilterBackend):
     def filter_queryset(self, request, queryset, view):
         """Filter by the requesting user's role (from object permissions).
 
-        ``?role=editor,owner`` returns projects where the user holds the
-        lowest-ranked requested role **or any higher role**. Roles are
-        derived from django-guardian object permissions, so we take the
-        lowest-ranked requested role and require its full Project permission
-        set: higher roles hold a superset of a lower role's permissions, so
-        this yields "that role and above". Unknown role names are a 400.
+        ``?role=editor`` returns projects where the user holds that role
+        **or any higher role**. Roles are derived from django-guardian
+        object permissions: we require the requested role's full Project
+        permission set, and higher roles hold a superset of a lower role's
+        permissions, so this yields "that role and above". Unknown role
+        names are a 400.
         """
         role = request.query_params.get("role")
 
         if not role:
             return queryset
 
-        requested = [r.strip() for r in role.split(",") if r.strip()]
-        unknown = [r for r in requested if r not in ROLES]
-        if unknown:
-            raise ParseError(_(f"Unknown role(s): {', '.join(unknown)}"))
-        if not requested:
-            return queryset
-        lowest = min(requested, key=lambda n: ROLES_ORDERED.index(ROLES[n]))
+        role = role.strip()
+        if role not in ROLES:
+            raise ParseError(_(f"Unknown role: {role}"))
         perms = [
             f"logger.{codename}"
-            for codename in ROLES[lowest].class_to_permissions.get(Project, [])
+            for codename in ROLES[role].class_to_permissions.get(Project, [])
         ]
         if not perms:
             # A role that grants no Project permissions matches no project.
             return queryset.none()
-        allowed = get_objects_for_user(
+        return get_objects_for_user(
             request.user,
             perms,
             klass=queryset,
@@ -219,7 +214,6 @@ class ProjectRoleFilter(filters.BaseFilterBackend):
             accept_global_perms=False,
             with_superuser=False,
         )
-        return queryset.filter(pk__in=allowed.values("pk"))
 
 
 # pylint: disable=too-few-public-methods

--- a/onadata/libs/filters.py
+++ b/onadata/libs/filters.py
@@ -149,11 +149,22 @@ class ProjectFilterSet(django_filter_filters.FilterSet):
     """
 
     shared = django_filter_filters.BooleanFilter(field_name="shared")
+    starred = django_filter_filters.BooleanFilter(method="filter_starred")
 
     # pylint: disable=missing-class-docstring
     class Meta:
         model = Project
         fields = []
+
+    # pylint: disable=unused-argument
+    def filter_starred(self, queryset, name, value):
+        """Filter by the requesting user's starred (favorited) projects."""
+        user = self.request.user
+        if value is True:
+            return queryset.filter(user_stars=user)
+        if value is False:
+            return queryset.exclude(user_stars=user)
+        return queryset
 
 
 # pylint: disable=too-few-public-methods

--- a/onadata/libs/filters.py
+++ b/onadata/libs/filters.py
@@ -19,7 +19,6 @@ from rest_framework import filters
 from rest_framework_guardian.filters import ObjectPermissionsFilter
 
 from onadata.apps.api.models import OrganizationProfile, Team
-from onadata.libs.utils.dataview_filters import get_filter_kwargs
 from onadata.apps.logger.models import (
     Attachment,
     DataView,
@@ -35,7 +34,9 @@ from onadata.libs.permissions import (
     exclude_items_from_queryset_using_xform_meta_perms,
 )
 from onadata.libs.utils.common_tags import MEDIA_FILE_TYPES
+from onadata.libs.utils.dataview_filters import get_filter_kwargs
 from onadata.libs.utils.numeric import int_or_parse_error
+from onadata.libs.utils.string import str2bool
 
 # pylint: disable=invalid-name
 User = get_user_model()
@@ -44,8 +45,10 @@ User = get_user_model()
 def _public_xform_id_or_none(export_id: int):
     export = Export.objects.filter(pk=export_id).first()
 
-    if export and export.xform.deleted_at is None and (
-        export.xform.shared_data or export.xform.shared
+    if (
+        export
+        and export.xform.deleted_at is None
+        and (export.xform.shared_data or export.xform.shared)
     ):
         return export.xform_id
 
@@ -147,43 +150,44 @@ class FormIDFilter(django_filter_filters.FilterSet):
         fields = ["formID"]
 
 
-class ProjectFilterSet(django_filter_filters.FilterSet):
-    """Query-param filters for the v2 projects endpoint.
-
-    Supports ?shared=, ?starred=, ?role=.
-    """
-
-    shared = django_filter_filters.BooleanFilter(field_name="shared")
-    starred = django_filter_filters.BooleanFilter(method="filter_starred")
-    role = django_filter_filters.CharFilter(method="filter_role")
-
-    # pylint: disable=missing-class-docstring
-    class Meta:
-        model = Project
-        fields = []
+# pylint: disable=too-few-public-methods
+class ProjectStarredFilter(filters.BaseFilterBackend):
+    """Project `starred` filter using the `starred` query parameter."""
 
     # pylint: disable=unused-argument
-    def filter_starred(self, queryset, name, value):
+    def filter_queryset(self, request, queryset, view):
         """Filter by the requesting user's starred (favorited) projects."""
-        user = self.request.user
-        if value is True:
-            return queryset.filter(user_stars=user)
-        if value is False:
-            return queryset.exclude(user_stars=user)
-        return queryset
+        starred = request.query_params.get("starred")
+
+        if starred is None:
+            return queryset
+
+        if str2bool(starred):
+            return queryset.filter(user_stars=request.user)
+
+        return queryset.exclude(user_stars=request.user)
+
+
+# pylint: disable=too-few-public-methods
+class ProjectRoleFilter(filters.BaseFilterBackend):
+    """Project `role` filter using the `role` query parameter."""
 
     # pylint: disable=unused-argument
-    def filter_role(self, queryset, name, value):
+    def filter_queryset(self, request, queryset, view):
         """Filter by the requesting user's role (from object permissions).
 
         ``?role=owner,manager`` returns projects where the user's role is in
         the requested set. Roles are derived from django-guardian object
         permissions, so we take the lowest-ranked requested role and require
         its full Project permission set: higher roles hold a superset of a
-        lower role's permissions, so this yields "that role and above" —
-        which equals the requested set for our top-contiguous role sets.
+        lower role's permissions, so this yields "that role and above".
         """
-        requested = [r.strip() for r in value.split(",") if r.strip() in ROLES]
+        role = request.query_params.get("role")
+
+        if not role:
+            return queryset
+
+        requested = [r.strip() for r in role.split(",") if r.strip() in ROLES]
         if not requested:
             return queryset
         lowest = min(requested, key=lambda n: ROLES_ORDERED.index(ROLES[n]))
@@ -192,7 +196,7 @@ class ProjectFilterSet(django_filter_filters.FilterSet):
             for codename in ROLES[lowest].class_to_permissions[Project]
         ]
         allowed = get_objects_for_user(
-            self.request.user,
+            request.user,
             perms,
             klass=queryset,
             any_perm=False,

--- a/onadata/libs/filters.py
+++ b/onadata/libs/filters.py
@@ -155,7 +155,9 @@ class ProjectFilterSet(django_filter_filters.FilterSet):
     """Project FilterSet; rejects unrecognized ``shared`` values with a 400."""
 
     shared = django_filter_filters.TypedChoiceFilter(
-        choices=[(choice, choice) for choice in ("true", "false", "True", "False", "1", "0")],
+        choices=[
+            (choice, choice) for choice in ("true", "false", "True", "False", "1", "0")
+        ],
         coerce=str2bool,
         error_messages={"invalid_choice": _("Select either true or false.")},
     )

--- a/onadata/libs/filters.py
+++ b/onadata/libs/filters.py
@@ -14,6 +14,7 @@ from django.shortcuts import get_object_or_404
 
 import six
 from django_filters import rest_framework as django_filter_filters
+from guardian.shortcuts import get_objects_for_user
 from rest_framework import filters
 from rest_framework_guardian.filters import ObjectPermissionsFilter
 
@@ -28,7 +29,11 @@ from onadata.apps.logger.models import (
     XForm,
 )
 from onadata.apps.viewer.models import Export
-from onadata.libs.permissions import exclude_items_from_queryset_using_xform_meta_perms
+from onadata.libs.permissions import (
+    ROLES,
+    ROLES_ORDERED,
+    exclude_items_from_queryset_using_xform_meta_perms,
+)
 from onadata.libs.utils.common_tags import MEDIA_FILE_TYPES
 from onadata.libs.utils.numeric import int_or_parse_error
 
@@ -150,6 +155,7 @@ class ProjectFilterSet(django_filter_filters.FilterSet):
 
     shared = django_filter_filters.BooleanFilter(field_name="shared")
     starred = django_filter_filters.BooleanFilter(method="filter_starred")
+    role = django_filter_filters.CharFilter(method="filter_role")
 
     # pylint: disable=missing-class-docstring
     class Meta:
@@ -165,6 +171,35 @@ class ProjectFilterSet(django_filter_filters.FilterSet):
         if value is False:
             return queryset.exclude(user_stars=user)
         return queryset
+
+    # pylint: disable=unused-argument
+    def filter_role(self, queryset, name, value):
+        """Filter by the requesting user's role (from object permissions).
+
+        ``?role=owner,manager`` returns projects where the user's role is in
+        the requested set. Roles are derived from django-guardian object
+        permissions, so we take the lowest-ranked requested role and require
+        its full Project permission set: higher roles hold a superset of a
+        lower role's permissions, so this yields "that role and above" —
+        which equals the requested set for our top-contiguous role sets.
+        """
+        requested = [r.strip() for r in value.split(",") if r.strip() in ROLES]
+        if not requested:
+            return queryset
+        lowest = min(requested, key=lambda n: ROLES_ORDERED.index(ROLES[n]))
+        perms = [
+            f"logger.{codename}"
+            for codename in ROLES[lowest].class_to_permissions[Project]
+        ]
+        allowed = get_objects_for_user(
+            self.request.user,
+            perms,
+            klass=queryset,
+            any_perm=False,
+            accept_global_perms=False,
+            with_superuser=False,
+        )
+        return queryset.filter(pk__in=allowed.values("pk"))
 
 
 # pylint: disable=too-few-public-methods

--- a/onadata/libs/filters.py
+++ b/onadata/libs/filters.py
@@ -11,11 +11,13 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.db.models import Q
 from django.http import Http404
 from django.shortcuts import get_object_or_404
+from django.utils.translation import gettext as _
 
 import six
 from django_filters import rest_framework as django_filter_filters
 from guardian.shortcuts import get_objects_for_user
 from rest_framework import filters
+from rest_framework.exceptions import ParseError
 from rest_framework_guardian.filters import ObjectPermissionsFilter
 
 from onadata.apps.api.models import OrganizationProfile, Team
@@ -162,6 +164,13 @@ class ProjectStarredFilter(filters.BaseFilterBackend):
         if starred is None:
             return queryset
 
+        if starred.lower() not in ("true", "false"):
+            raise ParseError(_("Invalid starred value. Use true or false."))
+
+        if not request.user.is_authenticated:
+            # An anonymous user has no stars.
+            return queryset.none() if str2bool(starred) else queryset
+
         if str2bool(starred):
             return queryset.filter(user_stars=request.user)
 
@@ -176,25 +185,32 @@ class ProjectRoleFilter(filters.BaseFilterBackend):
     def filter_queryset(self, request, queryset, view):
         """Filter by the requesting user's role (from object permissions).
 
-        ``?role=owner,manager`` returns projects where the user's role is in
-        the requested set. Roles are derived from django-guardian object
-        permissions, so we take the lowest-ranked requested role and require
-        its full Project permission set: higher roles hold a superset of a
-        lower role's permissions, so this yields "that role and above".
+        ``?role=editor,owner`` returns projects where the user holds the
+        lowest-ranked requested role **or any higher role**. Roles are
+        derived from django-guardian object permissions, so we take the
+        lowest-ranked requested role and require its full Project permission
+        set: higher roles hold a superset of a lower role's permissions, so
+        this yields "that role and above". Unknown role names are a 400.
         """
         role = request.query_params.get("role")
 
         if not role:
             return queryset
 
-        requested = [r.strip() for r in role.split(",") if r.strip() in ROLES]
+        requested = [r.strip() for r in role.split(",") if r.strip()]
+        unknown = [r for r in requested if r not in ROLES]
+        if unknown:
+            raise ParseError(_(f"Unknown role(s): {', '.join(unknown)}"))
         if not requested:
             return queryset
         lowest = min(requested, key=lambda n: ROLES_ORDERED.index(ROLES[n]))
         perms = [
             f"logger.{codename}"
-            for codename in ROLES[lowest].class_to_permissions[Project]
+            for codename in ROLES[lowest].class_to_permissions.get(Project, [])
         ]
+        if not perms:
+            # A role that grants no Project permissions matches no project.
+            return queryset.none()
         allowed = get_objects_for_user(
             request.user,
             perms,

--- a/onadata/libs/filters.py
+++ b/onadata/libs/filters.py
@@ -142,6 +142,20 @@ class FormIDFilter(django_filter_filters.FilterSet):
         fields = ["formID"]
 
 
+class ProjectFilterSet(django_filter_filters.FilterSet):
+    """Query-param filters for the v2 projects endpoint.
+
+    Supports ?shared=, ?starred=, ?role=.
+    """
+
+    shared = django_filter_filters.BooleanFilter(field_name="shared")
+
+    # pylint: disable=missing-class-docstring
+    class Meta:
+        model = Project
+        fields = []
+
+
 # pylint: disable=too-few-public-methods
 class OrganizationPermissionFilter(ObjectPermissionsFilter):
     """Organization profiles filter


### PR DESCRIPTION
### Changes / Features implemented

Server-side `search`, `ordering`, `shared`, `starred` and `role` query params on `GET /api/v2/projects`, so clients can query projects without fetching the full list. v1 is untouched. Parameter behavior is documented in `docs/projects.rst`.

### Steps taken to verify this change does what is intended

- Unit tests covering each param, combined params, both ordering directions, anonymous requests and invalid-input rejection

### Side effects of implementing this change

- None expected: the new filters only narrow the already permission-scoped queryset, and the `last_submission_date` annotation is applied only when requested for ordering

**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  - [x] Updated documentation
