### PR TITLE
Enforce PKCE S256 for authorization code flows

### DIFF
--- a/docs/authentication.rst
+++ b/docs/authentication.rst
@@ -63,103 +63,112 @@ class to your local_settings.py file, for example:
         'onadata.libs.authentication.TempTokenAuthentication',
         ...
 
-Using Oauth2 with the Ona API
------------------------------
+Using OAuth 2.0 with the Ona API
+--------------------------------
 
-You can learn more about oauth2 `here <http://tools.ietf.org/html/rfc6749>`_.
+Ona supports the OAuth 2.0 `Authorization Code flow
+<https://www.rfc-editor.org/rfc/rfc6749#section-4.1>`_. Every public or
+confidential client using this flow must use Proof Key for Code Exchange
+(PKCE) with the ``S256`` challenge method.
 
 1. Register your client application with Ona - `register`_
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 -  ``name`` - name of your application
--  ``client_type`` - Client Type: select confidential
--  ``authorization_grant_type`` - Authorization grant type: Authorization code
--  ``redirect_uri`` - Redirect urls: redirection endpoint
+-  ``client_type`` - select public or confidential as appropriate
+-  ``authorization_grant_type`` - select Authorization code
+-  ``redirect_uri`` - exact callback URL or URLs
 
-Keep note of the ``client_id`` and the ``client_secret``, it is required
-when requesting for an ``access_token``.
+Use a public client for software that cannot securely retain a client secret,
+such as a browser-based, native, or command-line application. A public client
+uses its ``client_id`` without a ``client_secret``. A confidential client must
+retain its ``client_secret`` securely and authenticate at the token endpoint.
+Both client types must use PKCE S256.
 
 .. _register: /o/applications/register/
 
-2. Authorize client application.
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+2. Create a PKCE verifier and challenge
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The authorization url is of the form:
-
-.. raw:: html
-
-   <pre class="prettyprint">
-   <b>GET</b> /o/authorize?client_id=XXXXXX&response_type=code&state=abc</pre>
-
-example:
+For each authorization request, generate a new cryptographically random
+``code_verifier`` containing 43 to 128 URI-unreserved characters. Keep the
+verifier private until the token request. Derive the challenge as:
 
 ::
 
-    http://api.ona.io/o/authorize?client_id=e8&response_type=code&state=xyz
+    code_challenge = BASE64URL(SHA256(ASCII(code_verifier)))
 
-.. note::
+The base64url value must not contain ``=`` padding. For example, the verifier
+and its derived challenge below are a matching pair from RFC 7636:
 
-  Providing the url to any user will prompt for a password and
-  request for read and write permission for the application whose
-  ``client_id`` is specified.
+::
+
+    code_verifier:  dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk
+    code_challenge: E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM
+
+Do not reuse this example pair in an application.
+
+3. Authorize the client application
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Direct the user's browser to the authorization endpoint with the derived
+challenge and the challenge method set to exactly ``S256``:
+
+::
+
+    https://api.ona.io/o/authorize/?client_id=CLIENT_ID&response_type=code&redirect_uri=https%3A%2F%2Fclient.example.org%2Foauth%2Fcallback&scope=read%20write&state=RANDOM_STATE&code_challenge=CODE_CHALLENGE&code_challenge_method=S256
 
 Where:
 
--  ``client_id`` - is the client application id - ensure its urlencoded
--  ``response_type`` - should be code
--  ``state`` - a random state string that you client application will
-   get when redirection happens
+-  ``client_id`` is the registered application ID
+-  ``response_type`` must be ``code``
+-  ``redirect_uri`` must exactly match a registered callback URL
+-  ``state`` must be a random, transaction-specific value that the client
+   validates after redirection
+-  ``code_challenge`` is derived from the verifier for this transaction
+-  ``code_challenge_method`` must be exactly ``S256``
 
-What happens:
+Ona rejects Authorization Code requests with a missing challenge, an omitted
+challenge method, ``plain``, or any unsupported challenge method.
 
-1. a login page is presented, the username used to login determines the
-   account that provides access.
-2. redirection to the client application occurs, the url is of the form:
-
-    REDIRECT_URI/?state=abc&code=YYYYYYYYY
-
-example redirect uri
-
-::
-
-    http://localhost:30000/?state=xyz&code=SWWk2PN6NdCwfpqiDiPRcLmvkw2uWd
-
--  ``code`` - is the code to use to request for ``access_token``
--  ``state`` - same state string used during authorization request
-
-Your client application should use the ``code`` to request for an
-access_token.
-
-3. Request for access token.
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-You need to make a ``POST`` request with ``grant_type``, ``code``,
-``client_id`` and ``redirect_uri`` as ``POST`` payload params. You
-should authenticate the request with ``Basic Authentication`` using your
-``client_id`` and ``client_secret`` as ``username:password`` pair.
-
-Request:
-
-.. raw:: html
-
-   <pre class="prettyprint">
-   <b>POST</b>/o/token</pre>
-
-Payload:
+The user signs in and approves the requested access. Ona then redirects the
+browser to the registered callback URL:
 
 ::
 
-    grant_type=authorization_code&code=YYYYYYYYY&client_id=XXXXXX&redirect_uri=http://redirect/uri/path
+    https://client.example.org/oauth/callback?state=RANDOM_STATE&code=AUTHORIZATION_CODE
 
-curl example:
+The client must validate ``state`` before exchanging the authorization code.
+
+4. Request an access token
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Exchange the authorization code at ``/o/token/``. The request must include the
+original ``code_verifier``. A missing or incorrect verifier is rejected.
+
+Public-client example:
 
 ::
 
-    curl -X POST -d "grant_type=authorization_code&
-    code=PSwrMilnJESZVFfFsyEmEukNv0sGZ8&
-    client_id=e8x4zzJJIyOikDqjPcsCJrmnU22QbpfHQo4HhRnv&
-    redirect_uri=http://localhost:30000" "http://api.ona.io/o/token/"
-    --user "e8:xo7i4LNpMj"
+    curl -X POST https://api.ona.io/o/token/ \
+        --data-urlencode grant_type=authorization_code \
+        --data-urlencode code=AUTHORIZATION_CODE \
+        --data-urlencode client_id=CLIENT_ID \
+        --data-urlencode redirect_uri=https://client.example.org/oauth/callback \
+        --data-urlencode code_verifier=CODE_VERIFIER
+
+A public client must not send a client secret. A confidential client sends the
+same payload and also authenticates with HTTP Basic Authentication:
+
+::
+
+    curl -X POST https://api.ona.io/o/token/ \
+        --user "CLIENT_ID:CLIENT_SECRET" \
+        --data-urlencode grant_type=authorization_code \
+        --data-urlencode code=AUTHORIZATION_CODE \
+        --data-urlencode client_id=CLIENT_ID \
+        --data-urlencode redirect_uri=https://client.example.org/oauth/callback \
+        --data-urlencode code_verifier=CODE_VERIFIER
 
 Response:
 
@@ -180,8 +189,8 @@ Where:
 
 Now that you have an ``access_token`` you can make API calls.
 
-4. Accessing the Ona API using the ``access_token``.
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+5. Access the Ona API with the ``access_token``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Example using curl:
 

