### PR TITLE
feat(entities): support restoring a soft-deleted EntityList

### DIFF
--- a/docs/management.rst
+++ b/docs/management.rst
@@ -35,6 +35,16 @@ You can also restore a form in Django admin interface:
 3. **Run Action**: Choose the "Restore selected soft-deleted forms" action from the dropdown menu and click "Go".
 
 
+Restore soft deleted EntityList
+-------------------------------
+
+Restores a soft deleted EntityList. The EntityList is identified by its ID.
+
+.. code-block:: bash
+
+    python manage.py restore_entity_list entity_list_id
+
+
 Soft delete user
 ----------------
 

--- a/docs/management.rst
+++ b/docs/management.rst
@@ -47,7 +47,7 @@ by the ID of a registration form (XForm) that creates entities in it.
 
 .. code-block:: bash
 
-    python manage.py restore_entity_list --xform-id xform_id
+    python manage.py restore_entity_list --contributor xform_id
 
 
 Soft delete user

--- a/docs/management.rst
+++ b/docs/management.rst
@@ -38,11 +38,16 @@ You can also restore a form in Django admin interface:
 Restore soft deleted EntityList
 -------------------------------
 
-Restores a soft deleted EntityList. The EntityList is identified by its ID.
+Restores a soft deleted EntityList. The EntityList is identified by its ID or
+by the ID of a registration form (XForm) that creates entities in it.
 
 .. code-block:: bash
 
     python manage.py restore_entity_list entity_list_id
+
+.. code-block:: bash
+
+    python manage.py restore_entity_list --xform-id xform_id
 
 
 Soft delete user

--- a/onadata/apps/logger/management/commands/restore_entity_list.py
+++ b/onadata/apps/logger/management/commands/restore_entity_list.py
@@ -13,7 +13,7 @@ class Command(BaseCommand):
 
     Usage:
     python manage.py restore_entity_list <entity_list_id>
