### PR TITLE
feat(entities): create/update Entities from repeats

### DIFF
--- a/onadata/apps/logger/tests/test_parsing.py
+++ b/onadata/apps/logger/tests/test_parsing.py
@@ -2,25 +2,26 @@
 import json
 import os
 import re
+
+from django.test import SimpleTestCase
+
 from defusedxml import minidom
 
-from onadata.apps.main.tests.test_base import TestBase
-from onadata.apps.logger.xform_instance_parser import (
-    XFormInstanceParser,
-    xpath_from_xml_node,
-)
-from onadata.apps.logger.xform_instance_parser import (
-    get_uuid_from_xml,
-    get_meta_from_xml,
-    get_deprecated_uuid_from_xml,
-)
-from onadata.libs.utils.common_tags import XFORM_ID_STRING
 from onadata.apps.logger.models.xform import XForm
 from onadata.apps.logger.xform_instance_parser import (
+    XFormInstanceParser,
     _xml_node_to_dict,
     clean_and_parse_xml,
+    get_deprecated_uuid_from_xml,
+    get_entity_group_data,
+    get_entity_label_from_node,
+    get_entity_nodes_from_xml,
+    get_meta_from_xml,
+    get_uuid_from_xml,
+    xpath_from_xml_node,
 )
-
+from onadata.apps.main.tests.test_base import TestBase
+from onadata.libs.utils.common_tags import XFORM_ID_STRING
 
 XML = "xml"
 DICT = "dict"
@@ -251,3 +252,130 @@ class TestXFormInstanceParser(TestBase):
             self.assertEqual(3, len(xml_dict["#document"]["RW_OUNIS_2016"]["S2A"]))
             with open(json_file) as file:
                 self.assertEqual(json.loads(file.read()), xml_dict)
+
+
+class GetEntityNodesFromXmlTestCase(SimpleTestCase):
+    """Tests for get_entity_nodes_from_xml"""
+
+    def test_top_level_entity(self):
+        """A top-level entity node is returned"""
+        xml = (
+            "<data>"
+            "<species>purpleheart</species>"
+            "<meta>"
+            "<instanceID>uuid:86d21baf-75a2-4907-be8d-84dbacae2ebd</instanceID>"
+            '<entity dataset="trees" create="1" id="dbee4c32">'
+            "<label>Purpleheart</label>"
+            "</entity>"
+            "</meta>"
+            "</data>"
+        )
+        entity_nodes = get_entity_nodes_from_xml(xml)
+
+        self.assertEqual(len(entity_nodes), 1)
+        self.assertEqual(entity_nodes[0].getAttribute("id"), "dbee4c32")
+
+    def test_entities_within_repeat(self):
+        """An entity node is returned for each repeat instance in order"""
+        xml = (
+            "<data>"
+            "<tree>"
+            "<tree_id>1</tree_id>"
+            "<meta>"
+            '<entity dataset="trees" create="1" id="a"><label>1</label></entity>'
+            "</meta>"
+            "</tree>"
+            "<tree>"
+            "<tree_id>2</tree_id>"
+            "<meta>"
+            '<entity dataset="trees" create="1" id="b"><label>2</label></entity>'
+            "</meta>"
+            "</tree>"
+            "<meta>"
+            "<instanceID>uuid:86d21baf-75a2-4907-be8d-84dbacae2ebd</instanceID>"
+            "</meta>"
+            "</data>"
+        )
+        entity_nodes = get_entity_nodes_from_xml(xml)
+
+        self.assertEqual([node.getAttribute("id") for node in entity_nodes], ["a", "b"])
+
+
+class GetEntityLabelFromNodeTestCase(SimpleTestCase):
+    """Tests for get_entity_label_from_node"""
+
+    def test_returns_label(self):
+        """The label defined within an entity node is returned"""
+        xml = (
+            "<data>"
+            "<meta>"
+            '<entity dataset="trees" create="1" id="dbee4c32">'
+            "<label>300cm purpleheart</label>"
+            "</entity>"
+            "</meta>"
+            "</data>"
+        )
+        entity_node = get_meta_from_xml(xml, "entity")
+
+        self.assertEqual(get_entity_label_from_node(entity_node), "300cm purpleheart")
+
+
+class GetEntityGroupDataTestCase(SimpleTestCase):
+    """Tests for get_entity_group_data"""
+
+    def test_top_level_entity(self):
+        """All submission fields are returned for a top-level entity"""
+        xml = (
+            "<data>"
+            "<species>purpleheart</species>"
+            "<meta>"
+            '<entity dataset="trees" create="1" id="dbee4c32">'
+            "<label>Purpleheart</label>"
+            "</entity>"
+            "</meta>"
+            "</data>"
+        )
+        instance_data = {
+            "species": "purpleheart",
+            "meta/instanceID": "uuid:86d21baf-75a2-4907-be8d-84dbacae2ebd",
+        }
+        entity_node = get_meta_from_xml(xml, "entity")
+
+        self.assertEqual(
+            get_entity_group_data(entity_node, instance_data), instance_data
+        )
+
+    def test_entity_within_repeat(self):
+        """Only the entity's repeat instance fields are returned"""
+        xml = (
+            "<data>"
+            "<tree>"
+            "<tree_id>1</tree_id>"
+            "<meta>"
+            '<entity dataset="trees" create="1" id="a"><label>1</label></entity>'
+            "</meta>"
+            "</tree>"
+            "<tree>"
+            "<tree_id>2</tree_id>"
+            "<meta>"
+            '<entity dataset="trees" create="1" id="b"><label>2</label></entity>'
+            "</meta>"
+            "</tree>"
+            "</data>"
+        )
+        instance_data = {
+            "tree": [
+                {"tree/tree_id": "1"},
+                {"tree/tree_id": "2"},
+            ],
+        }
+        entity_nodes = get_entity_nodes_from_xml(xml)
+
+        self.assertEqual(
+            get_entity_group_data(entity_nodes[0], instance_data),
+            {"tree/tree_id": "1"},
+        )
+        self.assertEqual(
+            get_entity_group_data(entity_nodes[1], instance_data),
+            {"tree/tree_id": "2"},
+        )

--- a/onadata/apps/logger/tests/test_parsing.py
+++ b/onadata/apps/logger/tests/test_parsing.py
@@ -443,3 +443,20 @@ class GetEntityGroupDataTestCase(SimpleTestCase):
             get_entity_group_data(entity_nodes[2]),
             {"tree/inspection/tree_id": "3"},
         )
+
+    def test_cdata_value(self):
+        """A field value stored as CDATA is returned"""
+        xml = (
+            "<data>"
+            "<species><![CDATA[purpleheart]]></species>"
+            "<meta>"
+            '<entity dataset="trees" create="1" id="a"><label>1</label></entity>'
+            "</meta>"
+            "</data>"
+        )
+        entity_node = get_meta_from_xml(xml, "entity")
+
+        self.assertEqual(
+            get_entity_group_data(entity_node),
+            {"species": "purpleheart"},
+        )

--- a/onadata/apps/logger/tests/test_parsing.py
+++ b/onadata/apps/logger/tests/test_parsing.py
@@ -379,3 +379,61 @@ class GetEntityGroupDataTestCase(SimpleTestCase):
             get_entity_group_data(entity_nodes[1], instance_data),
             {"tree/tree_id": "2"},
         )
+
+    def test_entity_within_nested_repeat(self):
+        """Only the entity's nested repeat instance fields are returned"""
+        xml = (
+            "<data>"
+            "<tree>"
+            "<inspection>"
+            "<tree_id>1</tree_id>"
+            "<meta>"
+            '<entity dataset="trees" create="1" id="a"><label>1</label></entity>'
+            "</meta>"
+            "</inspection>"
+            "<inspection>"
+            "<tree_id>2</tree_id>"
+            "<meta>"
+            '<entity dataset="trees" create="1" id="b"><label>2</label></entity>'
+            "</meta>"
+            "</inspection>"
+            "</tree>"
+            "<tree>"
+            "<inspection>"
+            "<tree_id>3</tree_id>"
+            "<meta>"
+            '<entity dataset="trees" create="1" id="c"><label>3</label></entity>'
+            "</meta>"
+            "</inspection>"
+            "</tree>"
+            "</data>"
+        )
+        instance_data = {
+            "tree": [
+                {
+                    "tree/inspection": [
+                        {"tree/inspection/tree_id": "1"},
+                        {"tree/inspection/tree_id": "2"},
+                    ],
+                },
+                {
+                    "tree/inspection": [
+                        {"tree/inspection/tree_id": "3"},
+                    ],
+                },
+            ],
+        }
+        entity_nodes = get_entity_nodes_from_xml(xml)
+
+        self.assertEqual(
+            get_entity_group_data(entity_nodes[0], instance_data),
+            {"tree/inspection/tree_id": "1"},
+        )
+        self.assertEqual(
+            get_entity_group_data(entity_nodes[1], instance_data),
+            {"tree/inspection/tree_id": "2"},
+        )
+        self.assertEqual(
+            get_entity_group_data(entity_nodes[2], instance_data),
+            {"tree/inspection/tree_id": "3"},
+        )

