### PR TITLE
fix(exports): make SAV locale independent of host

### DIFF
--- a/onadata/libs/tests/utils/test_export_builder.py
+++ b/onadata/libs/tests/utils/test_export_builder.py
@@ -7,6 +7,7 @@ from __future__ import unicode_literals
 
 import csv
 import datetime
+import locale
 import os
 import shutil
 import tempfile
@@ -683,6 +684,41 @@ class TestExportBuilder(TestBase):
             self.assertEqual(data["children.info/fav_colors/blue's"], "True")
             self.assertEqual(data["children.info/fav_colors/pink's"], "False")
             # check that red and blue are set to true
+
+    def test_zipped_sav_export_ignores_unsupported_environment_locale(self):
+        """SAV generation does not resolve its locale from the environment."""
+        md = """
+        | survey |
+        |        | type | name | label |
+        |        | text | name | Name  |
+        """
+        survey = self.md_to_pyxform_survey(md, {"name": "locale_test"})
+        export_builder = ExportBuilder()
+        export_builder.set_survey(survey)
+        sav_options = export_builder._get_sav_options(
+            list(export_builder.sections[0]["elements"])
+        )
+        self.assertEqual(sav_options["ioLocale"], "C")
+        self.assertIs(sav_options["ioUtf8"], True)
+        original_lc_all = os.environ.get("LC_ALL")
+        original_locale = locale.setlocale(locale.LC_ALL)
+
+        try:
+            os.environ["LC_ALL"] = "onadata_UNSUPPORTED.INVALID"
+            with NamedTemporaryFile(suffix=".zip") as temp_zip_file:
+                export_builder.to_zipped_sav(
+                    temp_zip_file.name, [{"name": "café 漢字"}]
+                )
+                temp_zip_file.seek(0)
+                with zipfile.ZipFile(temp_zip_file.name, "r") as zip_file:
+                    self.assertIn("locale_test.sav", zip_file.namelist())
+                self.assertEqual(locale.setlocale(locale.LC_ALL), original_locale)
+        finally:
+            if original_lc_all is None:
+                os.environ.pop("LC_ALL", None)
+            else:
+                os.environ["LC_ALL"] = original_lc_all
+            locale.setlocale(locale.LC_ALL, original_locale)
 
     # pylint: disable=invalid-name
     def test_zipped_sav_export_with_date_field(self):

--- a/onadata/libs/utils/export_builder.py
+++ b/onadata/libs/utils/export_builder.py
@@ -7,6 +7,7 @@ ExportBuilder
 from __future__ import unicode_literals
 
 import csv
+import locale
 import re
 import uuid
 from datetime import date, datetime
@@ -1278,7 +1279,8 @@ class ExportBuilder:
                 'varNames': var_names,   # a list of varNames
                 'varTypes': var_types,  # a dict of varTypes
                 'valueLabels': value_labels,  # a dict of valueLabels
-                'ioUtf8': True
+                'ioUtf8': True,
+                'ioLocale': 'C'
             }
         """
 
@@ -1425,6 +1427,11 @@ class ExportBuilder:
             "varTypes": var_types,
             "valueLabels": value_labels,
             "ioUtf8": True,
+            # SavReaderWriter otherwise resolves the locale from the host
+            # environment. Keep this at the universally available C locale,
+            # rather than an environment locale or en_US.UTF-8; ioUtf8 controls
+            # the encoding of Unicode SAV content independently.
+            "ioLocale": "C",
             "fileLabel": "File exported by Ona",
         }
 
@@ -1457,7 +1464,14 @@ class ExportBuilder:
         for section in self.sections:
             sav_options = self._get_sav_options(section["elements"])
             sav_file = NamedTemporaryFile(suffix=".sav")
-            sav_writer = SavWriter(sav_file.name, **sav_options)
+            process_locale = locale.setlocale(locale.LC_ALL)
+            try:
+                sav_writer = SavWriter(sav_file.name, **sav_options)
+            finally:
+                # SavReaderWriter changes Python's process-global locale while
+                # applying ioLocale. SPSS retains its own locale setting, so
+                # restore the caller's locale before writing any export data.
+                locale.setlocale(locale.LC_ALL, process_locale)
             sav_defs[section["name"]] = {"sav_file": sav_file, "sav_writer": sav_writer}
 
         media_xpaths = (


### PR DESCRIPTION
### Changes / Features implemented

- Set `ioLocale` to the universally available `C` locale for SAV exports while retaining `ioUtf8=True` for Unicode content.
- Restore the caller's process locale after `SavWriter` initialization because `SavReaderWriter` changes it globally.
- Document why `C` is intentional and should not be replaced with an environment-derived locale or `en_US.UTF-8`.
- Add regression coverage that:
  - sets `LC_ALL` to an unsupported locale;
  - verifies zipped SAV generation succeeds with Unicode content;
  - asserts `ioLocale == "C"` and `ioUtf8 is True`;
  - confirms the process locale is preserved.

### Steps taken to verify this change does what is intended

- Ran the complete export builder and export tools test modules:
  - 136 tests passed
  - 4 tests skipped
- Ran the focused unsupported-locale and SAV options tests successfully.

### Side effects of implementing this change

- The change is limited to SAV/SAV ZIP generation.
- `SavReaderWriter` briefly applies the `C` locale while initializing each writer; the previous process locale is restored immediately afterward.


**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  - [x] Updated documentation

Closes #3105

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/onaio/codesmith/onadata/pr/3210"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789219621&installation_model_id=422582&pr_number=3210&repository=onaio%2Fonadata&return_to=https%3A%2F%2Fgithub.com%2Fonaio%2Fonadata%2Fpull%2F3210&signature=6f297a148654905c96fbbb6da97f1f37bbf870b62bf573f013e24fa338f40a99"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->