### PR TITLE
Fix flaky test in test_abstract_viewset.py

### DIFF
--- a/onadata/apps/api/tests/viewsets/test_abstract_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_abstract_viewset.py
@@ -8,12 +8,12 @@ import os
 import re
 import warnings
 from glob import glob
-from tempfile import NamedTemporaryFile, TemporaryDirectory
+from tempfile import NamedTemporaryFile
 
 from django.conf import settings
 from django.contrib.auth import authenticate, get_user_model
 from django.contrib.auth.models import Permission
-from django.test import TestCase, override_settings
+from django.test import TestCase
 
 import requests
 from django_digest.test import Client as DigestClient
@@ -140,19 +140,6 @@ class TestAbstractViewSet(TestBase, TestCase):
     }
 
     def setUp(self):
-        shared_media_root = os.path.join(settings.PROJECT_ROOT, "test_media")
-        if os.path.normpath(settings.MEDIA_ROOT) == shared_media_root:
-            # Parallel test workers have separate database clones but share
-            # MEDIA_ROOT. Since the clones reuse primary keys, their attachment
-            # paths can collide and one worker can delete another worker's file.
-            media_directory = TemporaryDirectory(prefix="onadata-test-media-")
-            media_override = override_settings(
-                MEDIA_ROOT=f"{media_directory.name}{os.sep}"
-            )
-            media_override.enable()
-            self.addCleanup(media_directory.cleanup)
-            self.addCleanup(media_override.disable)
-
         TestCase.setUp(self)
         self.factory = APIRequestFactory()
         self._login_user_and_profile()

--- a/onadata/apps/api/tests/viewsets/test_abstract_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_abstract_viewset.py
@@ -6,14 +6,14 @@ Test base class for API viewset tests.
 import json
 import os
 import re
-import subprocess
 import warnings
-from tempfile import NamedTemporaryFile
+from glob import glob
+from tempfile import NamedTemporaryFile, TemporaryDirectory
 
 from django.conf import settings
 from django.contrib.auth import authenticate, get_user_model
 from django.contrib.auth.models import Permission
-from django.test import TestCase
+from django.test import TestCase, override_settings
 
 import requests
 from django_digest.test import Client as DigestClient
@@ -140,6 +140,19 @@ class TestAbstractViewSet(TestBase, TestCase):
     }
 
     def setUp(self):
+        shared_media_root = os.path.join(settings.PROJECT_ROOT, "test_media")
+        if os.path.normpath(settings.MEDIA_ROOT) == shared_media_root:
+            # Parallel test workers have separate database clones but share
+            # MEDIA_ROOT. Since the clones reuse primary keys, their attachment
+            # paths can collide and one worker can delete another worker's file.
+            media_directory = TemporaryDirectory(prefix="onadata-test-media-")
+            media_override = override_settings(
+                MEDIA_ROOT=f"{media_directory.name}{os.sep}"
+            )
+            media_override.enable()
+            self.addCleanup(media_directory.cleanup)
+            self.addCleanup(media_override.disable)
+
         TestCase.setUp(self)
         self.factory = APIRequestFactory()
         self._login_user_and_profile()
@@ -497,18 +510,17 @@ class TestAbstractViewSet(TestBase, TestCase):
             media_file,
         )
         if delete_existing_attachments:
