### PR TITLE
Fix flaky submission deletion and CSV export tests

### DIFF
--- a/onadata/libs/tests/utils/test_csv_builder.py
+++ b/onadata/libs/tests/utils/test_csv_builder.py
@@ -570,7 +570,7 @@ class TestCSVDataFrameBuilder(TestBase):
             self.xform.instances.all().order_by("id").values_list("json", flat=True)
         )
         csv_df_builder.export_to(temp_file.name, cursor)
-        csv_file = open(temp_file.name, "r")
+        csv_file = open(temp_file.name, "r", encoding="utf-8", newline="")
         csv_reader = csv.reader(csv_file)
         header = next(csv_reader)
         self.assertEqual(len(header), 17 + len(csv_df_builder.extra_columns))

--- a/onadata/libs/tests/utils/test_logger_tools.py
+++ b/onadata/libs/tests/utils/test_logger_tools.py
@@ -1115,10 +1115,11 @@ class DeleteXFormSubmissionsTestCase(TestBase):
     @patch("onadata.libs.utils.logger_tools.send_message")
     def test_action_recorded(self, mock_send_message):
         """Action is recorded in the audit log"""
-        delete_xform_submissions(self.xform, self.user, [self.instances[0].pk])
+        instance_id = self.instances[0].pk
+        delete_xform_submissions(self.xform, self.user, [instance_id])
 
         mock_send_message.assert_called_once_with(
-            instance_id=[self.instances[0].pk],
+            instance_id=[instance_id],
             target_id=self.xform.id,
             target_type="xform",
             user=self.user,


### PR DESCRIPTION
### Changes / Features implemented

- Stabilize `DeleteXFormSubmissionsTestCase.test_action_recorded` by resolving the selected submission ID before deletion and reusing it in the audit-log assertion.
- Stabilize `TestCSVDataFrameBuilder.test_windows_excel_compatible_csv_export` by reading the UTF-8 CSV with an explicit encoding instead of the process locale.
- Keep production audit logging, CSV generation, and public interfaces unchanged.

### Steps taken to verify this change does what is intended

- Ran `DeleteXFormSubmissionsTestCase.test_action_recorded` using Python 3.13.2 and the GitHub Actions settings.
- Ran the complete `DeleteXFormSubmissionsTestCase`; all 13 tests passed.
- Ran `test_windows_excel_compatible_csv_export` under the normal local locale.
- Ran the same CSV test with `LC_ALL=C`, Python UTF-8 mode disabled, and locale coercion disabled; it passed with an ASCII process default.
- Ran the complete `TestCSVDataFrameBuilder`; all 40 tests passed.

### Side effects of implementing this change

None expected. These are test-only changes.


**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  - [x] Updated documentation (not applicable to these test-only changes)