-    python manage.py restore_entity_list --xform-id <xform_id>
+    python manage.py restore_entity_list --contributor <xform_id>
     """
 
     help = "Restores a soft-deleted EntityList."
@@ -27,7 +27,7 @@ class Command(BaseCommand):
             help="The ID of the soft-deleted EntityList to restore",
         )
         parser.add_argument(
-            "--xform-id",
+            "--contributor",
             type=int,
             help=(
                 "The ID of a registration form (XForm) that creates entities "
@@ -38,10 +38,10 @@ class Command(BaseCommand):
     def _get_entity_list(self, options):
         """Retrieve the soft-deleted EntityList to restore"""
         entity_list_id = options["entity_list_id"]
-        xform_id = options["xform_id"]
+        xform_id = options["contributor"]
 
         if (entity_list_id is None) == (xform_id is None):
-            raise CommandError("Provide exactly one of entity_list_id or --xform-id")
+            raise CommandError("Provide exactly one of entity_list_id or --contributor")
 
         if entity_list_id is not None:
             try:

--- a/onadata/apps/logger/management/commands/restore_entity_list.py
+++ b/onadata/apps/logger/management/commands/restore_entity_list.py
@@ -61,7 +61,9 @@ class Command(BaseCommand):
 
         entity_lists = list(
             EntityList.objects.filter(
-                registration_forms__xform_id=xform_id, deleted_at__isnull=False
+                registration_forms__xform_id=xform_id,
+                registration_forms__is_active=True,
+                deleted_at__isnull=False,
             ).order_by("pk")
         )
 

--- a/onadata/apps/logger/management/commands/restore_entity_list.py
+++ b/onadata/apps/logger/management/commands/restore_entity_list.py
@@ -1,0 +1,65 @@
+"""
+Restore a soft-deleted EntityList object.
+"""
+
+from django.core.management.base import BaseCommand, CommandError
+
+from onadata.apps.logger.models import EntityList
+
+
+class Command(BaseCommand):
+    """
+    Management command to restore soft-deleted EntityList objects.
+
+    Usage:
+    python manage.py restore_entity_list <entity_list_id>
+    """
+
+    help = "Restores a soft-deleted EntityList."
+
+    def add_arguments(self, parser):
+        # Add an argument to specify the EntityList ID
+        parser.add_argument(
+            "entity_list_id",
+            type=int,
+            help="The ID of the soft-deleted EntityList to restore",
+        )
+
+    def handle(self, *args, **options):
+        entity_list_id = options["entity_list_id"]
+
+        try:
+            # Retrieve the soft-deleted EntityList
+            entity_list = EntityList.objects.get(pk=entity_list_id)
+
+            if entity_list.deleted_at is None:
+                raise CommandError(
+                    f"EntityList with ID {entity_list_id} is not soft-deleted"
+                )
+
+            # Perform the restoration
+            self.stdout.write(f"Restoring EntityList with ID {entity_list_id}...")
+            was_deleted_by = (
+                entity_list.deleted_by.username if entity_list.deleted_by else None
+            )
+            # was_deleted_at in the format Nov. 1, 2021, HH:MM UTC
+            was_deleted_at = entity_list.deleted_at.strftime("%b. %d, %Y, %H:%M UTC")
+            entity_list.restore()
+
+            # Display success message
+            success_msg = (
+                f"Successfully restored EntityList '{entity_list.name}' with "
+                f"ID {entity_list_id} deleted by {was_deleted_by} at "
+                f"{was_deleted_at}."
+            )
+            self.stdout.write(self.style.SUCCESS(success_msg))
+
+        except EntityList.DoesNotExist as exc:
+            raise CommandError(
+                f"EntityList with ID {entity_list_id} does not exist"
+            ) from exc
+
+        except Exception as exc:
+            raise CommandError(
+                f"An error occurred while restoring the EntityList: {exc}"
+            ) from exc

--- a/onadata/apps/logger/management/commands/restore_entity_list.py
+++ b/onadata/apps/logger/management/commands/restore_entity_list.py
@@ -13,6 +13,7 @@ class Command(BaseCommand):
 
     Usage:
     python manage.py restore_entity_list <entity_list_id>
+    python manage.py restore_entity_list --xform-id <xform_id>
     """
 
     help = "Restores a soft-deleted EntityList."
@@ -22,23 +23,68 @@ class Command(BaseCommand):
         parser.add_argument(
             "entity_list_id",
             type=int,
+            nargs="?",
             help="The ID of the soft-deleted EntityList to restore",
         )
+        parser.add_argument(
+            "--xform-id",
+            type=int,
+            help=(
+                "The ID of a registration form (XForm) that creates entities "
+                "in the soft-deleted EntityList to restore"
+            ),
+        )
 
-    def handle(self, *args, **options):
+    def _get_entity_list(self, options):
+        """Retrieve the soft-deleted EntityList to restore"""
         entity_list_id = options["entity_list_id"]
+        xform_id = options["xform_id"]
 
-        try:
-            # Retrieve the soft-deleted EntityList
-            entity_list = EntityList.objects.get(pk=entity_list_id)
+        if (entity_list_id is None) == (xform_id is None):
+            raise CommandError("Provide exactly one of entity_list_id or --xform-id")
+
+        if entity_list_id is not None:
+            try:
+                entity_list = EntityList.objects.get(pk=entity_list_id)
+
+            except EntityList.DoesNotExist as exc:
+                raise CommandError(
+                    f"EntityList with ID {entity_list_id} does not exist"
+                ) from exc
 
             if entity_list.deleted_at is None:
                 raise CommandError(
                     f"EntityList with ID {entity_list_id} is not soft-deleted"
                 )
 