-            try:
-                media_file_name = media_file.split(".")[0]
-                # Use the same folder pattern as the upload_to function in Attachment model
-                # Format: {xform.id}_{xform.id_string}
-                attachment_folder = f"{self.xform.id}_{self.xform.id_string}"
-                cmd = (
-                    f"rm {settings.MEDIA_ROOT}"
-                    f"{self.profile_data['username']}/attachments/{attachment_folder}/{media_file_name}*"
-                )
-                subprocess.run(cmd, shell=True, check=True)
-            except subprocess.CalledProcessError:
-                pass
+            media_file_name = os.path.splitext(media_file)[0]
+            attachment_folder = f"{self.xform.id}_{self.xform.id_string}"
+            attachment_pattern = os.path.join(
+                settings.MEDIA_ROOT,
+                self.profile_data["username"],
+                "attachments",
+                attachment_folder,
+                f"{media_file_name}*",
+            )
+            for attachment_path in glob(attachment_pattern):
+                os.unlink(attachment_path)
 
         with open(path, "rb") as f:
             self._make_submission(

--- a/onadata/apps/api/tests/viewsets/test_briefcase_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_briefcase_viewset.py
@@ -13,6 +13,7 @@ from django.core.files.storage import storages
 from django.test import override_settings
 from django.urls import reverse
 from django.utils import timezone
+
 from django_digest.test import DigestAuth
 
 from onadata.apps.api.tests.viewsets.test_abstract_viewset import TestAbstractViewSet
@@ -791,7 +792,8 @@ class TestBriefcaseViewSet(TestAbstractViewSet):
         optimized_instances = _query_optimization_fence(instances, 4)
         self.assertEqual(instances.count(), optimized_instances.count())
         op_sql_query = (
-            'SELECT "logger_instance"."id", "logger_instance"."uuid" FROM "logger_instance"'
+            'SELECT "logger_instance"."id" AS "pk", '
+            '"logger_instance"."uuid" AS "uuid" FROM "logger_instance"'
             f' WHERE "logger_instance"."id" IN ({optimized_instances[0].get("pk")},'
             f" {optimized_instances[1].get('pk')}, {optimized_instances[2].get('pk')},"
             f" {optimized_instances[3].get('pk')})"

--- a/onadata/apps/logger/tests/test_briefcase_client.py
+++ b/onadata/apps/logger/tests/test_briefcase_client.py
@@ -4,7 +4,6 @@ Test Briefcase client
 """
 
 import os.path
-import shutil
 from io import BytesIO
 
 import requests
@@ -236,10 +235,7 @@ class TestBriefcaseClient(TestBase):
 
     @classmethod
     def tearDownClass(cls):
-        # remove media files
-        for username in ["bob", "deno"]:
-            if storage.exists(username):
-                shutil.rmtree(storage.path(username), ignore_errors=True)
         MetaData.objects.all().delete()
         Instance.objects.all().delete()
         XForm.objects.all().delete()
+        super().tearDownClass()

--- a/onadata/apps/logger/tests/test_briefcase_client.py
+++ b/onadata/apps/logger/tests/test_briefcase_client.py
@@ -4,17 +4,17 @@ Test Briefcase client
 """
 
 import os.path
-import shutil
 from io import BytesIO
 
-import requests
-import requests_mock
 from django.conf import settings
 from django.contrib.auth import authenticate
 from django.core.files.storage import storages
 from django.core.files.uploadedfile import UploadedFile
 from django.test import RequestFactory
 from django.urls import reverse
+
+import requests
+import requests_mock
 from django_digest.test import Client as DigestClient
 from flaky import flaky
 from six.moves.urllib.parse import urljoin
@@ -70,9 +70,9 @@ def form_media(request, context):
     )
     ids = list(Instance.objects.values_list("id", flat=True))
     xids = list(XForm.objects.values_list("id", flat=True))
-    assert response.status_code == 200, (
-        f"{data_id} - {response.content} {response.status_code} -{ids} {xids} {path}"
-    )
+    assert (
+        response.status_code == 200
+    ), f"{data_id} - {response.content} {response.status_code} -{ids} {xids} {path}"
     return get_streaming_content(response)
 
 
@@ -236,10 +236,7 @@ class TestBriefcaseClient(TestBase):
 
     @classmethod
     def tearDownClass(cls):
-        # remove media files
-        for username in ["bob", "deno"]:
-            if storage.exists(username):
-                shutil.rmtree(storage.path(username), ignore_errors=True)
         MetaData.objects.all().delete()
         Instance.objects.all().delete()
         XForm.objects.all().delete()
+        super().tearDownClass()

--- a/onadata/apps/main/tests/test_base.py
+++ b/onadata/apps/main/tests/test_base.py
@@ -16,13 +16,13 @@ import subprocess
 import warnings
 from hashlib import md5
 from io import BytesIO, StringIO
-from tempfile import NamedTemporaryFile
+from tempfile import NamedTemporaryFile, TemporaryDirectory
 
 from django.conf import settings
 from django.contrib.auth import authenticate, get_user_model
 from django.contrib.contenttypes.models import ContentType
 from django.core.files.uploadedfile import InMemoryUploadedFile
-from django.test import RequestFactory, TransactionTestCase
+from django.test import RequestFactory, TransactionTestCase, override_settings
 from django.test.client import Client
 from django.utils import timezone
 from django.utils.encoding import smart_str
@@ -80,6 +80,42 @@ class TestBase(PyxformMarkdown, TransactionTestCase):
         "transport_2011-07-25_19-06-14",
     ]
     this_directory = os.path.abspath(os.path.dirname(__file__))
