### PR TITLE
perf: add composite xform_id date indexes to Instance

### DIFF
--- a/onadata/apps/logger/migrations/0045_add_xform_id_date_created_date_modified_last_edited_idx.py
+++ b/onadata/apps/logger/migrations/0045_add_xform_id_date_created_date_modified_last_edited_idx.py
@@ -3,8 +3,12 @@
 # logger_instance is a regular table by default but a partitioned table when
 # ENABLE_TABLE_PARTITIONING is on (see 0034-0037). Postgres cannot CREATE INDEX
 # CONCURRENTLY on a partitioned parent, so each index is built concurrently per
-# partition and attached to a parent index instead. Tables that already have an
-# equivalent index on the same columns (e.g. created by 0034) are skipped.
+# partition and attached to a parent index instead.
+#
+# An index that already covers the same columns is adopted rather than rebuilt:
+# it is renamed to the name recorded in Django's migration state, and on a
+# partitioned table it is attached to the parent index. Adopted indexes belong
+# to this migration from then on and are dropped when it is reversed.
 
 from django.conf import settings
 from django.db import migrations, models
@@ -14,6 +18,18 @@ INDEXES = [
     ("logger_inst_xform_i_eba640_idx", ["xform_id", "date_modified"]),
     ("logger_inst_xform_i_c024e3_idx", ["xform_id", "last_edited"]),
 ]
+
+
+def _is_compatible(definition, columns):
+    """Check a pg_get_indexdef definition is a plain btree index on columns.
+
+    Anything else the planner cannot use the same way - a unique index, another
+    access method, an expression, INCLUDE columns, a partial index, a
+    non-default operator class or sort order - renders a different definition.
+    """
+    return definition.startswith("CREATE INDEX ") and definition.endswith(
+        f" USING btree ({', '.join(columns)})"
+    )
 
 
 def _relkind(cursor, table):
@@ -30,28 +46,107 @@ def _relkind(cursor, table):
     return row[0] if row else None
 
 
-def _index_on_columns(cursor, table, columns):
-    """Return the name of a valid index on table covering exactly columns."""
+def _compatible_index(cursor, table, columns):
+    """Return the name of a valid index on table usable for columns."""
     cursor.execute(
         """
-        SELECT c.relname
+        SELECT c.relname, pg_get_indexdef(i.indexrelid)
         FROM pg_index i
         JOIN pg_class c ON c.oid = i.indexrelid
         JOIN pg_class t ON t.oid = i.indrelid
         JOIN pg_namespace n ON n.oid = t.relnamespace
-        WHERE n.nspname = 'public' AND t.relname = %s
-          AND i.indisvalid AND i.indpred IS NULL
-          AND (
-            SELECT array_agg(a.attname ORDER BY k.ord)
-            FROM unnest(i.indkey::int2[]) WITH ORDINALITY AS k(attnum, ord)
-            JOIN pg_attribute a ON a.attrelid = t.oid AND a.attnum = k.attnum
-          ) = %s::name[]
-        LIMIT 1
+        WHERE n.nspname = 'public' AND t.relname = %s AND i.indisvalid
+        ORDER BY c.relname
         """,
-        [table, columns],
+        [table],
+    )
+    for name, definition in cursor.fetchall():
+        if _is_compatible(definition, columns):
+            return name
+
+    return None
+
+
+def _claim_index_name(cursor, table, index_name, columns):
+    """Make index_name usable, dropping an index left by an interrupted build.
+
+    CREATE INDEX ... IF NOT EXISTS skips any relation of that name without
+    comparing its definition, so a leftover from a cancelled concurrent build
+    would be kept and the migration would report success without a usable
+    index. A partitioned index is instead invalid until every partition is
+    attached, which is the state a resumed run continues from.
+    """
+    cursor.execute(
+        """
+        SELECT c.relkind, i.indisvalid, t.relname, pg_get_indexdef(i.indexrelid)
+        FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        LEFT JOIN pg_index i ON i.indexrelid = c.oid
+        LEFT JOIN pg_class t ON t.oid = i.indrelid
+        WHERE n.nspname = 'public' AND c.relname = %s
+        """,
+        [index_name],
     )
     row = cursor.fetchone()
