### PR TITLE
feat(entities): capture audit log on EntityList deletion

### DIFF
--- a/docs/messaging.rst
+++ b/docs/messaging.rst
@@ -10,6 +10,10 @@ This endpoint provides access to event messages sent for a specific target. Wher
 
     - ``user``
 
+    - ``kmskey``
+
+    - ``entitylist``
+
 * ``target_id`` - The unique identifier of the target object.
 
 * ``verb`` - A specific action that has occured on the object. The supported verbs are:
@@ -24,6 +28,16 @@ This endpoint provides access to event messages sent for a specific target. Wher
     - ``submission_reviewed``
 
     - ``form_updated``
+
+    - ``kmskey_rotated``
+
+    - ``export_created``
+
+    - ``export_downloaded``
+
+    - ``entitylist_imported``
+
+    - ``entitylist_deleted``
 
 
 GET All event messages that have been sent for a form

--- a/onadata/apps/api/tests/viewsets/test_entity_list_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_entity_list_viewset.py
@@ -595,6 +595,20 @@ class DeleteEntityListTestCase(TestAbstractViewSet):
             self.entity_list.name, f'trees{mocked_date.strftime("-deleted-at-%s")}'
         )
 
+    @patch("onadata.apps.api.viewsets.entity_list_viewset.send_message")
+    def test_audit_log_capture(self, mock_send_message):
+        """Audit log is captured on deletion"""
+        request = self.factory.delete("/", **self.extra)
+        response = self.view(request, pk=self.entity_list.pk)
+        self.assertEqual(response.status_code, 204)
+        mock_send_message.assert_called_once_with(
+            instance_id=self.entity_list.pk,
+            target_id=self.entity_list.pk,
+            target_type="entitylist",
+            user=self.user,
+            message_verb="entitylist_deleted",
+        )
+
     def test_authentication_required(self):
         """Anonymous user cannot delete EntityList"""
         # Private EntityList

--- a/onadata/apps/api/viewsets/entity_list_viewset.py
+++ b/onadata/apps/api/viewsets/entity_list_viewset.py
@@ -17,9 +17,9 @@ from rest_framework.decorators import action
 from rest_framework.exceptions import NotFound, ParseError
 from rest_framework.mixins import (
     CreateModelMixin,
+    DestroyModelMixin,
     ListModelMixin,
     RetrieveModelMixin,
-    DestroyModelMixin,
 )
 from rest_framework.response import Response
 from rest_framework.settings import api_settings
@@ -29,6 +29,8 @@ from onadata.apps.api.permissions import EntityListPermissions
 from onadata.apps.api.tools import get_baseviewset_class
 from onadata.apps.logger.models import Entity, EntityList
 from onadata.apps.logger.tasks import import_entities_from_csv_async
+from onadata.apps.messaging.constants import ENTITY_LIST, ENTITY_LIST_DELETED
+from onadata.apps.messaging.serializers import send_message
 from onadata.libs.exceptions import CSVImportError
 from onadata.libs.filters import AnonUserEntityListFilter, EntityListProjectFilter
 from onadata.libs.mixins.cache_control_mixin import CacheControlMixin
@@ -226,6 +228,13 @@ class EntityListViewSet(
     def perform_destroy(self, instance):
         """Override `perform_detroy` method"""
         instance.soft_delete(self.request.user)
+        send_message(
+            instance_id=instance.pk,
+            target_id=instance.pk,
+            target_type=ENTITY_LIST,
+            user=self.request.user,
+            message_verb=ENTITY_LIST_DELETED,
+        )
 
     def create(self, request, *args, **kwargs):
         """Override `create` method"""

--- a/onadata/apps/messaging/constants.py
+++ b/onadata/apps/messaging/constants.py
@@ -34,6 +34,7 @@ EXPORT_DOWNLOADED = "export_downloaded"
 FORM_UPDATED = "form_updated"
 KMS_KEY_ROTATED = "kmskey_rotated"
 ENTITY_LIST_IMPORTED = "entitylist_imported"
+ENTITY_LIST_DELETED = "entitylist_deleted"
 MESSAGE_VERBS = [
     MESSAGE,
     SUBMISSION_REVIEWED,
@@ -45,6 +46,7 @@ MESSAGE_VERBS = [
     EXPORT_CREATED,
     EXPORT_DOWNLOADED,
     ENTITY_LIST_IMPORTED,
+    ENTITY_LIST_DELETED,
 ]
 VERB_TOPIC_DICT = {
     SUBMISSION_CREATED: "submission/created",
@@ -54,4 +56,5 @@ VERB_TOPIC_DICT = {
     FORM_UPDATED: "form/updated",
     KMS_KEY_ROTATED: "kmskey/rotated",
     ENTITY_LIST_IMPORTED: "entitylist/imported",
+    ENTITY_LIST_DELETED: "entitylist/deleted",
 }


### PR DESCRIPTION
### Changes / Features implemented

- Capture an audit log via `send_message` when an EntityList is deleted
- Added `entitylist_deleted` messaging verb
- Documented the messaging verbs and target types missing from `docs/messaging.rst`

### Steps taken to verify this change does what is intended

- [x] Added tests

### Side effects of implementing this change

- None

**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  - [x] Updated documentation

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/onaio/codesmith/onadata/pr/3180"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787134073&installation_id=135786473&pr_number=3180&repository=onaio%2Fonadata&return_to=https%3A%2F%2Fgithub.com%2Fonaio%2Fonadata%2Fpull%2F3180&signature=ca9e2ef19069a22829869d807c027ea2e2d0647bdbdac23f095ac625cc512fd7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->