### PR TITLE
chore: bump pre-commit hooks for Python 3.13

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,16 +1,16 @@
 default_language_version:
-  python: python3.10
+  python: python3.13
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v6.0.0
     hooks:
       - id: check-added-large-files
       - id: check-yaml
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.6.5
+    rev: v0.16.3
     hooks:
       # Run the linter.
       - id: ruff
@@ -18,11 +18,11 @@ repos:
       # Run the formatter.
       - id: ruff-format
   - repo: https://github.com/psf/black
-    rev: 24.8.0
+    rev: 26.5.1
     hooks:
       - id: black
   - repo: https://github.com/pycqa/isort
-    rev: 5.13.2
+    rev: 8.0.1
     hooks:
       - id: isort
         name: isort (python)


### PR DESCRIPTION
### Changes / Features implemented

- Update the default pre-commit Python version from Python 3.10 to Python 3.13.
- Update pre-commit hook revisions:
  - `pre-commit-hooks`: `v4.6.0` → `v6.0.0`
  - `ruff-pre-commit`: `v0.6.5` → `v0.16.3`
  - Black: `24.8.0` → `26.5.1`
  - isort: `5.13.2` → `8.0.1`
- Preserve the existing hook IDs, ordering, arguments, and behavior.

### Steps taken to verify this change does what is intended

- Ran `pre-commit validate-config`.
- Ran `git diff --check`.
- Confirmed all hook environments use Python 3.13.2.
- Ran all upgraded hooks against the repository.
  - The large-file check passed.
  - The upgraded hooks detected existing YAML, lint, formatting, and import-order issues.
  - Ruff fixed 1,632 findings and reported 1,549 remaining findings.
  - Hook-generated source changes were reviewed and excluded from this config-only PR.

### Side effects of implementing this change

- Developers running all hooks may see substantial formatting and lint changes from the upgraded Ruff, Black, and isort versions.
- This PR itself changes only `.pre-commit-config.yaml`.
- No public APIs, package metadata, CI workflows, or application behavior are changed.


**Before submitting this PR for review, please make sure you have:**

  - [ ] Included tests — not applicable; this is a tooling configuration change
  - [ ] Updated documentation — not applicable; there are no user-facing changes

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/onaio/codesmith/onadata/pr/3213"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789307426&installation_model_id=422582&pr_number=3213&repository=onaio%2Fonadata&return_to=https%3A%2F%2Fgithub.com%2Fonaio%2Fonadata%2Fpull%2F3213&signature=3c872d976997c621d6f94e0709ce7dd3dd86b5278bc9d40653e4087523b928a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->