--- a/onadata/apps/logger/tests/test_parsing.py
+++ b/onadata/apps/logger/tests/test_parsing.py
@@ -328,6 +328,7 @@ class GetEntityGroupDataTestCase(SimpleTestCase):
         xml = (
             "<data>"
             "<species>purpleheart</species>"
+            "<circumference>300</circumference>"
             "<meta>"
             '<entity dataset="trees" create="1" id="dbee4c32">'
             "<label>Purpleheart</label>"
@@ -335,14 +336,11 @@ class GetEntityGroupDataTestCase(SimpleTestCase):
             "</meta>"
             "</data>"
         )
-        instance_data = {
-            "species": "purpleheart",
-            "meta/instanceID": "uuid:86d21baf-75a2-4907-be8d-84dbacae2ebd",
-        }
         entity_node = get_meta_from_xml(xml, "entity")
 
         self.assertEqual(
-            get_entity_group_data(entity_node, instance_data), instance_data
+            get_entity_group_data(entity_node),
+            {"species": "purpleheart", "circumference": "300"},
         )
 
     def test_entity_within_repeat(self):
@@ -363,21 +361,44 @@ class GetEntityGroupDataTestCase(SimpleTestCase):
             "</tree>"
             "</data>"
         )
-        instance_data = {
-            "tree": [
-                {"tree/tree_id": "1"},
-                {"tree/tree_id": "2"},
-            ],
-        }
         entity_nodes = get_entity_nodes_from_xml(xml)
 
         self.assertEqual(
-            get_entity_group_data(entity_nodes[0], instance_data),
+            get_entity_group_data(entity_nodes[0]),
             {"tree/tree_id": "1"},
         )
         self.assertEqual(
-            get_entity_group_data(entity_nodes[1], instance_data),
+            get_entity_group_data(entity_nodes[1]),
             {"tree/tree_id": "2"},
+        )
+
+    def test_empty_fields_omitted(self):
+        """A repeat instance's empty fields are omitted"""
+        xml = (
+            "<data>"
+            "<tree>"
+            "<tree_id/>"
+            "<year_planted/>"
+            "<meta>"
+            '<entity dataset="trees" update="1" id="a" baseVersion="1"/>'
+            "</meta>"
+            "</tree>"
+            "<tree>"
+            "<tree_id>2</tree_id>"
+            "<year_planted>2016</year_planted>"
+            "<meta>"
+            '<entity dataset="trees" update="1" id="b" baseVersion="1"/>'
+            "</meta>"
+            "</tree>"
+            "</data>"
+        )
+        entity_nodes = get_entity_nodes_from_xml(xml)
+
+        # The first repeat instance is entirely empty
+        self.assertEqual(get_entity_group_data(entity_nodes[0]), {})
+        self.assertEqual(
+            get_entity_group_data(entity_nodes[1]),
+            {"tree/tree_id": "2", "tree/year_planted": "2016"},
         )
 
     def test_entity_within_nested_repeat(self):
@@ -408,32 +429,17 @@ class GetEntityGroupDataTestCase(SimpleTestCase):
             "</tree>"
             "</data>"
         )
-        instance_data = {
-            "tree": [
-                {
-                    "tree/inspection": [
-                        {"tree/inspection/tree_id": "1"},
-                        {"tree/inspection/tree_id": "2"},
-                    ],
-                },
-                {
-                    "tree/inspection": [
-                        {"tree/inspection/tree_id": "3"},
-                    ],
-                },
-            ],
-        }
         entity_nodes = get_entity_nodes_from_xml(xml)
 
         self.assertEqual(
-            get_entity_group_data(entity_nodes[0], instance_data),
+            get_entity_group_data(entity_nodes[0]),
             {"tree/inspection/tree_id": "1"},
         )
         self.assertEqual(
-            get_entity_group_data(entity_nodes[1], instance_data),
+            get_entity_group_data(entity_nodes[1]),
             {"tree/inspection/tree_id": "2"},
         )
         self.assertEqual(
-            get_entity_group_data(entity_nodes[2], instance_data),
+            get_entity_group_data(entity_nodes[2]),
             {"tree/inspection/tree_id": "3"},
         )

--- a/onadata/apps/logger/xform_instance_parser.py
+++ b/onadata/apps/logger/xform_instance_parser.py
@@ -215,7 +215,7 @@ def _xml_node_to_dict(node, repeats=None, encrypted=False):  # noqa C901
         if child_xpath in repeats or (encrypted and child_name == "media"):
             node_type = list
 
-        if node_type == dict:
+        if node_type is dict:
             if child_name not in value:
                 value[child_name] = child_dict[child_name]
             else:
@@ -463,3 +463,96 @@ def get_entity_uuid_from_xml(xml):
     """Returns the uuid for the XML submission's entity"""
     entity_node = get_meta_from_xml(xml, "entity")
     return entity_node.getAttribute("id")
+
+
+def get_entity_nodes_from_xml(xml_str):
+    """Return all entity nodes in a submission XML in document order.
+
+    A submission can define more than one entity when the entity is created
+    within a repeat, so entity nodes are collected from every meta section and
+    not just the top-level one.
+    """
+    xml = clean_and_parse_xml(xml_str)
+    entity_nodes = []
+
+    def is_meta(node):
+        return node.nodeType == Node.ELEMENT_NODE and node.tagName.lower() in (
+            "meta",
+            "orx:meta",
+        )
+
+    def is_entity(node):
+        return node.nodeType == Node.ELEMENT_NODE and node.tagName.lower() in (
+            "entity",
+            "orx:entity",
+        )
+
+    def collect(node):
+        for child in node.childNodes:
+            if child.nodeType != Node.ELEMENT_NODE:
+                continue
+
+            if is_meta(child):
+                entity_nodes.extend(n for n in child.childNodes if is_entity(n))
+            else:
+                collect(child)
+
+    collect(xml)
+
+    return entity_nodes
+
+
+def get_entity_label_from_node(entity_node):
+    """Return the label defined within a submission's entity node."""
+    for child in entity_node.childNodes:
+        if child.nodeType == Node.ELEMENT_NODE and child.tagName.lower() in (
+            "label",
+            "orx:label",
+        ):
+            return child.firstChild.nodeValue if child.firstChild else None
+
+    return None
+
+
+def _get_node_index(node):
+    """Return the position of ``node`` among its same-named siblings."""
+    index = 0
+    sibling = node.previousSibling
+
+    while sibling is not None:
+        if sibling.nodeType == Node.ELEMENT_NODE and sibling.tagName == node.tagName:
+            index += 1
+
+        sibling = sibling.previousSibling
+
+    return index
+
+
+def get_entity_group_data(entity_node, instance_data):
+    """Return the submission field values for an entity node's group.
+
+    For an entity defined within a repeat, only the fields of the specific
+    repeat instance the entity belongs to are returned. For a top-level entity,
+    all the submission fields are returned.
+
+    :param entity_node: The submission's entity XML node
+    :param instance_data: The submission's flat data dictionary
+    """
+    # entity -> meta -> group holding the entity
+    node = entity_node.parentNode.parentNode
+    root_node = node.ownerDocument.documentElement
+
+    while node is not None and node is not root_node:
+        repeat_data = instance_data.get(xpath_from_xml_node(node))
+
+        if isinstance(repeat_data, list):
+            index = _get_node_index(node)
+
+            if index < len(repeat_data):
+                return repeat_data[index]
+
+            return {}
+
+        node = node.parentNode
+
+    return instance_data

--- a/onadata/apps/logger/xform_instance_parser.py
+++ b/onadata/apps/logger/xform_instance_parser.py
@@ -514,54 +514,40 @@ def get_entity_label_from_node(entity_node):
     return None
 
 
-def _get_node_index(node):
-    """Return the position of ``node`` among its same-named siblings."""
-    index = 0
-    sibling = node.previousSibling
-
-    while sibling is not None:
-        if sibling.nodeType == Node.ELEMENT_NODE and sibling.tagName == node.tagName:
-            index += 1
-
-        sibling = sibling.previousSibling
-
-    return index
-
-
-def get_entity_group_data(entity_node, instance_data):
+def get_entity_group_data(entity_node):
     """Return the submission field values for an entity node's group.
 
-    For an entity defined within a repeat, only the fields of the specific
-    repeat instance the entity belongs to are returned. For a top-level entity,
-    all the submission fields are returned.
+    The values are read from the entity node's enclosing group in the
+    submission XML. An entity defined within a repeat therefore only sees the
+    fields of its own repeat instance, while a top-level entity sees all the
+    submission fields. Reading straight from the XML keeps each entity matched
+    to its own data even when a sibling repeat instance is empty and so dropped
+    from the parsed submission dictionary.
 
     :param entity_node: The submission's entity XML node
-    :param instance_data: The submission's flat data dictionary
+    :return: A mapping of field xpath to its string value
     """
-    root_node = entity_node.ownerDocument.documentElement
-    # The groups enclosing the entity, from the one directly holding it
-    # (entity -> meta -> group) up to, but excluding, the root
-    groups = []
-    node = entity_node.parentNode.parentNode
+    # entity -> meta -> group holding the entity
+    group_node = entity_node.parentNode.parentNode
+    group_data = {}
 
-    while node is not None and node is not root_node:
-        groups.append(node)
-        node = node.parentNode
+    def collect(node):
+        for child in node.childNodes:
+            if child.nodeType != Node.ELEMENT_NODE:
+                continue
 