-    return row[0] if row else None
+
+    if row is None:
+        return
+
+    relkind, is_valid, index_table, definition = row
+
+    if index_table == table:
+        if relkind == "I" and _is_compatible(definition, columns):
+            return
+
+        if relkind == "i":
+            if is_valid and _is_compatible(definition, columns):
+                return
+
+            if not is_valid:
+                cursor.execute(f'DROP INDEX CONCURRENTLY "{index_name}"')
+                return
+
+    raise RuntimeError(
+        f'Cannot create index "{index_name}" on "{table}": the name is already '
+        "taken by another relation. Drop or rename it, then run this migration "
+        "again."
+    )
+
+
+def _ensure_index(cursor, table, index_name, columns):
+    """Create an index on table and its partitions; return the index name."""
+    _claim_index_name(cursor, table, index_name, columns)
+
+    existing = _compatible_index(cursor, table, columns)
+
+    if existing == index_name:
+        return index_name
+
+    if existing:
+        cursor.execute(f'ALTER INDEX "{existing}" RENAME TO "{index_name}"')
+        return index_name
+
+    columns_sql = ", ".join(f'"{column}"' for column in columns)
+
+    if _relkind(cursor, table) == "p":
+        cursor.execute(
+            f'CREATE INDEX IF NOT EXISTS "{index_name}" '
+            f'ON ONLY "{table}" ({columns_sql})'
+        )
+        for child in _child_partitions(cursor, table):
+            child_index_name = f"{child}_{'_'.join(columns)}_idx"[:63]
+            child_index = _ensure_index(cursor, child, child_index_name, columns)
+            if not _is_attached(cursor, index_name, child_index):
+                cursor.execute(
+                    f'ALTER INDEX "{index_name}" ATTACH PARTITION "{child_index}"'
+                )
+    else:
+        cursor.execute(
+            f'CREATE INDEX CONCURRENTLY IF NOT EXISTS "{index_name}" '
+            f'ON "{table}" ({columns_sql})'
+        )
+
+    return index_name
 
 
 def _child_partitions(cursor, table):
@@ -79,38 +174,6 @@ def _is_attached(cursor, parent_index, child_index):
     return cursor.fetchone() is not None
 
 
-def _ensure_index(cursor, table, index_name, columns):
-    """Create an index on table and its partitions; return the index name.
-
-    Reuses an existing index when one already covers columns.
-    """
-    existing = _index_on_columns(cursor, table, columns)
-    if existing:
-        return existing
-
-    columns_sql = ", ".join(f'"{column}"' for column in columns)
-
-    if _relkind(cursor, table) == "p":
-        cursor.execute(
-            f'CREATE INDEX IF NOT EXISTS "{index_name}" '
-            f'ON ONLY "{table}" ({columns_sql})'
-        )
-        for child in _child_partitions(cursor, table):
-            child_index_name = f"{child}_{'_'.join(columns)}_idx"[:63]
-            child_index = _ensure_index(cursor, child, child_index_name, columns)
-            if not _is_attached(cursor, index_name, child_index):
-                cursor.execute(
-                    f'ALTER INDEX "{index_name}" ATTACH PARTITION "{child_index}"'
-                )
-    else:
-        cursor.execute(
-            f'CREATE INDEX CONCURRENTLY IF NOT EXISTS "{index_name}" '
-            f'ON "{table}" ({columns_sql})'
-        )
-
-    return index_name
-
-
 def create_instance_date_indexes(apps, schema_editor):
     with schema_editor.connection.cursor() as cursor:
         for index_name, columns in INDEXES:
@@ -118,6 +181,7 @@ def create_instance_date_indexes(apps, schema_editor):
 
 
 def drop_instance_date_indexes(apps, schema_editor):
+    """Drop the indexes, including any this migration adopted."""
     with schema_editor.connection.cursor() as cursor:
         for index_name, _columns in INDEXES:
             cursor.execute(f'DROP INDEX IF EXISTS "{index_name}"')

