### PR TITLE
Fix UserActivity creation with read replicas

### DIFF
--- a/onadata/apps/main/models/user_deactivation.py
+++ b/onadata/apps/main/models/user_deactivation.py
@@ -19,6 +19,7 @@ from django.db.models import F, Q
 from django.db.models.signals import post_save
 from django.utils import timezone
 
+from multidb.pinning import use_master
 from oauth2_provider.models import AccessToken, RefreshToken
 from rest_framework.authtoken.models import Token
 
@@ -808,16 +809,16 @@ def _get_permission_snapshot_source_ids(permission_row):
     }
 
 
+@use_master
 def get_or_create_user_activity(user):
     """
     Return a user's activity row, seeding it from historical activity if missing.
     """
-    try:
-        return UserActivity.objects.get(user=user)
-    except UserActivity.DoesNotExist:
-        return UserActivity.objects.create(
-            user=user, last_activity=get_initial_last_activity(user)
-        )
+    activity, _created = UserActivity.objects.get_or_create(
+        user=user,
+        defaults={"last_activity": lambda: get_initial_last_activity(user)},
+    )
+    return activity
 
 
 def sync_user_deactivation_state(user, inactivity_days=None):

--- a/onadata/apps/main/tests/test_user_deactivation.py
+++ b/onadata/apps/main/tests/test_user_deactivation.py
@@ -3,7 +3,7 @@
 Test user deactivation lifecycle state.
 """
 
-from datetime import timedelta
+from datetime import datetime, timedelta
 from unittest.mock import Mock, patch
 
 from django.conf import settings
@@ -46,6 +46,7 @@ from onadata.apps.main.models.user_deactivation import (
     get_deactivation_states_due_for_deactivation,
     get_deactivation_states_due_for_warning,
     get_deactivation_warning_days,
+    get_or_create_user_activity,
     get_pending_deactivation_actions,
     perform_deactivation_action,
     reactivate_user,
@@ -106,6 +107,15 @@ class TestUserDeactivationState(TestBase):
             user.deactivation_state.deactivation_scheduled_at,
             user.activity.last_activity + timedelta(days=365),
         )
+
+    def test_get_or_create_user_activity_creates_missing_activity(self):
+        user = User.objects.create_user(username="missing-activity")
+        UserActivity.objects.filter(user=user).delete()
+
+        activity = get_or_create_user_activity(user)
+
+        self.assertIsInstance(activity.last_activity, datetime)
+        self.assertEqual(activity.last_activity, user.date_joined)
 
     @override_settings(DEACTIVATION_INACTIVITY_DAYS=365)
     def test_sync_user_deactivation_state_schedules_from_activity(self):


### PR DESCRIPTION
### Changes / Features implemented

- Replace the replica-sensitive `UserActivity` read-then-create sequence with
  Django's atomic, write-routed `get_or_create()`.
- Keep the historical `last_activity` default lazy so existing rows do not
  trigger unnecessary activity queries.
- Add a regression test that routes ordinary reads to a stale replica and
  verifies the lookup uses the write database.

### Steps taken to verify this change does what is intended



### Side effects of implementing this change

- Existing activity lookups performed by this helper now go to the write
  database, ensuring read-after-write consistency in replica deployments.


**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  - [x] Updated documentation (not required for this internal correctness fix)

Closes #3188

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/onaio/codesmith/onadata/pr/3189"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788088939&installation_model_id=422582&pr_number=3189&repository=onaio%2Fonadata&return_to=https%3A%2F%2Fgithub.com%2Fonaio%2Fonadata%2Fpull%2F3189&signature=f0652de605c08b11cf15c2b84978278be6dff8adc650c656a0cd97d0b47e2cc5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->