-    # Descend from the outermost group inwards, following the specific repeat
-    # instance the entity belongs to at each level. Nested repeats keep their
-    # data nested, so a deeper repeat's data lives within its parent's instance.
-    data = instance_data
+            # A meta section holds entity definitions, not field data
+            if child.tagName.lower() in ("meta", "orx:meta"):
+                continue
 
-    for group in reversed(groups):
-        repeat_data = data.get(xpath_from_xml_node(group))
+            if (
+                len(child.childNodes) == 1
+                and child.childNodes[0].nodeType == Node.TEXT_NODE
+            ):
+                group_data[xpath_from_xml_node(child)] = child.childNodes[0].nodeValue
+            else:
+                collect(child)
 
-        if isinstance(repeat_data, list):
-            index = _get_node_index(group)
+    collect(group_node)
 
-            if index >= len(repeat_data):
-                return {}
-
-            data = repeat_data[index]
-
-    return data
+    return group_data

--- a/onadata/apps/logger/xform_instance_parser.py
+++ b/onadata/apps/logger/xform_instance_parser.py
@@ -540,9 +540,9 @@ def get_entity_group_data(entity_node):
             if child.tagName.lower() in ("meta", "orx:meta"):
                 continue
 
-            if (
-                len(child.childNodes) == 1
-                and child.childNodes[0].nodeType == Node.TEXT_NODE
+            if len(child.childNodes) == 1 and child.childNodes[0].nodeType in (
+                Node.TEXT_NODE,
+                Node.CDATA_SECTION_NODE,
             ):
                 group_data[xpath_from_xml_node(child)] = child.childNodes[0].nodeValue
             else:

--- a/onadata/apps/logger/xform_instance_parser.py
+++ b/onadata/apps/logger/xform_instance_parser.py
@@ -538,21 +538,30 @@ def get_entity_group_data(entity_node, instance_data):
     :param entity_node: The submission's entity XML node
     :param instance_data: The submission's flat data dictionary
     """
-    # entity -> meta -> group holding the entity
+    root_node = entity_node.ownerDocument.documentElement
+    # The groups enclosing the entity, from the one directly holding it
+    # (entity -> meta -> group) up to, but excluding, the root
+    groups = []
     node = entity_node.parentNode.parentNode
-    root_node = node.ownerDocument.documentElement
 
     while node is not None and node is not root_node:
-        repeat_data = instance_data.get(xpath_from_xml_node(node))
-
-        if isinstance(repeat_data, list):
-            index = _get_node_index(node)
-
-            if index < len(repeat_data):
-                return repeat_data[index]
-
-            return {}
-
+        groups.append(node)
         node = node.parentNode
 
-    return instance_data
+    # Descend from the outermost group inwards, following the specific repeat
+    # instance the entity belongs to at each level. Nested repeats keep their
+    # data nested, so a deeper repeat's data lives within its parent's instance.
+    data = instance_data
+
+    for group in reversed(groups):
+        repeat_data = data.get(xpath_from_xml_node(group))
+
+        if isinstance(repeat_data, list):
+            index = _get_node_index(group)
+
+            if index >= len(repeat_data):
+                return {}
+
+            data = repeat_data[index]
+
+    return data

--- a/onadata/apps/viewer/models/data_dictionary.py
+++ b/onadata/apps/viewer/models/data_dictionary.py
@@ -382,38 +382,47 @@ def create_registration_form(sender, instance=None, created=False, **kwargs):
     if not _has_entity_definition(instance_json):
         return
 
-    children = instance_json.get("children", [])
-    meta_list = filter(lambda child: child.get("name") == "meta", children)
+    def _register(children):
+        for child in children:
+            if child.get("children", []):
+                _register(child["children"])
 
-    for meta in meta_list:
-        for child in meta.get("children", []):
-            if child.get("name") == "entity":
-                dataset = _get_entity_dataset(child)
-                entity_list, _ = EntityList.objects.get_or_create(
-                    name=dataset, project=instance.project
-                )
-                (
-                    registration_form,
-                    registration_form_created,
-                ) = RegistrationForm.objects.get_or_create(
-                    entity_list=entity_list,
-                    xform=instance,
-                )
+        meta_list = filter(lambda child: child.get("name") == "meta", children)
 
-                if registration_form_created:
-                    # RegistrationForm contributing to any previous
-                    # EntityList should be disabled
-                    for form in instance.registration_forms.exclude(
-                        entity_list=entity_list, is_active=True
+        for meta in meta_list:
+            for child in meta.get("children", []):
+                if child.get("name") == "entity":
+                    dataset = _get_entity_dataset(child)
+                    entity_list, _ = EntityList.objects.get_or_create(
+                        name=dataset, project=instance.project
+                    )
+                    (
+                        registration_form,
+                        registration_form_created,
+                    ) = RegistrationForm.objects.get_or_create(
+                        entity_list=entity_list,
+                        xform=instance,
+                    )
+
+                    if registration_form_created:
+                        # RegistrationForm contributing to any previous
+                        # EntityList should be disabled
+                        for form in instance.registration_forms.exclude(
+                            entity_list=entity_list, is_active=True
+                        ):
+                            form.is_active = False
+                            form.save()
+                    elif (
+                        not registration_form_created
+                        and not registration_form.is_active
                     ):
-                        form.is_active = False
-                        form.save()
-                elif not registration_form_created and not registration_form.is_active:
-                    # If previously disabled, enable it
-                    registration_form.is_active = True
-                    registration_form.save()
+                        # If previously disabled, enable it
+                        registration_form.is_active = True
+                        registration_form.save()
 
-                return
+                    return
+
+    _register(instance_json.get("children", []))
 
 
 post_save.connect(

--- a/onadata/apps/viewer/tests/test_data_dictionary.py
+++ b/onadata/apps/viewer/tests/test_data_dictionary.py
@@ -203,6 +203,45 @@ class DataDictionaryTestCase(TestBase):
         )
         self.assertTrue(reg_form.is_active)
 
+    def test_create_reg_form_w_save_to_within_nested_group_within_repeat(self):
+        """A RegistrationForm is created for a form w/ save_to within a nested group, within repeat"""
+        md = """
+        | survey   |
+        |          | type         | name          | label         | save_to      |
+        |          | begin_repeat | tree          | Tree          |              |
+        |          | begin_group  | tree_details  | Tree Details  |              |
+        |          | begin_group  | planting_info | Planting Info |              |
+        |          | barcode      | tree_id       | Tree ID       |              |
+        |          | text         | year_planted  | Year planted  | year_planted |
+        |          | end_group    |               |               |              |
+        |          | end_group    |               |               |              |
+        |          | end_repeat   |               |               |              |
+        | settings |              |               |               |              |
+        |          | form_title   | form_id       |               |              |
+        |          | Trees        | trees         |               |              |
+        | entities |              |               |               |              |
+        |          | list_name    | label         |               |              |
+        |          | trees        | ${tree_id}    |               |              |
+        """
+        xform = self._publish_markdown(md, self.user)
+
+        self.assertTrue(EntityList.objects.filter(name="trees").exists())
+        self.assertTrue(
+            RegistrationForm.objects.filter(
+                xform=xform, entity_list__name="trees"
+            ).exists()
+        )
+
+        reg_form = RegistrationForm.objects.get(xform=xform, entity_list__name="trees")
+
+        self.assertEqual(
+            reg_form.get_save_to(),
+            {
+                "year_planted": "year_planted",
+            },
+        )
+        self.assertTrue(reg_form.is_active)
+
     def test_create_follow_up_form(self):
         """Follow up form created successfully"""
         entity_list = EntityList.objects.create(name="trees", project=self.project)

--- a/onadata/apps/viewer/tests/test_data_dictionary.py
+++ b/onadata/apps/viewer/tests/test_data_dictionary.py
@@ -86,8 +86,8 @@ class DataDictionaryTestCase(TestBase):
         )
         self.assertTrue(reg_form.is_active)
 
-    def test_create_registration_w_props_within_group(self):
-        """Registration form with properties within group works"""
+    def test_create_reg_form_w_save_to_within_group(self):
+        """A RegistrationForm is created for a form w/ save_to within a group"""
         md = """
         | survey   |
         |          | type               | name                                       | label                    | save_to                                    |
@@ -127,6 +127,41 @@ class DataDictionaryTestCase(TestBase):
                 "geometry": "location",
                 "species": "species",
                 "circumference_cm": "circumference",
+            },
+        )
+        self.assertTrue(reg_form.is_active)
+
+    def test_create_reg_form_w_save_to_within_repeat(self):
+        """A RegistrationForm is created for a form w/ save_to within a repeat"""
+        md = """
+        | survey   |
+        |          | type         | name         | label        | save_to      |
+        |          | begin_repeat | tree         | Tree         |              |
+        |          | barcode      | tree_id      | Tree ID      |              |
+        |          | text         | year_planted | Year planted | year_planted |
+        |          | end_repeat   |              |              |              |
+        | settings |              |              |              |              |
+        |          | form_title   | form_id      |              |              |
+        |          | Trees        | trees        |              |              |
+        | entities |              |              |              |              |
+        |          | list_name    | label        |              |              |
+        |          | trees        | ${tree_id}   |              |              |
+        """
+        xform = self._publish_markdown(md, self.user)
+
+        self.assertTrue(EntityList.objects.filter(name="trees").exists())
+        self.assertTrue(
+            RegistrationForm.objects.filter(
+                xform=xform, entity_list__name="trees"
+            ).exists()
+        )
+
+        reg_form = RegistrationForm.objects.get(xform=xform, entity_list__name="trees")
+
+        self.assertEqual(
+            reg_form.get_save_to(),
+            {
+                "year_planted": "year_planted",
             },
         )
         self.assertTrue(reg_form.is_active)