+            return entity_list
+
+        entity_lists = list(
+            EntityList.objects.filter(
+                registration_forms__xform_id=xform_id, deleted_at__isnull=False
+            ).order_by("pk")
+        )
+
+        if not entity_lists:
+            raise CommandError(
+                f"No soft-deleted EntityList found for XForm with ID {xform_id}"
+            )
+
+        if len(entity_lists) > 1:
+            entity_list_ids = ", ".join(str(dataset.pk) for dataset in entity_lists)
+            raise CommandError(
+                f"Multiple soft-deleted EntityLists found for XForm with ID "
+                f"{xform_id}: {entity_list_ids}. Restore using the EntityList ID."
+            )
+
+        return entity_lists[0]
+
+    def handle(self, *args, **options):
+        entity_list = self._get_entity_list(options)
+
+        try:
             # Perform the restoration
-            self.stdout.write(f"Restoring EntityList with ID {entity_list_id}...")
+            self.stdout.write(f"Restoring EntityList with ID {entity_list.pk}...")
             was_deleted_by = (
                 entity_list.deleted_by.username if entity_list.deleted_by else None
             )
@@ -49,15 +95,10 @@ class Command(BaseCommand):
             # Display success message
             success_msg = (
                 f"Successfully restored EntityList '{entity_list.name}' with "
-                f"ID {entity_list_id} deleted by {was_deleted_by} at "
+                f"ID {entity_list.pk} deleted by {was_deleted_by} at "
                 f"{was_deleted_at}."
             )
             self.stdout.write(self.style.SUCCESS(success_msg))
-
-        except EntityList.DoesNotExist as exc:
-            raise CommandError(
-                f"EntityList with ID {entity_list_id} does not exist"
-            ) from exc
 
         except Exception as exc:
             raise CommandError(

--- a/onadata/apps/logger/models/entity_list.py
+++ b/onadata/apps/logger/models/entity_list.py
@@ -84,9 +84,20 @@ class EntityList(BaseModel):
         meta_data = importlib.import_module("onadata.apps.main.models.meta_data")
 
         if self.deleted_at is not None:
+            deletion_suffix = self.deleted_at.strftime("-deleted-at-%s")
             self.deleted_at = None
             self.deleted_by = None
-            self.name = self.name.split("-deleted-at-")[0]
+
+            if self.name.endswith(deletion_suffix):
+                self.name = self.name[: -len(deletion_suffix)]
+            elif len(self.name) == 255:
+                # Soft delete truncated the name to 255 characters,
+                # retaining only part of the deletion suffix
+                for length in range(len(deletion_suffix) - 1, 0, -1):
+                    if self.name.endswith(deletion_suffix[:length]):
+                        self.name = self.name[:-length]
+                        break
+
             self.save()
             clear_project_cache(self.project.pk)
             # Restore follow up forms link
@@ -96,7 +107,8 @@ class EntityList(BaseModel):
             )
 
             for datum in queryset_iterator(metadata_qs):
-                datum.restore()
+                if datum.content_object.deleted_at is None:
+                    datum.restore()
 
     class Meta(BaseModel.Meta):
         app_label = "logger"

--- a/onadata/apps/logger/models/entity_list.py
+++ b/onadata/apps/logger/models/entity_list.py
@@ -77,6 +77,27 @@ class EntityList(BaseModel):
             for datum in queryset_iterator(metadata_qs):
                 datum.soft_delete()
 
+    @transaction.atomic()
+    def restore(self):
+        """Restore a soft-deleted EntityList"""
+        # Avoid circular import
+        meta_data = importlib.import_module("onadata.apps.main.models.meta_data")
+
+        if self.deleted_at is not None:
+            self.deleted_at = None
+            self.deleted_by = None
+            self.name = self.name.split("-deleted-at-")[0]
+            self.save()
+            clear_project_cache(self.project.pk)
+            # Restore follow up forms link
+            metadata_qs = meta_data.MetaData.objects.filter(
+                data_type="media",
+                data_value=f"entity_list {self.pk} {self.name}",
+            )
+
+            for datum in queryset_iterator(metadata_qs):
+                datum.restore()
+
     class Meta(BaseModel.Meta):
         app_label = "logger"
         unique_together = ("name", "project")

