### PR TITLE
fix: preserve managed encryption status when rebuilding survey from XLSForm

### DIFF
--- a/onadata/apps/logger/migrations/0039_restore_flipped_encryption.py
+++ b/onadata/apps/logger/migrations/0039_restore_flipped_encryption.py
@@ -31,7 +31,12 @@ def restore_flipped_encryption(apps, schema_editor):
         .only("id", "xml")
     )
 
+    eta = candidates.count()
+
     for xform in candidates.iterator(chunk_size=100):
+        eta -= 1
+        print("eta", eta)
+
         if "base64RsaPublicKey" not in (xform.xml or ""):
             continue
 

--- a/onadata/apps/logger/migrations/0039_restore_flipped_encryption.py
+++ b/onadata/apps/logger/migrations/0039_restore_flipped_encryption.py
@@ -1,0 +1,61 @@
+"""Restore encryption status for forms wrongly flipped to unencrypted."""
+
+from django.db import migrations
+
+
+def restore_flipped_encryption(apps, schema_editor):
+    """Restore forms whose post-publish public key was dropped from json.
+
+    Encryption enabled after publishing — via managed (KMS) keys or the
+    API ``public_key`` field — exists only in a form's stored json and
+    xml; the XLSForm file has no record of it. For forms whose stored
+    json predates the pyxform 4.1.0 upgrade (skipped by migration 0031),
+    ``XForm._get_survey()`` rebuilt the json from the XLSForm without
+    the key and a later full save recomputed ``encrypted`` as False.
+
+    The flip never touched the form xml, so wrongly flipped forms still
+    carry the key in their xml — unlike forms legitimately unencrypted
+    by an XLSForm replacement, whose replaced xml has no key.
+    """
+    # Use live model for get_survey_and_json_from_xlsform. This is
+    # needed because apps.get_model("logger", "XForm") returns a frozen
+    # version of XForm that has only the fields known at this migration
+    from onadata.apps.logger.models.xform import XForm as LiveXForm
+
+    # pylint: disable=invalid-name
+    XForm = apps.get_model("logger", "XForm")
+    candidates = (
+        XForm.objects.filter(deleted_at__isnull=True, encrypted=False)
+        .exclude(public_key="")
+        .exclude(public_key__isnull=True)
+        .only("id", "xml")
+    )
+
+    for xform in candidates.iterator(chunk_size=100):
+        if "base64RsaPublicKey" not in (xform.xml or ""):
+            continue
+
+        try:
+            live_xform = LiveXForm.objects.get(id=xform.id)
+            _, workbook_json = live_xform.get_survey_and_json_from_xlsform()
+            workbook_json["public_key"] = live_xform.public_key
+            XForm.objects.filter(id=xform.id).update(json=workbook_json, encrypted=True)
+            print(f"Restored encryption for XForm {xform.id}")
+
+        # pylint: disable=broad-exception-caught
+        except Exception as e:
+            # Best-effort repair; leave the form for manual follow-up
+            print(f"Restoring encryption for XForm {xform.id} failed: {e}")
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("logger", "0038_instance_last_edited_by"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            restore_flipped_encryption,
+            reverse_code=migrations.RunPython.noop,  # migration is irreversible
+        ),
+    ]

--- a/onadata/apps/logger/models/xform.py
+++ b/onadata/apps/logger/models/xform.py
@@ -512,7 +512,15 @@ class XFormMixin:
             if (is_itemset_error or is_trigger_error) and self.xls:
                 # Use get_survey_and_json_from_xlsform to get workbook_json
                 survey, workbook_json = self.get_survey_and_json_from_xlsform()
-                # Persist the workbook_json to avoid repeated XLS parsing
+                # Encryption enabled post-publish (e.g. via managed keys)
+                # exists only in the stored json, not the XLSForm
+                if self.public_key:
+                    survey.public_key = self.public_key
+                    workbook_json["public_key"] = self.public_key
+                # Persist the workbook_json to avoid repeated XLS parsing;
+                # updating the in-memory json keeps an enclosing save()
+                # from writing the stale json back
+                self.json = workbook_json
                 XForm.objects.filter(pk=self.pk).update(json=workbook_json)
                 return survey
             raise

