### PR TITLE
Fix AttributeError during CSV import with legacy XLSForm JSON

### DIFF
--- a/onadata/apps/logger/models/xform.py
+++ b/onadata/apps/logger/models/xform.py
@@ -743,9 +743,11 @@ class XFormMixin:
             and survey_element.bind.get("type") == "string"
             and survey_element.type == MULTIPLE_SELECT_TYPE
         ):
-            result.pop()
-            for child in survey_element.choices.options:
-                result.append("/".join([path, child.name]))
+            choices = survey_element.choices
+            if choices is not None:
+                result.pop()
+                for child in choices.options:
+                    result.append("/".join([path, child.name]))
         elif (
             hasattr(survey_element, "bind")
             and survey_element.bind is not None

--- a/onadata/apps/logger/models/xform.py
+++ b/onadata/apps/logger/models/xform.py
@@ -719,9 +719,11 @@ class XFormMixin:
             and survey_element.bind.get("type") == "string"
             and survey_element.type == MULTIPLE_SELECT_TYPE
         ):
-            result.pop()
-            for child in survey_element.choices.options:
-                result.append("/".join([path, child.name]))
+            choices = survey_element.choices
+            if choices is not None:
+                result.pop()
+                for child in choices.options:
+                    result.append("/".join([path, child.name]))
         elif (
             hasattr(survey_element, "bind")
             and survey_element.bind is not None

--- a/onadata/libs/tests/utils/test_csv_import.py
+++ b/onadata/libs/tests/utils/test_csv_import.py
@@ -8,6 +8,7 @@ from __future__ import unicode_literals
 import os
 import re
 from builtins import open
+from copy import deepcopy
 from datetime import datetime
 from io import BytesIO
 from unittest.mock import patch
@@ -606,8 +607,8 @@ class CSVImportTestCase(TestBase):
             submission.json["section_B/year_established"].startswith("1890")
         )
 
-    def test_select_multiples_grouped_repeating_w_split(self):
-        """Select multiple choices within group within repeat with split"""
+    def _publish_nested_repeat_select_multiple(self):
+        """Publish the nested repeat select-multiple test form."""
         md_xform = """
         | survey  |                          |              |                   |
         |         | type                     | name         | label             |
@@ -633,7 +634,33 @@ class CSVImportTestCase(TestBase):
         |         | browsers                 | chrome       | Chrome            |
         |         | browsers                 | ie           | Internet Explorer |
         |         | browsers                 | safari       | Safari            |"""
-        xform = self._publish_markdown(md_xform, self.user, id_string="nested_split")
+        return self._publish_markdown(md_xform, self.user, id_string="nested_split")
+
+    @staticmethod
+    def _use_legacy_inline_choices_json(xform):
+        """Move browser choices inline to recreate the legacy JSON shape."""
+        legacy_json = deepcopy(xform.json)
+        choices = legacy_json["choices"].pop("browsers")
+
+        elements = list(legacy_json["children"])
+        while elements:
+            element = elements.pop()
+            if element.get("name") == "browsers":
+                element["children"] = choices
+                break
+            elements.extend(element.get("children", []))
+        else:
+            raise AssertionError("Browsers question not found")
+
+        XForm.objects.filter(pk=xform.pk).update(json=legacy_json)
+        xform.refresh_from_db()
+        if hasattr(xform, "_survey"):
+            del xform._survey  # pylint: disable=protected-access
+        return legacy_json
+
+    def test_select_multiples_grouped_repeating_w_split(self):
+        """Select multiple choices within group within repeat with split"""
+        xform = self._publish_nested_repeat_select_multiple()
 
         with open(
             os.path.join(
@@ -657,6 +684,47 @@ class CSVImportTestCase(TestBase):
                     },
                 ],
             )
+
+    def test_select_multiples_grouped_repeating_w_split_legacy_json(self):
+        """CSV import handles legacy select-multiple choices being unavailable."""
+        xform = self._publish_nested_repeat_select_multiple()
+        legacy_json = self._use_legacy_inline_choices_json(xform)
+
+        self.assertIsNone(xform.get_survey_element("browsers").choices)
+        combined_header = "grp1/grp2/browser_use[1]/grp3/grp4/grp5/browsers"
+        headers = xform.get_headers(repeat_iterations=1)
+        self.assertIn(combined_header, headers)
+        self.assertFalse(
+            any(header.startswith(f"{combined_header}/") for header in headers)
+        )
+
+        with open(
+            os.path.join(
+                self.fixtures_dir,
+                "csv_import_multiple_split_group_repeat.csv",
+            ),
+            "rb",
+        ) as csv_file:
+            csv_import.submit_csv(self.user.username, xform, csv_file)
+
+        self.assertEqual(Instance.objects.count(), 1)
+        submission = Instance.objects.first()
+        repeat_path = "grp1/grp2/browser_use/grp3/grp4/grp5"
+        self.assertEqual(
+            submission.json["grp1/grp2/browser_use"],
+            [
+                {
+                    f"{repeat_path}/year": 2010,
+                    f"{repeat_path}/browsers": "firefox safari",
+                },
+                {
+                    f"{repeat_path}/year": 2011,
+                    f"{repeat_path}/browsers": "firefox chrome",
+                },
+            ],
+        )
+        xform.refresh_from_db()
+        self.assertEqual(xform.json, legacy_json)
 
     def test_select_multiples_grouped_repeating_wo_split(self):
         """Select multiple choices within group within repeat without split"""