--- a/onadata/apps/logger/models/entity_list.py
+++ b/onadata/apps/logger/models/entity_list.py
@@ -107,7 +107,10 @@ class EntityList(BaseModel):
             )
 
             for datum in queryset_iterator(metadata_qs):
-                if datum.content_object.deleted_at is None:
+                # Do not reactivate metadata whose owning form is itself
+                # soft deleted e.g. a follow-up form that was soft deleted
+                # before the EntityList was soft deleted
+                if getattr(datum.content_object, "deleted_at", None) is None:
                     datum.restore()
 
     class Meta(BaseModel.Meta):

--- a/onadata/apps/logger/tests/management/commands/test_restore_entity_list.py
+++ b/onadata/apps/logger/tests/management/commands/test_restore_entity_list.py
@@ -35,14 +35,14 @@ class RestoreEntityListTestCase(TestBase):
             out.getvalue(),
         )
 
-    def test_restore_by_xform_id(self):
-        """Soft deleted EntityList is restored via registration form XForm ID"""
+    def test_restore_by_contributor(self):
+        """Soft deleted EntityList is restored via contributing XForm ID"""
         xform = self._publish_registration_form(self.user)
         entity_list = EntityList.objects.get(name="trees")
         entity_list.soft_delete(self.user)
         out = StringIO()
 
-        call_command("restore_entity_list", xform_id=xform.pk, stdout=out)
+        call_command("restore_entity_list", contributor=xform.pk, stdout=out)
 
         entity_list.refresh_from_db()
         self.assertIsNone(entity_list.deleted_at)
@@ -68,18 +68,18 @@ class RestoreEntityListTestCase(TestBase):
         ):
             call_command("restore_entity_list", 1234)
 
-    def test_no_entity_list_for_xform(self):
-        """No soft-deleted EntityList found for the XForm ID fails"""
+    def test_no_entity_list_for_contributor(self):
+        """No soft-deleted EntityList found for the contributing XForm fails"""
         xform = self._publish_registration_form(self.user)
 
         with self.assertRaisesRegex(
             CommandError,
             f"No soft-deleted EntityList found for XForm with ID {xform.pk}",
         ):
-            call_command("restore_entity_list", xform_id=xform.pk)
+            call_command("restore_entity_list", contributor=xform.pk)
 
-    def test_multiple_entity_lists_for_xform(self):
-        """Multiple soft-deleted EntityLists for the XForm ID fails"""
+    def test_multiple_entity_lists_for_contributor(self):
+        """Multiple soft-deleted EntityLists for the contributing XForm fails"""
         xform = self._publish_registration_form(self.user)
         trees = EntityList.objects.get(name="trees")
         shrubs = EntityList.objects.create(name="shrubs", project=self.project)
@@ -92,16 +92,16 @@ class RestoreEntityListTestCase(TestBase):
             f"Multiple soft-deleted EntityLists found for XForm with ID "
             f"{xform.pk}: {trees.pk}, {shrubs.pk}",
         ):
-            call_command("restore_entity_list", xform_id=xform.pk)
+            call_command("restore_entity_list", contributor=xform.pk)
 
-    def test_id_or_xform_id_required(self):
-        """Exactly one of entity_list_id or --xform-id must be provided"""
+    def test_id_or_contributor_required(self):
+        """Exactly one of entity_list_id or --contributor must be provided"""
         entity_list = EntityList.objects.create(name="trees", project=self.project)
         entity_list.soft_delete(self.user)
-        expected_error = "Provide exactly one of entity_list_id or --xform-id"
+        expected_error = "Provide exactly one of entity_list_id or --contributor"
 
         with self.assertRaisesRegex(CommandError, expected_error):
             call_command("restore_entity_list")
 
         with self.assertRaisesRegex(CommandError, expected_error):