--- a/onadata/apps/viewer/tests/test_data_dictionary.py
+++ b/onadata/apps/viewer/tests/test_data_dictionary.py
@@ -166,6 +166,43 @@ class DataDictionaryTestCase(TestBase):
         )
         self.assertTrue(reg_form.is_active)
 
+    def test_create_reg_form_w_save_to_within_group_within_repeat(self):
+        """A RegistrationForm is created for a form w/ save_to within group, within repeat"""
+        md = """
+        | survey   |
+        |          | type         | name         | label        | save_to      |
+        |          | begin_repeat | tree         | Tree         |              |
+        |          | begin_group  | tree_details | Tree Details |              |
+        |          | barcode      | tree_id      | Tree ID      |              |
+        |          | text         | year_planted | Year planted | year_planted |
+        |          | end_group    |              |              |              |
+        |          | end_repeat   |              |              |              |
+        | settings |              |              |              |              |
+        |          | form_title   | form_id      |              |              |
+        |          | Trees        | trees        |              |              |
+        | entities |              |              |              |              |
+        |          | list_name    | label        |              |              |
+        |          | trees        | ${tree_id}   |              |              |
+        """
+        xform = self._publish_markdown(md, self.user)
+
+        self.assertTrue(EntityList.objects.filter(name="trees").exists())
+        self.assertTrue(
+            RegistrationForm.objects.filter(
+                xform=xform, entity_list__name="trees"
+            ).exists()
+        )
+
+        reg_form = RegistrationForm.objects.get(xform=xform, entity_list__name="trees")
+
+        self.assertEqual(
+            reg_form.get_save_to(),
+            {
+                "year_planted": "year_planted",
+            },
+        )
+        self.assertTrue(reg_form.is_active)
+
     def test_create_follow_up_form(self):
         """Follow up form created successfully"""
         entity_list = EntityList.objects.create(name="trees", project=self.project)

--- a/onadata/apps/viewer/tests/test_data_dictionary.py
+++ b/onadata/apps/viewer/tests/test_data_dictionary.py
@@ -242,6 +242,43 @@ class DataDictionaryTestCase(TestBase):
         )
         self.assertTrue(reg_form.is_active)
 
+    def test_create_reg_form_w_save_to_within_nested_repeat(self):
+        """A RegistrationForm is created for a form w/ save_to within a nested repeat"""
+        md = """
+        | survey   |
+        |          | type         | name         | label        | save_to      |
+        |          | begin_repeat | tree         | Tree         |              |
+        |          | begin_repeat | inspection   | Inspection   |              |
+        |          | barcode      | tree_id      | Tree ID      |              |
+        |          | text         | year_planted | Year planted | year_planted |
+        |          | end_repeat   |              |              |              |
+        |          | end_repeat   |              |              |              |
+        | settings |              |              |              |              |
+        |          | form_title   | form_id      |              |              |
+        |          | Trees        | trees        |              |              |
+        | entities |              |              |              |              |
+        |          | list_name    | label        |              |              |
+        |          | trees        | ${tree_id}   |              |              |
+        """
+        xform = self._publish_markdown(md, self.user)
+
+        self.assertTrue(EntityList.objects.filter(name="trees").exists())
+        self.assertTrue(
+            RegistrationForm.objects.filter(
+                xform=xform, entity_list__name="trees"
+            ).exists()
+        )
+
+        reg_form = RegistrationForm.objects.get(xform=xform, entity_list__name="trees")
+
+        self.assertEqual(
+            reg_form.get_save_to(),
+            {
+                "year_planted": "year_planted",
+            },
+        )
+        self.assertTrue(reg_form.is_active)
+
     def test_create_follow_up_form(self):
         """Follow up form created successfully"""
         entity_list = EntityList.objects.create(name="trees", project=self.project)

