### PR TITLE
fix(oidc): serve the ona-oidc account-proxy routes

### DIFF
--- a/onadata/apps/main/oidc_viewsets.py
+++ b/onadata/apps/main/oidc_viewsets.py
@@ -7,13 +7,20 @@ establish a session via SSO. The base viewset looks a user up by the email or
 username claim coming from the IdP and calls ``django.contrib.auth.login``
 directly, bypassing ``onadata.apps.main.backends.ModelBackend``. Guarding only
 the backend is therefore not enough; the rejection must also happen here.
+
+The Keycloak Account REST proxy is *not* part of the default viewset. It is
+Keycloak-specific and stores the user's access and refresh tokens in the
+session, so a deployment opts in by pointing ``VIEWSET_CLASS`` at
+``OnaKeycloakOpenIDConnectViewset`` below.
 """
 
 from django.conf import settings
 from django.utils.translation import gettext as _
 
+from oidc.keycloak import KeycloakAccountMixin
 from oidc.viewsets import SSO_COOKIE_NAME, UserModelOpenIDConnectViewset
 from rest_framework import status
+from rest_framework.decorators import action
 from rest_framework.response import Response
 
 from onadata.apps.main.models.user_profile import UserProfile
@@ -27,6 +34,15 @@ class OnaOpenIDConnectViewset(  # pylint: disable=too-few-public-methods
 
     authentication_classes = []
 
+    # Re-declared, not just overridden: the router builds routes from the
+    # ``@action`` metadata on the function, and a plain override drops it,
+    # silently removing /oidc/<server>/login. Must mirror the base viewset.
+    @action(
+        methods=["GET"],
+        detail=False,
+        url_path=r"login/?",
+        url_name="openid_connect_login",
+    )
     def login(self, request, **kwargs):
         # Evict stale auth cookies a partly-logged-out browser may still
         # be sending; without this, a 401 from the downstream callback
@@ -84,3 +100,20 @@ class OnaOpenIDConnectViewset(  # pylint: disable=too-few-public-methods
             }
         )
         return data
+
+
+class OnaKeycloakOpenIDConnectViewset(  # pylint: disable=too-many-ancestors
+    KeycloakAccountMixin, OnaOpenIDConnectViewset
+):
+    """``OnaOpenIDConnectViewset`` plus Keycloak's Account REST proxy.
+
+    Opt-in — point ``OPENID_CONNECT_VIEWSET_CONFIG["VIEWSET_CLASS"]`` here on
+    deployments whose IdP is Keycloak and whose SPA needs the Account tab.
+    The proxy keeps the user's access and refresh tokens in the session, so
+    it also requires a server-side ``SESSION_ENGINE``; ona-oidc's own deploy
+    check enforces that.
+
+    The mixin comes first so its actions win, matching ona-oidc's
+    ``KeycloakOpenIDConnectViewset``. The organization-account rejection is
+    inherited unchanged.
+    """

--- a/onadata/apps/main/oidc_viewsets.py
+++ b/onadata/apps/main/oidc_viewsets.py
@@ -7,11 +7,17 @@ establish a session via SSO. The base viewset looks a user up by the email or
 username claim coming from the IdP and calls ``django.contrib.auth.login``
 directly, bypassing ``onadata.apps.main.backends.ModelBackend``. Guarding only
 the backend is therefore not enough; the rejection must also happen here.
+
+The Keycloak Account REST proxy is *not* part of the default viewset. It is
+Keycloak-specific and stores the user's access and refresh tokens in the
+session, so a deployment opts in by pointing ``VIEWSET_CLASS`` at
+``OnaKeycloakOpenIDConnectViewset`` below.
 """
 
 from django.conf import settings
 from django.utils.translation import gettext as _
 
+from oidc.keycloak import KeycloakAccountMixin
 from oidc.viewsets import SSO_COOKIE_NAME, UserModelOpenIDConnectViewset
 from rest_framework import status
 from rest_framework.response import Response
