### PR TITLE
ci: run checks for security branch pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@
 name: CI
 on:  # yamllint disable-line rule:truthy
   pull_request:
-    branches: ["*"]
+    branches: ["*", "security/*"]
   push:
     branches: ["main"]
 concurrency:


### PR DESCRIPTION
## Summary

- run the CI workflow for pull requests targeting `security/*` branches
- preserve the existing behavior for top-level branch targets

The `security/*` branch protection rule requires the five GitHub Actions checks, but branch protection only enforces results; it does not trigger workflows. The existing `*` Actions glob does not match branch names containing `/`, so PRs targeting branches such as `security/2026-08` receive no checks.

## Verification

- workflow YAML parses successfully
- the same change triggered CI for onaio/onadata-api#116 after it was retargeted to `security/2026-08`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/onaio/codesmith/onadata/pr/3208"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789144790&installation_model_id=422582&pr_number=3208&repository=onaio%2Fonadata&return_to=https%3A%2F%2Fgithub.com%2Fonaio%2Fonadata%2Fpull%2F3208&signature=7c5c9b04d9e28f103c28d9362e5545bb104c0b11e947cf99897d90b8dd2163d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->