### PR TITLE
fix: wrap entity mutations in a transaction

### DIFF
--- a/onadata/libs/utils/entities_utils.py
+++ b/onadata/libs/utils/entities_utils.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 from typing import Any, Iterator, TextIO
 
 from django.contrib.auth.models import AbstractBaseUser
+from django.db import transaction
 from django.db.models import QuerySet
 from django.utils.translation import gettext as _
 
@@ -146,6 +147,7 @@ def soft_delete_entities_bulk(entity_qs: QuerySet[Entity], deleted_by=None) -> N
         entity.soft_delete(deleted_by)
 
 
+@transaction.atomic()
 def create_or_update_entity_from_instance(instance: Instance) -> None:
     """Create or Update Entity from Instance
 

--- a/onadata/libs/utils/tests/test_entities_utils.py
+++ b/onadata/libs/utils/tests/test_entities_utils.py
@@ -6,6 +6,7 @@ from io import StringIO
 from unittest.mock import call, patch
 
 from django.core.cache import cache
+from django.core.exceptions import ValidationError
 from django.db.models.signals import post_save
 from django.test import override_settings
 from django.utils import timezone
@@ -1709,6 +1710,58 @@ class CreateUpdateEntityTestCase(TestBase):
         entity_list.soft_delete()
 
         create_or_update_entity_from_instance(self.instance)
+
+        self.assertEqual(Entity.objects.count(), 0)
+
+    def test_mutations_atomic(self):
+        """Entity mutations from a single Instance are applied atomically"""
+        md = """
+        | survey   |
+        |          | type         | name         | label        | save_to      |
+        |          | begin_repeat | tree         | Tree         |              |
+        |          | barcode      | tree_id      | Tree ID      |              |
+        |          | text         | year_planted | Year planted | year_planted |
+        |          | end_repeat   |              |              |              |
+        | settings |              |              |              |              |
+        |          | form_title   | form_id      | version      |              |
+        |          | Trees        | trees        | 202607241122 |              |
+        | entities |              |              |              |              |
+        |          | list_name    | label        |              |              |
+        |          | trees_repeat | ${tree_id}   |              |              |
+        """
+        xform = self._publish_markdown(md, self.user)
+        xml = (
+            '<data xmlns:jr="http://openrosa.org/javarosa" xmlns:orx='
+            '"http://openrosa.org/xforms" id="trees_repeats" version="202607241122">'
+            "<formhub><uuid>080c4868778a4c9fa20e71f6dc3ef285</uuid></formhub>"
+            "<tree>"
+            "<tree_id>1</tree_id>"
+            "<year_planted>2014</year_planted>"
+            "<meta>"
+            '<entity dataset="trees_repeat" create="1" '
+            'id="e02dc9a9-0451-419d-934d-6d5621e4c5d6">'
+            "<label>1</label>"
+            "</entity>"
+            "</meta>"
+            "</tree>"
+            "<tree>"
+            "<tree_id>2</tree_id>"
+            "<year_planted>2014</year_planted>"
+            "<meta>"
+            '<entity dataset="trees_repeat" create="1" id="invalid-uuid">'
+            "<label>2</label>"
+            "</entity>"
+            "</meta>"
+            "</tree>"
+            "<meta>"
+            "<instanceID>uuid:86d21baf-75a2-4907-be8d-84dbacae2ebd</instanceID>"
+            "</meta>"
+            "</data>"
+        )
+        instance = Instance.objects.create(xml=xml, user=self.user, xform=xform)
+
+        with self.assertRaises(ValidationError):
+            create_or_update_entity_from_instance(instance)
 
         self.assertEqual(Entity.objects.count(), 0)
 


### PR DESCRIPTION
### Changes / Features implemented

- `create_or_update_entity_from_instance` now runs in a transaction; a failure on any entity node rolls back all Entity mutations from the submission
- Previously an error mid-way (e.g. an invalid entity UUID on a later node) left earlier mutations committed, which could leave partial entity mutations applied during submission-review approval

### Steps taken to verify this change does what is intended

- [x] Added tests

### Side effects of implementing this change

None

**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  - [ ] Updated documentation

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/onaio/codesmith/onadata/pr/3195"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788443088&installation_model_id=422582&pr_number=3195&repository=onaio%2Fonadata&return_to=https%3A%2F%2Fgithub.com%2Fonaio%2Fonadata%2Fpull%2F3195&signature=398dfa67eb71819de6ff2a7b083a62bdb5eb0b2151fb83d3e51e17661ac37ffa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->