--- a/onadata/apps/main/management/commands/register_oauth_public_application.py
+++ b/onadata/apps/main/management/commands/register_oauth_public_application.py
@@ -1,0 +1,222 @@
+# -*- coding: utf-8 -*-
+"""Register a public Authorization Code OAuth application safely."""
+
+from django.contrib.auth import get_user_model
+from django.core.exceptions import ValidationError
+from django.core.management.base import BaseCommand, CommandError
+from django.db import IntegrityError, transaction
+
+from oauth2_provider.models import get_application_model
+
+from onadata.libs.authentication import is_pkce_s256_enforced
+
+
+class Command(BaseCommand):
+    """Create or verify a public OAuth application with a disabled owner."""
+
+    help = (
+        "Register or verify a public Authorization Code OAuth application "
+        "whose effective policy requires PKCE S256."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument("--client-id", required=True)
+        parser.add_argument("--owner-username", required=True)
+        parser.add_argument("--application-name", required=True)
+        parser.add_argument(
+            "--redirect-uri",
+            action="append",
+            required=True,
+            dest="redirect_uris",
+            help="Approved callback URI. Repeat for every approved URI.",
+        )
+
+    def handle(self, *args, **options):
+        client_id = self._required_text(options["client_id"], "client ID")
+        owner_username = self._required_text(
+            options["owner_username"], "owner username"
+        )
+        application_name = self._required_text(
+            options["application_name"], "application name"
+        )
+        redirect_uris = self._validate_redirect_uris(options["redirect_uris"])
+
+        application_model = get_application_model()
+        candidate = application_model(
+            client_id=client_id,
+            client_type=application_model.CLIENT_PUBLIC,
+            authorization_grant_type=application_model.GRANT_AUTHORIZATION_CODE,
+        )
+        if not is_pkce_s256_enforced(candidate):
+            raise CommandError(
+                "PKCE S256 is not effective for the requested OAuth application."
+            )
+
+        try:
+            with transaction.atomic():
+                result = self._register_or_verify(
+                    client_id=client_id,
+                    owner_username=owner_username,
+                    application_name=application_name,
+                    redirect_uris=redirect_uris,
+                )
+        except (IntegrityError, ValidationError) as exc:
+            raise CommandError(
+                "The OAuth application registration is invalid or conflicts "
+                "with an existing record."
+            ) from exc
+
+        if options["verbosity"] > 0:
+            self.stdout.write(self.style.SUCCESS(f"{result} OAuth registration."))
+
+    def _register_or_verify(
+        self,
+        *,
+        client_id,
+        owner_username,
+        application_name,
+        redirect_uris,
+    ):
+        application_model = get_application_model()
+        users = list(
+            get_user_model()
+            .objects.select_for_update()
+            .filter(username=owner_username)[:2]
+        )
+        if len(users) > 1:
+            raise CommandError("The OAuth application owner is ambiguous.")
+        owner = users[0] if users else None
+
+        applications = list(
+            application_model.objects.select_for_update().filter(client_id=client_id)[
+                :2
+            ]
+        )
+        if len(applications) > 1:
+            raise CommandError("The OAuth application is ambiguous.")
+        application = applications[0] if applications else None
+
+        if application is not None:
+            if owner is None or application.user_id != owner.pk:
+                raise CommandError("The OAuth client ID belongs to a different owner.")
+            self._validate_owner(owner, application_model, application)
+            self._validate_application(
+                application,
+                owner,
+                application_name,
+                redirect_uris,
+            )
+            if not is_pkce_s256_enforced(application):
+                raise CommandError(
+                    "PKCE S256 is not effective for the existing OAuth application."
+                )
+            return "Verified"
+
+        if owner is None:
+            owner = self._create_owner(owner_username)
+        else:
+            self._validate_owner(owner, application_model)
+
+        application = application_model(
+            user=owner,
+            name=application_name,
+            client_id=client_id,
+            client_type=application_model.CLIENT_PUBLIC,
+            authorization_grant_type=application_model.GRANT_AUTHORIZATION_CODE,
+            redirect_uris=" ".join(redirect_uris),
+            skip_authorization=False,
+            algorithm=application_model.NO_ALGORITHM,
+        )
+        application.full_clean()
+        application.save()
+
+        if not is_pkce_s256_enforced(application):
+            raise CommandError(
+                "PKCE S256 is not effective for the created OAuth application."
+            )
+        return "Created"
+
+    @staticmethod
+    def _required_text(value, label):
+        if not isinstance(value, str) or not value.strip():
+            raise CommandError(f"The {label} must not be empty.")
+        return value.strip()
+
+    @classmethod
+    def _validate_redirect_uris(cls, values):
+        redirect_uris = [cls._required_text(value, "redirect URI") for value in values]
+        if len(redirect_uris) != len(set(redirect_uris)):
+            raise CommandError("Redirect URIs must not be repeated.")
+        if any(any(character.isspace() for character in uri) for uri in redirect_uris):
+            raise CommandError("A redirect URI must not contain whitespace.")
+        return redirect_uris
+
+    @staticmethod
+    def _create_owner(username):
+        user_model = get_user_model()
+        owner = user_model(username=username, is_active=False)
+        owner.set_unusable_password()
+        owner.is_staff = False
+        owner.is_superuser = False
+        owner.full_clean()
+        owner.save()
+        # User-creation signals in this project assign default permissions.
+        # A dedicated OAuth owner must retain none of them.
+        owner.groups.clear()
+        owner.user_permissions.clear()
+        return owner
+
+    @staticmethod
+    def _validate_owner(owner, application_model, target_application=None):
+        if owner.is_active or owner.has_usable_password():
+            raise CommandError("The existing OAuth application owner can sign in.")
+        if owner.is_staff or owner.is_superuser:
+            raise CommandError(
+                "The existing OAuth application owner has elevated privileges."
+            )
+        if owner.groups.exists() or owner.user_permissions.exists():
+            raise CommandError(
+                "The existing OAuth application owner has assigned privileges."
+            )
+
+        owned_applications = application_model.objects.filter(user=owner)
+        if target_application is not None:
+            owned_applications = owned_applications.exclude(pk=target_application.pk)
+        if owned_applications.exists():
+            raise CommandError(
+                "The existing owner owns an unrelated OAuth application."
+            )
+
+    @staticmethod
+    def _validate_application(
+        application,
+        owner,
+        application_name,
+        redirect_uris,
+    ):
+        application_model = type(application)
+        if application.user_id != owner.pk:
+            raise CommandError("The OAuth client ID belongs to a different owner.")
+        if application.client_type != application_model.CLIENT_PUBLIC:
+            raise CommandError("The existing OAuth application is not public.")
+        if (
+            application.authorization_grant_type
+            != application_model.GRANT_AUTHORIZATION_CODE
+        ):
+            raise CommandError(
+                "The existing OAuth application is not an Authorization Code client."
+            )
+        if application.name != application_name:
+            raise CommandError("The existing OAuth application name is unexpected.")
+        if set(application.redirect_uris.split()) != set(redirect_uris):
+            raise CommandError(
+                "The existing OAuth application callback URL set is unexpected."
+            )
+        if application.skip_authorization:
+            raise CommandError(
+                "The existing OAuth application skips user authorization."
+            )
+        if application.algorithm != application_model.NO_ALGORITHM:
+            raise CommandError(
+                "The existing OAuth application has an OIDC signing algorithm."
+            )

--- a/onadata/apps/main/tests/management/commands/test_register_oauth_public_application.py
+++ b/onadata/apps/main/tests/management/commands/test_register_oauth_public_application.py
@@ -1,0 +1,363 @@
+"""Tests for the public OAuth application registration command."""
+
+from concurrent.futures import ThreadPoolExecutor
+from datetime import timedelta
+from io import StringIO
+
+from django.contrib.auth import authenticate, get_user_model
+from django.contrib.auth.models import Group, Permission
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from django.db import close_old_connections
+from django.test import (
+    TestCase,
+    TransactionTestCase,
+    override_settings,
+    skipUnlessDBFeature,
+)
+from django.utils import timezone
+
+from oauth2_provider.models import get_application_model
+
+
+class RegisterOAuthPublicApplicationTestCase(TestCase):
+    """Exercise safe creation, verification, and conflict handling."""
+
+    client_id = "public-client"
+    owner_username = "public-client-owner"
+    application_name = "Public client"
+    redirect_uris = [
+        "https://client.example.test/oauth/callback",
+        "https://client.example.test/oauth/secondary-callback",
+    ]
+
+    def _command_arguments(self, **overrides):
+        values = {
+            "client_id": self.client_id,
+            "owner_username": self.owner_username,
+            "application_name": self.application_name,
+            "redirect_uris": self.redirect_uris,
+        }
+        values.update(overrides)
+        arguments = [
+            "register_oauth_public_application",
+            "--client-id",
+            values["client_id"],
+            "--owner-username",
+            values["owner_username"],
+            "--application-name",
+            values["application_name"],
+        ]
+        for redirect_uri in values["redirect_uris"]:
+            arguments.extend(["--redirect-uri", redirect_uri])
+        return arguments
+
+    def _call_command(self, **overrides):
+        output = StringIO()
+        call_command(*self._command_arguments(**overrides), stdout=output)
+        return output.getvalue()
+
+    def _secure_owner(self, username=None):
+        owner = get_user_model().objects.create(
+            username=username or self.owner_username,
+            is_active=False,
+            is_staff=False,
+            is_superuser=False,
+        )
+        owner.set_unusable_password()
+        owner.save(update_fields=["password"])
+        owner.groups.clear()
+        owner.user_permissions.clear()
+        return owner
+
+    def _application(self, owner=None, **overrides):
+        application_model = get_application_model()
+        values = {
+            "user": owner or self._secure_owner(),
+            "name": self.application_name,
+            "client_id": self.client_id,
+            "client_type": application_model.CLIENT_PUBLIC,
+            "authorization_grant_type": (application_model.GRANT_AUTHORIZATION_CODE),
+            "redirect_uris": " ".join(self.redirect_uris),
+            "skip_authorization": False,
+            "algorithm": application_model.NO_ALGORITHM,
+        }
+        values.update(overrides)
+        return application_model.objects.create(**values)
+
+    def test_creates_secure_owner_and_public_application(self):
+        output = self._call_command()
+
+        owner = get_user_model().objects.get(username=self.owner_username)
+        application = get_application_model().objects.get(client_id=self.client_id)
+        self.assertFalse(owner.is_active)
+        self.assertFalse(owner.has_usable_password())
+        self.assertFalse(owner.is_staff)
+        self.assertFalse(owner.is_superuser)
+        self.assertFalse(owner.groups.exists())
+        self.assertFalse(owner.user_permissions.exists())
+        self.assertIsNone(
+            authenticate(username=self.owner_username, password="anything")
+        )
+        self.assertEqual(application.user, owner)
+        self.assertEqual(application.client_type, application.CLIENT_PUBLIC)
+        self.assertEqual(
+            application.authorization_grant_type,
+            application.GRANT_AUTHORIZATION_CODE,
+        )
+        self.assertEqual(
+            set(application.redirect_uris.split()), set(self.redirect_uris)
+        )
+        self.assertFalse(application.skip_authorization)
+        self.assertEqual(application.algorithm, application.NO_ALGORITHM)
+        self.assertEqual(output, "Created OAuth registration.\n")
+        self.assertNotIn(application.client_secret, output)
+
+    def test_second_identical_invocation_does_not_change_records(self):
+        self._call_command()
+        application = get_application_model().objects.get(client_id=self.client_id)
+        original_values = (
+            get_user_model().objects.count(),
+            get_application_model().objects.count(),
+            application.updated,
+        )
+
+        output = self._call_command()
+
+        application.refresh_from_db()
+        current_values = (
+            get_user_model().objects.count(),
+            get_application_model().objects.count(),
+            application.updated,
+        )
+        self.assertEqual(current_values, original_values)
+        self.assertEqual(output, "Verified OAuth registration.\n")
+
+    def test_reuses_only_an_already_secure_dedicated_owner(self):
+        owner = self._secure_owner()
+
+        self.assertEqual(self._call_command(), "Created OAuth registration.\n")
+
+        owner.refresh_from_db()
+        self.assertFalse(owner.is_active)
+        self.assertFalse(owner.has_usable_password())
+        self.assertEqual(
+            get_application_model().objects.get(client_id=self.client_id).user,
+            owner,
+        )
+
+    @override_settings(OAUTH2_PKCE_S256_MODE="observe")
+    def test_observe_mode_fails_before_creating_owner_or_application(self):
+        with self.assertRaisesRegex(CommandError, "S256 is not effective"):
+            self._call_command()
+
+        self.assertFalse(
+            get_user_model().objects.filter(username=self.owner_username).exists()
+        )
+        self.assertFalse(
+            get_application_model().objects.filter(client_id=self.client_id).exists()
+        )
+
+    def test_active_legacy_window_prevents_verification(self):
+        application = self._application()
+        now = timezone.now()
+        get_application_model().objects.filter(pk=application.pk).update(
+            created=now - timedelta(days=2)
+        )
+        application.refresh_from_db()
+        with override_settings(
+            OAUTH2_PKCE_S256_MODE="enforce",
+            OAUTH2_PKCE_S256_MIGRATION_CUTOFF=now - timedelta(days=1),
+            OAUTH2_PKCE_S256_MIGRATION_EXPIRES_AT=now + timedelta(days=1),
+        ):
+            with self.assertRaisesRegex(CommandError, "S256 is not effective"):
+                self._call_command()
+
+    def test_active_legacy_window_does_not_exempt_new_registration(self):
+        now = timezone.now()
+        with override_settings(
+            OAUTH2_PKCE_S256_MODE="enforce",
+            OAUTH2_PKCE_S256_MIGRATION_CUTOFF=now - timedelta(days=1),
+            OAUTH2_PKCE_S256_MIGRATION_EXPIRES_AT=now + timedelta(days=1),
+        ):
+            self.assertEqual(self._call_command(), "Created OAuth registration.\n")
+
+    def test_verifies_existing_compliant_application(self):
+        self._application()
+
+        output = self._call_command()
+
+        self.assertEqual(output, "Verified OAuth registration.\n")
+
+    def test_rejects_owner_that_can_sign_in_without_repairing_it(self):
+        owner = get_user_model().objects.create_user(
+            username=self.owner_username,
+            password="existing-password",
+            is_active=True,
+        )
+        password = owner.password
+
+        with self.assertRaisesRegex(CommandError, "owner can sign in"):
+            self._call_command()
+
+        owner.refresh_from_db()
+        self.assertTrue(owner.is_active)
+        self.assertEqual(owner.password, password)
+        self.assertFalse(
+            get_application_model().objects.filter(client_id=self.client_id).exists()
+        )
+
+    def test_rejects_inactive_owner_with_usable_password(self):
+        owner = get_user_model().objects.create_user(
+            username=self.owner_username,
+            password="existing-password",
+            is_active=False,
+        )
+
+        with self.assertRaisesRegex(CommandError, "owner can sign in"):
+            self._call_command()
+
+        owner.refresh_from_db()
+        self.assertTrue(owner.has_usable_password())
+
+    def test_rejects_staff_superuser_group_and_direct_permission_owners(self):
+        permission = Permission.objects.order_by("pk").first()
+        cases = ("staff", "superuser", "group", "permission")
+        for case in cases:
+            with self.subTest(case=case):
+                owner = self._secure_owner(f"{self.owner_username}-{case}")
+                if case == "staff":
+                    owner.is_staff = True
+                    owner.save(update_fields=["is_staff"])
+                elif case == "superuser":
+                    owner.is_superuser = True
+                    owner.save(update_fields=["is_superuser"])
+                elif case == "group":
+                    owner.groups.add(Group.objects.create(name=f"group-{case}"))
+                else:
+                    owner.user_permissions.add(permission)
+
+                with self.assertRaisesRegex(CommandError, "privileges"):
+                    self._call_command(owner_username=owner.username)
+
+                self.assertFalse(
+                    get_application_model()
+                    .objects.filter(client_id=self.client_id)
+                    .exists()
+                )
+
+    def test_rejects_owner_of_an_unrelated_application(self):
+        owner = self._secure_owner()
+        application_model = get_application_model()
+        application_model.objects.create(
+            user=owner,
+            name="Unrelated",
+            client_id="unrelated-client",
+            client_type=application_model.CLIENT_CONFIDENTIAL,
+            authorization_grant_type=application_model.GRANT_CLIENT_CREDENTIALS,
+        )
+
+        with self.assertRaisesRegex(CommandError, "unrelated OAuth application"):
+            self._call_command()
+
+        self.assertFalse(
+            application_model.objects.filter(client_id=self.client_id).exists()
+        )
+
+    def test_rejects_client_id_owned_by_another_user(self):
+        application = self._application(owner=self._secure_owner("different-owner"))
+        original_updated = application.updated
+
+        with self.assertRaisesRegex(CommandError, "different owner"):
+            self._call_command()
+
+        application.refresh_from_db()
+        self.assertEqual(application.updated, original_updated)
+
+    def test_rejects_existing_application_contract_conflicts(self):
+        application_model = get_application_model()
+        cases = {
+            "confidential": {
+                "client_type": application_model.CLIENT_CONFIDENTIAL,
+            },
+            "another grant": {
+                "authorization_grant_type": application_model.GRANT_PASSWORD,
+            },
+            "callback URL": {
+                "redirect_uris": "https://unexpected.example.test/callback",
+            },
+            "name": {"name": "Unexpected name"},
+            "skips": {"skip_authorization": True},
+            "OIDC": {"algorithm": application_model.RS256_ALGORITHM},
+        }
+        for label, updates in cases.items():
+            with self.subTest(conflict=label):
+                application = self._application()
+                application_model.objects.filter(pk=application.pk).update(**updates)
+
+                with self.assertRaises(CommandError):
+                    self._call_command()
+
+                application.delete()
+                application.user.delete()
+
+    def test_rejects_duplicate_or_empty_redirect_uri(self):
+        for redirect_uris in (
+            [self.redirect_uris[0], self.redirect_uris[0]],
+            [""],
+        ):
+            with self.subTest(redirect_uris=redirect_uris):
+                with self.assertRaises(CommandError):
+                    self._call_command(redirect_uris=redirect_uris)
+
+        self.assertFalse(
+            get_user_model().objects.filter(username=self.owner_username).exists()
+        )
+
+
+@skipUnlessDBFeature("has_select_for_update")
+class RegisterOAuthPublicApplicationConcurrencyTestCase(TransactionTestCase):
+    """Concurrent command runs must converge on one registration."""
+
+    def _invoke_command(self):
+        output = StringIO()
+        try:
+            call_command(
+                "register_oauth_public_application",
+                "--client-id",
+                "concurrent-public-client",
+                "--owner-username",
+                "concurrent-public-owner",
+                "--application-name",
+                "Concurrent public client",
+                "--redirect-uri",
+                "https://client.example.test/oauth/callback",
+                stdout=output,
+            )
+        except CommandError:
+            result = "conflict"
+        else:
+            result = output.getvalue().strip()
+        finally:
+            close_old_connections()
+        return result
+
+    def test_concurrent_invocations_do_not_create_duplicate_records(self):
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            results = list(
+                executor.map(lambda _index: self._invoke_command(), range(2))
+            )
+
+        self.assertTrue(any(result != "conflict" for result in results))
+        self.assertEqual(
+            get_user_model().objects.filter(username="concurrent-public-owner").count(),
+            1,
+        )
+        application_model = get_application_model()
+        application = application_model.objects.get(
+            client_id="concurrent-public-client"
+        )
+        self.assertEqual(
+            application_model.objects.filter(pk=application.pk).count(),
+            1,
+        )

--- a/onadata/apps/main/tests/test_oauth_pkce.py
+++ b/onadata/apps/main/tests/test_oauth_pkce.py
@@ -1,0 +1,407 @@
+"""OAuth endpoint acceptance tests for the PKCE S256 policy."""
+
+import base64
+import hashlib
+import json
+from datetime import timedelta
+from urllib.parse import parse_qs, urlparse
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase, override_settings
+from django.utils import timezone
+
+from oauth2_provider.models import (
+    AccessToken,
+    Grant,
+    RefreshToken,
+    get_application_model,
+)
+
+
+@override_settings(
+    OAUTH2_PKCE_S256_MODE="enforce",
+    OAUTH2_PKCE_S256_MIGRATION_CUTOFF=None,
+    OAUTH2_PKCE_S256_MIGRATION_EXPIRES_AT=None,
+)
+class OAuthPKCEEndpointTestCase(TestCase):
+    """Prove policy behavior through the real authorization and token views."""
+
+    redirect_uri = "https://client.example.test/oauth/callback"
+    verifier = "v" * 43
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.resource_owner = get_user_model().objects.create_user(
+            username="pkce-resource-owner",
+            password="resource-owner-password",
+        )
+
+    def setUp(self):
+        self.client.force_login(self.resource_owner)
+
+    @property
+    def challenge(self):
+        digest = hashlib.sha256(self.verifier.encode("ascii")).digest()
+        return base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+
+    def _create_application(self, client_type, suffix, grant_type=None):
+        application_model = get_application_model()
+        owner = get_user_model().objects.create(
+            username=f"pkce-app-owner-{suffix}",
+            is_active=False,
+        )
+        owner.set_unusable_password()
+        owner.save(update_fields=["password"])
+        raw_secret = f"confidential-secret-{suffix}"
+        application = application_model.objects.create(
+            user=owner,
+            name=f"PKCE application {suffix}",
+            client_id=f"pkce-client-{suffix}",
+            client_secret=raw_secret,
+            client_type=client_type,
+            authorization_grant_type=(
+                grant_type or application_model.GRANT_AUTHORIZATION_CODE
+            ),
+            redirect_uris=self.redirect_uri,
+            skip_authorization=False,
+        )
+        return application, raw_secret
+
+    def _authorization_data(self, application, challenge=None, method=None):
+        data = {
+            "client_id": application.client_id,
+            "redirect_uri": self.redirect_uri,
+            "response_type": "code",
+            "scope": "read",
+            "state": "safe-state",
+        }
+        if challenge is not None:
+            data["code_challenge"] = challenge
+        if method is not None:
+            data["code_challenge_method"] = method
+        return data
+
+    def _authorize(self, application, challenge=None, method=None):
+        data = self._authorization_data(application, challenge, method)
+        consent = self.client.get("/o/authorize/", data)
+        self.assertEqual(consent.status_code, 200)
+
+        data["allow"] = True
+        response = self.client.post("/o/authorize/", data)
+        self.assertEqual(response.status_code, 302)
+        parameters = parse_qs(urlparse(response["Location"]).query)
+        self.assertNotIn("error", parameters)
+        return parameters["code"][0]
+
+    def _token_data(self, application, code, verifier=None):
+        data = {
+            "grant_type": "authorization_code",
+            "client_id": application.client_id,
+            "redirect_uri": self.redirect_uri,
+            "code": code,
+        }
+        if verifier is not None:
+            data["code_verifier"] = verifier
+        return data
+
+    @staticmethod
+    def _basic_authorization(client_id, client_secret):
+        credentials = f"{client_id}:{client_secret}".encode("utf-8")
+        return "Basic " + base64.b64encode(credentials).decode("ascii")
+
+    def _exchange(
+        self,
+        application,
+        raw_secret,
+        code,
+        verifier=None,
+    ):
+        headers = {}
+        if application.client_type == application.CLIENT_CONFIDENTIAL:
+            headers["HTTP_AUTHORIZATION"] = self._basic_authorization(
+                application.client_id, raw_secret
+            )
+        return self.client.post(
+            "/o/token/",
+            self._token_data(application, code, verifier),
+            **headers,
+        )
+
+    def _assert_oauth_redirect_error(self, response, expected_error):
+        self.assertEqual(response.status_code, 302)
+        parameters = parse_qs(urlparse(response["Location"]).query)
+        self.assertEqual(parameters["error"], [expected_error])
+
+    def test_public_and_confidential_s256_flows_succeed(self):
+        application_model = get_application_model()
+        for client_type in (
+            application_model.CLIENT_PUBLIC,
+            application_model.CLIENT_CONFIDENTIAL,
+        ):
+            with self.subTest(client_type=client_type):
+                suffix = client_type
+                application, raw_secret = self._create_application(client_type, suffix)
+                code = self._authorize(
+                    application,
+                    challenge=self.challenge,
+                    method="S256",
+                )
+
+                response = self._exchange(
+                    application,
+                    raw_secret,
+                    code,
+                    verifier=self.verifier,
+                )
+
+                self.assertEqual(response.status_code, 200)
+                self.assertIn("access_token", json.loads(response.content))
+                self.assertTrue(
+                    AccessToken.objects.filter(application=application).exists()
+                )
+                self.assertTrue(
+                    RefreshToken.objects.filter(application=application).exists()
+                )
+                self.assertFalse(Grant.objects.filter(application=application).exists())
+
+    def test_public_token_exchange_does_not_send_a_client_secret(self):
+        application_model = get_application_model()
+        application, raw_secret = self._create_application(
+            application_model.CLIENT_PUBLIC, "public-no-secret"
+        )
+        code = self._authorize(application, self.challenge, "S256")
+
+        response = self.client.post(
+            "/o/token/",
+            self._token_data(application, code, self.verifier),
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, raw_secret)
+
+    def test_authorization_rejects_missing_or_non_s256_pkce_for_both_client_types(
+        self,
+    ):
+        application_model = get_application_model()
+        cases = (
+            ("missing-challenge", None, None),
+            ("missing-method", self.challenge, None),
+            ("plain", self.verifier, "plain"),
+            ("unsupported", self.challenge, "S512"),
+        )
+        for client_type in (
+            application_model.CLIENT_PUBLIC,
+            application_model.CLIENT_CONFIDENTIAL,
+        ):
+            for label, challenge, method in cases:
+                with self.subTest(client_type=client_type, case=label):
+                    application, _raw_secret = self._create_application(
+                        client_type, f"{client_type}-{label}"
+                    )
+
+                    response = self.client.get(
+                        "/o/authorize/",
+                        self._authorization_data(application, challenge, method),
+                    )
+
+                    self._assert_oauth_redirect_error(response, "invalid_request")
+                    self.assertFalse(
+                        Grant.objects.filter(application=application).exists()
+                    )
+
+    def test_changed_hidden_pkce_method_is_rejected_without_a_grant(self):
+        application_model = get_application_model()
+        application, _raw_secret = self._create_application(
+            application_model.CLIENT_PUBLIC, "changed-hidden-method"
+        )
+        data = self._authorization_data(application, self.challenge, "S256")
+        self.assertEqual(self.client.get("/o/authorize/", data).status_code, 200)
+        data.update({"allow": True, "code_challenge_method": "plain"})
+
+        response = self.client.post("/o/authorize/", data)
+
+        self._assert_oauth_redirect_error(response, "invalid_request")
+        self.assertFalse(Grant.objects.filter(application=application).exists())
+
+    def test_missing_and_wrong_verifiers_create_no_tokens(self):
+        application_model = get_application_model()
+        for client_type in (
+            application_model.CLIENT_PUBLIC,
+            application_model.CLIENT_CONFIDENTIAL,
+        ):
+            for label, verifier, expected_error in (
+                ("missing", None, "invalid_request"),
+                ("wrong", "w" * 43, "invalid_grant"),
+            ):
+                with self.subTest(client_type=client_type, case=label):
+                    application, raw_secret = self._create_application(
+                        client_type, f"{client_type}-verifier-{label}"
+                    )
+                    code = self._authorize(application, self.challenge, "S256")
+
+                    response = self._exchange(
+                        application,
+                        raw_secret,
+                        code,
+                        verifier=verifier,
+                    )
+
+                    self.assertEqual(response.status_code, 400)
+                    self.assertEqual(
+                        json.loads(response.content)["error"], expected_error
+                    )
+                    self.assertFalse(
+                        AccessToken.objects.filter(application=application).exists()
+                    )
+                    self.assertFalse(
+                        RefreshToken.objects.filter(application=application).exists()
+                    )
+
+    def _stored_grant(self, application, suffix, challenge="", method=""):
+        return Grant.objects.create(
+            user=self.resource_owner,
+            application=application,
+            code=f"stored-code-{suffix}",
+            expires=timezone.now() + timedelta(minutes=1),
+            redirect_uri=self.redirect_uri,
+            scope="read",
+            code_challenge=challenge,
+            code_challenge_method=method,
+        )
+
+    def test_legacy_stored_grants_create_no_tokens(self):
+        application_model = get_application_model()
+        for client_type in (
+            application_model.CLIENT_PUBLIC,
+            application_model.CLIENT_CONFIDENTIAL,
+        ):
+            for label, challenge, method, verifier in (
+                ("no-challenge", "", "", self.verifier),
+                ("plain", self.verifier, "plain", self.verifier),
+            ):
+                with self.subTest(client_type=client_type, case=label):
+                    application, raw_secret = self._create_application(
+                        client_type, f"{client_type}-stored-{label}"
+                    )
+                    grant = self._stored_grant(
+                        application,
+                        f"{client_type}-{label}",
+                        challenge,
+                        method,
+                    )
+
+                    response = self._exchange(
+                        application,
+                        raw_secret,
+                        grant.code,
+                        verifier=verifier,
+                    )
+
+                    self.assertEqual(response.status_code, 400)
+                    self.assertEqual(
+                        json.loads(response.content)["error"], "invalid_grant"
+                    )
+                    self.assertFalse(
+                        AccessToken.objects.filter(application=application).exists()
+                    )
+                    self.assertFalse(
+                        RefreshToken.objects.filter(application=application).exists()
+                    )
+
+    def test_active_legacy_window_preserves_prior_authorization_behavior(self):
+        application_model = get_application_model()
+        now = timezone.now()
+        cutoff = now - timedelta(days=1)
+        for client_type in (
+            application_model.CLIENT_PUBLIC,
+            application_model.CLIENT_CONFIDENTIAL,
+        ):
+            with self.subTest(client_type=client_type):
+                application, raw_secret = self._create_application(
+                    client_type, f"active-legacy-window-{client_type}"
+                )
+                application_model.objects.filter(pk=application.pk).update(
+                    created=cutoff - timedelta(days=1)
+                )
+                application.refresh_from_db()
+                with override_settings(
+                    OAUTH2_PKCE_S256_MIGRATION_CUTOFF=cutoff,
+                    OAUTH2_PKCE_S256_MIGRATION_EXPIRES_AT=(now + timedelta(days=1)),
+                ):
+                    code = self._authorize(application)
+                    response = self._exchange(
+                        application,
+                        raw_secret,
+                        code,
+                    )
+
+                self.assertEqual(response.status_code, 200)
+                self.assertTrue(
+                    AccessToken.objects.filter(application=application).exists()
+                )
+
+    def test_active_legacy_window_still_accepts_valid_s256(self):
+        application_model = get_application_model()
+        application, raw_secret = self._create_application(
+            application_model.CLIENT_PUBLIC, "active-legacy-window-s256"
+        )
+        now = timezone.now()
+        cutoff = now - timedelta(days=1)
+        application_model.objects.filter(pk=application.pk).update(
+            created=cutoff - timedelta(days=1)
+        )
+        application.refresh_from_db()
+        with override_settings(
+            OAUTH2_PKCE_S256_MIGRATION_CUTOFF=cutoff,
+            OAUTH2_PKCE_S256_MIGRATION_EXPIRES_AT=now + timedelta(days=1),
+        ):
+            code = self._authorize(application, self.challenge, "S256")
+            response = self._exchange(
+                application,
+                raw_secret,
+                code,
+                verifier=self.verifier,
+            )
+
+        self.assertEqual(response.status_code, 200)
+
+    def test_expired_legacy_window_does_not_bypass_s256(self):
+        application_model = get_application_model()
+        now = timezone.now()
+        cutoff = now - timedelta(days=1)
+        for client_type in (
+            application_model.CLIENT_PUBLIC,
+            application_model.CLIENT_CONFIDENTIAL,
+        ):
+            with self.subTest(client_type=client_type):
+                application, _raw_secret = self._create_application(
+                    client_type, f"expired-legacy-window-{client_type}"
+                )
+                application_model.objects.filter(pk=application.pk).update(
+                    created=cutoff - timedelta(days=1)
+                )
+                application.refresh_from_db()
+                with override_settings(
+                    OAUTH2_PKCE_S256_MIGRATION_CUTOFF=cutoff,
+                    OAUTH2_PKCE_S256_MIGRATION_EXPIRES_AT=(now - timedelta(seconds=1)),
+                ):
+                    response = self.client.get(
+                        "/o/authorize/",
+                        self._authorization_data(application),
+                    )
+
+                self._assert_oauth_redirect_error(response, "invalid_request")
+                self.assertFalse(Grant.objects.filter(application=application).exists())
+
+    @override_settings(OAUTH2_PKCE_S256_MODE="observe")
+    def test_observe_mode_preserves_prior_authorization_behavior(self):
+        application_model = get_application_model()
+        application, raw_secret = self._create_application(
+            application_model.CLIENT_PUBLIC, "observe"
+        )
+
+        code = self._authorize(application)
+        response = self._exchange(application, raw_secret, code)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(AccessToken.objects.filter(application=application).exists())

--- a/onadata/libs/authentication.py
+++ b/onadata/libs/authentication.py
@@ -7,12 +7,14 @@ from __future__ import unicode_literals
 
 import base64
 import binascii
+import logging
 from datetime import datetime
 from typing import Optional, Tuple
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import update_last_login
+from django.core.exceptions import ImproperlyConfigured
 from django.core.signing import BadSignature
 from django.db import DataError
 from django.db.models import Q
@@ -25,6 +27,7 @@ from multidb.pinning import use_master
 from oauth2_provider.models import AccessToken
 from oauth2_provider.oauth2_validators import OAuth2Validator
 from oauth2_provider.settings import oauth2_settings
+from oauthlib.oauth2.rfc6749 import errors as oauth2_errors
 from oidc.utils import authenticate_sso
 from rest_framework import exceptions
 from rest_framework.authentication import (
@@ -73,6 +76,131 @@ LOCKOUT_EXCLUDED_PATHS = getattr(
 
 # pylint: disable=invalid-name
 User = get_user_model()
+
+PKCE_S256_MODE_ENFORCE = "enforce"
+PKCE_S256_MODE_OBSERVE = "observe"
+PKCE_S256_MODES = (PKCE_S256_MODE_ENFORCE, PKCE_S256_MODE_OBSERVE)
+PKCE_S256_METHOD = "S256"
+PKCE_MIGRATION_LOGGER = logging.getLogger("pkce_migration")
+
+
+def _validated_pkce_s256_settings():
+    """Return PKCE migration settings or fail closed on invalid values."""
+    mode = getattr(settings, "OAUTH2_PKCE_S256_MODE", PKCE_S256_MODE_ENFORCE)
+    if not isinstance(mode, str) or mode not in PKCE_S256_MODES:
+        raise ImproperlyConfigured(
+            "OAUTH2_PKCE_S256_MODE must be 'enforce' or 'observe'."
+        )
+
+    cutoff = getattr(settings, "OAUTH2_PKCE_S256_MIGRATION_CUTOFF", None)
+    expires_at = getattr(
+        settings,
+        "OAUTH2_PKCE_S256_MIGRATION_EXPIRES_AT",
+        None,
+    )
+    for name, value in (
+        ("OAUTH2_PKCE_S256_MIGRATION_CUTOFF", cutoff),
+        ("OAUTH2_PKCE_S256_MIGRATION_EXPIRES_AT", expires_at),
+    ):
+        if value is not None and (
+            not isinstance(value, datetime) or timezone.is_naive(value)
+        ):
+            raise ImproperlyConfigured(
+                f"{name} must be None or a timezone-aware datetime."
+            )
+
+    if (cutoff is None) != (expires_at is None):
+        raise ImproperlyConfigured(
+            "The PKCE S256 migration cutoff and expiry must either both be "
+            "set or both be None."
+        )
+
+    return mode, cutoff, expires_at
+
+
+def _uses_authorization_code(application):
+    """Return whether an application has an explicitly code-based grant."""
+    if application is None:
+        return False
+
+    return application.authorization_grant_type in (
+        application.GRANT_AUTHORIZATION_CODE,
+        application.GRANT_OPENID_HYBRID,
+    )
+
+
+def _is_pkce_legacy_window_active(
+    application,
+    cutoff,
+    expires_at,
+    at,
+):
+    """Return whether the shared legacy-application window is still active."""
+    if cutoff is None or expires_at is None or expires_at <= at:
+        return False
+
+    created = getattr(application, "created", None)
+    return (
+        isinstance(created, datetime)
+        and timezone.is_aware(created)
+        and created < cutoff
+    )
+
+
+def is_pkce_s256_enforced(application, at=None):
+    """Return whether S256 is effective for an OAuth application.
+
+    This helper accepts unsaved applications so registration commands can
+    verify the effective policy before making any database writes.
+    """
+    mode, cutoff, expires_at = _validated_pkce_s256_settings()
+
+    if not _uses_authorization_code(application):
+        return False
+    if mode == PKCE_S256_MODE_OBSERVE:
+        return False
+
+    effective_at = at if at is not None else timezone.now()
+    if not isinstance(effective_at, datetime) or timezone.is_naive(effective_at):
+        raise ValueError("at must be a timezone-aware datetime.")
+
+    return not _is_pkce_legacy_window_active(
+        application,
+        cutoff,
+        expires_at,
+        effective_at,
+    )
+
+
+def _pkce_challenge_method_category(challenge, challenge_method):
+    """Reduce challenge input to the approved migration-log categories."""
+    if challenge is None:
+        return "not_applicable"
+    if challenge_method is None:
+        return "missing"
+    if challenge_method == PKCE_S256_METHOD:
+        return PKCE_S256_METHOD
+    if challenge_method == "plain":
+        return "plain"
+    return "unsupported"
+
+
+def _log_pkce_migration_observation(application, request):
+    """Emit one allowlisted, identity-free structured migration event."""
+    challenge = getattr(request, "code_challenge", None)
+    challenge_method = getattr(request, "code_challenge_method", None)
+    PKCE_MIGRATION_LOGGER.info(
+        "pkce_migration",
+        extra={
+            "application_pk": application.pk,
+            "client_type": application.client_type,
+            "grant_type": application.authorization_grant_type,
+            "challenge_absent": challenge is None,
+            "challenge_method_category": _pkce_challenge_method_category(
+                challenge, challenge_method
+            ),
+        },
+    )
 
 
 def expired(time_token_created):
@@ -491,6 +619,65 @@ class MasterReplicaOAuth2Validator(OAuth2Validator):
     def validate_silent_login(self, request):
         """See oauthlib.oauth2.rfc6749.request_validator"""
         raise NotImplementedError("Subclasses must implement this method.")
+
+    def is_pkce_required(self, client_id, request):
+        """Require PKCE for code grants when the effective policy enforces it."""
+        application = getattr(request, "client", None)
+        if application is None:
+            application = self._load_application(client_id, request)
+        return is_pkce_s256_enforced(application)
+
+    def validate_response_type(
+        self, client_id, response_type, client, request, *args, **kwargs
+    ):
+        """Reject authorization requests that do not use PKCE S256.
+
+        OAuthLib defaults a missing challenge method to ``plain`` after this
+        hook, so checking here also protects the authorization-response POST
+        from a changed hidden form value.
+        """
+        valid = super().validate_response_type(
+            client_id, response_type, client, request, *args, **kwargs
+        )
+        if (
+            not valid
+            or not isinstance(response_type, str)
+            or "code" not in response_type.split()
+            or not _uses_authorization_code(client)
+        ):
+            return valid
+
+        if not is_pkce_s256_enforced(client):
+            _log_pkce_migration_observation(client, request)
+            return valid
+
+        challenge = getattr(request, "code_challenge", None)
+        challenge_method = getattr(request, "code_challenge_method", None)
+        if challenge is None:
+            raise oauth2_errors.InvalidRequestError(
+                description="PKCE code_challenge is required.",
+                request=request,
+            )
+        if challenge_method != PKCE_S256_METHOD:
+            raise oauth2_errors.InvalidRequestError(
+                description="PKCE code_challenge_method must be S256.",
+                request=request,
+            )
+
+        return valid
+
+    def get_code_challenge_method(self, code, request):
+        """Reject legacy stored grants when their effective policy enforces."""
+        challenge_method = super().get_code_challenge_method(code, request)
+        if (
+            is_pkce_s256_enforced(getattr(request, "client", None))
+            and challenge_method != PKCE_S256_METHOD
+        ):
+            raise oauth2_errors.InvalidGrantError(
+                description="Authorization grant does not use PKCE S256.",
+                request=request,
+            )
+        return challenge_method
 
     def validate_bearer_token(self, token, scopes, request):
         if not token:

--- a/onadata/libs/tests/test_pkce.py
+++ b/onadata/libs/tests/test_pkce.py
@@ -1,0 +1,305 @@
+"""Focused tests for the effective PKCE S256 validator policy."""
+
+from datetime import timedelta
+from unittest.mock import patch
+
+from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
+from django.test import SimpleTestCase, override_settings
+from django.utils import timezone
+
+from oauth2_provider.models import get_application_model
+from oauth2_provider.oauth2_validators import OAuth2Validator
+from oauthlib.common import Request
+from oauthlib.oauth2.rfc6749.errors import InvalidGrantError, InvalidRequestError
+
+from onadata.libs.authentication import (
+    MasterReplicaOAuth2Validator,
+    is_pkce_s256_enforced,
+)
+
+
+class PKCETestMixin:
+    """Build OAuth applications without database writes."""
+
+    @staticmethod
+    def application(grant_type=None, pk=None, created=None):
+        application_model = get_application_model()
+        application = application_model(
+            client_id="pkce-test-client",
+            client_type=application_model.CLIENT_PUBLIC,
+            authorization_grant_type=(
+                grant_type or application_model.GRANT_AUTHORIZATION_CODE
+            ),
+        )
+        application.pk = pk
+        application.created = created
+        return application
+
+    @staticmethod
+    def request(application, challenge=None, challenge_method=None):
+        request = Request("https://server.example/o/authorize/")
+        request.client = application
+        request.code_challenge = challenge
+        request.code_challenge_method = challenge_method
+        return request
+
+
+class TestPKCES256Settings(PKCETestMixin, SimpleTestCase):
+    def test_source_default_is_enforce(self):
+        self.assertEqual(settings.OAUTH2_PKCE_S256_MODE, "enforce")
+        self.assertIsNone(settings.OAUTH2_PKCE_S256_MIGRATION_CUTOFF)
+        self.assertIsNone(settings.OAUTH2_PKCE_S256_MIGRATION_EXPIRES_AT)
+
+    def test_unsaved_code_application_is_enforced_before_any_write(self):
+        self.assertTrue(is_pkce_s256_enforced(self.application()))
+
+    @override_settings(OAUTH2_PKCE_S256_MODE="observe")
+    def test_observe_mode_does_not_enforce_unsaved_code_application(self):
+        self.assertFalse(is_pkce_s256_enforced(self.application()))
+
+    def test_non_code_grants_are_not_subject_to_pkce(self):
+        application_model = get_application_model()
+        for grant_type in (
+            application_model.GRANT_CLIENT_CREDENTIALS,
+            application_model.GRANT_PASSWORD,
+            application_model.GRANT_IMPLICIT,
+            application_model.GRANT_DEVICE_CODE,
+        ):
+            with self.subTest(grant_type=grant_type):
+                self.assertFalse(is_pkce_s256_enforced(self.application(grant_type)))
+
+    def test_invalid_modes_fail_closed(self):
+        for mode in (None, "", "ENFORCE", "invalid", False, 1, lambda: "observe"):
+            with self.subTest(mode=mode), override_settings(OAUTH2_PKCE_S256_MODE=mode):
+                with self.assertRaises(ImproperlyConfigured):
+                    is_pkce_s256_enforced(self.application())
+
+    def test_invalid_migration_timestamps_fail_closed(self):
+        invalid_values = (
+            "",
+            0,
+            timezone.now().replace(tzinfo=None),
+            lambda: timezone.now(),
+        )
+        for setting_name in (
+            "OAUTH2_PKCE_S256_MIGRATION_CUTOFF",
+            "OAUTH2_PKCE_S256_MIGRATION_EXPIRES_AT",
+        ):
+            for value in invalid_values:
+                with self.subTest(
+                    setting_name=setting_name, value=value
+                ), override_settings(**{setting_name: value}):
+                    with self.assertRaises(ImproperlyConfigured):
+                        is_pkce_s256_enforced(self.application())
+
+    def test_migration_cutoff_and_expiry_must_be_configured_together(self):
+        now = timezone.now()
+        incomplete_settings = (
+            {
+                "OAUTH2_PKCE_S256_MIGRATION_CUTOFF": None,
+                "OAUTH2_PKCE_S256_MIGRATION_EXPIRES_AT": now,
+            },
+            {
+                "OAUTH2_PKCE_S256_MIGRATION_CUTOFF": now,
+                "OAUTH2_PKCE_S256_MIGRATION_EXPIRES_AT": None,
+            },
+        )
+        for values in incomplete_settings:
+            with self.subTest(values=values), override_settings(**values):
+                with self.assertRaises(ImproperlyConfigured):
+                    is_pkce_s256_enforced(self.application(pk=1, created=now))
+
+    def test_at_must_be_fixed_and_timezone_aware(self):
+        with self.assertRaises(ValueError):
+            is_pkce_s256_enforced(
+                self.application(), at=timezone.now().replace(tzinfo=None)
+            )
+
+
+class TestEffectivePKCES256Policy(PKCETestMixin, SimpleTestCase):
+    def setUp(self):
+        self.now = timezone.now()
+        self.cutoff = self.now - timedelta(days=1)
+        self.application_instance = self.application(
+            pk=123, created=self.cutoff - timedelta(microseconds=1)
+        )
+
+    def effective(self, **overrides):
+        values = {
+            "OAUTH2_PKCE_S256_MODE": "enforce",
+            "OAUTH2_PKCE_S256_MIGRATION_CUTOFF": self.cutoff,
+            "OAUTH2_PKCE_S256_MIGRATION_EXPIRES_AT": (self.now + timedelta(days=1)),
+        }
+        values.update(overrides)
+        with override_settings(
+            **values,
+        ):
+            return is_pkce_s256_enforced(self.application_instance, at=self.now)
+
+    def test_old_application_before_expiry_preserves_prior_behavior(self):
+        self.assertFalse(self.effective())
+
+    def test_expiry_boundary_enforces(self):
+        self.assertTrue(self.effective(OAUTH2_PKCE_S256_MIGRATION_EXPIRES_AT=self.now))
+
+    def test_absent_migration_window_enforces(self):
+        with override_settings(
+            OAUTH2_PKCE_S256_MODE="enforce",
+            OAUTH2_PKCE_S256_MIGRATION_CUTOFF=None,
+            OAUTH2_PKCE_S256_MIGRATION_EXPIRES_AT=None,
+        ):
+            self.assertTrue(
+                is_pkce_s256_enforced(self.application_instance, at=self.now)
+            )
+
+    def test_created_time_must_be_strictly_before_cutoff(self):
+        for delta, expected in (
+            (-timedelta(microseconds=1), False),
+            (timedelta(0), True),
+            (timedelta(microseconds=1), True),
+        ):
+            with self.subTest(delta=delta):
+                self.application_instance.created = self.cutoff + delta
+                self.assertEqual(self.effective(), expected)
+
+    def test_missing_or_naive_created_time_cannot_receive_exemption(self):
+        for created in (None, self.now.replace(tzinfo=None)):
+            with self.subTest(created=created):
+                self.application_instance.created = created
+                self.assertTrue(self.effective())
+
+
+@override_settings(
+    OAUTH2_PKCE_S256_MODE="enforce",
+    OAUTH2_PKCE_S256_MIGRATION_CUTOFF=None,
+    OAUTH2_PKCE_S256_MIGRATION_EXPIRES_AT=None,
+)
+class TestPKCES256Validator(PKCETestMixin, SimpleTestCase):
+    def setUp(self):
+        self.application_instance = self.application()
+        self.validator = MasterReplicaOAuth2Validator()
+
+    def validate(self, challenge=None, method=None, response_type="code"):
+        request = self.request(
+            self.application_instance,
+            challenge=challenge,
+            challenge_method=method,
+        )
+        result = self.validator.validate_response_type(
+            self.application_instance.client_id,
+            response_type,
+            self.application_instance,
+            request,
+        )
+        return result, request
+
+    def test_authorization_accepts_exact_s256(self):
+        result, _request = self.validate("safe-category-only", "S256")
+        self.assertTrue(result)
+
+    def test_authorization_rejects_missing_plain_and_unsupported_methods(self):
+        cases = (
+            (None, None),
+            ("challenge", None),
+            ("challenge", "plain"),
+            ("challenge", "s256"),
+            ("challenge", "unsupported"),
+        )
+        for challenge, method in cases:
+            with self.subTest(challenge=challenge, method=method):
+                with self.assertRaises(InvalidRequestError):
+                    self.validate(challenge, method)
+
+    def test_openid_hybrid_authorization_requires_s256(self):
+        application_model = get_application_model()
+        self.application_instance.authorization_grant_type = (
+            application_model.GRANT_OPENID_HYBRID
+        )
+        result, _request = self.validate(
+            "safe-category-only", "S256", response_type="code id_token"
+        )
+        self.assertTrue(result)
+
+        with self.assertRaises(InvalidRequestError):
+            self.validate(response_type="code id_token")
+
+    def test_is_pkce_required_uses_effective_application_policy(self):
+        request = self.request(self.application_instance)
+        self.assertTrue(
+            self.validator.is_pkce_required(
+                self.application_instance.client_id, request
+            )
+        )
+
+    @patch.object(OAuth2Validator, "get_code_challenge_method", return_value="plain")
+    def test_token_rejects_stored_plain_grant(self, _get_method):
+        request = self.request(self.application_instance)
+        with self.assertRaises(InvalidGrantError):
+            self.validator.get_code_challenge_method("legacy-code", request)
+
+    @patch.object(OAuth2Validator, "get_code_challenge_method", return_value="S256")
+    def test_token_accepts_stored_s256_grant(self, _get_method):
+        request = self.request(self.application_instance)
+        self.assertEqual(
+            self.validator.get_code_challenge_method("safe-code", request),
+            "S256",
+        )
+
+    def test_subclass_inherits_s256_enforcement(self):
+        class ClaimsValidator(MasterReplicaOAuth2Validator):
+            pass
+
+        request = self.request(self.application_instance)
+        with self.assertRaises(InvalidRequestError):
+            ClaimsValidator().validate_response_type(
+                self.application_instance.client_id,
+                "code",
+                self.application_instance,
+                request,
+            )
+
+
+@override_settings(OAUTH2_PKCE_S256_MODE="observe")
+class TestPKCEObservation(PKCETestMixin, SimpleTestCase):
+    def test_observation_uses_only_allowlisted_fields(self):
+        application = self.application(pk=321)
+        request = self.request(
+            application,
+            challenge="do-not-log-this-challenge",
+            challenge_method="unrecognized-do-not-log",
+        )
+
+        with patch(
+            "onadata.libs.authentication.PKCE_MIGRATION_LOGGER.info"
+        ) as log_info:
+            self.assertTrue(
+                MasterReplicaOAuth2Validator().validate_response_type(
+                    application.client_id,
+                    "code",
+                    application,
+                    request,
+                )
+            )
+
+        log_info.assert_called_once_with(
+            "pkce_migration",
+            extra={
+                "application_pk": 321,
+                "client_type": application.CLIENT_PUBLIC,
+                "grant_type": application.GRANT_AUTHORIZATION_CODE,
+                "challenge_absent": False,
+                "challenge_method_category": "unsupported",
+            },
+        )
+
+    @patch.object(OAuth2Validator, "get_code_challenge_method", return_value="plain")
+    def test_observe_mode_retains_stored_grant_behavior(self, _get_method):
+        application = self.application()
+        request = self.request(application)
+        self.assertEqual(
+            MasterReplicaOAuth2Validator().get_code_challenge_method(
+                "legacy-code", request
+            ),
+            "plain",
+        )

--- a/onadata/settings/common.py
+++ b/onadata/settings/common.py
@@ -254,6 +254,13 @@ OAUTH2_PROVIDER = {
     "OAUTH2_VALIDATOR_CLASS": "onadata.libs.authentication.MasterReplicaOAuth2Validator",  # noqa
 }
 
+# Authorization Code and code-based OpenID Connect applications require PKCE
+# S256 by default. The remaining settings support a bounded migration and
+# should be empty in a fully migrated deployment.
+OAUTH2_PKCE_S256_MODE = "enforce"
+OAUTH2_PKCE_S256_MIGRATION_CUTOFF = None
+OAUTH2_PKCE_S256_MIGRATION_EXPIRES_AT = None
+
 OPENID_CONNECT_VIEWSET_CONFIG = {
     "REDIRECT_AFTER_AUTH": "http://localhost:3000",
     "USE_SSO_COOKIE": True,
@@ -404,6 +411,14 @@ LOGGING = {
         },
         "simple": {"format": "%(levelname)s %(message)s"},
         "profiler": {"format": "%(levelname)s %(asctime)s %(message)s"},
+        "pkce_migration": {
+            "format": (
+                "%(message)s application_pk=%(application_pk)s "
+                "client_type=%(client_type)s grant_type=%(grant_type)s "
+                "challenge_absent=%(challenge_absent)s "
+                "challenge_method_category=%(challenge_method_category)s"
+            )
+        },
         "sql": {
             "format": "%(levelname)s %(process)d %(thread)d"
             + " %(time)s seconds %(message)s %(sql)s"
@@ -431,6 +446,12 @@ LOGGING = {
             "level": "DEBUG",
             "class": "logging.StreamHandler",
             "formatter": "verbose",
+            "stream": sys.stdout,
+        },
+        "pkce_migration_console": {
+            "level": "INFO",
+            "class": "logging.StreamHandler",
+            "formatter": "pkce_migration",
             "stream": sys.stdout,
         },
         "audit": {
@@ -464,6 +485,11 @@ LOGGING = {
             "propagate": True,
         },
         "audit_logger": {"handlers": ["audit"], "level": "DEBUG", "propagate": True},
+        "pkce_migration": {
+            "handlers": ["pkce_migration_console"],
+            "level": "INFO",
+            "propagate": False,
+        },
         # 'sql_logger': {
         #     'handlers': ['sql_handler'],
         #     'level': 'DEBUG',


### PR DESCRIPTION
### Changes / Features implemented

- Enforce PKCE using the exact `S256` method for public and confidential
  Authorization Code applications.
- Apply the same policy to explicitly classified code-based OpenID Connect
  applications, including OpenID hybrid grants.
- Reject missing, `plain`, and unsupported challenge methods at authorization,
  and reject legacy non-S256 grants during token exchange.
- Add validated `observe` and `enforce` modes with a bounded legacy migration
  window based on application creation time, a fixed cutoff, and a fixed
  expiry.
- Emit identity-free `pkce_migration` observations during the observation or
  legacy compatibility window.
- Add `register_oauth_public_application` for idempotent registration of public
  Authorization Code applications with inactive, unprivileged owners.

### Steps taken to verify this change does what is intended

- Ran the focused authentication, PKCE endpoint, and registration command
  suites: 83 tests passed.
- Ran the complete affected CI test group:

      python manage.py test \
        onadata/libs onadata/apps/main onadata/apps/restservice \
        onadata/apps/sms_support onadata/apps/viewer onadata/apps/messaging \
        --noinput --timing --settings=onadata.settings.github_actions_test \
        --verbosity=1 --parallel=4

  Result: 1,309 tests passed, 6 skipped.

### Side effects of implementing this change

- The source default is enforcement. Existing Authorization Code clients that
  do not use S256 will fail unless the deployment first selects observation
  mode or configures the bounded legacy migration window.
- Changing the effective policy can invalidate an in-flight authorization
  code; affected clients must start a new authorization flow.
- Observation and legacy-window authorization requests emit structured
  `pkce_migration` log events containing only application and PKCE-method
  categories.
- No OAuth client secrets, challenges, verifiers, tokens, URLs, or user
  identities are logged.

**Before submitting this PR for review, please make sure you have:**

- [x] Included tests
- [x] Updated inline settings and management-command documentation

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/onaio/codesmith/onadata/pr/3192"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788357435&installation_model_id=422582&pr_number=3192&repository=onaio%2Fonadata&return_to=https%3A%2F%2Fgithub.com%2Fonaio%2Fonadata%2Fpull%2F3192&signature=a3f205435a996306b5556f9f2b4d50f8092db1af5e41a0167510b390ff7da112"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->