### PR TITLE
Enforce active organization visibility for projects and forms

### DIFF
--- a/docs/adr/0001-active-organization-project-form-visibility.md
+++ b/docs/adr/0001-active-organization-project-form-visibility.md
@@ -1,0 +1,68 @@
+# ADR 0001: Active organization visibility for project and form APIs
+
+## Status
+
+Proposed
+
+## Area
+
+API / Access control
+
+## Date
+
+2026-07-16
+
+## Context
+
+Project and form API endpoints do not apply active organization filtering
+consistently. Public sharing and object permissions should not expose resources
+owned by inactive organizations.
+
+Forms need one important distinction: visibility should depend on the form's
+project organization, not on the active state of the user who uploaded or
+created the form. An uploader can become inactive while the organization remains
+active.
+
+Performance was checked separately with `EXPLAIN ANALYZE`. The project list
+paths need partial indexes for ordered non-deleted and public non-deleted
+queries; the sampled form paths did not require a new form index.
+
+## Decision
+
+Project API visibility requires:
+
+```python
+deleted_at__isnull=True,
+organization__is_active=True,
+```
+
+Form API visibility requires:
+
+```python
+deleted_at__isnull=True,
+project__organization__is_active=True,
+```
+
+The form rule intentionally does not require `XForm.user.is_active`,
+`XForm.created_by.is_active`, or any uploader active-state predicate.
+
+This rule applies to API endpoints that return or target projects, forms, or
+resources selected through a project or form, including public/shared,
+owner-filtered, nested, detail, and permission-filtered paths.
+
+## Consequences
+
+Projects and forms owned by inactive organizations are omitted from list
+endpoints and should behave as not found on detail/action endpoints.
+
+Public and authenticated behavior remains otherwise unchanged: public endpoints
+still require public sharing, and authenticated endpoints still require the
+existing permissions.
+
+The implementation should enforce the rule through the DRF queryset/filter
+lifecycle where possible. Any direct project/form lookup or public queryset
+union must preserve the same predicate.
+
+Project list performance relies on the partial indexes added for non-deleted and
+public non-deleted project ordering. The SQL investigation did not show a need
+for a new form index.

--- a/onadata/apps/api/tests/viewsets/test_project_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_project_viewset.py
@@ -383,6 +383,26 @@ class TestProjectViewSet(TestAbstractViewSet):
             Version.objects.get_for_object(self.project).count(), version_count
         )
 
+    def test_projects_get_inactive_organization_not_found(self):
+        self._org_create()
+        self._project_create(
+            {
+                "name": "organization_project",
+                "owner": (
+                    "http://testserver/api/v1/users/"
+                    f"{self.organization.user.username}"
+                ),
+            }
+        )
+        self.project.organization.is_active = False
+        self.project.organization.save()
+
+        view = ProjectViewSet.as_view({"get": "retrieve"})
+        request = self.factory.get("/", **self.extra)
+        response = view(request, pk=self.project.pk)
+
+        self.assertEqual(response.status_code, 404)
+
     def test_project_get_deleted_form(self):
         self._publish_xls_form_to_project()
 
@@ -415,6 +435,27 @@ class TestProjectViewSet(TestAbstractViewSet):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 0)
+
+    def test_project_forms_inactive_organization_not_found(self):
+        self._org_create()
+        self._project_create(
+            {
+                "name": "organization_project",
+                "owner": (
+                    "http://testserver/api/v1/users/"
+                    f"{self.organization.user.username}"
+                ),
+            }
+        )
+        self._publish_xls_form_to_project()
+        self.project.organization.is_active = False
+        self.project.organization.save()
+
+        view = ProjectViewSet.as_view({"get": "forms"})
+        request = self.factory.get("/", **self.extra)
+        response = view(request, pk=self.project.pk)
+
+        self.assertEqual(response.status_code, 404)
 
     # pylint: disable=invalid-name
     def test_none_empty_forms_and_dataview_properties_in_returned_json(self):
@@ -1776,6 +1817,16 @@ class TestProjectViewSet(TestAbstractViewSet):
         self.assertEqual(response.status_code, 200)
         self.assertIn(alice_project_data, response.data)
         self.assertFalse(PROJECT_PUBLIC_EXCLUDED_FIELDS & set(response.data[0]))
+
+        self.project.organization.is_active = False
+        self.project.organization.save()
+        request = self.factory.get("/", {"owner": "alice"}, **self.extra)
+        response = self.view(request)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual([], response.data)
+
+        self.project.organization.is_active = True
+        self.project.organization.save()
 
         # should show deleted project public project when filtered by owner
         self.project.soft_delete()

--- a/onadata/apps/api/tests/viewsets/test_xform_list_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_xform_list_viewset.py
@@ -385,6 +385,18 @@ class TestXFormListViewSet(TestAbstractViewSet, TransactionTestCase):
             self.assertTrue(response.has_header("Date"))
             self.assertEqual(response["Content-Type"], "text/xml; charset=utf-8")
 