--- a/onadata/apps/logger/tests/models/test_xform.py
+++ b/onadata/apps/logger/tests/models/test_xform.py
@@ -592,6 +592,96 @@ class TestXForm(TestBase):
         # The json should now be workbook_json, not the old survey.to_json_dict() format
         self.assertEqual(xform.json, original_workbook_json)
 
+    def _make_stale_managed_xform(self, public_key):
+        """Publish a form and recreate a stale managed encrypted state.
+
+        Managed (KMS) encryption injects the public key into the stored
+        ``json`` after publishing; the XLSForm file has no record of it.
+        Stored json that predates the pyxform 4.1.0 upgrade — a select
+        question with inline children and no itemset — fails parsing,
+        making ``_get_survey`` fall back to rebuilding from the XLSForm.
+        Migration logger.0031 skipped encrypted forms, so such forms
+        exist in production.
+        """
+        self._publish_transportation_form()
+        xform = XForm.objects.get(pk=self.xform.pk)
+        self.publish_time_workbook_json = xform.json.copy()
+        stale_json = {
+            "name": self.publish_time_workbook_json["name"],
+            "title": xform.title,
+            "id_string": xform.id_string,
+            "sms_keyword": xform.id_string,
+            "type": "survey",
+            "default_language": "default",
+            "public_key": public_key,
+            "children": [
+                {
+                    "name": "fruit",
+                    "type": "select one",
+                    "label": "Fruit",
+                    "children": [
+                        {"name": "mango", "label": "Mango"},
+                        {"name": "orange", "label": "Orange"},
+                    ],
+                },
+                {
+                    "name": "meta",
+                    "type": "group",
+                    "control": {"bodyless": True},
+                    "children": [
+                        {
+                            "name": "instanceID",
+                            "type": "calculate",
+                            "bind": {"readonly": "true()", "jr:preload": "uid"},
+                        }
+                    ],
+                },
+            ],
+        }
+        XForm.objects.filter(pk=xform.pk).update(
+            json=stale_json,
+            encrypted=True,
+            is_managed=True,
+            public_key=public_key,
+            # The form has data, so _set_public_key_field does not
+            # re-inject the key on save
+            num_of_submissions=1,
+        )
+        xform.refresh_from_db()
+        return xform
+
+    def test_save_preserves_managed_encryption_on_stale_json(self):
+        """A full save keeps a managed form encrypted when its json is stale.
+
+        The XLSForm-rebuilt survey must retain the injected public key,
+        otherwise the save recomputes ``encrypted`` as False.
+        """
+        public_key = "fake-managed-public-key"
+        xform = self._make_stale_managed_xform(public_key)
+
+        xform.save()
+
+        xform.refresh_from_db()
+        self.assertTrue(xform.encrypted)
+
+    def test_save_heals_stale_json_of_managed_form(self):
+        """A full save persists the rebuilt json, key included.
+
+        The stale json should be replaced by the XLSForm-rebuilt workbook
+        json with the injected public key retained, so later saves do not
+        re-parse the XLSForm.
+        """
+        public_key = "fake-managed-public-key"
+        xform = self._make_stale_managed_xform(public_key)
+
+        xform.save()
+
+        xform.refresh_from_db()
+        self.assertEqual(
+            xform.json,
+            {**self.publish_time_workbook_json, "public_key": public_key},
+        )
+
     def test_is_was_managed_when_managed(self):
         """is_was_managed returns True when is_managed is True"""
         self._publish_transportation_form()


### PR DESCRIPTION
### Changes / Features implemented

- Managed encryption and updating the public key via the API injects the public key into a form's stored json after publishing; the XLSForm file has no record of it. When parsing stale pre-pyxform-4.1.0 json fails and `_get_survey ` falls back to rebuilding from the XLSForm, the rebuilt survey lost the key and a full save recomputed encrypted field as False. Re-inject the form's public_key into the rebuilt survey and workbook json
- Data migration `logger.0039_restore_flipped_encryption` restoring already-flipped forms

### Steps taken to verify this change does what is intended

- [x] Added tests

### Side effects of implementing this change

- Forms carrying stale json now have it healed (rebuilt workbook format, key retained) on first full save, so later saves no longer re-parse the XLSForm.
- The data migration restores already-flipped forms automatically on upgrade

**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  - [ ] Updated documentation

Closes #3190