### PR TITLE
Fix CSV import delimiter detection

### DIFF
--- a/onadata/libs/tests/utils/test_csv_import.py
+++ b/onadata/libs/tests/utils/test_csv_import.py
@@ -99,6 +99,21 @@ class CSVImportTestCase(TestBase):
         )
         self.assertNotEqual(safe_create_args[4], None)
 
+    def test_submit_semicolon_delimited_csv(self):
+        """Test importing a CSV that uses a semicolon delimiter."""
+        self._publish_xls_file(self.xls_file_path)
+        xform = XForm.objects.get()
+        semicolon_csv = BytesIO()
+        writer = ucsv.writer(semicolon_csv, delimiter=";")
+        with open(os.path.join(self.fixtures_dir, "single.csv"), "rb") as source:
+            writer.writerows(ucsv.reader(source, encoding="utf-8-sig"))
+        semicolon_csv.seek(0)
+
+        result = csv_import.submit_csv(self.user.username, xform, semicolon_csv)
+
+        self.assertEqual(result.get("additions"), 1)
+        self.assertEqual(Instance.objects.count(), 1)
+
     @patch("onadata.libs.utils.csv_import.safe_create_instance")
     @patch("onadata.libs.utils.csv_import.dict2xmlsubmission")
     def test_submit_csv_xml_location_property_test(self, d2x, safe_create_instance):

--- a/onadata/libs/utils/csv_import.py
+++ b/onadata/libs/utils/csv_import.py
@@ -3,6 +3,7 @@
 CSV data import module.
 """
 
+import csv
 import functools
 import sys
 import uuid
@@ -59,9 +60,27 @@ PROGRESS_BATCH_UPDATE = getattr(
     settings, "EXPORT_TASK_PROGRESS_UPDATE_BATCH", DEFAULT_UPDATE_BATCH
 )
 IGNORED_COLUMNS = ["formhub/uuid", "meta/instanceID"]
+SUPPORTED_CSV_DELIMITERS = ",;\t|"
 
 # pylint: disable=invalid-name
 User = get_user_model()
+
+
+def get_csv_delimiter(csv_file):
+    """Return the delimiter used by a CSV file, defaulting to a comma."""
+    csv_file.seek(0)
+    header = csv_file.readline()
+    csv_file.seek(0)
+
+    if isinstance(header, bytes):
+        header = header.decode("utf-8-sig")
+
+    try:
+        return (
+            csv.Sniffer().sniff(header, delimiters=SUPPORTED_CSV_DELIMITERS).delimiter
+        )
+    except csv.Error:
+        return ","
 
 
 def get_submission_meta_dict(xform, instance_id):
@@ -219,8 +238,11 @@ def validate_csv_file(csv_file, xform):
     # Ensure stream position is at the start of the file
     csv_file.seek(0)
 
-    # Retrieve CSV Headers from the CSV File
-    csv_headers = ucsv.DictReader(csv_file, encoding="utf-8-sig").fieldnames
+    # Retrieve CSV headers using the delimiter found in the uploaded file.
+    delimiter = get_csv_delimiter(csv_file)
+    csv_headers = ucsv.DictReader(
+        csv_file, encoding="utf-8-sig", delimiter=delimiter
+    ).fieldnames
 
     # Make sure CSV headers have no spaces
     # because these are converted to XLSForm names
@@ -280,7 +302,11 @@ def validate_csv_file(csv_file, xform):
         if col.find("[") == -1 and col not in mutliple_select_col
     ]
 
-    return {"valid": True, "additional_col": additional_col}
+    return {
+        "valid": True,
+        "additional_col": additional_col,
+        "delimiter": delimiter,
+    }
 
 
 def flatten_split_select_multiples(
@@ -335,6 +361,7 @@ def submit_csv(username, xform, csv_file, overwrite=False):  # noqa
 
     if csv_file_validation_summary.get("valid"):
         additional_col = csv_file_validation_summary.get("additional_col")
+        delimiter = csv_file_validation_summary.get("delimiter", ",")
     else:
         return async_status(FAILED, csv_file_validation_summary.get("error_msg"))
 
@@ -343,7 +370,7 @@ def submit_csv(username, xform, csv_file, overwrite=False):  # noqa
     # Change stream position to start of file
     csv_file.seek(0)
 
-    csv_reader = ucsv.DictReader(csv_file, encoding="utf-8-sig")
+    csv_reader = ucsv.DictReader(csv_file, encoding="utf-8-sig", delimiter=delimiter)
     xform_json = xform.json_dict()
     select_multiples = [
         qstn.name for qstn in xform.get_survey_elements_of_type(MULTIPLE_SELECT_TYPE)


### PR DESCRIPTION
### Changes / Features implemented

- Detect comma, semicolon, tab, and pipe CSV delimiters from the header.
- Reuse the detected delimiter for both validation and submission parsing.
- Fall back to comma when delimiter detection is inconclusive.
- Add a regression test for semicolon-delimited imports.

### Steps taken to verify this change does what is intended

- Ran `python manage.py test onadata.libs.tests.utils.test_csv_import.CSVImportTestCase --noinput --settings=onadata.settings.github_actions_test --verbosity=1`.
- All 27 tests passed, including `test_submit_semicolon_delimited_csv`.

### Side effects of implementing this change

CSV imports can now accept the supported non-comma delimiters. Existing comma-delimited behavior remains the fallback.

**Before submitting this PR for review, please make sure you have:**

- [x] Included tests
- [ ] Updated documentation