-            call_command("restore_entity_list", entity_list.pk, xform_id=1)
+            call_command("restore_entity_list", entity_list.pk, contributor=1)

--- a/onadata/apps/logger/tests/management/commands/test_restore_entity_list.py
+++ b/onadata/apps/logger/tests/management/commands/test_restore_entity_list.py
@@ -94,6 +94,31 @@ class RestoreEntityListTestCase(TestBase):
         ):
             call_command("restore_entity_list", contributor=xform.pk)
 
+    def test_inactive_contributor_link_ignored(self):
+        """Only active registration form links are considered"""
+        xform = self._publish_registration_form(self.user)
+        trees = EntityList.objects.get(name="trees")
+        shrubs = EntityList.objects.create(name="shrubs", project=self.project)
+        RegistrationForm.objects.create(entity_list=shrubs, xform=xform)
+        trees_link = RegistrationForm.objects.get(entity_list=trees, xform=xform)
+        trees_link.is_active = False
+        trees_link.save()
+        trees.soft_delete(self.user)
+        shrubs.soft_delete(self.user)
+        out = StringIO()
+
+        call_command("restore_entity_list", contributor=xform.pk, stdout=out)
+
+        shrubs.refresh_from_db()
+        trees.refresh_from_db()
+        self.assertIsNone(shrubs.deleted_at)
+        self.assertEqual(shrubs.name, "shrubs")
+        self.assertIsNotNone(trees.deleted_at)
+        self.assertIn(
+            f"Successfully restored EntityList 'shrubs' with ID {shrubs.pk}",
+            out.getvalue(),
+        )
+
     def test_id_or_contributor_required(self):
         """Exactly one of entity_list_id or --contributor must be provided"""
         entity_list = EntityList.objects.create(name="trees", project=self.project)

--- a/onadata/apps/logger/tests/management/commands/test_restore_entity_list.py
+++ b/onadata/apps/logger/tests/management/commands/test_restore_entity_list.py
@@ -5,7 +5,7 @@ from io import StringIO
 from django.core.management import call_command
 from django.core.management.base import CommandError
 
-from onadata.apps.logger.models import EntityList
+from onadata.apps.logger.models import EntityList, RegistrationForm
 from onadata.apps.main.tests.test_base import TestBase
 from onadata.libs.utils.user_auth import get_user_default_project
 
@@ -35,6 +35,23 @@ class RestoreEntityListTestCase(TestBase):
             out.getvalue(),
         )
 
+    def test_restore_by_xform_id(self):
+        """Soft deleted EntityList is restored via registration form XForm ID"""
+        xform = self._publish_registration_form(self.user)
+        entity_list = EntityList.objects.get(name="trees")
+        entity_list.soft_delete(self.user)
+        out = StringIO()
+
+        call_command("restore_entity_list", xform_id=xform.pk, stdout=out)
+
+        entity_list.refresh_from_db()
+        self.assertIsNone(entity_list.deleted_at)
+        self.assertEqual(entity_list.name, "trees")
+        self.assertIn(
+            f"Successfully restored EntityList 'trees' with ID {entity_list.pk}",
+            out.getvalue(),
+        )
+
     def test_not_soft_deleted(self):
         """Restoring an EntityList that is not soft deleted fails"""
         entity_list = EntityList.objects.create(name="trees", project=self.project)
@@ -50,3 +67,41 @@ class RestoreEntityListTestCase(TestBase):
             CommandError, "EntityList with ID 1234 does not exist"
         ):
             call_command("restore_entity_list", 1234)
