### PR TITLE
feat(api): send instance_attachments with enketo edit URL requests

### DIFF
--- a/onadata/apps/api/tests/viewsets/test_data_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_data_viewset.py
@@ -15,6 +15,7 @@ from datetime import timedelta
 from io import StringIO
 from tempfile import NamedTemporaryFile
 from unittest.mock import Mock, patch
+from urllib.parse import parse_qs
 
 from django.conf import settings
 from django.core.cache import cache
@@ -79,6 +80,18 @@ def enketo_edit_mock(url, request):
         'rnUrl=http://test.io/test_url", "code": 201}'
     )
     return response
+
+
+def enketo_edit_capture_mock(captured):
+    """``enketo_edit_mock``, recording the request body into ``captured``."""
+
+    @urlmatch(netloc=r"(.*\.)?enketo\.ona\.io$")
+    def capture(url, request):
+        captured["body"] = request.body
+
+        return enketo_edit_mock(url, request)
+
+    return capture
 
 
 @urlmatch(netloc=r"(.*\.)?enketo\.ona\.io$")
@@ -1544,6 +1557,61 @@ class TestDataViewSet(SerializeMixin, TestBase):
             response = view(request, pk=formid, dataid=dataid)
             self.assertEqual(response.status_code, 400)
             self.assertEqual(response.get("Cache-Control"), None)
+
+    def test_enketo_edit_url_sends_instance_attachments(self):
+        """The edit link request carries the submission's attachments.
+
+        The instance XML records only their file names, so each is sent paired
+        with an absolute download URL.
+        """
+        self._submit_transport_instance_w_attachment()
+        view = DataViewSet.as_view({"get": "enketo"})
+        request = self.factory.get(
+            "/", data={"return_url": "http://test.io/test_url"}, **self.extra
+        )
+
+        captured = {}
+
+        with HTTMock(enketo_edit_capture_mock(captured)):
+            view(
+                request,
+                pk=self.xform.pk,
+                dataid=self.xform.instances.all().order_by("id")[0].pk,
+            )
+
+        posted = parse_qs(captured["body"])
+
+        self.assertEqual(
+            posted["instance_attachments[1335783522563.jpg]"],
+            [
+                "http://testserver/api/v1/files/"
+                f"{self.attachment.pk}?filename={self.attachment.media_file.name}"
+            ],
+        )
+
+    def test_enketo_edit_url_skips_deleted_attachments(self):
+        """A deleted attachment is not sent.
+
+        Its file is gone from storage, so a URL for it would only resolve to a
+        broken download.
+        """
+        self._submit_transport_instance_w_attachment()
+        instance = self.xform.instances.all().order_by("id")[0]
+        self.attachment.deleted_at = timezone.now()
+        self.attachment.save()
+        view = DataViewSet.as_view({"get": "enketo"})
+        request = self.factory.get(
+            "/", data={"return_url": "http://test.io/test_url"}, **self.extra
+        )
+
+        captured = {}
+
+        with HTTMock(enketo_edit_capture_mock(captured)):
+            view(request, pk=self.xform.pk, dataid=instance.pk)
+
+        posted = parse_qs(captured["body"])
+
+        self.assertNotIn("instance_attachments[1335783522563.jpg]", posted)
 
     def test_get_form_public_data(self):
         self._make_submissions()

--- a/onadata/apps/api/viewsets/data_viewset.py
+++ b/onadata/apps/api/viewsets/data_viewset.py
@@ -75,7 +75,11 @@ from onadata.libs.utils.cache_tools import (
     safe_cache_set,
 )
 from onadata.libs.utils.common_tools import json_stream, str_to_bool