--- a/onadata/libs/utils/entities_utils.py
+++ b/onadata/libs/utils/entities_utils.py
@@ -17,8 +17,9 @@ from onadata.apps.logger.models import (
     RegistrationForm,
 )
 from onadata.apps.logger.xform_instance_parser import (
-    get_entity_uuid_from_xml,
-    get_meta_from_xml,
+    get_entity_group_data,
+    get_entity_label_from_node,
+    get_entity_nodes_from_xml,
 )
 from onadata.libs.exceptions import CSVImportError
 from onadata.libs.utils.cache_tools import (
@@ -38,73 +39,60 @@ logger = logging.getLogger(__name__)
 
 
 def get_entity_json_from_instance(
-    instance: Instance, registration_form: RegistrationForm
+    instance: Instance, registration_form: RegistrationForm, entity_node
 ) -> dict:
-    """Parses Instance json and returns Entity json
+    """Parses Instance data and returns Entity json for a single entity node
+
+    A submission can create more than one Entity when the entity is defined
+    within a repeat, so the Entity json is built from the fields belonging to
+    the entity node's group.
 
     :param instance: Instance to create Entity from
     :param registration_form: RegistrationForm to create Entity from
+    :param entity_node: The submission's entity XML node
     :return: Entity properties
     """
-    instance_json: dict[str, Any] = instance.get_dict()
     # Getting a mapping of save_to field to the field name
     mapped_properties = registration_form.get_save_to(instance.version)
-    # Field names with an alias defined
-    property_fields = list(mapped_properties.values())
+    # Field names with an alias defined mapped to the alias
+    field_alias = {field: alias for alias, field in mapped_properties.items()}
+    group_data = get_entity_group_data(entity_node, instance.get_dict())
+    entity_json: dict[str, Any] = {}
 
-    def get_field_alias(field_name: str) -> str:
-        """Get the alias (save_to value) of a form field"""
-        for alias, field in mapped_properties.items():
-            if field == field_name:
-                return alias
+    for field_name, field_data in group_data.items():
+        # We extract field names within grouped sections
+        ungrouped_field_name = field_name.split("/")[-1]
 
-        return field_name
+        if ungrouped_field_name in field_alias:
+            entity_json[field_alias[ungrouped_field_name]] = field_data
 
-    def parse_instance_json(data: dict[str, Any]) -> None:
-        """Parse the original json, replacing field names with their alias
+    label = get_entity_label_from_node(entity_node)
 
-        The data keys are modified in place
-        """
-        for field_name in list(data):
-            field_data = data[field_name]
-            del data[field_name]
+    # An update submission may omit the label, leaving it unchanged
+    if label is not None:
+        entity_json["label"] = label
 
-            if field_name.startswith("formhub"):
-                continue
-
-            if field_name.startswith("meta"):
-                if field_name == "meta/entity/label":
-                    data["label"] = field_data
-
-                continue
-
-            # We extract field names within grouped sections
-            ungrouped_field_name = field_name.split("/")[-1]
-
-            if ungrouped_field_name in property_fields:
-                field_alias = get_field_alias(ungrouped_field_name)
-                data[field_alias] = field_data
-
-    parse_instance_json(instance_json)
-
-    return instance_json
+    return entity_json
 
 
 def _create_entity_from_instance(
-    instance: Instance, registration_form: RegistrationForm
+    instance: Instance, registration_form: RegistrationForm, entity_node
 ) -> Entity:
     """Create an Entity
 
     :param instance: Submission from which the Entity is created from
     :param registration_form: RegistrationForm creating the Entity
+    :param entity_node: The submission's entity XML node
     :return: A newly created Entity
     """
-    entity_json = get_entity_json_from_instance(instance, registration_form)
+    entity_json = get_entity_json_from_instance(
+        instance, registration_form, entity_node
+    )
     entity_list = registration_form.entity_list
     entity = Entity.objects.create(
         entity_list=entity_list,
         json=entity_json,
-        uuid=get_entity_uuid_from_xml(instance.xml),
+        uuid=entity_node.getAttribute("id"),
     )
     entity.history.create(
         registration_form=registration_form,
@@ -120,16 +108,20 @@ def _create_entity_from_instance(
 
 
 def _update_entity_from_instance(
-    entity: Entity, instance: Instance, registration_form: RegistrationForm
+    entity: Entity,
+    instance: Instance,
+    registration_form: RegistrationForm,
+    entity_node,
 ) -> Entity:
     """Updates Entity
 
     :param entity: Entity to be updated
     :param instance: Submission that updates an Entity
     :param registration_form: RegistrationForm updating the Entity
+    :param entity_node: The submission's entity XML node
     :return: updated Entity if uuid valid, else None
     """
-    patch_data = get_entity_json_from_instance(instance, registration_form)
+    patch_data = get_entity_json_from_instance(instance, registration_form, entity_node)
     entity.json = {**entity.json, **patch_data}
     entity.save()
     entity.history.create(
@@ -163,16 +155,21 @@ def create_or_update_entity_from_instance(instance: Instance) -> None:
     registration_form_qs = RegistrationForm.objects.filter(
         xform=instance.xform, is_active=True
     )
-    entity_node = get_meta_from_xml(instance.xml, "entity")
+    entity_nodes = get_entity_nodes_from_xml(instance.xml)
 
-    if not registration_form_qs.exists() or not entity_node:
+    if not registration_form_qs.exists() or not entity_nodes:
         return
 
     registration_form = registration_form_qs.first()
     mutation_success_checks = ["1", "true"]
-    entity_uuid = entity_node.getAttribute("id")
 
-    if entity_uuid:
+    # A repeat can create multiple Entities in the same EntityList
+    for entity_node in entity_nodes:
+        entity_uuid = entity_node.getAttribute("id")
+
+        if not entity_uuid:
+            continue
+
         try:
             entity = Entity.objects.get(
                 uuid=entity_uuid, entity_list=registration_form.entity_list
@@ -180,12 +177,14 @@ def create_or_update_entity_from_instance(instance: Instance) -> None:
         except Entity.DoesNotExist:
             if entity_node.getAttribute("create") in mutation_success_checks:
                 # Create Entity
-                _create_entity_from_instance(instance, registration_form)
+                _create_entity_from_instance(instance, registration_form, entity_node)
 
         else:
             if entity_node.getAttribute("update") in mutation_success_checks:
                 # Update Entity
-                _update_entity_from_instance(entity, instance, registration_form)
+                _update_entity_from_instance(
+                    entity, instance, registration_form, entity_node
+                )
 
 
 def adjust_elist_num_entities(entity_list: EntityList, delta: int) -> None:

--- a/onadata/libs/utils/entities_utils.py
+++ b/onadata/libs/utils/entities_utils.py
@@ -56,7 +56,9 @@ def get_entity_json_from_instance(
     mapped_properties = registration_form.get_save_to(instance.version)
     # Field names with an alias defined mapped to the alias
     field_alias = {field: alias for alias, field in mapped_properties.items()}
-    group_data = get_entity_group_data(entity_node, instance.get_dict())
+    # Field values are read from the submission XML and numeric fields
+    # converted to match the parsed submission dictionary
+    group_data = instance.numeric_converter(get_entity_group_data(entity_node))
     entity_json: dict[str, Any] = {}
 
     for field_name, field_data in group_data.items():

--- a/onadata/libs/utils/tests/test_entities_utils.py
+++ b/onadata/libs/utils/tests/test_entities_utils.py
@@ -624,6 +624,102 @@ class CreateUpdateEntityTestCase(TestBase):
         self.assertEqual(third_history.created_by, instance.user)
         self.assertEqual(third_history.mutation_type, EntityHistory.MutationType.CREATE)
 
+    def test_entities_updated_from_repeat(self):
+        """A repeat updates multiple Entities in the same EntityList"""
+        md = """
+        | survey   |
+        |          | type         | name         | label        | save_to      |
+        |          | begin_repeat | tree         | Tree         |              |
+        |          | barcode      | tree_id      | Tree ID      |              |
+        |          | text         | year_planted | Year planted | year_planted |
+        |          | end_repeat   |              |              |              |
+        | settings |              |              |              |              |
+        |          | form_title   | form_id      | version      |              |
+        |          | Trees        | trees        | 202607241130 |              |
+        | entities |              |              |              |              |
+        |          | list_name    | label        |              |              |
+        |          | trees_repeat | ${tree_id}   |              |              |
+        """
+        xform = self._publish_markdown(md, self.user)
+        entity_list = EntityList.objects.get(name="trees_repeat")
+        # Existing Entities to be updated
+        first_entity = Entity.objects.create(
+            entity_list=entity_list,
+            json={"year_planted": "2014", "label": "1"},
+            uuid="e02dc9a9-0451-419d-934d-6d5621e4c5d6",
+        )
+        second_entity = Entity.objects.create(
+            entity_list=entity_list,
+            json={"year_planted": "2014", "label": "2"},
+            uuid="c14614e1-0bec-491c-b287-d2a4f7353ab9",
+        )
+        xml = (
+            '<data xmlns:jr="http://openrosa.org/javarosa" xmlns:orx='
+            '"http://openrosa.org/xforms" id="trees_repeats" version="202607241130">'
+            "<formhub><uuid>080c4868778a4c9fa20e71f6dc3ef285</uuid></formhub>"
+            "<tree>"
+            "<tree_id>1</tree_id>"
+            "<year_planted>2015</year_planted>"
+            "<meta>"
+            '<entity dataset="trees_repeat" update="1" '
+            'id="e02dc9a9-0451-419d-934d-6d5621e4c5d6" baseVersion="1"/>'
+            "</meta>"
+            "</tree>"
+            "<tree>"
+            "<tree_id>2</tree_id>"
+            "<year_planted>2016</year_planted>"
+            "<meta>"
+            '<entity dataset="trees_repeat" update="1" '
+            'id="c14614e1-0bec-491c-b287-d2a4f7353ab9" baseVersion="1"/>'
+            "</meta>"
+            "</tree>"
+            "<meta>"
+            "<instanceID>uuid:86d21baf-75a2-4907-be8d-84dbacae2ebd</instanceID>"
+            "</meta>"
+            "</data>"
+        )
+        instance = Instance.objects.create(xml=xml, user=self.user, xform=xform)
+
+        create_or_update_entity_from_instance(instance)
+
+        # No new Entities created
+        self.assertEqual(Entity.objects.filter(entity_list=entity_list).count(), 2)
+
+        registration_form = RegistrationForm.objects.get(xform=xform)
+
+        # Each repeat instance updates its own Entity, leaving the label unchanged
+        first_entity.refresh_from_db()
+        first_json = {"year_planted": "2015", "label": "1"}
+        self.assertDictEqual(first_entity.json, first_json)
+        self.assertEqual(first_entity.history.count(), 1)
+
+        first_history = first_entity.history.first()
+
+        self.assertEqual(first_history.registration_form, registration_form)
+        self.assertEqual(first_history.instance, instance)
+        self.assertEqual(first_history.xml, instance.xml)
+        self.assertDictEqual(first_history.json, first_json)
+        self.assertEqual(first_history.form_version, xform.version)
+        self.assertEqual(first_history.created_by, instance.user)
+        self.assertEqual(first_history.mutation_type, EntityHistory.MutationType.UPDATE)
+
+        second_entity.refresh_from_db()
+        second_json = {"year_planted": "2016", "label": "2"}
+        self.assertDictEqual(second_entity.json, second_json)
+        self.assertEqual(second_entity.history.count(), 1)
+
+        second_history = second_entity.history.first()
+
+        self.assertEqual(second_history.registration_form, registration_form)
+        self.assertEqual(second_history.instance, instance)
+        self.assertEqual(second_history.xml, instance.xml)
+        self.assertDictEqual(second_history.json, second_json)
+        self.assertEqual(second_history.form_version, xform.version)
+        self.assertEqual(second_history.created_by, instance.user)
+        self.assertEqual(
+            second_history.mutation_type, EntityHistory.MutationType.UPDATE
+        )
+
 
 class EntityListNumEntitiesBase(TestBase):
     def setUp(self):

--- a/onadata/libs/utils/tests/test_entities_utils.py
+++ b/onadata/libs/utils/tests/test_entities_utils.py
@@ -505,6 +505,125 @@ class CreateUpdateEntityTestCase(TestBase):
             entity_history.mutation_type, EntityHistory.MutationType.UPDATE
         )
 
+    def test_entities_created_from_repeat(self):
+        """A repeat creates multiple Entities in the same EntityList"""
+        # Publish registration form
+        md = """
+        | survey   |
+        |          | type         | name         | label        | save_to      |
+        |          | begin_repeat | tree         | Tree         |              |
+        |          | barcode      | tree_id      | Tree ID      |              |
+        |          | text         | year_planted | Year planted | year_planted |
+        |          | end_repeat   |              |              |              |
+        | settings |              |              |              |              |
+        |          | form_title   | form_id      | version      |              |
+        |          | Trees        | trees        | 202607241122 |              |
+        | entities |              |              |              |              |
+        |          | list_name    | label        |              |              |
+        |          | trees_repeat | ${tree_id}   |              |              |
+        """
+        xform = self._publish_markdown(md, self.user)
+        entity_list = EntityList.objects.get(name="trees_repeat")
+        xml = (
+            '<data xmlns:jr="http://openrosa.org/javarosa" xmlns:orx='
+            '"http://openrosa.org/xforms" id="trees_repeats" version="202607241122">'
+            "<formhub><uuid>080c4868778a4c9fa20e71f6dc3ef285</uuid></formhub>"
+            "<tree>"
+            "<tree_id>1</tree_id>"
+            "<year_planted>2014</year_planted>"
+            "<meta>"
+            '<entity dataset="trees_repeat" create="1" '
+            'id="e02dc9a9-0451-419d-934d-6d5621e4c5d6">'
+            "<label>1</label>"
+            "</entity>"
+            "</meta>"
+            "</tree>"
+            "<tree>"
+            "<tree_id>2</tree_id>"
+            "<year_planted>2014</year_planted>"
+            "<meta>"
+            '<entity dataset="trees_repeat" create="1" '
+            'id="c14614e1-0bec-491c-b287-d2a4f7353ab9">'
+            "<label>2</label>"
+            "</entity>"
+            "</meta>"
+            "</tree>"
+            "<tree>"
+            "<tree_id>3</tree_id>"
+            "<year_planted>2015</year_planted>"
+            "<meta>"
+            '<entity dataset="trees_repeat" create="1" '
+            'id="e3b6446f-40f1-4ff5-8cd1-1b7f562ff8c5">'
+            "<label>3</label>"
+            "</entity>"
+            "</meta>"
+            "</tree>"
+            "<meta>"
+            "<instanceID>uuid:86d21baf-75a2-4907-be8d-84dbacae2ebd</instanceID>"
+            "</meta>"
+            "</data>"
+        )
+        instance = Instance.objects.create(xml=xml, user=self.user, xform=xform)
+
+        self.assertEqual(Entity.objects.filter(entity_list=entity_list).count(), 0)
+
+        create_or_update_entity_from_instance(instance)
+
+        self.assertEqual(Entity.objects.filter(entity_list=entity_list).count(), 3)
+
+        registration_form = RegistrationForm.objects.get(xform=xform)
+
+        # Each repeat instance creates an Entity from its own data
+        first_entity = Entity.objects.get(uuid="e02dc9a9-0451-419d-934d-6d5621e4c5d6")
+        first_json = {"year_planted": "2014", "label": "1"}
+        self.assertEqual(first_entity.entity_list, entity_list)
+        self.assertDictEqual(first_entity.json, first_json)
+        self.assertEqual(first_entity.history.count(), 1)
+
+        first_history = first_entity.history.first()
+
+        self.assertEqual(first_history.registration_form, registration_form)
+        self.assertEqual(first_history.instance, instance)
+        self.assertEqual(first_history.xml, instance.xml)
+        self.assertDictEqual(first_history.json, first_json)
+        self.assertEqual(first_history.form_version, xform.version)
+        self.assertEqual(first_history.created_by, instance.user)
+        self.assertEqual(first_history.mutation_type, EntityHistory.MutationType.CREATE)
+
+        second_entity = Entity.objects.get(uuid="c14614e1-0bec-491c-b287-d2a4f7353ab9")
+        second_json = {"year_planted": "2014", "label": "2"}
+        self.assertEqual(second_entity.entity_list, entity_list)
+        self.assertDictEqual(second_entity.json, second_json)
+        self.assertEqual(second_entity.history.count(), 1)
+
+        second_history = second_entity.history.first()
+
+        self.assertEqual(second_history.registration_form, registration_form)
+        self.assertEqual(second_history.instance, instance)
+        self.assertEqual(second_history.xml, instance.xml)
+        self.assertDictEqual(second_history.json, second_json)
+        self.assertEqual(second_history.form_version, xform.version)
+        self.assertEqual(second_history.created_by, instance.user)
+        self.assertEqual(
+            second_history.mutation_type, EntityHistory.MutationType.CREATE
+        )
+
+        third_entity = Entity.objects.get(uuid="e3b6446f-40f1-4ff5-8cd1-1b7f562ff8c5")
+        third_json = {"year_planted": "2015", "label": "3"}
+        self.assertEqual(third_entity.entity_list, entity_list)
+        self.assertDictEqual(third_entity.json, third_json)
+        self.assertEqual(third_entity.history.count(), 1)
+
+        third_history = third_entity.history.first()
+
+        self.assertEqual(third_history.registration_form, registration_form)
+        self.assertEqual(third_history.instance, instance)
+        self.assertEqual(third_history.xml, instance.xml)
+        self.assertDictEqual(third_history.json, third_json)
+        self.assertEqual(third_history.form_version, xform.version)
+        self.assertEqual(third_history.created_by, instance.user)
+        self.assertEqual(third_history.mutation_type, EntityHistory.MutationType.CREATE)
+
 
 class EntityListNumEntitiesBase(TestBase):
     def setUp(self):

--- a/onadata/libs/utils/tests/test_entities_utils.py
+++ b/onadata/libs/utils/tests/test_entities_utils.py
@@ -720,6 +720,232 @@ class CreateUpdateEntityTestCase(TestBase):
             second_history.mutation_type, EntityHistory.MutationType.UPDATE
         )
 
+    def test_entities_created_from_nested_repeat(self):
+        """A nested repeat creates multiple Entities in the same EntityList"""
+        md = """
+        | survey   |
+        |          | type         | name         | label        | save_to      |
+        |          | begin_repeat | tree         | Tree         |              |
+        |          | begin_repeat | inspection   | Inspection   |              |
+        |          | barcode      | tree_id      | Tree ID      |              |
+        |          | text         | year_planted | Year planted | year_planted |
+        |          | end_repeat   |              |              |              |
+        |          | end_repeat   |              |              |              |
+        | settings |              |              |              |              |
+        |          | form_title   | form_id      | version      |              |
+        |          | Trees        | trees        | 202607241122 |              |
+        | entities |              |              |              |              |
+        |          | list_name    | label        |              |              |
+        |          | trees_repeat | ${tree_id}   |              |              |
+        """
+        xform = self._publish_markdown(md, self.user)
+        entity_list = EntityList.objects.get(name="trees_repeat")
+        xml = (
+            '<data xmlns:jr="http://openrosa.org/javarosa" xmlns:orx='
+            '"http://openrosa.org/xforms" id="trees" version="202607241122">'
+            "<formhub><uuid>080c4868778a4c9fa20e71f6dc3ef285</uuid></formhub>"
+            "<tree>"
+            "<inspection>"
+            "<tree_id>1</tree_id>"
+            "<year_planted>2014</year_planted>"
+            "<meta>"
+            '<entity dataset="trees_repeat" create="1" '
+            'id="e02dc9a9-0451-419d-934d-6d5621e4c5d6">'
+            "<label>1</label>"
+            "</entity>"
+            "</meta>"
+            "</inspection>"
+            "<inspection>"
+            "<tree_id>2</tree_id>"
+            "<year_planted>2015</year_planted>"
+            "<meta>"
+            '<entity dataset="trees_repeat" create="1" '
+            'id="c14614e1-0bec-491c-b287-d2a4f7353ab9">'
+            "<label>2</label>"
+            "</entity>"
+            "</meta>"
+            "</inspection>"
+            "</tree>"
+            "<tree>"
+            "<inspection>"
+            "<tree_id>3</tree_id>"
+            "<year_planted>2016</year_planted>"
+            "<meta>"
+            '<entity dataset="trees_repeat" create="1" '
+            'id="e3b6446f-40f1-4ff5-8cd1-1b7f562ff8c5">'
+            "<label>3</label>"
+            "</entity>"
+            "</meta>"
+            "</inspection>"
+            "</tree>"
+            "<meta>"
+            "<instanceID>uuid:86d21baf-75a2-4907-be8d-84dbacae2ebd</instanceID>"
+            "</meta>"
+            "</data>"
+        )
+        instance = Instance.objects.create(xml=xml, user=self.user, xform=xform)
+
+        self.assertEqual(Entity.objects.filter(entity_list=entity_list).count(), 0)
+
+        create_or_update_entity_from_instance(instance)
+
+        self.assertEqual(Entity.objects.filter(entity_list=entity_list).count(), 3)
+
+        registration_form = RegistrationForm.objects.get(xform=xform)
+
+        # An entity is created from each nested repeat instance's own data
+        first_entity = Entity.objects.get(uuid="e02dc9a9-0451-419d-934d-6d5621e4c5d6")
+        first_json = {"year_planted": "2014", "label": "1"}
+        self.assertEqual(first_entity.entity_list, entity_list)
+        self.assertDictEqual(first_entity.json, first_json)
+        self.assertEqual(first_entity.history.count(), 1)
+
+        first_history = first_entity.history.first()
+
+        self.assertEqual(first_history.registration_form, registration_form)
+        self.assertEqual(first_history.instance, instance)
+        self.assertEqual(first_history.xml, instance.xml)
+        self.assertDictEqual(first_history.json, first_json)
+        self.assertEqual(first_history.form_version, xform.version)
+        self.assertEqual(first_history.created_by, instance.user)
+        self.assertEqual(first_history.mutation_type, EntityHistory.MutationType.CREATE)
+
+        second_entity = Entity.objects.get(uuid="c14614e1-0bec-491c-b287-d2a4f7353ab9")
+        second_json = {"year_planted": "2015", "label": "2"}
+        self.assertEqual(second_entity.entity_list, entity_list)
+        self.assertDictEqual(second_entity.json, second_json)
+        self.assertEqual(second_entity.history.count(), 1)
+
+        second_history = second_entity.history.first()
+
+        self.assertEqual(second_history.registration_form, registration_form)
+        self.assertEqual(second_history.instance, instance)
+        self.assertEqual(second_history.xml, instance.xml)
+        self.assertDictEqual(second_history.json, second_json)
+        self.assertEqual(second_history.form_version, xform.version)
+        self.assertEqual(second_history.created_by, instance.user)
+        self.assertEqual(
+            second_history.mutation_type, EntityHistory.MutationType.CREATE
+        )
+
+        third_entity = Entity.objects.get(uuid="e3b6446f-40f1-4ff5-8cd1-1b7f562ff8c5")
+        third_json = {"year_planted": "2016", "label": "3"}
+        self.assertEqual(third_entity.entity_list, entity_list)
+        self.assertDictEqual(third_entity.json, third_json)
+        self.assertEqual(third_entity.history.count(), 1)
+
+        third_history = third_entity.history.first()
+
+        self.assertEqual(third_history.registration_form, registration_form)
+        self.assertEqual(third_history.instance, instance)
+        self.assertEqual(third_history.xml, instance.xml)
+        self.assertDictEqual(third_history.json, third_json)
+        self.assertEqual(third_history.form_version, xform.version)
+        self.assertEqual(third_history.created_by, instance.user)
+        self.assertEqual(third_history.mutation_type, EntityHistory.MutationType.CREATE)
+
+    def test_entities_updated_from_nested_repeat(self):
+        """A nested repeat updates multiple Entities in the same EntityList"""
+        md = """
+        | survey   |
+        |          | type         | name         | label        | save_to      |
+        |          | begin_repeat | tree         | Tree         |              |
+        |          | begin_repeat | inspection   | Inspection   |              |
+        |          | barcode      | tree_id      | Tree ID      |              |
+        |          | text         | year_planted | Year planted | year_planted |
+        |          | end_repeat   |              |              |              |
+        |          | end_repeat   |              |              |              |
+        | settings |              |              |              |              |
+        |          | form_title   | form_id      | version      |              |
+        |          | Trees        | trees        | 202607241130 |              |
+        | entities |              |              |              |              |
+        |          | list_name    | label        |              |              |
+        |          | trees_repeat | ${tree_id}   |              |              |
+        """
+        xform = self._publish_markdown(md, self.user)
+        entity_list = EntityList.objects.get(name="trees_repeat")
+        # Existing Entities to be updated
+        first_entity = Entity.objects.create(
+            entity_list=entity_list,
+            json={"year_planted": "2014", "label": "1"},
+            uuid="e02dc9a9-0451-419d-934d-6d5621e4c5d6",
+        )
+        second_entity = Entity.objects.create(
+            entity_list=entity_list,
+            json={"year_planted": "2014", "label": "2"},
+            uuid="c14614e1-0bec-491c-b287-d2a4f7353ab9",
+        )
+        xml = (
+            '<data xmlns:jr="http://openrosa.org/javarosa" xmlns:orx='
+            '"http://openrosa.org/xforms" id="trees" version="202607241130">'
+            "<formhub><uuid>080c4868778a4c9fa20e71f6dc3ef285</uuid></formhub>"
+            "<tree>"
+            "<inspection>"
+            "<tree_id>1</tree_id>"
+            "<year_planted>2015</year_planted>"
+            "<meta>"
+            '<entity dataset="trees_repeat" update="1" '
+            'id="e02dc9a9-0451-419d-934d-6d5621e4c5d6" baseVersion="1"/>'
+            "</meta>"
+            "</inspection>"
+            "</tree>"
+            "<tree>"
+            "<inspection>"
+            "<tree_id>2</tree_id>"
+            "<year_planted>2016</year_planted>"
+            "<meta>"
+            '<entity dataset="trees_repeat" update="1" '
+            'id="c14614e1-0bec-491c-b287-d2a4f7353ab9" baseVersion="1"/>'
+            "</meta>"
+            "</inspection>"
+            "</tree>"
+            "<meta>"
+            "<instanceID>uuid:86d21baf-75a2-4907-be8d-84dbacae2ebd</instanceID>"
+            "</meta>"
+            "</data>"
+        )
+        instance = Instance.objects.create(xml=xml, user=self.user, xform=xform)
+
+        create_or_update_entity_from_instance(instance)
+
+        # No new Entities created
+        self.assertEqual(Entity.objects.filter(entity_list=entity_list).count(), 2)
+
+        registration_form = RegistrationForm.objects.get(xform=xform)
+
+        # Each nested repeat instance updates its own Entity, leaving the label unchanged
+        first_entity.refresh_from_db()
+        first_json = {"year_planted": "2015", "label": "1"}
+        self.assertDictEqual(first_entity.json, first_json)
+        self.assertEqual(first_entity.history.count(), 1)
+
+        first_history = first_entity.history.first()
+
+        self.assertEqual(first_history.registration_form, registration_form)
+        self.assertEqual(first_history.instance, instance)
+        self.assertEqual(first_history.xml, instance.xml)
+        self.assertDictEqual(first_history.json, first_json)
+        self.assertEqual(first_history.form_version, xform.version)
+        self.assertEqual(first_history.created_by, instance.user)
+        self.assertEqual(first_history.mutation_type, EntityHistory.MutationType.UPDATE)
+
+        second_entity.refresh_from_db()
+        second_json = {"year_planted": "2016", "label": "2"}
+        self.assertDictEqual(second_entity.json, second_json)
+        self.assertEqual(second_entity.history.count(), 1)
+
+        second_history = second_entity.history.first()
+
+        self.assertEqual(second_history.registration_form, registration_form)
+        self.assertEqual(second_history.instance, instance)
+        self.assertEqual(second_history.xml, instance.xml)
+        self.assertDictEqual(second_history.json, second_json)
+        self.assertEqual(second_history.form_version, xform.version)
+        self.assertEqual(second_history.created_by, instance.user)
+        self.assertEqual(
+            second_history.mutation_type, EntityHistory.MutationType.UPDATE
+        )
+
 
 class EntityListNumEntitiesBase(TestBase):
     def setUp(self):

--- a/onadata/libs/utils/tests/test_entities_utils.py
+++ b/onadata/libs/utils/tests/test_entities_utils.py
@@ -112,6 +112,33 @@ class CreateUpdateEntityTestCase(TestBase):
             entity_history.mutation_type, EntityHistory.MutationType.CREATE
         )
 
+    def test_entity_created_with_cdata_property(self):
+        """Entity property stored as CDATA is created"""
+        xml = (
+            '<?xml version="1.0" encoding="UTF-8"?>'
+            '<data xmlns:jr="http://openrosa.org/javarosa" xmlns:orx='
+            '"http://openrosa.org/xforms" id="trees_registration" version="2022110901">'
+            "<formhub><uuid>d156a2dce4c34751af57f21ef5c4e6cc</uuid></formhub>"
+            "<location>-1.286905 36.772845 0 0</location>"
+            "<species><![CDATA[purpleheart]]></species>"
+            "<circumference>300</circumference>"
+            "<intake_notes />"
+            "<meta>"
+            "<instanceID>uuid:aa3f042e-cfec-4d2a-8b5b-212e3b04802b</instanceID>"
+            "<instanceName>300cm purpleheart</instanceName>"
+            '<entity create="1" dataset="trees" id="cc3e4c32-a922-451c-9df7-42f40bf78f48">'
+            "<label>300cm purpleheart</label>"
+            "</entity>"
+            "</meta>"
+            "</data>"
+        )
+        instance = Instance.objects.create(xml=xml, user=self.user, xform=self.xform)
+
+        create_or_update_entity_from_instance(instance)
+
+        entity = Entity.objects.get(uuid="cc3e4c32-a922-451c-9df7-42f40bf78f48")
+        self.assertEqual(entity.json["species"], "purpleheart")
+
     def test_entity_updated(self):
         """Entity is updated from a Instance"""
         # Create existing entity
@@ -177,6 +204,45 @@ class CreateUpdateEntityTestCase(TestBase):
         self.assertEqual(
             entity_history.mutation_type, EntityHistory.MutationType.UPDATE
         )
+
+    def test_entity_updated_with_cdata_property(self):
+        """Entity property stored as CDATA is updated"""
+        entity_list = EntityList.objects.get(name="trees", project=self.project)
+        entity = Entity.objects.create(
+            entity_list=entity_list,
+            json={
+                "species": "purpleheart",
+                "geometry": "-1.286905 36.772845 0 0",
+                "circumference_cm": 300,
+                "label": "300cm purpleheart",
+            },
+            uuid="dbee4c32-a922-451c-9df7-42f40bf78f48",
+        )
+        update_xform = self._publish_entity_update_form(self.user)
+        update_xml = (
+            '<?xml version="1.0" encoding="UTF-8"?>'
+            '<data xmlns:jr="http://openrosa.org/javarosa" xmlns:orx='
+            '"http://openrosa.org/xforms" id="trees_update" version="2024050801">'
+            "<formhub><uuid>a9caf13e366b44a68f173bbb6746e3d4</uuid></formhub>"
+            "<tree>dbee4c32-a922-451c-9df7-42f40bf78f48</tree>"
+            "<circumference><![CDATA[30]]></circumference>"
+            "<today>2024-05-28</today>"
+            "<meta>"
+            "<instanceID>uuid:45d27780-48fd-4035-8655-9332649385bd</instanceID>"
+            "<instanceName>30cm dbee4c32-a922-451c-9df7-42f40bf78f48</instanceName>"
+            '<entity dataset="trees" id="dbee4c32-a922-451c-9df7-42f40bf78f48"'
+            ' update="1" baseVersion=""/>'
+            "</meta>"
+            "</data>"
+        )
+        update_instance = Instance.objects.create(
+            xml=update_xml, user=self.user, xform=update_xform
+        )
+
+        create_or_update_entity_from_instance(update_instance)
+
+        entity.refresh_from_db()
+        self.assertEqual(entity.json["circumference_cm"], 30)
 
     def test_entity_created_if_create_attribute_is_true(self):
         """Entity is created if create attribute value is 'true'"""

--- a/onadata/libs/utils/tests/test_entities_utils.py
+++ b/onadata/libs/utils/tests/test_entities_utils.py
@@ -548,16 +548,6 @@ class CreateUpdateEntityTestCase(TestBase):
             "</entity>"
             "</meta>"
             "</tree>"
-            "<tree>"
-            "<tree_id>3</tree_id>"
-            "<year_planted>2015</year_planted>"
-            "<meta>"
-            '<entity dataset="trees_repeat" create="1" '
-            'id="e3b6446f-40f1-4ff5-8cd1-1b7f562ff8c5">'
-            "<label>3</label>"
-            "</entity>"
-            "</meta>"
-            "</tree>"
             "<meta>"
             "<instanceID>uuid:86d21baf-75a2-4907-be8d-84dbacae2ebd</instanceID>"
             "</meta>"
@@ -569,7 +559,7 @@ class CreateUpdateEntityTestCase(TestBase):
 
         create_or_update_entity_from_instance(instance)
 
-        self.assertEqual(Entity.objects.filter(entity_list=entity_list).count(), 3)
+        self.assertEqual(Entity.objects.filter(entity_list=entity_list).count(), 2)
 
         registration_form = RegistrationForm.objects.get(xform=xform)
 
@@ -607,22 +597,6 @@ class CreateUpdateEntityTestCase(TestBase):
         self.assertEqual(
             second_history.mutation_type, EntityHistory.MutationType.CREATE
         )
-
-        third_entity = Entity.objects.get(uuid="e3b6446f-40f1-4ff5-8cd1-1b7f562ff8c5")
-        third_json = {"year_planted": "2015", "label": "3"}
-        self.assertEqual(third_entity.entity_list, entity_list)
-        self.assertDictEqual(third_entity.json, third_json)
-        self.assertEqual(third_entity.history.count(), 1)
-
-        third_history = third_entity.history.first()
-
-        self.assertEqual(third_history.registration_form, registration_form)
-        self.assertEqual(third_history.instance, instance)
-        self.assertEqual(third_history.xml, instance.xml)
-        self.assertDictEqual(third_history.json, third_json)
-        self.assertEqual(third_history.form_version, xform.version)
-        self.assertEqual(third_history.created_by, instance.user)
-        self.assertEqual(third_history.mutation_type, EntityHistory.MutationType.CREATE)
 
     def test_entities_updated_from_repeat(self):
         """A repeat updates multiple Entities in the same EntityList"""
@@ -836,18 +810,6 @@ class CreateUpdateEntityTestCase(TestBase):
             "</meta>"
             "</inspection>"
             "</tree>"
-            "<tree>"
-            "<inspection>"
-            "<tree_id>3</tree_id>"
-            "<year_planted>2016</year_planted>"
-            "<meta>"
-            '<entity dataset="trees_repeat" create="1" '
-            'id="e3b6446f-40f1-4ff5-8cd1-1b7f562ff8c5">'
-            "<label>3</label>"
-            "</entity>"
-            "</meta>"
-            "</inspection>"
-            "</tree>"
             "<meta>"
             "<instanceID>uuid:86d21baf-75a2-4907-be8d-84dbacae2ebd</instanceID>"
             "</meta>"
@@ -859,7 +821,7 @@ class CreateUpdateEntityTestCase(TestBase):
 
         create_or_update_entity_from_instance(instance)
 
-        self.assertEqual(Entity.objects.filter(entity_list=entity_list).count(), 3)
+        self.assertEqual(Entity.objects.filter(entity_list=entity_list).count(), 2)
 
         registration_form = RegistrationForm.objects.get(xform=xform)
 
@@ -897,22 +859,6 @@ class CreateUpdateEntityTestCase(TestBase):
         self.assertEqual(
             second_history.mutation_type, EntityHistory.MutationType.CREATE
         )
-
-        third_entity = Entity.objects.get(uuid="e3b6446f-40f1-4ff5-8cd1-1b7f562ff8c5")
-        third_json = {"year_planted": "2016", "label": "3"}
-        self.assertEqual(third_entity.entity_list, entity_list)
-        self.assertDictEqual(third_entity.json, third_json)
-        self.assertEqual(third_entity.history.count(), 1)
-
-        third_history = third_entity.history.first()
-
-        self.assertEqual(third_history.registration_form, registration_form)
-        self.assertEqual(third_history.instance, instance)
-        self.assertEqual(third_history.xml, instance.xml)
-        self.assertDictEqual(third_history.json, third_json)
-        self.assertEqual(third_history.form_version, xform.version)
-        self.assertEqual(third_history.created_by, instance.user)
-        self.assertEqual(third_history.mutation_type, EntityHistory.MutationType.CREATE)
 
     def test_entities_updated_from_nested_repeat(self):
         """A nested repeat updates multiple Entities in the same EntityList"""

--- a/onadata/libs/utils/tests/test_entities_utils.py
+++ b/onadata/libs/utils/tests/test_entities_utils.py
@@ -720,6 +720,76 @@ class CreateUpdateEntityTestCase(TestBase):
             second_history.mutation_type, EntityHistory.MutationType.UPDATE
         )
 
+    def test_entities_updated_from_repeat_with_empty_instance(self):
+        """Each Entity is updated from its own repeat instance
+
+        An empty repeat instance is dropped from the parsed submission, so each
+        Entity is matched to its own data by reading the submission XML.
+        """
+        md = """
+        | survey   |
+        |          | type         | name         | label        | save_to      |
+        |          | begin_repeat | tree         | Tree         |              |
+        |          | barcode      | tree_id      | Tree ID      |              |
+        |          | text         | year_planted | Year planted | year_planted |
+        |          | end_repeat   |              |              |              |
+        | settings |              |              |              |              |
+        |          | form_title   | form_id      | version      |              |
+        |          | Trees        | trees        | 202607241131 |              |
+        | entities |              |              |              |              |
+        |          | list_name    | label        |              |              |
+        |          | trees_repeat | ${tree_id}   |              |              |
+        """
+        xform = self._publish_markdown(md, self.user)
+        entity_list = EntityList.objects.get(name="trees_repeat")
+        # Existing Entities to be updated
+        first_entity = Entity.objects.create(
+            entity_list=entity_list,
+            json={"year_planted": "2014", "label": "1"},
+            uuid="e02dc9a9-0451-419d-934d-6d5621e4c5d6",
+        )
+        second_entity = Entity.objects.create(
+            entity_list=entity_list,
+            json={"year_planted": "2014", "label": "2"},
+            uuid="c14614e1-0bec-491c-b287-d2a4f7353ab9",
+        )
+        # The first repeat instance is blank and precedes a populated one
+        xml = (
+            '<data xmlns:jr="http://openrosa.org/javarosa" xmlns:orx='
+            '"http://openrosa.org/xforms" id="trees" version="202607241131">'
+            "<formhub><uuid>080c4868778a4c9fa20e71f6dc3ef285</uuid></formhub>"
+            "<tree>"
+            "<tree_id/>"
+            "<year_planted/>"
+            "<meta>"
+            '<entity dataset="trees_repeat" update="1" '
+            'id="e02dc9a9-0451-419d-934d-6d5621e4c5d6" baseVersion="1"/>'
+            "</meta>"
+            "</tree>"
+            "<tree>"
+            "<tree_id>2</tree_id>"
+            "<year_planted>2016</year_planted>"
+            "<meta>"
+            '<entity dataset="trees_repeat" update="1" '
+            'id="c14614e1-0bec-491c-b287-d2a4f7353ab9" baseVersion="1"/>'
+            "</meta>"
+            "</tree>"
+            "<meta>"
+            "<instanceID>uuid:86d21baf-75a2-4907-be8d-84dbacae2ebd</instanceID>"
+            "</meta>"
+            "</data>"
+        )
+        instance = Instance.objects.create(xml=xml, user=self.user, xform=xform)
+
+        create_or_update_entity_from_instance(instance)
+
+        # The populated instance updates its own Entity
+        second_entity.refresh_from_db()
+        self.assertDictEqual(second_entity.json, {"year_planted": "2016", "label": "2"})
+        # The blank instance leaves its own Entity's saved value in place
+        first_entity.refresh_from_db()
+        self.assertDictEqual(first_entity.json, {"year_planted": "2014", "label": "1"})
+
     def test_entities_created_from_nested_repeat(self):
         """A nested repeat creates multiple Entities in the same EntityList"""
         md = """

--- a/requirements/base.pip
+++ b/requirements/base.pip
@@ -303,7 +303,7 @@ pytz==2026.2
     # via
     #   django-query-builder
     #   fleming
-pyxform==4.4.1
+pyxform==4.5.0
     # via
     #   onadata
     #   pyfloip

--- a/requirements/dev.pip
+++ b/requirements/dev.pip
@@ -428,7 +428,7 @@ pytz==2026.2
     # via
     #   django-query-builder
     #   fleming
-pyxform==4.4.1
+pyxform==4.5.0
     # via
     #   onadata
     #   pyfloip


### PR DESCRIPTION
### Changes / Features implemented

Add support for creating/updating Entities  from repeats

**Constraints**

- **ALL** `save_to` values **MUST** be in the **SAME** repeat (or groups in that repeat)
- `label` and other expressions on the entities sheet may **ONLY** reference fields in the repeat (or groups in that repeat). 

### Steps taken to verify this change does what is intended

- [x] QA

### Side effects of implementing this change

None

**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  - [ ] Updated documentation

Closes #3184

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/onaio/codesmith/onadata/pr/3186"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787489489&installation_model_id=422582&pr_number=3186&repository=onaio%2Fonadata&return_to=https%3A%2F%2Fgithub.com%2Fonaio%2Fonadata%2Fpull%2F3186&signature=baedbebb609c4711c308b3f12c059d114d8aa3483f8197c5d61c1e8581f708cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->