--- a/onadata/libs/tests/utils/test_csv_import.py
+++ b/onadata/libs/tests/utils/test_csv_import.py
@@ -8,6 +8,7 @@ from __future__ import unicode_literals
 import os
 import re
 from builtins import open
+from copy import deepcopy
 from datetime import datetime
 from io import BytesIO
 from unittest.mock import patch
@@ -736,8 +737,8 @@ class CSVImportTestCase(TestBase):
             submission.json["section_B/year_established"].startswith("1890")
         )
 
-    def test_select_multiples_grouped_repeating_w_split(self):
-        """Select multiple choices within group within repeat with split"""
+    def _publish_nested_repeat_select_multiple(self):
+        """Publish the nested repeat select-multiple test form."""
         md_xform = """
         | survey  |                          |              |                   |
         |         | type                     | name         | label             |
@@ -763,7 +764,33 @@ class CSVImportTestCase(TestBase):
         |         | browsers                 | chrome       | Chrome            |
         |         | browsers                 | ie           | Internet Explorer |
         |         | browsers                 | safari       | Safari            |"""
-        xform = self._publish_markdown(md_xform, self.user, id_string="nested_split")
+        return self._publish_markdown(md_xform, self.user, id_string="nested_split")
+
+    @staticmethod
+    def _use_legacy_inline_choices_json(xform):
+        """Move browser choices inline to recreate the legacy JSON shape."""
+        legacy_json = deepcopy(xform.json)
+        choices = legacy_json["choices"].pop("browsers")
+
+        elements = list(legacy_json["children"])
+        while elements:
+            element = elements.pop()
+            if element.get("name") == "browsers":
+                element["children"] = choices
+                break
+            elements.extend(element.get("children", []))
+        else:
+            raise AssertionError("Browsers question not found")
+
+        XForm.objects.filter(pk=xform.pk).update(json=legacy_json)
+        xform.refresh_from_db()
+        if hasattr(xform, "_survey"):
+            del xform._survey  # pylint: disable=protected-access
+        return legacy_json
+
+    def test_select_multiples_grouped_repeating_w_split(self):
+        """Select multiple choices within group within repeat with split"""
+        xform = self._publish_nested_repeat_select_multiple()
 
         with open(
             os.path.join(
@@ -787,6 +814,47 @@ class CSVImportTestCase(TestBase):
                     },
                 ],
             )
+
+    def test_select_multiples_grouped_repeating_w_split_legacy_json(self):
+        """CSV import handles legacy select-multiple choices being unavailable."""
+        xform = self._publish_nested_repeat_select_multiple()
+        legacy_json = self._use_legacy_inline_choices_json(xform)
+
+        self.assertIsNone(xform.get_survey_element("browsers").choices)
+        combined_header = "grp1/grp2/browser_use[1]/grp3/grp4/grp5/browsers"
+        headers = xform.get_headers(repeat_iterations=1)
+        self.assertIn(combined_header, headers)
+        self.assertFalse(
+            any(header.startswith(f"{combined_header}/") for header in headers)
+        )
+
+        with open(
+            os.path.join(
+                self.fixtures_dir,
+                "csv_import_multiple_split_group_repeat.csv",
+            ),
+            "rb",
+        ) as csv_file:
+            csv_import.submit_csv(self.user.username, xform, csv_file)
+
+        self.assertEqual(Instance.objects.count(), 1)
+        submission = Instance.objects.first()
+        repeat_path = "grp1/grp2/browser_use/grp3/grp4/grp5"
+        self.assertEqual(
+            submission.json["grp1/grp2/browser_use"],
+            [
+                {
+                    f"{repeat_path}/year": 2010,
+                    f"{repeat_path}/browsers": "firefox safari",
+                },
+                {
+                    f"{repeat_path}/year": 2011,
+                    f"{repeat_path}/browsers": "firefox chrome",
+                },
+            ],
+        )
+        xform.refresh_from_db()
+        self.assertEqual(xform.json, legacy_json)
 
     def test_select_multiples_grouped_repeating_wo_split(self):
         """Select multiple choices within group within repeat without split"""


### PR DESCRIPTION
### Changes / Features implemented

- Prevent `XFormMixin.xpaths()` from accessing `.options` when a select-multiple question has `choices=None`.
- Retain the combined select-multiple header when choices cannot be enumerated.
- Add regression coverage using the existing nested-group and repeat CSV-import example.
- Keep the stored legacy form JSON unchanged.

### Steps taken to verify this change does what is intended

- Recreated legacy form JSON where inline select-multiple children are not reconstructed as a PyXForm `Itemset`.
- Verified `get_headers()` retains the combined question header without raising `AttributeError`.
- Verified the existing split select-multiple CSV fixture imports successfully.
- Ran the CSV-import test module: 27 tests passed.

### Side effects of implementing this change

Select-multiple questions without reconstructed choices are represented by their combined header instead of individual choice headers. Forms with available choices continue producing split headers as before.

No form JSON is reprocessed or modified.


**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  - [ ] Updated documentation (not required for this internal error-handling change)

Closes #3201

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/onaio/codesmith/onadata/pr/3202"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788635546&installation_model_id=422582&pr_number=3202&repository=onaio%2Fonadata&return_to=https%3A%2F%2Fgithub.com%2Fonaio%2Fonadata%2Fpull%2F3202&signature=ef2993aabe171e1e2cd8da40666ea4935be82b46b62595b2c82ca56201bad693"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->