+    def test_get_xform_list_project_pk_inactive_organization_returns_empty(self):
+        self.xform.shared = True
+        self.xform.save()
+        self.project.organization.is_active = False
+        self.project.organization.save()
+
+        request = self.factory.get(f"/projects/{self.project.pk}/formList")
+        response = self.view(request, project_pk=self.project.pk)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data, [])
+
     def test_get_xform_list_xform_pk_filter(self):
         """
         Test formList xform_pk filter for authenticated user.
@@ -428,6 +440,42 @@ class TestXFormListViewSet(TestAbstractViewSet, TransactionTestCase):
             self.assertTrue(response.has_header("X-OpenRosa-Accept-Content-Length"))
             self.assertTrue(response.has_header("Date"))
             self.assertEqual(response["Content-Type"], "text/xml; charset=utf-8")
+
+    def test_get_xform_list_xform_pk_inactive_organization_not_found(self):
+        self.xform.shared = True
+        self.xform.save()
+        self.project.organization.is_active = False
+        self.project.organization.save()
+
+        request = self.factory.get(f"/forms/{self.xform.pk}/formList")
+        response = self.view(request, xform_pk=self.xform.pk)
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_get_xform_list_ignores_inactive_uploader(self):
+        self._org_create()
+        self._project_create(
+            {
+                "name": "organization_project",
+                "owner": (
+                    "http://testserver/api/v1/users/"
+                    f"{self.organization.user.username}"
+                ),
+            }
+        )
+        self._publish_xls_form_to_project()
+        self.xform.shared = True
+        self.xform.save()
+        self.xform.created_by.is_active = False
+        self.xform.created_by.save()
+
+        request = self.factory.get(f"/{self.organization.user.username}/formList")
+        response = self.view(request, username=self.organization.user.username)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(self.xform.project.organization.is_active)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]["formID"], self.xform.id_string)
 
     def test_get_xform_list_of_logged_in_user_with_username_param(self):
         # publish 2 forms as bob

--- a/onadata/apps/api/tests/viewsets/test_xform_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_xform_viewset.py
@@ -1164,6 +1164,81 @@ class TestXFormViewSet(XFormViewSetBaseTestCase):
         self.assertNotIn(deleted_form.pk, form_ids)
         self.assertIn(active_form.pk, form_ids)
 
+    def test_public_form_list_excludes_inactive_project_organization(self):
+        self._publish_xls_form_to_project()
+        self.xform.shared = True
+        self.xform.save()
+        self.project.organization.is_active = False
+        self.project.organization.save()
+
+        self.view = XFormViewSet.as_view({"get": "retrieve"})
+        request = self.factory.get("/")
+        response = self.view(request, pk="public")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data, [])
+
+    def test_form_retrieve_inactive_project_organization_not_found(self):
+        self._publish_xls_form_to_project()
+        self.xform.shared = True
+        self.xform.save()
+        self.project.organization.is_active = False
+        self.project.organization.save()
+
+        self.view = XFormViewSet.as_view({"get": "retrieve"})
+        request = self.factory.get("/")
+        response = self.view(request, pk=self.xform.pk)
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_form_list_excludes_inactive_project_organization(self):
+        self._org_create()
+        self._project_create(
+            {
+                "name": "organization_project",
+                "owner": (
+                    "http://testserver/api/v1/users/"
+                    f"{self.organization.user.username}"
+                ),
+            }
+        )
+        self._publish_xls_form_to_project()
+        self.project.organization.is_active = False
+        self.project.organization.save()
+
+        request = self.factory.get("/", **self.extra)
+        response = self.view(request)
+        form_ids = [form["formid"] for form in response.data]
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotIn(self.xform.pk, form_ids)
+
+    def test_public_form_list_ignores_inactive_uploader(self):
+        self._org_create()
+        self._project_create(
+            {
+                "name": "organization_project",
+                "owner": (
+                    "http://testserver/api/v1/users/"
+                    f"{self.organization.user.username}"
+                ),
+            }
+        )
+        self._publish_xls_form_to_project()
+        self.xform.shared = True
+        self.xform.save()
+        self.xform.created_by.is_active = False
+        self.xform.created_by.save()
+
+        self.view = XFormViewSet.as_view({"get": "retrieve"})
+        request = self.factory.get("/")
+        response = self.view(request, pk="public")
+        form_ids = [form["formid"] for form in response.data]
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(self.xform.project.organization.is_active)
+        self.assertIn(self.xform.pk, form_ids)
+
     def test_form_list_other_user_access(self):
         with HTTMock(enketo_urls_mock):
             """Test that a different user has no access to bob's form"""

--- a/onadata/apps/api/tests/viewsets/v2/test_project_viewset.py
+++ b/onadata/apps/api/tests/viewsets/v2/test_project_viewset.py
@@ -87,6 +87,19 @@ class GetProjectListTestCase(TestAbstractViewSet):
         public_excluded_fields = PROJECT_PUBLIC_EXCLUDED_FIELDS | {"current_user_role"}
         self.assertFalse(public_excluded_fields & set(response.data[0]))
 
+    def test_public_inactive_organization_project_excluded(self):
+        """Anonymous list omits public projects under inactive organizations."""
+        self.project.shared = True
+        self.project.save()
+        self.project.organization.is_active = False
+        self.project.organization.save()
+
+        request = self.factory.get("/")
+        response = self.view(request)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data, [])
+
 
 @override_settings(TIME_ZONE="UTC")
 class RetrieveProjectTestCase(TestAbstractViewSet):

--- a/onadata/apps/api/tools.py
+++ b/onadata/apps/api/tools.py
@@ -117,7 +117,10 @@ def get_accessible_forms(owner=None, shared_form=False, shared_data=False):
     Returns only public forms if owner is 'public' otherwise returns forms
     belonging to owner.
     """
-    xforms = XForm.objects.filter()
+    xforms = XForm.objects.filter(
+        deleted_at__isnull=True,
+        project__organization__is_active=True,
+    )
 
     if shared_form and not shared_data:
         xforms = xforms.filter(shared=True)
@@ -434,13 +437,23 @@ def publish_project_xform(request, project):
         otherwise returns False.
         """
         try:
-            XForm.objects.get(user=project.organization, id_string=xform.id_string)
+            XForm.objects.get(
+                user=project.organization,
+                id_string=xform.id_string,
+                deleted_at__isnull=True,
+                project__organization__is_active=True,
+            )
         except XForm.DoesNotExist:
             return False
         return True
 
     if "formid" in request.data:
-        xform = get_object_or_404(XForm, pk=request.data.get("formid"))
+        xform = get_object_or_404(
+            XForm,
+            pk=request.data.get("formid"),
+            deleted_at__isnull=True,
+            project__organization__is_active=True,
+        )
         clear_project_owner_cache(xform.project.pk)
         safe_cache_delete(f"{PROJ_FORMS_CACHE}{xform.project.pk}")
         safe_cache_delete(f"{PROJ_BASE_FORMS_CACHE}{xform.project.pk}")

