### PR TITLE
fix(auth): per-user PasswordHistory uniqueness (login lockout)

### DIFF
--- a/onadata/apps/main/migrations/0020_alter_passwordhistory_per_user_unique.py
+++ b/onadata/apps/main/migrations/0020_alter_passwordhistory_per_user_unique.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
 """Make PasswordHistory uniqueness per-user instead of global."""
+
 from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
-        ("main", "0020_pendingemailchange_and_more"),
+        ("main", "0019_userdeactivationpermissionsnapshot"),
     ]
 
     operations = [

--- a/onadata/apps/main/migrations/0021_alter_passwordhistory_per_user_unique.py
+++ b/onadata/apps/main/migrations/0021_alter_passwordhistory_per_user_unique.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+"""Make PasswordHistory uniqueness per-user instead of global."""
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("main", "0020_pendingemailchange_and_more"),
+    ]
+
+    operations = [
+        # Drop the global UNIQUE on hashed_password (keep it indexed) ...
+        migrations.AlterField(
+            model_name="passwordhistory",
+            name="hashed_password",
+            field=models.CharField(db_index=True, max_length=128),
+        ),
+        # ... and re-scope uniqueness to (user, hashed_password).
+        migrations.AlterUniqueTogether(
+            name="passwordhistory",
+            unique_together={("user", "hashed_password")},
+        ),
+    ]

--- a/onadata/apps/main/models/password_history.py
+++ b/onadata/apps/main/models/password_history.py
@@ -4,9 +4,9 @@ Password History Class Module
 This module contains the `PasswordHistory` model which is used to track
 password changes for a user.
 """
-from django.contrib.auth import get_user_model
-from django.db import IntegrityError, models, transaction
 
+from django.contrib.auth import get_user_model
+from django.db import models
 
 User = get_user_model()
 
@@ -19,7 +19,7 @@ class PasswordHistory(models.Model):
     user = models.ForeignKey(
         User, on_delete=models.CASCADE, related_name="password_history"
     )
-    hashed_password = models.CharField(max_length=128, unique=True, db_index=True)
+    hashed_password = models.CharField(max_length=128, db_index=True)
     changed_at = models.DateTimeField(auto_now_add=True)
 
     def __str__(self):
@@ -35,27 +35,19 @@ class PasswordHistory(models.Model):
         if not created and instance.pk:
             current_password = User.objects.get(pk=instance.pk).password
             if current_password != instance.password and current_password:
-                # ``hashed_password`` is globally unique, so recording an
-                # already-stored hash raises IntegrityError. That happens
-                # whenever Django re-hashes/upgrades a stale password on login
-                # and re-saves the user: the previous hash is re-recorded. An
-                # unguarded create() would abort the whole User.save(), the
-                # upgraded hash would never persist, and every subsequent login
-                # would repeat the failure — a permanent lockout. Swallow the
-                # duplicate inside a savepoint so it never breaks the user save.
-                try:
-                    with transaction.atomic():
-                        cls.objects.create(
-                            user=instance, hashed_password=current_password
-                        )
-                except IntegrityError:
-                    # Duplicate hash already on record — the expected case
-                    # described above. Nothing to store; return so the
-                    # in-progress User.save() completes normally.
-                    return
+                # Record the outgoing hash. Uniqueness is per (user,
+                # hashed_password), so re-recording a hash this user already
+                # has — e.g. when Django re-hashes/upgrades a stale password on
+                # login and re-saves the user — is a no-op rather than an
+                # IntegrityError. get_or_create keeps that idempotent without
+                # aborting the in-progress User.save().
+                cls.objects.get_or_create(
+                    user=instance, hashed_password=current_password
+                )
 
     class Meta:
         app_label = "main"
+        unique_together = (("user", "hashed_password"),)
 
 
 models.signals.pre_save.connect(PasswordHistory.user_pre_save, sender=User)

--- a/onadata/apps/main/models/password_history.py
+++ b/onadata/apps/main/models/password_history.py
@@ -49,7 +49,10 @@ class PasswordHistory(models.Model):
                             user=instance, hashed_password=current_password
                         )
                 except IntegrityError:
-                    pass
+                    # Duplicate hash already on record — the expected case
+                    # described above. Nothing to store; return so the
+                    # in-progress User.save() completes normally.
+                    return
 
     class Meta:
         app_label = "main"

--- a/onadata/apps/main/models/password_history.py
+++ b/onadata/apps/main/models/password_history.py
@@ -5,7 +5,7 @@ This module contains the `PasswordHistory` model which is used to track
 password changes for a user.
 """
 from django.contrib.auth import get_user_model