@@ -84,3 +90,20 @@ class OnaOpenIDConnectViewset(  # pylint: disable=too-few-public-methods
             }
         )
         return data
+
+
+class OnaKeycloakOpenIDConnectViewset(  # pylint: disable=too-many-ancestors
+    KeycloakAccountMixin, OnaOpenIDConnectViewset
+):
+    """``OnaOpenIDConnectViewset`` plus Keycloak's Account REST proxy.
+
+    Opt-in — point ``OPENID_CONNECT_VIEWSET_CONFIG["VIEWSET_CLASS"]`` here on
+    deployments whose IdP is Keycloak and whose SPA needs the Account tab.
+    The proxy keeps the user's access and refresh tokens in the session, so
+    it also requires a server-side ``SESSION_ENGINE``; ona-oidc's own deploy
+    check enforces that.
+
+    The mixin comes first so its actions win, matching ona-oidc's
+    ``KeycloakOpenIDConnectViewset``. The organization-account rejection is
+    inherited unchanged.
+    """

--- a/onadata/apps/main/tests/test_urls_without_admin.py
+++ b/onadata/apps/main/tests/test_urls_without_admin.py
@@ -14,6 +14,10 @@ from django.urls import (
 
 from onadata.apps.api.urls import v1_urls as api_v1_urls_module
 from onadata.apps.main import urls as main_urls_module
+from onadata.apps.main.oidc_viewsets import (
+    OnaKeycloakOpenIDConnectViewset,
+    OnaOpenIDConnectViewset,
+)
 
 
 class TestUrlsAdminToggle(SimpleTestCase):
@@ -138,3 +142,78 @@ class TestHyphenatedUsernameUrls(SimpleTestCase):
             with self.subTest(path=path):
                 with self.assertRaises(Resolver404):
                     resolve(path)
+
+
+class TestOidcAccountProxyIsOptIn(SimpleTestCase):
+    """The Keycloak account proxy is not part of the default viewset.
+
+    ona-oidc derives its routes from the ``@action`` decorators on whichever
+    class ``VIEWSET_CLASS`` names, so which viewset a deployment configures
+    decides whether the proxy endpoints exist at all. That is silent either
+    way -- there is no error, the routes are simply absent -- which is what
+    these pin.
+
+    Pure URLconf resolution and class inspection; no database required.
+    """
+
+    PROXY_ACTIONS = (
+        "sessions_list",
+        "sessions_revoke_one",
+        "sessions_revoke_others",
+        "linked_list",
+        "linked_unlink",
+        "linked_link_url",
+        "credentials_list",
+    )
+
+    def test_the_default_viewset_has_no_proxy_actions(self):
+        """Settings ship the plain viewset, so nothing routes the proxy."""
+        for action in self.PROXY_ACTIONS:
+            self.assertFalse(
+                hasattr(OnaOpenIDConnectViewset, action),
+                f"{action} should be opt-in, not on the default viewset",
+            )
+        self.assertFalse(OnaOpenIDConnectViewset.stash_oidc_tokens)
+
+    def test_the_keycloak_viewset_adds_them(self):
+        for action in self.PROXY_ACTIONS:
+            self.assertTrue(
+                hasattr(OnaKeycloakOpenIDConnectViewset, action),
+                f"{action} missing -- the SPA's Account tab would 404",
+            )
+        # Without this the callback keeps no access token, so the routes
+        # would exist but every call would 401.
+        self.assertTrue(OnaKeycloakOpenIDConnectViewset.stash_oidc_tokens)
+
+    def test_the_keycloak_viewset_still_refuses_organization_accounts(self):
+        """The whole reason onadata owns a viewset. Composition order must
+        not let the mixin displace it."""
+        self.assertTrue(
+            issubclass(OnaKeycloakOpenIDConnectViewset, OnaOpenIDConnectViewset)
+        )
+        self.assertIs(
+            OnaKeycloakOpenIDConnectViewset.is_session_allowed,
+            OnaOpenIDConnectViewset.is_session_allowed,
+        )
+
+    def test_the_proxy_paths_do_not_resolve_under_the_default_viewset(self):
+        for path in (
+            "/oidc/example/sessions",
+            "/oidc/example/credentials",
+            "/oidc/example/linked-accounts",
+        ):
+            with self.subTest(path=path):
+                with self.assertRaises(Resolver404):
+                    resolve(path)
+
+    def test_session_still_resolves_to_the_session_probe(self):
+        """``session`` is on the base viewset, so it routes either way -- and
+        its ``$`` anchor keeps it from prefix-matching ``sessions``."""
+        match = resolve("/oidc/example/session")
+        self.assertEqual(match.func.actions.get("get"), "session")
+
+    def test_the_removed_account_endpoint_is_not_routed(self):
+        """ona-oidc dropped the profile-update ``account`` action -- the proxy
+        is read-and-revoke only."""
+        with self.assertRaises(Resolver404):
+            resolve("/oidc/example/account")

--- a/onadata/apps/main/urls.py
+++ b/onadata/apps/main/urls.py
@@ -12,8 +12,6 @@ from django.contrib.staticfiles import views as staticfiles_views
 from django.urls import include, re_path
 from django.views.generic import RedirectView
 
-from rest_framework.renderers import JSONRenderer
-
 from onadata.apps import sms_support
 from onadata.apps.api.constants import USERNAME_LOOKUP_REGEX
 from onadata.apps.api.urls.v1_urls import (
@@ -27,7 +25,6 @@ from onadata.apps.api.viewsets.xform_list_viewset import PreviewXFormListViewSet
 from onadata.apps.api.viewsets.xform_viewset import XFormViewSet
 from onadata.apps.logger import views as logger_views
 from onadata.apps.main import views as main_views
-from onadata.apps.main.oidc_viewsets import OnaOpenIDConnectViewset
 from onadata.apps.main.registration_urls import urlpatterns as registration_patterns
 from onadata.apps.restservice import views as restservice_views
 from onadata.apps.sms_support import views as sms_support_views
@@ -66,46 +63,13 @@ urlpatterns += [
     re_path("^api/v2/", include(api_v2_router.urls)),
     # open id connect urls
     #
-    # Routed to the project-owned OnaOpenIDConnectViewset (instead of the
-    # blanket ``include("oidc.urls")``) so SSO login rejects organization
-    # accounts. The "oidc" namespace and route names mirror oidc/urls.py so
-    # that reverse("oidc:openid_connect_login") still resolves.
-    re_path(
-        r"^",
-        include(
-            (
-                [
-                    re_path(
-                        r"^oidc/(?P<auth_server>\w+)/login",
-                        OnaOpenIDConnectViewset.as_view({"get": "login"}),
-                        name="openid_connect_login",
-                    ),
-                    re_path(
-                        r"^oidc/(?P<auth_server>\w+)/callback",
-                        OnaOpenIDConnectViewset.as_view(
-                            {"get": "callback", "post": "callback"}
-                        ),
-                        name="openid_connect_callback",
-                    ),
-                    re_path(
-                        r"^oidc/(?P<auth_server>\w+)/logout",
-                        OnaOpenIDConnectViewset.as_view({"get": "logout"}),
-                        name="openid_connect_logout",
-                    ),
-                    re_path(
-                        r"^oidc/(?P<auth_server>\w+)/session",
-                        OnaOpenIDConnectViewset.as_view(
-                            {"get": "session"},
-                            authentication_classes=[],
-                            renderer_classes=[JSONRenderer],
-                        ),
-                        name="openid_connect_session",
-                    ),
-                ],
-                "oidc",
-            ),
-        ),
-    ),
+    # ona-oidc routes every one of its URLs to OnaOpenIDConnectViewset via
+    # OPENID_CONNECT_VIEWSET_CONFIG["VIEWSET_CLASS"], so SSO login still
+    # rejects organization accounts. Re-declaring them here meant mirroring
+    # each new upstream route and every as_view() kwarg by hand. The "oidc"
+    # namespace comes from ona-oidc's app_name, so
+    # reverse("oidc:openid_connect_login") still resolves.
+    re_path(r"^", include("oidc.urls")),
     re_path(
         r"^api-docs/", RedirectView.as_view(url=settings.STATIC_DOC, permanent=True)
     ),

--- a/onadata/settings/common.py
+++ b/onadata/settings/common.py
@@ -262,6 +262,10 @@ OAUTH2_PKCE_S256_MIGRATION_CUTOFF = None
 OAUTH2_PKCE_S256_MIGRATION_EXPIRES_AT = None
 
 OPENID_CONNECT_VIEWSET_CONFIG = {
+    # Route ona-oidc's URLs to the project-owned subclass, which refuses SSO
+    # login for organization accounts. Without this, changing the viewset
+    # meant copying ona-oidc's whole URLconf into onadata/apps/main/urls.py.
+    "VIEWSET_CLASS": "onadata.apps.main.oidc_viewsets.OnaOpenIDConnectViewset",
     "REDIRECT_AFTER_AUTH": "http://localhost:3000",
     "USE_SSO_COOKIE": True,
     "SSO_COOKIE_DATA": "email",

--- a/onadata/settings/common.py
+++ b/onadata/settings/common.py
@@ -255,6 +255,10 @@ OAUTH2_PROVIDER = {
 }
 
 OPENID_CONNECT_VIEWSET_CONFIG = {
+    # Route ona-oidc's URLs to the project-owned subclass, which refuses SSO
+    # login for organization accounts. Without this, changing the viewset
+    # meant copying ona-oidc's whole URLconf into onadata/apps/main/urls.py.
+    "VIEWSET_CLASS": "onadata.apps.main.oidc_viewsets.OnaOpenIDConnectViewset",
     "REDIRECT_AFTER_AUTH": "http://localhost:3000",
     "USE_SSO_COOKIE": True,
     "SSO_COOKIE_DATA": "email",

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -11,7 +11,7 @@ git+https://github.com/onaio/django-digest.git@6bf61ec08502fd3545d4f2c0838b6cb15
 git+https://github.com/onaio/django-multidb-router.git@f711368180d58eef87eda54fadfd5f8355623d52#egg=django-multidb-router
 git+https://github.com/onaio/floip-py.git@3c980eb184069ae7c3c9136b18441978237cd41d#egg=pyfloip
 git+https://github.com/onaio/python-json2xlsclient.git@62b4645f7b4f2684421a13ce98da0331a9dd66a0#egg=python-json2xlsclient
-git+https://github.com/onaio/ona-oidc.git@8f39ec029a3ac07a3f4d565c8f3d30e0061f318d#egg=ona-oidc
+git+https://github.com/onaio/ona-oidc.git@5417e1bd39223b914c6b17a7f028459cd15ad4e8#egg=ona-oidc
 -e git+https://github.com/onaio/savreaderwriter.git@fix-pep-440-issues#egg=savreaderwriter
 git+https://git@github.com/onaio/valigetta.git@v0.2.2#egg=valigetta
 codetiming

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -11,7 +11,7 @@ git+https://github.com/onaio/django-digest.git@6bf61ec08502fd3545d4f2c0838b6cb15
 git+https://github.com/onaio/django-multidb-router.git@f711368180d58eef87eda54fadfd5f8355623d52#egg=django-multidb-router
 git+https://github.com/onaio/floip-py.git@3c980eb184069ae7c3c9136b18441978237cd41d#egg=pyfloip
 git+https://github.com/onaio/python-json2xlsclient.git@62b4645f7b4f2684421a13ce98da0331a9dd66a0#egg=python-json2xlsclient
-git+https://github.com/onaio/ona-oidc.git@5417e1bd39223b914c6b17a7f028459cd15ad4e8#egg=ona-oidc
+git+https://github.com/onaio/ona-oidc.git@0461c0b8d5aad5d8a717275712f24e43251e1f41#egg=ona-oidc
 -e git+https://github.com/onaio/savreaderwriter.git@fix-pep-440-issues#egg=savreaderwriter
 git+https://git@github.com/onaio/valigetta.git@v0.2.2#egg=valigetta
 codetiming

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -11,7 +11,7 @@ git+https://github.com/onaio/django-digest.git@6bf61ec08502fd3545d4f2c0838b6cb15
 git+https://github.com/onaio/django-multidb-router.git@f711368180d58eef87eda54fadfd5f8355623d52#egg=django-multidb-router
 git+https://github.com/onaio/floip-py.git@3c980eb184069ae7c3c9136b18441978237cd41d#egg=pyfloip
 git+https://github.com/onaio/python-json2xlsclient.git@62b4645f7b4f2684421a13ce98da0331a9dd66a0#egg=python-json2xlsclient
-git+https://github.com/onaio/ona-oidc.git@8f39ec029a3ac07a3f4d565c8f3d30e0061f318d#egg=ona-oidc
+git+https://github.com/onaio/ona-oidc.git@0697676270b227637f71fa9e9b4c3cf52a5c0a80#egg=ona-oidc
 -e git+https://github.com/onaio/savreaderwriter.git@fix-pep-440-issues#egg=savreaderwriter
 git+https://git@github.com/onaio/valigetta.git@v0.2.2#egg=valigetta
 codetiming

--- a/requirements/base.pip
+++ b/requirements/base.pip
@@ -244,7 +244,7 @@ oauthlib==3.3.1
     # via
     #   django-oauth-toolkit
     #   requests-oauthlib
-ona-oidc @ git+https://github.com/onaio/ona-oidc.git@8f39ec029a3ac07a3f4d565c8f3d30e0061f318d
+ona-oidc @ git+https://github.com/onaio/ona-oidc.git@5417e1bd39223b914c6b17a7f028459cd15ad4e8
     # via -r requirements/base.in
 openpyxl==3.1.5
     # via

--- a/requirements/base.pip
+++ b/requirements/base.pip
@@ -244,7 +244,7 @@ oauthlib==3.3.1
     # via
     #   django-oauth-toolkit
     #   requests-oauthlib
-ona-oidc @ git+https://github.com/onaio/ona-oidc.git@8f39ec029a3ac07a3f4d565c8f3d30e0061f318d
+ona-oidc @ git+https://github.com/onaio/ona-oidc.git@0697676270b227637f71fa9e9b4c3cf52a5c0a80
     # via -r requirements/base.in
 openpyxl==3.1.5
     # via

--- a/requirements/base.pip
+++ b/requirements/base.pip
@@ -244,7 +244,7 @@ oauthlib==3.3.1
     # via
     #   django-oauth-toolkit
     #   requests-oauthlib
-ona-oidc @ git+https://github.com/onaio/ona-oidc.git@5417e1bd39223b914c6b17a7f028459cd15ad4e8
+ona-oidc @ git+https://github.com/onaio/ona-oidc.git@0461c0b8d5aad5d8a717275712f24e43251e1f41
     # via -r requirements/base.in
 openpyxl==3.1.5
     # via

--- a/requirements/dev.pip
+++ b/requirements/dev.pip
@@ -310,7 +310,7 @@ oauthlib==3.3.1
     # via
     #   django-oauth-toolkit
     #   requests-oauthlib
-ona-oidc @ git+https://github.com/onaio/ona-oidc.git@8f39ec029a3ac07a3f4d565c8f3d30e0061f318d
+ona-oidc @ git+https://github.com/onaio/ona-oidc.git@5417e1bd39223b914c6b17a7f028459cd15ad4e8
     # via -r requirements/base.in
 openpyxl==3.1.5
     # via

--- a/requirements/dev.pip
+++ b/requirements/dev.pip
@@ -310,7 +310,7 @@ oauthlib==3.3.1
     # via
     #   django-oauth-toolkit
     #   requests-oauthlib
-ona-oidc @ git+https://github.com/onaio/ona-oidc.git@8f39ec029a3ac07a3f4d565c8f3d30e0061f318d
+ona-oidc @ git+https://github.com/onaio/ona-oidc.git@ecb7acab5edae3e91207a6b77eaa1b81ba7ddd2e
     # via -r requirements/base.in
 openpyxl==3.1.5
     # via

--- a/requirements/dev.pip
+++ b/requirements/dev.pip
@@ -310,7 +310,7 @@ oauthlib==3.3.1
     # via
     #   django-oauth-toolkit
     #   requests-oauthlib
-ona-oidc @ git+https://github.com/onaio/ona-oidc.git@5417e1bd39223b914c6b17a7f028459cd15ad4e8
+ona-oidc @ git+https://github.com/onaio/ona-oidc.git@0461c0b8d5aad5d8a717275712f24e43251e1f41
     # via -r requirements/base.in
 openpyxl==3.1.5
     # via


### PR DESCRIPTION
### Changes / Features implemented

Serve ona-oidc's Keycloak account-proxy routes (`/oidc/<server>/sessions`, `/linked-accounts`, `/credentials`) so the SPA's Account tab works, and bump ona-oidc to pick up onaio/ona-oidc#124.

- **Inherit ona-oidc's URLconf instead of copying it.** #3090 replaced `include("oidc.urls")` with an inline copy so routes could point at `OnaOpenIDConnectViewset`, which refuses SSO login for organization accounts. ona-oidc now takes `VIEWSET_CLASS`, so the blanket include is restored without losing that rejection. The copy had already drifted — the `session` route lost its `$` anchor and prefix-matched `/sessions`.
- **Add an opt-in `OnaKeycloakOpenIDConnectViewset`.** ona-oidc moved the proxy actions into `KeycloakAccountMixin` and derives routes from the `@action` decorators on whichever class `VIEWSET_CLASS` names. The proxy is Keycloak-specific and keeps the user's access/refresh tokens in the session, so it is **not** on the default viewset: `OnaOpenIDConnectViewset` is unchanged, and a deployment opts in by pointing `VIEWSET_CLASS` at the new subclass. The organization-account rejection is inherited either way.

### Steps taken to verify this change does what is intended

- `test_urls_without_admin.py` pins both halves of the opt-in: the default viewset exposes none of the seven proxy actions and its paths 404, the Keycloak subclass exposes all of them with `stash_oidc_tokens=True`, and the subclass still refuses organization accounts. Also pins that `session` does not prefix-match `sessions`.
- Whether the proxy is routed is silent either way — no error, the routes simply exist or don't — which is why these are asserted rather than left to a smoke test.
- Covered upstream by ona-oidc's suite (294 tests, green on the pinned commit).

### Side effects of implementing this change

- Depends on ona-oidc `0697676`, pinned here. That change renames the OIDC session keys with no fallback read, so **live sessions get one forced re-login** at deploy.
- The `/oidc/<server>/account` route is gone; ona-oidc removed that action.
- ona-oidc now requires a server-side `SESSION_ENGINE` for the proxy viewset and applies its `Origin` allowlist to reads, so `LOGIN_REDIRECT_ALLOWED_HOSTS` must contain the SPA's exact netloc — host **and** port — in every environment.
- No behaviour change for existing deployments: the default viewset is untouched and `VIEWSET_CLASS` still points at it. Deployments wanting the Account tab set it to `OnaKeycloakOpenIDConnectViewset` via their own settings overlay.
- `str_to_bool` upstream now reads `"false"`, `"0"`, `""`, `"no"` and `"off"` as false; previously only the exact literal `"False"` was. Settings here are real booleans, so nothing changes for this repo — but a deployment that feeds any `OPENID_CONNECT_VIEWSET_CONFIG` flag from an env var was getting the opposite of what it asked for, and will now get what it asked for.
- Supersedes the bump in #3176, which can be closed.

**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  - [x] Updated documentation

Closes #