--- a/onadata/apps/api/viewsets/attachment_viewset.py
+++ b/onadata/apps/api/viewsets/attachment_viewset.py
@@ -134,7 +134,6 @@ class AttachmentViewSet(
                     xform = get_object_or_404(
                         XForm,
                         pk=xform,
-                        deleted_at__isnull=True,
                         project__organization__is_active=True,
                     )
                     if not xform.shared_data:

--- a/onadata/apps/api/viewsets/attachment_viewset.py
+++ b/onadata/apps/api/viewsets/attachment_viewset.py
@@ -7,6 +7,7 @@ from urllib.parse import quote
 
 from django.conf import settings
 from django.core.files.storage import default_storage
+from django.db.models import Q
 from django.http import Http404
 from django.shortcuts import get_object_or_404
 from django.utils.translation import gettext as _
@@ -60,7 +61,16 @@ class AttachmentViewSet(
     filter_backends = (filters.AttachmentFilter, filters.AttachmentTypeFilter)
     lookup_field = "pk"
     queryset = Attachment.objects.filter(
-        instance__deleted_at__isnull=True, deleted_at__isnull=True
+        Q(
+            xform__deleted_at__isnull=True,
+            xform__project__organization__is_active=True,
+        )
+        | Q(
+            instance__xform__deleted_at__isnull=True,
+            instance__xform__project__organization__is_active=True,
+        ),
+        instance__deleted_at__isnull=True,
+        deleted_at__isnull=True,
     )
     permission_classes = (AttachmentObjectPermissions,)
     serializer_class = AttachmentSerializer
@@ -121,7 +131,12 @@ class AttachmentViewSet(
             if xform:
                 xform = parse_int(xform)
                 if xform:
-                    xform = get_object_or_404(XForm, pk=xform)
+                    xform = get_object_or_404(
+                        XForm,
+                        pk=xform,
+                        deleted_at__isnull=True,
+                        project__organization__is_active=True,
+                    )
                     if not xform.shared_data:
                         raise Http404(_("Not Found"))
                 else:

--- a/onadata/apps/api/viewsets/briefcase_viewset.py
+++ b/onadata/apps/api/viewsets/briefcase_viewset.py
@@ -2,6 +2,7 @@
 """
 The /briefcase API implementation.
 """
+
 from xml.dom import NotFoundErr
 
 from django.conf import settings
@@ -103,8 +104,7 @@ def _query_optimization_fence(instances, num_entries):
     raw_queryset = Instance.objects.raw(outer_query, [num_entries])
     # convert raw queryset to queryset
     instances_data = [
-        {"pk": item.id, "uuid": item.uuid}
-        for item in raw_queryset.iterator()
+        {"pk": item.id, "uuid": item.uuid} for item in raw_queryset.iterator()
     ]
     # Create QuerySet from the instances dict
     instances = Instance.objects.filter(
@@ -126,9 +126,14 @@ class BriefcaseViewset(
     https://code.google.com/p/opendatakit/wiki/BriefcaseAggregateAPI).
     """
 
-    authentication_classes = (DigestAuthentication, TokenAuthentication,)
+    authentication_classes = (
+        DigestAuthentication,
+        TokenAuthentication,
+    )
     filter_backends = (filters.AnonDjangoObjectPermissionFilter,)
-    queryset = XForm.objects.all()
+    queryset = XForm.objects.filter(
+        deleted_at__isnull=True, project__organization__is_active=True
+    )
     permission_classes = (permissions.IsAuthenticated, ViewDjangoObjectPermissions)
     renderer_classes = (TemplateXMLRenderer, BrowsableAPIRenderer)
     serializer_class = XFormListSerializer
@@ -158,6 +163,8 @@ class BriefcaseViewset(
             Instance,
             xform__user__username__iexact=username,
             xform__id_string__iexact=id_string,
+            xform__deleted_at__isnull=True,
+            xform__project__organization__is_active=True,
             uuid=uuid,
         )
         self.check_object_permissions(self.request, obj.xform)

--- a/onadata/apps/api/viewsets/charts_viewset.py
+++ b/onadata/apps/api/viewsets/charts_viewset.py
@@ -84,8 +84,13 @@ class ChartsViewSet(
     ChartsViewSet: /charts api endpoint for chart data and chart widgets
     """
 
-    filter_backends = (filters.AnonDjangoObjectPermissionFilter,)
-    queryset = XForm.objects.all()
+    filter_backends = (
+        filters.AnonDjangoObjectPermissionFilter,
+        filters.ActiveXFormOrganizationFilter,
+    )
+    queryset = XForm.objects.filter(
+        deleted_at__isnull=True, project__organization__is_active=True
+    )
     serializer_class = ChartSerializer
     lookup_field = "pk"
     renderer_classes = (

--- a/onadata/apps/api/viewsets/data_viewset.py
+++ b/onadata/apps/api/viewsets/data_viewset.py
@@ -144,6 +144,7 @@ class DataViewSet(
         filters.DataAnonDjangoObjectPermissionFilter,
         filters.XFormOwnerFilter,
         filters.DataFilter,
+        filters.ActiveXFormOrganizationFilter,
     )
     serializer_class = DataSerializer
     permission_classes = (XFormPermissions,)
@@ -154,7 +155,9 @@ class DataViewSet(
     public_data_endpoint = "public"
     pagination_class = CountOverridablePageNumberPagination
 
-    queryset = XForm.objects.filter(deleted_at__isnull=True)
+    queryset = XForm.objects.filter(
+        deleted_at__isnull=True, project__organization__is_active=True
+    )
 
     def get_serializer_class(self):
         """Returns appropriate serializer class based on context."""
@@ -222,7 +225,9 @@ class DataViewSet(
 
     def _get_public_forms_queryset(self):
         return XForm.objects.filter(
-            Q(shared=True) | Q(shared_data=True), deleted_at__isnull=True
+            Q(shared=True) | Q(shared_data=True),
+            deleted_at__isnull=True,
+            project__organization__is_active=True,
         )
 
     def _filtered_or_shared_queryset(self, queryset, form_pk):
@@ -232,6 +237,7 @@ class DataViewSet(
         if not queryset:
             filter_kwargs["shared_data"] = True
             filter_kwargs["deleted_at__isnull"] = True
+            filter_kwargs["project__organization__is_active"] = True
             queryset = XForm.objects.filter(**filter_kwargs).only("id", "shared")
 
             if not queryset:
@@ -588,7 +594,8 @@ class DataViewSet(
             if is_merged_dataset:
                 merged_form = MergedXForm.objects.get(pk=xform_id)
                 queryset = merged_form.xforms.filter(
-                    deleted_at__isnull=True
+                    deleted_at__isnull=True,
+                    project__organization__is_active=True,
                 ).values_list("id", "num_of_submissions")
                 try:
                     pks, num_of_submissions = [list(value) for value in zip(*queryset)]
@@ -596,7 +603,11 @@ class DataViewSet(
                 except ValueError:
                     pks, num_of_submissions = [], 0
             else:
-                num_of_submissions = XForm.objects.get(id=xform_id).num_of_submissions
+                num_of_submissions = XForm.objects.get(
+                    id=xform_id,
+                    deleted_at__isnull=True,
+                    project__organization__is_active=True,
+                ).num_of_submissions
             # pylint: disable=attribute-defined-outside-init
             # Include geom and xform_id fields for geojson format to avoid N+1 queries
             if export_type == "geojson":

--- a/onadata/apps/api/viewsets/dataview_viewset.py
+++ b/onadata/apps/api/viewsets/dataview_viewset.py
@@ -80,7 +80,13 @@ class DataViewViewSet(
     A simple ViewSet for viewing and editing DataViews.
     """
 
-    queryset = DataView.objects.filter(deleted_at__isnull=True).select_related()
+    queryset = DataView.objects.filter(
+        deleted_at__isnull=True,
+        xform__deleted_at__isnull=True,
+        xform__project__organization__is_active=True,
+        project__deleted_at__isnull=True,
+        project__organization__is_active=True,
+    ).select_related()
     serializer_class = DataViewSerializer
     permission_classes = [DataViewViewsetPermissions]
     lookup_field = "pk"

--- a/onadata/apps/api/viewsets/entity_list_viewset.py
+++ b/onadata/apps/api/viewsets/entity_list_viewset.py
@@ -66,7 +66,11 @@ class EntityListViewSet(
     DestroyModelMixin,
 ):
     queryset = (
-        EntityList.objects.filter(deleted_at__isnull=True)
+        EntityList.objects.filter(
+            deleted_at__isnull=True,
+            project__deleted_at__isnull=True,
+            project__organization__is_active=True,
+        )
         .order_by("pk")
         .prefetch_related(
             "registration_forms",

--- a/onadata/apps/api/viewsets/export_viewset.py
+++ b/onadata/apps/api/viewsets/export_viewset.py
@@ -4,6 +4,7 @@ The /api/v1/exports API implementation.
 
 List, Create, Update, Destroy Export model objects.
 """
+
 import os
 
 from rest_framework.mixins import DestroyModelMixin
@@ -30,7 +31,10 @@ class ExportViewSet(DestroyModelMixin, ReadOnlyModelViewSet):
     authentication_classes = api_settings.DEFAULT_AUTHENTICATION_CLASSES + [
         TempTokenURLParameterAuthentication
     ]
-    queryset = Export.objects.all()
+    queryset = Export.objects.filter(
+        xform__deleted_at__isnull=True,
+        xform__project__organization__is_active=True,
+    )
     renderer_classes = api_settings.DEFAULT_RENDERER_CLASSES + [
         renderers.CSVRenderer,
         renderers.CSVZIPRenderer,

--- a/onadata/apps/api/viewsets/floip_viewset.py
+++ b/onadata/apps/api/viewsets/floip_viewset.py
@@ -2,6 +2,7 @@
 """
 FloipViewSet: API endpoint for /api/floip
 """
+
 from uuid import UUID
 
 from django.db.models import Q
@@ -75,9 +76,12 @@ class FloipViewSet(
     filter_backends = (
         filters.AnonDjangoObjectPermissionFilter,
         filters.PublicDatasetsFilter,
+        filters.ActiveXFormOrganizationFilter,
     )
     permission_classes = [XFormPermissions]
-    queryset = XForm.objects.filter(deleted_at__isnull=True)
+    queryset = XForm.objects.filter(
+        deleted_at__isnull=True, project__organization__is_active=True
+    )
     serializer_class = FloipSerializer
 
     pagination_class = PageNumberPagination

--- a/onadata/apps/api/viewsets/merged_xform_viewset.py
+++ b/onadata/apps/api/viewsets/merged_xform_viewset.py
@@ -22,8 +22,8 @@ from onadata.libs.serializers.geojson_serializer import GeoJsonSerializer
 from onadata.libs.serializers.merged_xform_serializer import MergedXFormSerializer
 from onadata.libs.utils.bbox_tools import compute_instance_bbox
 from onadata.libs.utils.cache_tools import (
-    get_bbox_cache_ttl,
     MERGED_XFORM_BBOX_CACHE,
+    get_bbox_cache_ttl,
     safe_cache_get,
     safe_cache_set,
 )
@@ -44,10 +44,13 @@ class MergedXFormViewSet(
     filter_backends = (
         filters.AnonDjangoObjectPermissionFilter,
         filters.PublicDatasetsFilter,
+        filters.ActiveXFormOrganizationFilter,
     )
     permission_classes = [XFormPermissions]
     queryset = (
-        MergedXForm.objects.filter(deleted_at__isnull=True)
+        MergedXForm.objects.filter(
+            deleted_at__isnull=True, project__organization__is_active=True
+        )
         .annotate(number_of_submissions=Sum("xforms__num_of_submissions"))
         .all()
     )
@@ -116,7 +119,12 @@ class MergedXFormViewSet(
         if cached is not None:
             return Response(cached)
 
-        xform_ids = list(merged_xform.xforms.values_list("pk", flat=True))
+        xform_ids = list(
+            merged_xform.xforms.filter(
+                deleted_at__isnull=True,
+                project__organization__is_active=True,
+            ).values_list("pk", flat=True)
+        )
         data = {"bbox": compute_instance_bbox(xform_ids)}
         safe_cache_set(cache_key, data, get_bbox_cache_ttl())
         return Response(data)
@@ -129,7 +137,11 @@ class MergedXFormViewSet(
         export_type = self.kwargs.get("format", request.GET.get("format"))
         queryset = (
             Instance.objects.filter(
-                xform__in=merged_xform.xforms.all(), deleted_at__isnull=True
+                xform__in=merged_xform.xforms.filter(
+                    deleted_at__isnull=True,
+                    project__organization__is_active=True,
+                ),
+                deleted_at__isnull=True,
             )
             .only("id", "json", "geom", "xform_id")
             .order_by("pk")

--- a/onadata/apps/api/viewsets/open_data_viewset.py
+++ b/onadata/apps/api/viewsets/open_data_viewset.py
@@ -352,7 +352,12 @@ class OpenDataViewSet(ETagsMixin, CacheControlMixin, BaseViewset, ModelViewSet):
             )
 
         if data_type == "xform":
-            xform = get_object_or_404(XForm, id=object_id)
+            xform = get_object_or_404(
+                XForm,
+                id=object_id,
+                deleted_at__isnull=True,
+                project__organization__is_active=True,
+            )
             if request.user.has_perm("change_xform", xform):
                 content_type = ContentType.objects.get_for_model(xform)
                 _open_data = get_object_or_404(

--- a/onadata/apps/api/viewsets/osm_viewset.py
+++ b/onadata/apps/api/viewsets/osm_viewset.py
@@ -2,6 +2,7 @@
 """
 The osm API endpoint.
 """
+
 from django.http import HttpResponsePermanentRedirect
 from django.shortcuts import get_object_or_404
 from django.utils.translation import gettext as _
@@ -39,7 +40,6 @@ class OsmViewSet(
     BaseViewset,
     ReadOnlyModelViewSet,
 ):
-
     """
     This endpoint provides public access to OSM submitted data in OSM format.
     No authentication is required. Where:
@@ -101,7 +101,9 @@ class OsmViewSet(
     extra_lookup_fields = None
     public_data_endpoint = "public"
 
-    queryset = XForm.objects.filter(deleted_at__isnull=True).select_related()
+    queryset = XForm.objects.filter(
+        deleted_at__isnull=True, project__organization__is_active=True
+    ).select_related()
 
     def get_serializer_class(self):
         """Returns the OSMSiteMapSerializer class when list API is invoked."""
@@ -137,6 +139,7 @@ class OsmViewSet(
                 pk=dataid,
                 xform__pk=form_pk,
                 xform__deleted_at__isnull=True,
+                xform__project__organization__is_active=True,
                 deleted_at__isnull=True,
             )
 

--- a/onadata/apps/api/viewsets/project_viewset.py
+++ b/onadata/apps/api/viewsets/project_viewset.py
@@ -22,7 +22,12 @@ from onadata.apps.logger.models import Project, ProjectInvitation, XForm
 from onadata.apps.main.models import UserProfile
 from onadata.apps.main.models.meta_data import MetaData
 from onadata.libs.data import strtobool
-from onadata.libs.filters import AnonUserProjectFilter, ProjectOwnerFilter, TagFilter
+from onadata.libs.filters import (
+    ActiveProjectOrganizationFilter,
+    AnonUserProjectFilter,
+    ProjectOwnerFilter,
+    TagFilter,
+)
 from onadata.libs.mixins.authenticate_header_mixin import AuthenticateHeaderMixin
 from onadata.libs.mixins.cache_control_mixin import CacheControlMixin
 from onadata.libs.mixins.etags_mixin import ETagsMixin
@@ -83,7 +88,7 @@ class ProjectViewSet(
 
     # pylint: disable=no-member
     queryset = (
-        Project.objects.filter(deleted_at__isnull=True)
+        Project.objects.filter(deleted_at__isnull=True, organization__is_active=True)
         .order_by("-date_created")
         .select_related()
     )
@@ -91,7 +96,12 @@ class ProjectViewSet(
     lookup_field = "pk"
     extra_lookup_fields = None
     permission_classes = [ProjectPermissions]
-    filter_backends = (AnonUserProjectFilter, ProjectOwnerFilter, TagFilter)
+    filter_backends = (
+        AnonUserProjectFilter,
+        ProjectOwnerFilter,
+        TagFilter,
+        ActiveProjectOrganizationFilter,
+    )
     pagination_class = StandardPageNumberPagination
     api_version = "v1"
 
@@ -112,7 +122,7 @@ class ProjectViewSet(
         return super().get_serializer_class()
 
     def get_queryset(self):
-        """Use 'prepared' prefetched queryset for GET requests."""
+        """Use the active-organization prefetched queryset."""
         if self.request.method.upper() in ["GET", "OPTIONS"]:
             self.queryset = Project.prefetched.filter(
                 deleted_at__isnull=True, organization__is_active=True
@@ -184,7 +194,11 @@ class ProjectViewSet(
             logger.info("%s: %s", message_subject, error_message)
             return Response(survey, status=status.HTTP_400_BAD_REQUEST)
 
-        xforms = XForm.objects.filter(project=project, deleted_at__isnull=True)
+        xforms = XForm.objects.filter(
+            project=project,
+            deleted_at__isnull=True,
+            project__organization__is_active=True,
+        )
         serializer = XFormSerializer(xforms, context={"request": request}, many=True)
 
         return Response(serializer.data)
@@ -244,7 +258,12 @@ class ProjectViewSet(
         """
         user = request.user
         # pylint: disable=attribute-defined-outside-init
-        self.object = project = get_object_or_404(Project, pk=kwargs.get("pk"))
+        self.object = project = get_object_or_404(
+            Project,
+            pk=kwargs.get("pk"),
+            deleted_at__isnull=True,
+            organization__is_active=True,
+        )
 
         if request.method == "DELETE":
             project.user_stars.remove(user)

--- a/onadata/apps/api/viewsets/stats_viewset.py
+++ b/onadata/apps/api/viewsets/stats_viewset.py
@@ -2,6 +2,7 @@
 """
 The /api/v1/stats API endpoint implementaion.
 """
+
 from rest_framework import viewsets
 
 from onadata.apps.api.permissions import XFormPermissions
@@ -36,8 +37,13 @@ class StatsViewSet(
     """
 
     lookup_field = "pk"
-    queryset = XForm.objects.all()
-    filter_backends = (filters.AnonDjangoObjectPermissionFilter,)
+    queryset = XForm.objects.filter(
+        deleted_at__isnull=True, project__organization__is_active=True
+    )
+    filter_backends = (
+        filters.AnonDjangoObjectPermissionFilter,
+        filters.ActiveXFormOrganizationFilter,
+    )
     permission_classes = [
         XFormPermissions,
     ]

--- a/onadata/apps/api/viewsets/submissionstats_viewset.py
+++ b/onadata/apps/api/viewsets/submissionstats_viewset.py
@@ -2,9 +2,11 @@
 """
 The /api/v1/stats/submissions API endpoint implementation.
 """
+
 from rest_framework import viewsets
 
 from onadata.apps.api.permissions import XFormPermissions
+from onadata.apps.api.tools import get_baseviewset_class
 from onadata.apps.logger.models.xform import XForm
 from onadata.libs import filters
 from onadata.libs.mixins.anonymous_user_public_forms_mixin import (
@@ -14,10 +16,9 @@ from onadata.libs.mixins.authenticate_header_mixin import AuthenticateHeaderMixi
 from onadata.libs.mixins.cache_control_mixin import CacheControlMixin
 from onadata.libs.mixins.etags_mixin import ETagsMixin
 from onadata.libs.serializers.stats_serializer import (
-    SubmissionStatsSerializer,
     SubmissionStatsInstanceSerializer,
+    SubmissionStatsSerializer,
 )
-from onadata.apps.api.tools import get_baseviewset_class
 
 BaseViewset = get_baseviewset_class()
 
@@ -31,7 +32,6 @@ class SubmissionStatsViewSet(
     BaseViewset,
     viewsets.ReadOnlyModelViewSet,
 ):
-
     """
     Provides submissions counts grouped by a specified field.
     It accepts query parameters `group` and `name`. Default result
@@ -73,8 +73,13 @@ class SubmissionStatsViewSet(
     """
 
     lookup_field = "pk"
-    queryset = XForm.objects.all()
-    filter_backends = (filters.AnonDjangoObjectPermissionFilter,)
+    queryset = XForm.objects.filter(
+        deleted_at__isnull=True, project__organization__is_active=True
+    )
+    filter_backends = (
+        filters.AnonDjangoObjectPermissionFilter,
+        filters.ActiveXFormOrganizationFilter,
+    )
     permission_classes = [
         XFormPermissions,
     ]

--- a/onadata/apps/api/viewsets/v2/project_viewset.py
+++ b/onadata/apps/api/viewsets/v2/project_viewset.py
@@ -11,6 +11,7 @@ from rest_framework.response import Response
 
 from onadata.apps.api.viewsets.project_viewset import ProjectViewSet as ProjectViewSetV1
 from onadata.libs.filters import (
+    ActiveProjectOrganizationFilter,
     AnonUserProjectFilter,
     ProjectFilterSet,
     ProjectOwnerFilter,
@@ -49,6 +50,7 @@ class ProjectViewSet(ProjectViewSetV1):
         ProjectRoleFilter,
         SearchFilter,
         OrderingFilter,
+        ActiveProjectOrganizationFilter,
     )
     filterset_class = ProjectFilterSet
     search_fields = ["name", "organization__username"]

--- a/onadata/apps/api/viewsets/widget_viewset.py
+++ b/onadata/apps/api/viewsets/widget_viewset.py
@@ -2,23 +2,26 @@
 """
 Expose and persist charts and corresponding data.
 """
+
+from django.contrib.contenttypes.models import ContentType
+from django.http import Http404
 from django.shortcuts import get_object_or_404
 from django.utils.translation import gettext as _
-from django.contrib.contenttypes.models import ContentType
 
-from rest_framework.viewsets import ModelViewSet
-from rest_framework.response import Response
 from rest_framework.exceptions import ParseError
+from rest_framework.response import Response
+from rest_framework.viewsets import ModelViewSet
 
+from onadata.apps.api.permissions import WidgetViewSetPermissions
+from onadata.apps.api.tools import get_baseviewset_class
+from onadata.apps.logger.models.data_view import DataView
+from onadata.apps.logger.models.widget import Widget
+from onadata.apps.logger.models.xform import XForm
 from onadata.libs import filters
 from onadata.libs.mixins.authenticate_header_mixin import AuthenticateHeaderMixin
 from onadata.libs.mixins.cache_control_mixin import CacheControlMixin
 from onadata.libs.mixins.etags_mixin import ETagsMixin
-from onadata.apps.logger.models.widget import Widget
-from onadata.apps.logger.models.data_view import DataView
 from onadata.libs.serializers.widget_serializer import WidgetSerializer
-from onadata.apps.api.permissions import WidgetViewSetPermissions
-from onadata.apps.api.tools import get_baseviewset_class
 
 BaseViewset = get_baseviewset_class()
 
@@ -46,7 +49,14 @@ class WidgetViewSet(
             except ValueError as exc:
                 raise ParseError(f"Invalid value for dataview {dataviewid}.") from exc
 
-            dataview = get_object_or_404(DataView, pk=dataviewid)
+            dataview = get_object_or_404(
+                DataView,
+                pk=dataviewid,
+                xform__deleted_at__isnull=True,
+                xform__project__organization__is_active=True,
+                project__deleted_at__isnull=True,
+                project__organization__is_active=True,
+            )
             dataview_ct = ContentType.objects.get_for_model(dataview)
             dataview_qs = Widget.objects.filter(
                 object_id=dataview.pk, content_type=dataview_ct
@@ -55,12 +65,26 @@ class WidgetViewSet(
 
         return super().filter_queryset(queryset)
 
+    @staticmethod
+    def _check_active_widget_target(widget):
+        content_object = widget.content_object
+        if isinstance(content_object, DataView):
+            xform = content_object.xform
+        elif isinstance(content_object, XForm):
+            xform = content_object
+        else:
+            return
+
+        if xform.deleted_at is not None or not xform.project.organization.is_active:
+            raise Http404
+
     # pylint: disable=unused-argument
     def get_object(self, queryset=None):
         widget_pk = self.kwargs.get("pk")
 
         if widget_pk is not None:
             obj = get_object_or_404(Widget, pk=widget_pk)
+            self._check_active_widget_target(obj)
             self.check_object_permissions(self.request, obj)
         else:
             raise ParseError(_("'pk' required for this action"))
@@ -71,6 +95,7 @@ class WidgetViewSet(
         if "key" in request.GET:
             key = request.GET["key"]
             obj = get_object_or_404(Widget, key=key)
+            self._check_active_widget_target(obj)
 
             serializer = self.get_serializer(obj)
 

--- a/onadata/apps/api/viewsets/xform_list_viewset.py
+++ b/onadata/apps/api/viewsets/xform_list_viewset.py
@@ -71,7 +71,10 @@ class XFormListViewSet(ETagsMixin, BaseViewset, viewsets.ReadOnlyModelViewSet):
         django_filter_filters.DjangoFilterBackend,
     )
     queryset = XForm.objects.filter(
-        downloadable=True, deleted_at=None, is_merged_dataset=False
+        downloadable=True,
+        deleted_at=None,
+        is_merged_dataset=False,
+        project__organization__is_active=True,
     ).only(
         "id_string", "title", "version", "uuid", "description", "user__username", "hash"
     )
@@ -84,7 +87,10 @@ class XFormListViewSet(ETagsMixin, BaseViewset, viewsets.ReadOnlyModelViewSet):
     def get_object(self):
         queryset = self.filter_queryset(self.get_queryset())
         filter_kwargs = {self.lookup_field: self.kwargs[self.lookup_field]}
-        obj = get_object_or_404(queryset or XForm, **filter_kwargs)
+        try:
+            obj = get_object_or_404(queryset, **filter_kwargs)
+        except Http404:
+            obj = get_object_or_404(self.get_queryset(), **filter_kwargs)
         self.check_object_permissions(self.request, obj)
 
         if self.request.user.is_anonymous and obj.require_auth:
@@ -158,11 +164,20 @@ class XFormListViewSet(ETagsMixin, BaseViewset, viewsets.ReadOnlyModelViewSet):
                 queryset = queryset | forms_shared_with_user
                 if self.request.user != profile.user:
                     public_forms = profile.user.xforms.filter(
-                        downloadable=True, shared=True
+                        downloadable=True,
+                        shared=True,
+                        deleted_at=None,
+                        is_merged_dataset=False,
+                        project__organization__is_active=True,
                     )
                     queryset = queryset | public_forms
 
-        return queryset
+        return queryset.filter(
+            downloadable=True,
+            deleted_at=None,
+            is_merged_dataset=False,
+            project__organization__is_active=True,
+        )
 
     def _get_xform_list_cache_key(self):
         xform_pk = self.kwargs.get("xform_pk")
@@ -170,12 +185,22 @@ class XFormListViewSet(ETagsMixin, BaseViewset, viewsets.ReadOnlyModelViewSet):
         cache_key = None
 
         if xform_pk:
-            xform = get_object_or_404(XForm, pk=xform_pk)
+            xform = get_object_or_404(
+                XForm,
+                pk=xform_pk,
+                deleted_at__isnull=True,
+                project__organization__is_active=True,
+            )
             cache_key = get_xform_list_cache_key(self.request.user, xform)
 
         elif project_pk:
-            project = get_object_or_404(Project, pk=project_pk)
-            cache_key = get_xform_list_cache_key(self.request.user, project)
+            project = Project.objects.filter(
+                pk=project_pk,
+                deleted_at__isnull=True,
+                organization__is_active=True,
+            ).first()
+            if project is not None:
+                cache_key = get_xform_list_cache_key(self.request.user, project)
 
         return cache_key
 
@@ -185,7 +210,13 @@ class XFormListViewSet(ETagsMixin, BaseViewset, viewsets.ReadOnlyModelViewSet):
         xform_pk = self.kwargs.get("xform_pk")
 
         if submission_pk and xform_pk:
-            get_object_or_404(Instance, pk=submission_pk, xform_id=xform_pk)
+            get_object_or_404(
+                Instance,
+                pk=submission_pk,
+                xform_id=xform_pk,
+                xform__deleted_at__isnull=True,
+                xform__project__organization__is_active=True,
+            )
 
     def list(self, request, *args, **kwargs):
         headers = get_openrosa_headers(request, location=False)

--- a/onadata/apps/api/viewsets/xform_submission_viewset.py
+++ b/onadata/apps/api/viewsets/xform_submission_viewset.py
@@ -145,7 +145,13 @@ class XFormSubmissionViewSet(
 
         instance_pk = kwargs.get("pk")
         xform_pk = kwargs.get("xform_pk")
-        instance = get_object_or_404(Instance, pk=instance_pk, xform_id=xform_pk)
+        instance = get_object_or_404(
+            Instance,
+            pk=instance_pk,
+            xform_id=xform_pk,
+            xform__deleted_at__isnull=True,
+            xform__project__organization__is_active=True,
+        )
         serializer = self.get_serializer(instance, data=request.data)
         serializer.is_valid(raise_exception=True)
         self.perform_update(serializer)

--- a/onadata/apps/api/viewsets/xform_viewset.py
+++ b/onadata/apps/api/viewsets/xform_viewset.py
@@ -491,6 +491,7 @@ class XFormViewSet(
         filters.TagFilter,
         filters.XFormOwnerFilter,
         DjangoFilterBackend,
+        filters.ActiveXFormOrganizationFilter,
     )
     filterset_fields = ("instances_with_osm",)
 

--- a/onadata/apps/logger/migrations/0041_project_date_created_indexes.py
+++ b/onadata/apps/logger/migrations/0041_project_date_created_indexes.py
@@ -1,0 +1,60 @@
+# Generated manually to create project list indexes without blocking writes.
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    atomic = False
+
+    dependencies = [
+        ("logger", "0040_backfill_attachment_user"),
+    ]
+
+    operations = [
+        migrations.SeparateDatabaseAndState(
+            database_operations=[
+                migrations.RunSQL(
+                    sql=(
+                        'CREATE INDEX CONCURRENTLY "idx_lproj_notdel_created" '
+                        'ON "logger_project" ("date_created" DESC) '
+                        'INCLUDE ("id", "organization_id") '
+                        'WHERE "deleted_at" IS NULL;'
+                    ),
+                    reverse_sql=(
+                        'DROP INDEX CONCURRENTLY "idx_lproj_notdel_created";'
+                    ),
+                ),
+                migrations.RunSQL(
+                    sql=(
+                        'CREATE INDEX CONCURRENTLY "idx_lproj_shr_notdel_created" '
+                        'ON "logger_project" ("date_created" DESC) '
+                        'INCLUDE ("id", "organization_id") '
+                        'WHERE "deleted_at" IS NULL AND "shared";'
+                    ),
+                    reverse_sql=(
+                        'DROP INDEX CONCURRENTLY "idx_lproj_shr_notdel_created";'
+                    ),
+                ),
+            ],
+            state_operations=[
+                migrations.AddIndex(
+                    model_name="project",
+                    index=models.Index(
+                        fields=["-date_created"],
+                        name="idx_lproj_notdel_created",
+                        include=["id", "organization"],
+                        condition=models.Q(deleted_at__isnull=True),
+                    ),
+                ),
+                migrations.AddIndex(
+                    model_name="project",
+                    index=models.Index(
+                        fields=["-date_created"],
+                        name="idx_lproj_shr_notdel_created",
+                        include=["id", "organization"],
+                        condition=models.Q(deleted_at__isnull=True, shared=True),
+                    ),
+                ),
+            ],
+        ),
+    ]

--- a/onadata/apps/logger/models/project.py
+++ b/onadata/apps/logger/models/project.py
@@ -8,7 +8,7 @@ from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ValidationError
 from django.db import models, transaction
-from django.db.models import Prefetch
+from django.db.models import Prefetch, Q
 from django.db.models.signals import post_save
 from django.utils import timezone
 
@@ -138,6 +138,18 @@ class Project(BaseModel):
         )
         indexes = [
             models.Index(fields=["deleted_at"], name="idx_logger_project_deleted_at"),
+            models.Index(
+                fields=["-date_created"],
+                name="idx_lproj_notdel_created",
+                include=["id", "organization"],
+                condition=Q(deleted_at__isnull=True),
+            ),
+            models.Index(
+                fields=["-date_created"],
+                name="idx_lproj_shr_notdel_created",
+                include=["id", "organization"],
+                condition=Q(deleted_at__isnull=True, shared=True),
+            ),
         ]
 
     def __str__(self):

--- a/onadata/apps/restservice/viewsets/restservices_viewset.py
+++ b/onadata/apps/restservice/viewsets/restservices_viewset.py
@@ -2,6 +2,7 @@
 """
 Implements the /api/v1/restservices endpoint.
 """
+
 from django.conf import settings
 from django.utils.module_loading import import_string
 
@@ -49,7 +50,10 @@ class RestServicesViewSet(
     This endpoint provides access to form rest services.
     """
 
-    queryset = RestService.objects.select_related("xform")
+    queryset = RestService.objects.select_related("xform").filter(
+        xform__deleted_at__isnull=True,
+        xform__project__organization__is_active=True,
+    )
     serializer_class = RestServiceSerializer
     permission_classes = [
         RestServiceObjectPermissions,

--- a/onadata/libs/filters.py
+++ b/onadata/libs/filters.py
@@ -495,10 +495,7 @@ class XFormPermissionFilterMixin:
                 xform, "Invalid value for formid. It must be a positive integer."
             )
             self.xform = get_object_or_404(
-                XForm,
-                pk=xform,
-                deleted_at__isnull=True,
-                project__organization__is_active=True,
+                XForm, pk=xform, project__organization__is_active=True
             )
             xform_qs = XForm.objects.filter(pk=self.xform.pk)
             public_forms = XForm.objects.filter(

--- a/onadata/libs/filters.py
+++ b/onadata/libs/filters.py
@@ -44,11 +44,16 @@ User = get_user_model()
 
 
 def _public_xform_id_or_none(export_id: int):
-    export = Export.objects.filter(pk=export_id).first()
+    export = (
+        Export.objects.select_related("xform__project__organization")
+        .filter(pk=export_id)
+        .first()
+    )
 
     if (
         export
         and export.xform.deleted_at is None
+        and export.xform.project.organization.is_active
         and (export.xform.shared_data or export.xform.shared)
     ):
         return export.xform_id
@@ -67,7 +72,9 @@ class AnonDjangoObjectPermissionFilter(ObjectPermissionsFilter):
         form_id = view.kwargs.get(view.lookup_field, view.kwargs.get("xform_pk"))
         lookup_field = view.lookup_field
 
-        queryset = queryset.filter(deleted_at=None)
+        queryset = queryset.filter(
+            deleted_at=None, project__organization__is_active=True
+        )
         if request.user.is_anonymous:
             return queryset
 
@@ -118,6 +125,24 @@ class XFormListObjectPermissionFilter(AnonDjangoObjectPermissionFilter):
     """XFormList permission filter with using [app].report_[model] form."""
 
     perm_format = "%(app_label)s.report_%(model_name)s"
+
+
+class ActiveXFormOrganizationFilter(filters.BaseFilterBackend):
+    """Limit form querysets to active project organizations."""
+
+    # pylint: disable=unused-argument
+    def filter_queryset(self, request, queryset, view):
+        return queryset.filter(
+            deleted_at__isnull=True, project__organization__is_active=True
+        )
+
+
+class ActiveProjectOrganizationFilter(filters.BaseFilterBackend):
+    """Limit project querysets to active organizations."""
+
+    # pylint: disable=unused-argument
+    def filter_queryset(self, request, queryset, view):
+        return queryset.filter(deleted_at__isnull=True, organization__is_active=True)
 
 
 class XFormListXFormPKFilter:
@@ -363,7 +388,10 @@ class ProjectOwnerFilter(filters.BaseFilterBackend):
             kwargs = {self.owner_prefix + "__username__iexact": owner}
 
             return queryset.filter(**kwargs) | Project.objects.filter(
-                shared=True, deleted_at__isnull=True, **kwargs
+                shared=True,
+                deleted_at__isnull=True,
+                organization__is_active=True,
+                **kwargs,
             )
 
         return queryset
@@ -466,12 +494,18 @@ class XFormPermissionFilterMixin:
             int_or_parse_error(
                 xform, "Invalid value for formid. It must be a positive integer."
             )
-            self.xform = get_object_or_404(XForm, pk=xform)
+            self.xform = get_object_or_404(
+                XForm,
+                pk=xform,
+                deleted_at__isnull=True,
+                project__organization__is_active=True,
+            )
             xform_qs = XForm.objects.filter(pk=self.xform.pk)
             public_forms = XForm.objects.filter(
                 pk=self.xform.pk,
                 shared_data=True,
                 deleted_at__isnull=True,
+                project__organization__is_active=True,
             )
         elif filename:
             attachment = get_object_or_404(Attachment, pk=view.kwargs.get("pk"))
@@ -481,6 +515,7 @@ class XFormPermissionFilterMixin:
                 pk=self.xform.pk,
                 shared_data=True,
                 deleted_at__isnull=True,
+                project__organization__is_active=True,
             )
         else:
             if queryset is not None and "pk" in view.kwargs:
@@ -499,7 +534,9 @@ class XFormPermissionFilterMixin:
             else:
                 # No form filter supplied - return empty list.
                 xform_qs = XForm.objects.none()
-        xform_qs = xform_qs.filter(deleted_at=None)
+        xform_qs = xform_qs.filter(
+            deleted_at=None, project__organization__is_active=True
+        )
 
         if request.user.is_anonymous:
             xforms = xform_qs.filter(shared_data=True)
@@ -525,10 +562,17 @@ class ProjectPermissionFilterMixin:
                 "Invalid value for projectid. It must be a positive integer.",
             )
 
-            project = get_object_or_404(Project, pk=project_id)
+            project = get_object_or_404(
+                Project,
+                pk=project_id,
+                deleted_at__isnull=True,
+                organization__is_active=True,
+            )
             project_qs = Project.objects.filter(pk=project.id)
         else:
-            project_qs = Project.objects.all()
+            project_qs = Project.objects.filter(
+                deleted_at__isnull=True, organization__is_active=True
+            )
 
         projects = super().filter_queryset(request, project_qs, view)
 
@@ -561,17 +605,32 @@ class InstancePermissionFilterMixin:
                     "Invalid value for instanceid. It must be a positive integer.",
                 )
 
-            instance = get_object_or_404(Instance, pk=instance_id)
+            instance = get_object_or_404(
+                Instance,
+                pk=instance_id,
+                xform__deleted_at__isnull=True,
+                xform__project__organization__is_active=True,
+            )
             # test if user has permissions on the project
 
             if xform_id:
-                xform = get_object_or_404(XForm, pk=xform_id)
+                xform = get_object_or_404(
+                    XForm,
+                    pk=xform_id,
+                    deleted_at__isnull=True,
+                    project__organization__is_active=True,
+                )
                 parent = xform.instances.filter(id=instance.id) and xform
 
             else:
                 return {}
 
-            project = get_object_or_404(Project, pk=project_id)
+            project = get_object_or_404(
+                Project,
+                pk=project_id,
+                deleted_at__isnull=True,
+                organization__is_active=True,
+            )
             project_qs = Project.objects.filter(pk=project.id)
 
             if parent and parent.project == project:
@@ -658,10 +717,18 @@ class AttachmentFilter(XFormPermissionFilterMixin, ObjectPermissionsFilter):
         xform = getattr(self, "xform", None)
         # Ensure queryset is filtered by XForm meta permissions
         if xform is None:
-            xform_ids = list(set(queryset.values_list("xform", flat=True)))
+            xform_ids = [
+                xform_id
+                for xform_id in set(queryset.values_list("xform", flat=True))
+                if xform_id
+            ]
             if xform_ids:
                 # only the first form xform_ids[0]
-                xform = XForm.objects.get(pk=xform_ids[0])
+                xform = XForm.objects.get(
+                    pk=xform_ids[0],
+                    deleted_at__isnull=True,
+                    project__organization__is_active=True,
+                )
 
         if xform is not None:
             queryset = exclude_items_from_queryset_using_xform_meta_perms(
@@ -674,7 +741,12 @@ class AttachmentFilter(XFormPermissionFilterMixin, ObjectPermissionsFilter):
                 instance_id,
                 "Invalid value for instance_id. It must be a positive integer.",
             )
-            instance = get_object_or_404(Instance, pk=instance_id)
+            instance = get_object_or_404(
+                Instance,
+                pk=instance_id,
+                xform__deleted_at__isnull=True,
+                xform__project__organization__is_active=True,
+            )
             queryset = queryset.filter(instance=instance)
 
         return queryset
@@ -810,7 +882,12 @@ class NoteFilter(filters.BaseFilterBackend):
                 "Invalid value for instance_id. It must be a positive integer",
             )
 
-            instance = get_object_or_404(Instance, pk=instance_id)
+            instance = get_object_or_404(
+                Instance,
+                pk=instance_id,
+                xform__deleted_at__isnull=True,
+                xform__project__organization__is_active=True,
+            )
             queryset = queryset.filter(instance=instance)
 
         return queryset
@@ -885,9 +962,16 @@ class EntityListProjectFilter(filters.BaseFilterBackend):
         project_id = request.query_params.get("project")
 
         if project_id:
-            return queryset.filter(project__pk=project_id)
+            return queryset.filter(
+                project__pk=project_id,
+                project__deleted_at__isnull=True,
+                project__organization__is_active=True,
+            )
 
-        return queryset
+        return queryset.filter(
+            project__deleted_at__isnull=True,
+            project__organization__is_active=True,
+        )
 
 
 class AnonUserEntityListFilter(ObjectPermissionsFilter):
@@ -895,6 +979,17 @@ class AnonUserEntityListFilter(ObjectPermissionsFilter):
 
     def filter_queryset(self, request, queryset, view):
         if request.user.is_anonymous:
-            return queryset.filter(project__shared=True)
+            return queryset.filter(
+                project__shared=True,
+                project__deleted_at__isnull=True,
+                project__organization__is_active=True,
+            )
 
-        return super().filter_queryset(request, queryset, view)
+        return (
+            super()
+            .filter_queryset(request, queryset, view)
+            .filter(
+                project__deleted_at__isnull=True,
+                project__organization__is_active=True,
+            )
+        )

--- a/onadata/libs/mixins/anonymous_user_public_forms_mixin.py
+++ b/onadata/libs/mixins/anonymous_user_public_forms_mixin.py
@@ -4,6 +4,7 @@ Implements the AnonymousUserPublicFormsMixin class
 
 Filters only public forms.
 """
+
 from onadata.apps.logger.models.xform import XForm
 
 
@@ -15,7 +16,11 @@ class AnonymousUserPublicFormsMixin:  # pylint: disable=too-few-public-methods
     """
 
     def _get_public_forms_queryset(self):
-        return XForm.objects.filter(shared=True, deleted_at__isnull=True)
+        return XForm.objects.filter(
+            shared=True,
+            deleted_at__isnull=True,
+            project__organization__is_active=True,
+        )
 
     def get_queryset(self):
         """Public forms only for anonymous Users."""


### PR DESCRIPTION
### Changes / Features implemented

- Add partial project list indexes for non-deleted and public non-deleted project ordering.
- Enforce active project organization visibility for project APIs and active form project organization visibility for form APIs.
- Apply the active organization predicate across public/shared, owner-filtered, nested, detail, and related resource endpoints that target projects or forms.
- Document the visibility decision in ADR 0001.

### Steps taken to verify this change does what is intended

- `python manage.py check --settings=onadata.settings.github_actions_test`
- `python manage.py makemigrations --check --dry-run logger api restservice --settings=onadata.settings.github_actions_test`
- Targeted project/form regression tests passed.
- Broader affected project/form viewset test suite passed: 397 tests, 1 skipped.

### Side effects of implementing this change

- Projects and forms owned by inactive organizations are omitted from list endpoints and behave as not found on detail/action endpoints.
- Form visibility intentionally depends on `project.organization.is_active`, not uploader or creator active state.
- Project list performance depends on the new partial indexes for ordered non-deleted and public non-deleted queries.


**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  - [x] Updated documentation

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/onaio/codesmith/onadata/pr/3178"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786828509&installation_id=135786473&pr_number=3178&repository=onaio%2Fonadata&return_to=https%3A%2F%2Fgithub.com%2Fonaio%2Fonadata%2Fpull%2F3178&signature=a2c66d1e38d91cb9a88deb8233a16a5ac4a68c40f386131c49377a60a255df72"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->