+
+    def test_no_entity_list_for_xform(self):
+        """No soft-deleted EntityList found for the XForm ID fails"""
+        xform = self._publish_registration_form(self.user)
+
+        with self.assertRaisesRegex(
+            CommandError,
+            f"No soft-deleted EntityList found for XForm with ID {xform.pk}",
+        ):
+            call_command("restore_entity_list", xform_id=xform.pk)
+
+    def test_multiple_entity_lists_for_xform(self):
+        """Multiple soft-deleted EntityLists for the XForm ID fails"""
+        xform = self._publish_registration_form(self.user)
+        trees = EntityList.objects.get(name="trees")
+        shrubs = EntityList.objects.create(name="shrubs", project=self.project)
+        RegistrationForm.objects.create(entity_list=shrubs, xform=xform)
+        trees.soft_delete(self.user)
+        shrubs.soft_delete(self.user)
+
+        with self.assertRaisesRegex(
+            CommandError,
+            f"Multiple soft-deleted EntityLists found for XForm with ID "
+            f"{xform.pk}: {trees.pk}, {shrubs.pk}",
+        ):
+            call_command("restore_entity_list", xform_id=xform.pk)
+
+    def test_id_or_xform_id_required(self):
+        """Exactly one of entity_list_id or --xform-id must be provided"""
+        entity_list = EntityList.objects.create(name="trees", project=self.project)
+        entity_list.soft_delete(self.user)
+        expected_error = "Provide exactly one of entity_list_id or --xform-id"
+
+        with self.assertRaisesRegex(CommandError, expected_error):
+            call_command("restore_entity_list")
+
+        with self.assertRaisesRegex(CommandError, expected_error):
+            call_command("restore_entity_list", entity_list.pk, xform_id=1)

--- a/onadata/apps/logger/tests/management/commands/test_restore_entity_list.py
+++ b/onadata/apps/logger/tests/management/commands/test_restore_entity_list.py
@@ -1,0 +1,52 @@
+"""Tests for restore_entity_list management command"""
+
+from io import StringIO
+
+from django.core.management import call_command
+from django.core.management.base import CommandError
+
+from onadata.apps.logger.models import EntityList
+from onadata.apps.main.tests.test_base import TestBase
+from onadata.libs.utils.user_auth import get_user_default_project
+
+
+class RestoreEntityListTestCase(TestBase):
+    """Tests for restore_entity_list management command"""
+
+    def setUp(self):
+        super().setUp()
+
+        self.project = get_user_default_project(self.user)
+
+    def test_restore(self):
+        """Soft deleted EntityList is restored"""
+        entity_list = EntityList.objects.create(name="trees", project=self.project)
+        entity_list.soft_delete(self.user)
+        out = StringIO()
+
+        call_command("restore_entity_list", entity_list.pk, stdout=out)
+
+        entity_list.refresh_from_db()
+        self.assertIsNone(entity_list.deleted_at)
+        self.assertIsNone(entity_list.deleted_by)
+        self.assertEqual(entity_list.name, "trees")
+        self.assertIn(
+            f"Successfully restored EntityList 'trees' with ID {entity_list.pk}",
+            out.getvalue(),
+        )
+
+    def test_not_soft_deleted(self):
+        """Restoring an EntityList that is not soft deleted fails"""
+        entity_list = EntityList.objects.create(name="trees", project=self.project)
+
+        with self.assertRaisesRegex(
+            CommandError, f"EntityList with ID {entity_list.pk} is not soft-deleted"
+        ):
+            call_command("restore_entity_list", entity_list.pk)
+
+    def test_does_not_exist(self):
+        """Restoring an EntityList that does not exist fails"""
+        with self.assertRaisesRegex(
+            CommandError, "EntityList with ID 1234 does not exist"
+        ):
+            call_command("restore_entity_list", 1234)

--- a/onadata/apps/logger/tests/models/test_entity_list.py
+++ b/onadata/apps/logger/tests/models/test_entity_list.py
@@ -181,6 +181,55 @@ class EntityListTestCase(TestBase):
         self.assertEqual(entity_list.name, "trees")
         self.assertIsNone(follow_up_form_meta_datum.deleted_at)
 