-from onadata.libs.utils.viewer_tools import get_enketo_urls, get_form_url
+from onadata.libs.utils.viewer_tools import (
+    get_enketo_attachment_params,
+    get_enketo_urls,
+    get_form_url,
+)
 
 SAFE_METHODS = ["GET", "HEAD", "OPTIONS"]
 SUBMISSION_RETRIEVAL_THRESHOLD = getattr(
@@ -350,6 +354,7 @@ class DataViewSet(
                         instance_id=self.object.uuid,
                         instance_xml=self.object.xml,
                         return_url=return_url,
+                        **get_enketo_attachment_params(request, self.object),
                     )
                     if "edit_url" in data:
                         data["url"] = data.pop("edit_url")

--- a/onadata/apps/logger/tests/test_webforms.py
+++ b/onadata/apps/logger/tests/test_webforms.py
@@ -1,14 +1,17 @@
 import os
+from urllib.parse import parse_qs
+
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.urls import reverse
 
 import requests
-from django.urls import reverse
-from httmock import urlmatch, HTTMock
+from httmock import HTTMock, urlmatch
 
 from onadata.apps.logger.models.instance import Instance
 from onadata.apps.logger.views import edit_data
 from onadata.apps.logger.xform_instance_parser import get_uuid_from_xml
 from onadata.apps.main.tests.test_base import TestBase
-from onadata.libs.utils.logger_tools import inject_instanceid
+from onadata.libs.utils.logger_tools import inject_instanceid, save_attachments
 
 
 @urlmatch(netloc=r"(.*\.)?enketo\.ona\.io$")
@@ -19,6 +22,18 @@ def enketo_edit_mock(url, request):
     return response
 
 
+def enketo_edit_capture_mock(captured):
+    """``enketo_edit_mock``, recording the request body into ``captured``."""
+
+    @urlmatch(netloc=r"(.*\.)?enketo\.ona\.io$")
+    def capture(url, request):
+        captured["body"] = request.body
+
+        return enketo_edit_mock(url, request)
+
+    return capture
+
+
 class TestWebforms(TestBase):
     def setUp(self):
         super(TestWebforms, self).setUp()
@@ -27,6 +42,22 @@ class TestWebforms(TestBase):
     def __load_fixture(self, *path):
         with open(os.path.join(os.path.dirname(__file__), *path), "r") as f:
             return f.read()
+
+    def __attach_media(self, instance, media_file):
+        """Attach a fixture media file to an existing submission."""
+        path = os.path.join(
+            self.this_directory,
+            "fixtures",
+            "transportation",
+            "instances",
+            self.surveys[0],
+            media_file,
+        )
+        with open(path, "rb") as f:
+            upload = SimpleUploadedFile(media_file, f.read(), content_type="image/jpeg")
+            save_attachments(self.xform, instance, [upload])
+
+        return instance.attachments.get(name=media_file)
 
     def test_edit_url(self):
         instance = Instance.objects.order_by("id").reverse()[0]
@@ -42,6 +73,38 @@ class TestWebforms(TestBase):
             response = self.client.get(edit_url)
             self.assertEqual(response.status_code, 302)
             self.assertEqual(response["location"], "https://hmh2a.enketo.ona.io")
+
+    def test_edit_url_sends_instance_attachments(self):
+        """The edit link request carries the submission's attachments.
+
+        The instance XML records only their file names, so each is sent paired
+        with an absolute download URL.
+        """
+        instance = Instance.objects.order_by("id").reverse()[0]
+        attachment = self.__attach_media(instance, "1335783522563.jpg")
+        edit_url = reverse(
+            edit_data,
+            kwargs={
+                "username": self.user.username,
+                "id_string": self.xform.id_string,
+                "data_id": instance.id,
+            },
+        )
+
+        captured = {}
+
+        with HTTMock(enketo_edit_capture_mock(captured)):
+            self.client.get(edit_url)
+
+        posted = parse_qs(captured["body"])
+
+        self.assertEqual(
+            posted["instance_attachments[1335783522563.jpg]"],
+            [
+                "http://testserver/api/v1/files/"
+                f"{attachment.pk}?filename={attachment.media_file.name}"
+            ],
+        )
 
     def test_inject_instanceid(self):
         """

--- a/onadata/apps/logger/views.py
+++ b/onadata/apps/logger/views.py
@@ -57,7 +57,12 @@ from onadata.libs.utils.user_auth import (
     has_permission,
     helper_auth_helper,
 )
-from onadata.libs.utils.viewer_tools import get_enketo_urls, get_form, get_form_url
+from onadata.libs.utils.viewer_tools import (
+    get_enketo_attachment_params,
+    get_enketo_urls,
+    get_form,
+    get_form_url,
+)
 
 IO_ERROR_STRINGS = ["request data read error", "error during read(65536) on wsgi.input"]
 
@@ -640,6 +645,7 @@ def edit_data(request, username, id_string, data_id):
             instance_xml=injected_xml,
             instance_id=instance.uuid,
             return_url=return_url,
+            **get_enketo_attachment_params(request, instance),
         )
     except EnketoError as e:
         context.message = {

--- a/onadata/libs/tests/utils/test_export_tools.py
+++ b/onadata/libs/tests/utils/test_export_tools.py
@@ -5,6 +5,7 @@ Test export_tools module
 
 import csv
 import json
+import locale
 import os
 import shutil
 import tempfile
@@ -1086,6 +1087,13 @@ class TestExportTools(TestAbstractViewSet):
         expected_data = {"fruit": {"orange": "Orange", "mango": "Mango"}}
         self.assertEqual(export_builder._get_sav_value_labels(), expected_data)
 
+    def _restore_locale_after_sav_writer(self):
+        # SavWriter applies its ioLocale with locale.setlocale, changing the
+        # locale for the whole process. Unrestored, the C locale it is given
+        # leaves every later open() in this process decoding as ASCII.
+        process_locale = locale.setlocale(locale.LC_ALL)
+        self.addCleanup(locale.setlocale, locale.LC_ALL, process_locale)
+
     def test_sav_duplicate_columns(self):
         more_than_64_char = (
             "akjasdlsakjdkjsadlsakjgdlsagdgdgdsajdgkjdsdgsjadsasdasgdsahdsahdsadgsd"
@@ -1123,6 +1131,7 @@ class TestExportTools(TestAbstractViewSet):
         export_builder.set_survey(survey)
         export_builder.INCLUDE_LABELS = True
         export_builder.set_survey(survey)
+        self._restore_locale_after_sav_writer()
 
         for sec in export_builder.sections:
             sav_options = export_builder._get_sav_options(sec["elements"])
@@ -1137,6 +1146,7 @@ class TestExportTools(TestAbstractViewSet):
         export_builder.set_survey(survey)
         export_builder.INCLUDE_LABELS = True
         export_builder.set_survey(survey)
+        self._restore_locale_after_sav_writer()
 
         for sec in export_builder.sections:
             sav_options = export_builder._get_sav_options(sec["elements"])

--- a/onadata/libs/tests/utils/test_viewer_tools.py
+++ b/onadata/libs/tests/utils/test_viewer_tools.py
@@ -23,6 +23,7 @@ from onadata.libs.utils.viewer_tools import (
     export_def_from_filename,
     generate_enketo_form_defaults,
     get_client_ip,
+    get_enketo_attachment_params,
     get_form,
     get_form_url,
     handle_enketo_error,
@@ -205,6 +206,81 @@ class TestViewerTools(TestBase):
 
         self.assertTrue(rpt_mock.called)
         rpt_mock.assert_called_with(message[0], message[1])
+
+
+class TestGetEnketoAttachmentParams(TestBase):
+    """Test get_enketo_attachment_params()."""
+
+    def setUp(self):
+        super().setUp()
+        self._publish_transportation_form_and_submit_instance()
+        self.instance = Instance.objects.all()[0]
+        self.request = RequestFactory().get("/")
+
+    def _create_attachment(self, name="1335783522563.jpg", **kwargs):
+        """Create an attachment on the submission from the image fixture."""
+        media_file = os.path.join(
+            self.this_directory,
+            "fixtures",
+            "transportation",
+            "instances",
+            self.surveys[0],
+            "1335783522563.jpg",
+        )
+
+        return Attachment.objects.create(
+            instance=self.instance,
+            media_file=File(open(media_file, "rb"), media_file),
+            name=name,
+            **kwargs,
+        )
+
+    def test_maps_file_name_to_absolute_download_url(self):
+        """Each attachment is keyed by file name, with a download URL."""
+        attachment = self._create_attachment()
+
+        params = get_enketo_attachment_params(self.request, self.instance)
+
+        self.assertEqual(
+            params,
+            {
+                "instance_attachments[1335783522563.jpg]": (
+                    "http://testserver/api/v1/files/"
+                    f"{attachment.pk}?filename={attachment.media_file.name}"
+                )
+            },
+        )
+
+    def test_falls_back_to_media_file_basename(self):
+        """Without a recorded name, the stored file's basename is used.
+
+        Attachments predating the name field have none, and media_file holds a
+        full storage path rather than the bare file name the XML references.
+        """
+        attachment = self._create_attachment(name=None)
+
+        params = get_enketo_attachment_params(self.request, self.instance)
+
+        self.assertIn("/", attachment.media_file.name)
+        self.assertEqual(list(params), ["instance_attachments[1335783522563.jpg]"])
+
+    def test_skips_deleted_attachments(self):
+        """A deleted attachment is left out.
+
+        Its file is gone from storage, so a URL for it would only resolve to a
+        broken download.
+        """
+        self._create_attachment(deleted_at=timezone.now())
+
+        params = get_enketo_attachment_params(self.request, self.instance)
+
+        self.assertEqual(params, {})
+
+    def test_submission_without_attachments(self):
+        """A submission with no attachments contributes no params."""
+        params = get_enketo_attachment_params(self.request, self.instance)
+
+        self.assertEqual(params, {})
 
 
 def _mock_response(status_code, content, text=None):

--- a/onadata/libs/tests/utils/test_viewer_tools.py
+++ b/onadata/libs/tests/utils/test_viewer_tools.py
@@ -228,12 +228,13 @@ class TestGetEnketoAttachmentParams(TestBase):
             "1335783522563.jpg",
         )
 
-        return Attachment.objects.create(
-            instance=self.instance,
-            media_file=File(open(media_file, "rb"), media_file),
-            name=name,
-            **kwargs,
-        )
+        with open(media_file, "rb") as media:
+            return Attachment.objects.create(
+                instance=self.instance,
+                media_file=File(media, media_file),
+                name=name,
+                **kwargs,
+            )
 
     def test_maps_file_name_to_absolute_download_url(self):
         """Each attachment is keyed by file name, with a download URL."""

--- a/onadata/libs/utils/viewer_tools.py
+++ b/onadata/libs/utils/viewer_tools.py
@@ -141,6 +141,34 @@ def get_client_ip(request):
     return request.META.get("REMOTE_ADDR")
 
 
+def get_enketo_attachment_params(request, instance) -> Dict[str, str]:
+    """Return the `instance_attachments[<filename>]` params for a submission.
+
+    The instance XML records only the file name of each attachment, so these
+    params pair every one of them with an absolute download URL. They are sent
+    alongside the instance when requesting an edit URL, and without them the
+    attachments cannot be resolved.
+
+    :param request: HttpRequest object, used to make the download URLs absolute.
+    :param instance: Instance object whose attachments to send.
+    """
+    # Avoid cyclic import
+    # pylint: disable=import-outside-toplevel
+    from onadata.apps.logger.models.instance import get_attachment_url
+
+    params = {}
+
+    for attachment in instance.attachments.filter(deleted_at__isnull=True):
+        # `name` is the file name as submitted, which is the one the XML
+        # references; storage may have suffixed `media_file` to avoid a clash.
+        filename = attachment.name or os.path.basename(attachment.media_file.name)
+        params[f"instance_attachments[{filename}]"] = request.build_absolute_uri(
+            get_attachment_url(attachment)
+        )
+
+    return params
+
+
 def get_enketo_urls(
     form_url, id_string, instance_xml=None, instance_id=None, return_url=None, **kwargs
 ) -> Dict[str, str]:


### PR DESCRIPTION
### Changes / Features implemented

No attachment information went out with a request for an edit URL. The request sends the submission itself, which refers to its attachments by file name alone, and nothing saying where those files can be downloaded from.

The request now also includes a download link for each of the submission's current attachments, from both the API and the legacy edit view.

### Steps taken to verify this change does what is intended

- [x] Added tests
- [x] QA

### Side effects of implementing this change

- None

**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  - [ ] Updated documentation

Closes #3211