+
+    @classmethod
+    def _cleanup_test_media(cls):
+        if cls._test_media_override is not None:
+            cls._test_media_override.disable()
+            cls._test_media_override = None
+        if cls._test_media_directory is not None:
+            cls._test_media_directory.cleanup()
+            cls._test_media_directory = None
+
+    @classmethod
+    def _pre_setup(cls):
+        cls._test_media_directory = None
+        cls._test_media_override = None
+        shared_media_root = os.path.join(settings.PROJECT_ROOT, "test_media")
+        if os.path.normpath(settings.MEDIA_ROOT) == shared_media_root:
+            # Parallel test workers have separate database clones but share
+            # MEDIA_ROOT. Since the clones reuse primary keys, their files can
+            # collide and one worker can delete another worker's files.
+            cls._test_media_directory = TemporaryDirectory(prefix="onadata-test-media-")
+            cls._test_media_override = override_settings(
+                MEDIA_ROOT=f"{cls._test_media_directory.name}{os.sep}"
+            )
+            cls._test_media_override.enable()
+
+        try:
+            super()._pre_setup()
+        except Exception:
+            cls._cleanup_test_media()
+            raise
+
+    def _post_teardown(self):
+        try:
+            super()._post_teardown()
+        finally:
+            self.__class__._cleanup_test_media()
 
     def setUp(self):
         self.maxDiff = None


### PR DESCRIPTION
### Changes / Features implemented

- Give tests inheriting the shared TestBase an isolated temporary MEDIA_ROOT for each test lifecycle.
- Reuse the shared isolation automatically in TestAbstractViewSet.
- Restore the original media configuration and remove temporary files after each test.
- Replace shell-based wildcard attachment deletion with scoped Python file cleanup.
- Remove TestBriefcaseClient cleanup that deleted the shared user media directory.
- Update the query optimization SQL expectation for Django 5.2's explicit value aliases.

Parallel Django workers use separate database clones but previously shared the same media directory. Since cloned databases reuse primary keys and usernames, workers could generate identical paths or remove files owned by another worker. This caused intermittent attachment and XLSForm retrieval failures.

### Steps taken to verify this change does what is intended

- Ran all 319 Logger tests successfully with four parallel workers.
- Ran the failing XForm test concurrently with the cleanup-heavy briefcase tests using three parallel workers successfully.
- Ran all 13 TestAttachmentViewSet tests successfully.
- Ran test_query_optimization_fence successfully on Django 5.2.15.

### Side effects of implementing this change

- Each applicable test creates a temporary media directory, which is automatically removed during teardown.
- Tests with an explicitly customized MEDIA_ROOT are unaffected.
- Production media storage and attachment paths are unchanged.

**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests — this is a test-isolation change exercised by the existing attachment, XForm, and briefcase tests.
  - [x] Updated documentation — not applicable because there is no user-facing behavior change.