--- a/onadata/apps/logger/migrations/0045_add_xform_id_date_created_date_modified_last_edited_idx.py
+++ b/onadata/apps/logger/migrations/0045_add_xform_id_date_created_date_modified_last_edited_idx.py
@@ -1,0 +1,169 @@
+# Generated manually to create instance date indexes without blocking writes.
+#
+# logger_instance is a regular table by default but a partitioned table when
+# ENABLE_TABLE_PARTITIONING is on (see 0034-0037). Postgres cannot CREATE INDEX
+# CONCURRENTLY on a partitioned parent, so each index is built concurrently per
+# partition and attached to a parent index instead. Tables that already have an
+# equivalent index on the same columns (e.g. created by 0034) are skipped.
+
+from django.conf import settings
+from django.db import migrations, models
+
+INDEXES = [
+    ("logger_inst_xform_i_3d0789_idx", ["xform_id", "date_created"]),
+    ("logger_inst_xform_i_eba640_idx", ["xform_id", "date_modified"]),
+    ("logger_inst_xform_i_c024e3_idx", ["xform_id", "last_edited"]),
+]
+
+
+def _relkind(cursor, table):
+    cursor.execute(
+        """
+        SELECT c.relkind
+        FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'public' AND c.relname = %s
+        """,
+        [table],
+    )
+    row = cursor.fetchone()
+    return row[0] if row else None
+
+
+def _index_on_columns(cursor, table, columns):
+    """Return the name of a valid index on table covering exactly columns."""
+    cursor.execute(
+        """
+        SELECT c.relname
+        FROM pg_index i
+        JOIN pg_class c ON c.oid = i.indexrelid
+        JOIN pg_class t ON t.oid = i.indrelid
+        JOIN pg_namespace n ON n.oid = t.relnamespace
+        WHERE n.nspname = 'public' AND t.relname = %s
+          AND i.indisvalid AND i.indpred IS NULL
+          AND (
+            SELECT array_agg(a.attname ORDER BY k.ord)
+            FROM unnest(i.indkey::int2[]) WITH ORDINALITY AS k(attnum, ord)
+            JOIN pg_attribute a ON a.attrelid = t.oid AND a.attnum = k.attnum
+          ) = %s::name[]
+        LIMIT 1
+        """,
+        [table, columns],
+    )
+    row = cursor.fetchone()
+    return row[0] if row else None
+
+
+def _child_partitions(cursor, table):
+    cursor.execute(
+        """
+        SELECT c.relname
+        FROM pg_inherits h
+        JOIN pg_class c ON c.oid = h.inhrelid
+        WHERE h.inhparent = %s::regclass
+        ORDER BY c.relname
+        """,
+        [table],
+    )
+    return [row[0] for row in cursor.fetchall()]
+
+
+def _is_attached(cursor, parent_index, child_index):
+    cursor.execute(
+        """
+        SELECT 1 FROM pg_inherits
+        WHERE inhrelid = %s::regclass AND inhparent = %s::regclass
+        """,
+        [child_index, parent_index],
+    )
+    return cursor.fetchone() is not None
+
+
+def _ensure_index(cursor, table, index_name, columns):
+    """Create an index on table and its partitions; return the index name.
+
+    Reuses an existing index when one already covers columns.
+    """
+    existing = _index_on_columns(cursor, table, columns)
+    if existing:
+        return existing
+
+    columns_sql = ", ".join(f'"{column}"' for column in columns)
+
+    if _relkind(cursor, table) == "p":
+        cursor.execute(
+            f'CREATE INDEX IF NOT EXISTS "{index_name}" '
+            f'ON ONLY "{table}" ({columns_sql})'
+        )
+        for child in _child_partitions(cursor, table):
+            child_index_name = f"{child}_{'_'.join(columns)}_idx"[:63]
+            child_index = _ensure_index(cursor, child, child_index_name, columns)
+            if not _is_attached(cursor, index_name, child_index):
+                cursor.execute(
+                    f'ALTER INDEX "{index_name}" ATTACH PARTITION "{child_index}"'
+                )
+    else:
+        cursor.execute(
+            f'CREATE INDEX CONCURRENTLY IF NOT EXISTS "{index_name}" '
+            f'ON "{table}" ({columns_sql})'
+        )
+
+    return index_name
+
+
+def create_instance_date_indexes(apps, schema_editor):
+    with schema_editor.connection.cursor() as cursor:
+        for index_name, columns in INDEXES:
+            _ensure_index(cursor, "logger_instance", index_name, columns)
+
+
+def drop_instance_date_indexes(apps, schema_editor):
+    with schema_editor.connection.cursor() as cursor:
+        for index_name, _columns in INDEXES:
+            cursor.execute(f'DROP INDEX IF EXISTS "{index_name}"')
+
+
+class Migration(migrations.Migration):
+    atomic = False
+
+    dependencies = [
+        ("logger", "0044_xform_unique_active_id_string"),
+        (
+            "taggit",
+            "0006_rename_taggeditem_content_type_object_id_taggit_tagg_content_8fc721_idx",
+        ),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.SeparateDatabaseAndState(
+            database_operations=[
+                migrations.RunPython(
+                    create_instance_date_indexes, drop_instance_date_indexes
+                ),
+            ],
+            state_operations=[
+                migrations.AddIndex(
+                    model_name="instance",
+                    index=models.Index(
+                        fields=["xform_id", "date_created"],
+                        name="logger_inst_xform_i_3d0789_idx",
+                    ),
+                ),
+                migrations.AddIndex(
+                    model_name="instance",
+                    index=models.Index(
+                        fields=["xform_id", "date_modified"],
+                        name="logger_inst_xform_i_eba640_idx",
+                    ),
+                ),
+                migrations.AddIndex(
+                    model_name="instance",
+                    index=models.Index(
+                        fields=["xform_id", "last_edited"],
+                        name="logger_inst_xform_i_c024e3_idx",
+                    ),
+                ),
+            ],
+        )
+    ]