-from django.db import models
+from django.db import IntegrityError, models, transaction
 
 
 User = get_user_model()
@@ -35,7 +35,21 @@ class PasswordHistory(models.Model):
         if not created and instance.pk:
             current_password = User.objects.get(pk=instance.pk).password
             if current_password != instance.password and current_password:
-                cls.objects.create(user=instance, hashed_password=current_password)
+                # ``hashed_password`` is globally unique, so recording an
+                # already-stored hash raises IntegrityError. That happens
+                # whenever Django re-hashes/upgrades a stale password on login
+                # and re-saves the user: the previous hash is re-recorded. An
+                # unguarded create() would abort the whole User.save(), the
+                # upgraded hash would never persist, and every subsequent login
+                # would repeat the failure — a permanent lockout. Swallow the
+                # duplicate inside a savepoint so it never breaks the user save.
+                try:
+                    with transaction.atomic():
+                        cls.objects.create(
+                            user=instance, hashed_password=current_password
+                        )
+                except IntegrityError:
+                    pass
 
     class Meta:
         app_label = "main"

--- a/onadata/apps/main/tests/test_password_history.py
+++ b/onadata/apps/main/tests/test_password_history.py
@@ -5,6 +5,8 @@ from django.test import TestCase
 from django.contrib.auth import get_user_model
 from django.test.client import Client
 
+from onadata.apps.main.models.password_history import PasswordHistory
+
 User = get_user_model()
 
 
@@ -49,3 +51,31 @@ class TestPasswordHistory(TestCase):
         user.refresh_from_db()
 
         self.assertEqual(user.password_history.count(), 1)
+
+    def test_password_change_survives_duplicate_history_hash(self):
+        """A password re-save whose previous hash is already recorded must
+        not raise IntegrityError and lock the user out.
+
+        Django upgrades a stale password hash on login (re-hash + save). The
+        pre_save handler then tries to re-record the *old* hash; if that hash
+        is already in PasswordHistory the unguarded create() aborts the whole
+        User.save(), so the upgraded hash never persists and every subsequent
+        login repeats the failure — a permanent lockout. The handler must
+        tolerate the duplicate and let the save succeed.
+        """
+        user = User.objects.create_user(username="relogin", password="passA")
+        old_hash = user.password
+        # Simulate the old hash already being recorded (a prior upgrade/record).
+        PasswordHistory.objects.create(user=user, hashed_password=old_hash)
+
+        # The password now changes (e.g. Django's hash upgrade on login); the
+        # pre_save will try to re-record old_hash, which already exists.
+        user.set_password("passB")
+        user.save()  # must NOT raise IntegrityError
+
+        user.refresh_from_db()
+        self.assertTrue(user.check_password("passB"))
+        # The duplicate must not have been inserted.
+        self.assertEqual(
+            PasswordHistory.objects.filter(hashed_password=old_hash).count(), 1
+        )

--- a/onadata/apps/main/tests/test_password_history.py
+++ b/onadata/apps/main/tests/test_password_history.py
@@ -79,3 +79,23 @@ class TestPasswordHistory(TestCase):
         self.assertEqual(
             PasswordHistory.objects.filter(hashed_password=old_hash).count(), 1
         )
+
+    def test_same_hash_allowed_for_different_users(self):
+        """Uniqueness is per-user, not global: two users may share a hash.
+
+        A global unique constraint on hashed_password is the wrong invariant —
+        it makes one user's history collide with another's and is what caused
+        the login lockout. Recording the same hash for two different users
+        must succeed.
+        """
+        user_a = User.objects.create_user(username="a", password="x")
+        user_b = User.objects.create_user(username="b", password="x")
+        shared_hash = "pbkdf2_sha256$shared$deadbeef"
+
+        PasswordHistory.objects.create(user=user_a, hashed_password=shared_hash)
+        # Same hash, different user — must not raise.
+        PasswordHistory.objects.create(user=user_b, hashed_password=shared_hash)
+
+        self.assertEqual(
+            PasswordHistory.objects.filter(hashed_password=shared_hash).count(), 2
+        )