+    def test_restore_follow_up_form_deleted(self):
+        """Metadata of a soft-deleted follow-up form stays deleted on restore"""
+        with patch("django.utils.timezone.now") as mock_now:
+            mock_now.return_value = self.mocked_now
+            entity_list = EntityList.objects.create(name="trees", project=self.project)
+            follow_up_form = self._publish_follow_up_form(self.user)
+            follow_up_form.soft_delete(self.user)
+            entity_list.soft_delete(self.user)
+
+        entity_list.restore()
+
+        entity_list.refresh_from_db()
+        follow_up_form_meta_datum = follow_up_form.metadata_set.get(
+            data_value=f"entity_list {entity_list.pk} trees"
+        )
+        self.assertIsNone(entity_list.deleted_at)
+        self.assertIsNotNone(follow_up_form_meta_datum.deleted_at)
+
+    def test_restore_name_contains_deletion_marker(self):
+        """Name containing the deletion marker is restored intact"""
+        with patch("django.utils.timezone.now") as mock_now:
+            mock_now.return_value = self.mocked_now
+            entity_list = EntityList.objects.create(
+                name="trees-deleted-at-noon", project=self.project
+            )
+            entity_list.soft_delete(self.user)
+
+        entity_list.restore()
+
+        entity_list.refresh_from_db()
+        self.assertIsNone(entity_list.deleted_at)
+        self.assertEqual(entity_list.name, "trees-deleted-at-noon")
+
+    def test_restore_truncated_name(self):
+        """Name truncated to 255 characters on soft delete is restored"""
+        original_name = "x" * 250
+        with patch("django.utils.timezone.now") as mock_now:
+            mock_now.return_value = self.mocked_now
+            entity_list = EntityList.objects.create(
+                name=original_name, project=self.project
+            )
+            entity_list.soft_delete(self.user)
+
+        entity_list.restore()
+
+        entity_list.refresh_from_db()
+        self.assertIsNone(entity_list.deleted_at)
+        self.assertEqual(entity_list.name, original_name)
+
     def test_hard_delete(self):
         """Hard delete removes consumers' metadata"""
         entity_list = EntityList.objects.create(name="trees", project=self.project)

--- a/onadata/apps/logger/tests/models/test_entity_list.py
+++ b/onadata/apps/logger/tests/models/test_entity_list.py
@@ -162,6 +162,25 @@ class EntityListTestCase(TestBase):
         entity_list.refresh_from_db()
         self.assertEqual(entity_list.name, dataset_name)
 
+    def test_restore(self):
+        """Soft deleted EntityList is restored"""
+        with patch("django.utils.timezone.now") as mock_now:
+            mock_now.return_value = self.mocked_now
+            entity_list = EntityList.objects.create(name="trees", project=self.project)
+            follow_up_form = self._publish_follow_up_form(self.user)
+            entity_list.soft_delete(self.user)
+
+        entity_list.restore()
+
+        entity_list.refresh_from_db()
+        follow_up_form_meta_datum = follow_up_form.metadata_set.get(
+            data_value=f"entity_list {entity_list.pk} trees"
+        )
+        self.assertIsNone(entity_list.deleted_at)
+        self.assertIsNone(entity_list.deleted_by)
+        self.assertEqual(entity_list.name, "trees")
+        self.assertIsNone(follow_up_form_meta_datum.deleted_at)
+
     def test_hard_delete(self):
         """Hard delete removes consumers' metadata"""
         entity_list = EntityList.objects.create(name="trees", project=self.project)


### PR DESCRIPTION
### Changes / Features implemented

- Added `EntityList.restore()` which reverses `EntityList.soft_delete()`
- Added a `restore_entity_list` management command

### Steps taken to verify this change does what is intended

- [x] Added tests

### Side effects of implementing this change

- None

**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  - [x] Updated documentation