--- a/onadata/apps/logger/models/instance.py
+++ b/onadata/apps/logger/models/instance.py
@@ -733,6 +733,9 @@ class Instance(models.Model, InstanceBaseClass):
             models.Index(fields=["deleted_at"]),
             models.Index(fields=["xform_id", "id"]),
             models.Index(fields=["decryption_status"]),
+            models.Index(fields=["xform_id", "date_created"]),
+            models.Index(fields=["xform_id", "date_modified"]),
+            models.Index(fields=["xform_id", "last_edited"]),
         ]
 
     @classmethod


### PR DESCRIPTION
### Changes / Features implemented

Adds three composite indexes to `logger_instance`: `(xform_id, date_created)`, `(xform_id, date_modified)` and `(xform_id, last_edited)`.

The data API filters `_submission_time`, `_date_modified` and `_last_edited` against these real columns (`get_where_clause` in `onadata/apps/viewer/parsed_instance_tools.py`), but no composite index covers them. On large forms the planner falls back to walking the `(xform_id, id)` index in id order with a heap fetch per row, which degrades pathologically when the date filter only matches recent submissions

Migration 0045 creates the indexes without blocking writes:

- Regular tables: `CREATE INDEX CONCURRENTLY`.
- Partitioned tables (`ENABLE_TABLE_PARTITIONING`, see 0034-0037): Postgres cannot `CREATE INDEX CONCURRENTLY` on a partitioned parent, so the parent index is created `ON ONLY` and each partition (recursing into sub-partitioned levels) gets a concurrent build that is then attached.
- An index whose definition already matches is adopted rather than rebuilt, and renamed to the name recorded in Django's migration state so the database and the migration state stay in agreement. Partitioned deployments (which got `(xform_id, date_created)` and `(xform_id, date_modified)` from the 0034 cutover) and databases carrying a manually created hotfix index therefore skip those builds — no `--fake` step is needed anywhere.
- An index left behind by an interrupted concurrent build is dropped and rebuilt, because `CREATE INDEX ... IF NOT EXISTS` skips any relation of that name without comparing its definition, which would otherwise leave the migration reporting success without a usable index. On a partitioned table an invalid parent index is instead the normal intermediate state of an interrupted run, so it is kept and the resumed run continues attaching partitions rather than rebuilding them.

### Steps taken to verify this change does what is intended

- `migrate` forward, backward (`migrate logger 0044_xform_unique_active_id_string`) and forward again on a regular-table database, including a run where an index on the same columns under a different name was planted first: it is adopted and renamed instead of duplicated. `makemigrations --check` reports no drift.
- Exercised the partitioned code path against a scratch hash-partitioned table with a sub-partitioned child (mirroring the `p_shared` layout): the parent index ends up valid with every partition index attached, a pre-existing leaf index is adopted, a run resumed from an invalid parent index completes, re-running is a no-op, and the planner uses the index (`Index Cond` on both columns).
- Checked that indexes the planner cannot use the same way are not mistaken for the wanted one: `INCLUDE`, BRIN, unique and `DESC` variants on the same columns are all rejected.
- Checked that an invalid index left under the target name by an interrupted build is replaced by a valid index with the right definition, and that a name held by an unrelated relation fails with an actionable error rather than silently succeeding.
- `EXPLAIN ANALYZE` on a production replica confirmed the planner uses `(xform_id, date_created)` for the affected query shape.

### Side effects of implementing this change

- The migration builds up to three indexes over `logger_instance`; on large deployments this takes time (two table scans per concurrent build) and disk, though writes are not blocked.
- An adopted index belongs to this migration from then on: reversing 0045 drops it, including indexes that predate the migration on partitioned deployments, and dropping a partitioned parent index also drops the partition indexes attached to it.

**Before submitting this PR for review, please make sure you have:**

  - [ ] Included tests
  - [ ] Updated documentation