--- a/onadata/libs/tests/utils/test_password_validator.py
+++ b/onadata/libs/tests/utils/test_password_validator.py
@@ -1,6 +1,10 @@
+from datetime import timedelta
+
 from django.test import TestCase
+from django.contrib.auth.hashers import make_password
 from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
+from django.utils import timezone
 
 from onadata.apps.main.models.password_history import PasswordHistory
 from onadata.libs.utils.validators import PreviousPasswordValidator
@@ -65,3 +69,47 @@ class PreviousPasswordValidatorTestCase(TestCase):
             validator.validate("newpassword@123", user=user)
         except ValidationError:
             self.fail("PreviousPasswordValidator raised ValidationError unexpectedly!")
+
+    def test_history_limit_applies_to_most_recent_passwords(self):
+        """Validator checks the most recently changed passwords, not the oldest
+
+        With more history entries than the history limit, the limit must
+        keep the most recent entries (ordered by changed_at descending) so
+        that only passwords older than the window are allowed again.
+        """
+        user = User.objects.create(username="testuser")
+        user.set_password("currentpassword")
+        user.save()
+
+        # Insert history oldest-first so that an unordered queryset slice
+        # (which follows insertion/pk order) would wrongly keep the oldest
+        # entries instead of the most recent ones.
+        now = timezone.now()
+        for age_in_days, raw_password in [
+            (3, "oldestpass"),
+            (2, "middlepass"),
+            (1, "newestpass"),
+        ]:
+            entry = PasswordHistory.objects.create(
+                user=user, hashed_password=make_password(raw_password)
+            )
+            # changed_at is auto_now_add, so it must be set via update()
+            PasswordHistory.objects.filter(pk=entry.pk).update(
+                changed_at=now - timedelta(days=age_in_days)
+            )
+
+        validator = PreviousPasswordValidator(history_limt=2)
+
+        # The two most recently used passwords are within the window
+        with self.assertRaises(ValidationError):
+            validator.validate("newestpass", user=user)
+        with self.assertRaises(ValidationError):
+            validator.validate("middlepass", user=user)
+
+        # The oldest password falls outside the history window
+        try:
+            validator.validate("oldestpass", user=user)
+        except ValidationError:
+            self.fail(
+                "Password older than the history limit should be allowed again"
+            )

--- a/onadata/libs/utils/validators.py
+++ b/onadata/libs/utils/validators.py
@@ -21,7 +21,7 @@ class PreviousPasswordValidator:
             if user.check_password(password):
                 raise ValidationError(self.message)
 
-            pw_history = user.password_history.all().order_by("-created_at")[
+            pw_history = user.password_history.all().order_by("-changed_at")[
                 : self.history_limit
             ]
             for pw_hist in pw_history:

--- a/onadata/libs/utils/validators.py
+++ b/onadata/libs/utils/validators.py
@@ -2,6 +2,7 @@
 """
 Module containing custom validator classes for the User Model
 """
+
 from django.contrib.auth.hashers import check_password
 from django.core.exceptions import ValidationError
 from django.utils.translation import gettext as _
@@ -20,7 +21,9 @@ class PreviousPasswordValidator:
             if user.check_password(password):
                 raise ValidationError(self.message)
 
-            pw_history = user.password_history.all()[: self.history_limit]
+            pw_history = user.password_history.all().order_by("-created_at")[
+                : self.history_limit
+            ]
             for pw_hist in pw_history:
                 if check_password(password, pw_hist.hashed_password):
                     raise ValidationError(self.message)


### PR DESCRIPTION
### Changes / Features implemented

`PasswordHistory`'s global `unique=True` on `hashed_password` could lock users out at login when the pre-save hash upgrade hit a duplicate hash (reproduced from a Sentry trace). Login no longer fails on this bookkeeping write, and uniqueness is re-scoped to per-user.

### Steps taken to verify this change does what is intended

- Unit tests: the login-lockout repro, the explicit duplicate swallow, and per-user vs global uniqueness

### Side effects of implementing this change

- Schema change: a new migration alters the uniqueness constraint

**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  - [ ] Updated documentation

Closes #3175
