### PR TITLE
chore(migrations): normalize autodetected MetaData index name

### DIFF
--- a/onadata/apps/main/migrations/0020_rename_metadata_object_index.py
+++ b/onadata/apps/main/migrations/0020_rename_metadata_object_index.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+"""Normalize an autodetected MetaData index name.
+
+Pre-existing drift between the models state and the migrations state:
+any ``makemigrations`` run regenerates this rename until it lands.
+"""
+
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("main", "0019_userdeactivationpermissionsnapshot"),
+    ]
+
+    operations = [
+        migrations.RenameIndex(
+            model_name="metadata",
+            new_name="main_metada_object__3d1433_idx",
+            old_name="main_metada_object__363d70_idx",
+        ),
+    ]


### PR DESCRIPTION
### Changes / Features implemented

Normalizes an autodetected `MetaData` index name. There is pre-existing drift between the models state and the migrations state on `main`, so every `makemigrations` run keeps regenerating this rename until it lands.

### Steps taken to verify this change does what is intended

- The `RenameIndex` operation is generated verbatim by `makemigrations` on main; CI runs migrations

### Side effects of implementing this change

- None beyond the index rename

**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests (migration only — covered by the migration-check CI job)
  - [ ] Updated documentation
