### PR TITLE
feat(auth): graceful CSRF-failure retry on login

### DIFF
--- a/onadata/libs/csrf_failure.py
+++ b/onadata/libs/csrf_failure.py
@@ -1,0 +1,45 @@
+"""
+Graceful CSRF-failure handler.
+
+A CSRF failure on the login page is almost always a stale or rotated token
+(an old tab, the back button, or the cookie rotating between page render and
+submit) rather than a genuine attack. Django's default response is a dead-end
+403 page, which strands the user. This handler instead sends a failed *login*
+POST back to a fresh login page so a new CSRF token is issued and the user can
+simply try again — preserving a safe ``next`` so a brokered OIDC login flow
+continues to its destination. CSRF failures on any other path keep Django's
+default behavior, so genuine cross-site POSTs to the API are not masked.
+"""
+from urllib.parse import urlencode
+
+from django.conf import settings
+from django.contrib.auth import REDIRECT_FIELD_NAME
+from django.http import HttpResponse, HttpResponseRedirect
+from django.utils.http import url_has_allowed_host_and_scheme
+from django.views.csrf import CSRF_FAILURE_TEMPLATE_NAME
+from django.views.csrf import csrf_failure as default_csrf_failure
+
+
+def _login_path() -> str:
+    return getattr(settings, "LOGIN_URL", "/accounts/login/")
+
+
+def csrf_failure(
+    request, reason: str = "", template_name: str = CSRF_FAILURE_TEMPLATE_NAME
+) -> HttpResponse:
+    """Redirect a failed login POST back to a fresh login; else default 403."""
+    login_path = _login_path()
+    if request.path == login_path:
+        next_url = request.POST.get(REDIRECT_FIELD_NAME) or request.GET.get(
+            REDIRECT_FIELD_NAME
+        )
+        if next_url and url_has_allowed_host_and_scheme(
+            next_url,
+            allowed_hosts={request.get_host()},
+            require_https=request.is_secure(),
+        ):
+            return HttpResponseRedirect(
+                f"{login_path}?{urlencode({REDIRECT_FIELD_NAME: next_url})}"
+            )
+        return HttpResponseRedirect(login_path)
+    return default_csrf_failure(request, reason=reason, template_name=template_name)

--- a/onadata/libs/tests/test_csrf_failure.py
+++ b/onadata/libs/tests/test_csrf_failure.py
@@ -1,0 +1,41 @@
+"""Tests for the graceful CSRF-failure handler."""
+from django.test import RequestFactory, TestCase
+
+from onadata.libs.csrf_failure import csrf_failure
+
+
+class CsrfFailureTests(TestCase):
+    """The login flow should self-heal on a CSRF failure; other paths default."""
+
+    def setUp(self):
+        self.factory = RequestFactory()
+
+    def test_login_csrf_failure_redirects_to_fresh_login(self):
+        request = self.factory.post(
+            "/accounts/login/", {"next": "/o/authorize/?client_id=x"}
+        )
+        response = csrf_failure(request, reason="CSRF token incorrect")
+        self.assertEqual(response.status_code, 302)
+        self.assertTrue(response["Location"].startswith("/accounts/login/"))
+        self.assertIn("next=", response["Location"])
+
+    def test_login_csrf_failure_without_next_redirects_to_bare_login(self):
+        request = self.factory.post("/accounts/login/", {})
+        response = csrf_failure(request, reason="CSRF token incorrect")
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response["Location"], "/accounts/login/")
+
+    def test_login_csrf_failure_drops_unsafe_next(self):
+        request = self.factory.post(
+            "/accounts/login/", {"next": "https://evil.example.com/steal"}
+        )
+        response = csrf_failure(request, reason="CSRF token incorrect")
+        self.assertEqual(response.status_code, 302)
+        # Open-redirect target must be dropped, not preserved.
+        self.assertEqual(response["Location"], "/accounts/login/")
+
+    def test_non_login_csrf_failure_uses_default(self):
+        request = self.factory.post("/api/v1/forms.json", {})
+        response = csrf_failure(request, reason="CSRF token incorrect")
+        # Default Django behavior: a 403, not a redirect.
+        self.assertEqual(response.status_code, 403)

--- a/onadata/settings/common.py
+++ b/onadata/settings/common.py
@@ -124,6 +124,9 @@ CSRF_COOKIE_SAMESITE = os.environ.get("DJANGO_CSRF_COOKIE_SAMESITE", "Lax")
 # CSRF_COOKIE_HTTPONLY is left at Django's default (False) because the
 # JS client reads the CSRF token from the cookie to set the X-CSRFToken
 # header on AJAX requests.
+# Send a failed login POST back to a fresh login (new token) instead of the
+# dead-end 403 page, so a stale/rotated CSRF token lets the user just retry.
+CSRF_FAILURE_VIEW = "onadata.libs.csrf_failure.csrf_failure"
 
 # Login URLs
 LOGIN_URL = "/accounts/login/"


### PR DESCRIPTION
### Changes / Features implemented

A login POST that fails CSRF validation (stale or rotated token — e.g. a login tab left open across a deploy) now redirects back to a fresh login page with the safe `next` preserved, instead of dead-ending on Django's 403 page.

### Steps taken to verify this change does what is intended

- Unit tests: redirect target, `next` safety (unsafe values dropped), non-login paths keep the default 403

### Side effects of implementing this change

- Only the login path gets the redirect; every other view keeps Django's default CSRF-failure behavior

**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  - [ ] Updated documentation
