### PR TITLE
Sign Azure original image attachment URLs

### DIFF
--- a/onadata/apps/viewer/tests/test_attachment_url.py
+++ b/onadata/apps/viewer/tests/test_attachment_url.py
@@ -2,12 +2,14 @@
 """
 Test attachments.
 """
+
 import os
 from unittest.mock import patch
 
 from django.conf import settings
 from django.contrib.auth import authenticate
 from django.http import HttpResponseRedirect
+from django.test import override_settings
 from django.urls import reverse
 
 from rest_framework.test import APIRequestFactory
@@ -73,6 +75,34 @@ class TestAttachmentUrl(TestBase):
             self.url, {"attachment_id": self.attachment.id, "no_redirect": "true"}
         )
         self.assertEqual(response.status_code, 200)  # no redirects to amazon
+
+    @override_settings(
+        STORAGES={
+            "default": {"BACKEND": "storages.backends.azure_storage.AzureStorage"}
+        },
+        AZURE_ACCOUNT_NAME="test-account",
+        AZURE_ACCOUNT_KEY="test-key",
+        AZURE_CONTAINER="test-container",
+    )
+    @patch("azure.storage.blob.generate_blob_sas")
+    def test_original_image_attachment_url_has_azure_sas_token(
+        self, mock_generate_blob_sas
+    ):
+        """Test original image attachment url has azure sas token"""
+        sas_token = "se=ab736fba7261"  # nosec
+        mock_generate_blob_sas.return_value = sas_token
+        expected_url = (
+            "https://test-account.blob.core.windows.net/test-container/"
+            f"{self.attachment_media_file.name}?{sas_token}"
+        )
+
+        response = self.client.get(
+            self.url, {"media_file": self.attachment_media_file.name}
+        )
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, expected_url)
+        self.assertIn(f"?{sas_token}", str(response.url))
 
     @patch("onadata.apps.viewer.views.generate_media_download_url")
     def test_attachment_url_has_azure_sas_token(self, mock_media_url):

--- a/onadata/libs/utils/image_tools.py
+++ b/onadata/libs/utils/image_tools.py
@@ -147,10 +147,14 @@ def image_url(attachment, suffix):
     """Return url of an image given size(@param suffix)
     e.g large, medium, small, or generate required thumbnail
     """
-    url = attachment.media_file.url
-
     if suffix == "original":
-        return url
+        return (
+            generate_media_url_with_sas(attachment.media_file.name)
+            if is_azure_storage()
+            else attachment.media_file.url
+        )
+
+    url = attachment.media_file.url
 
     default_storage = storages["default"]
     file_storage = storages.create_storage(


### PR DESCRIPTION
### Changes / Features implemented

- Generate a signed Azure Blob Storage URL when requesting an original image attachment.
- Preserve the existing behavior for non-Azure storage backends and resized images.
- Add regression coverage for Azure SAS tokens on original image attachment redirects.

### Steps taken to verify this change does what is intended

### Side effects of implementing this change

Original-size image URLs on Azure now include an expiring SAS token. Other storage backends and thumbnail URLs are unchanged.


**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  - [ ] Updated documentation (not required for this behavioral fix)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/onaio/codesmith/onadata/pr/3198"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788605393&installation_model_id=422582&pr_number=3198&repository=onaio%2Fonadata&return_to=https%3A%2F%2Fgithub.com%2Fonaio%2Fonadata%2Fpull%2F3198&signature=3639e291027aeaf7e5089c1279e58980c6157ab7fd091b921d2d892b2d4c4e21"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
