### PR TITLE
feat(messaging): audit log profile changes

### DIFF
--- a/docs/messaging.rst
+++ b/docs/messaging.rst
@@ -39,6 +39,8 @@ This endpoint provides access to event messages sent for a specific target. Wher
 
     - ``entitylist_deleted``
 
+    - ``require_auth_changed``
+
 
 GET All event messages that have been sent for a form
 ------------------------------------------------------

--- a/docs/messaging.rst
+++ b/docs/messaging.rst
@@ -39,7 +39,7 @@ This endpoint provides access to event messages sent for a specific target. Wher
 
     - ``entitylist_deleted``
 
-    - ``require_auth_changed``
+    - ``profile_updated``
 
 
 GET All event messages that have been sent for a form

--- a/onadata/apps/api/admin.py
+++ b/onadata/apps/api/admin.py
@@ -1,8 +1,11 @@
 # -*- coding: utf-8 -*-
 """API Django admin amendments."""
+
 from django.contrib import admin
 
-from onadata.apps.api.models import Team, OrganizationProfile, TempToken
+from reversion.admin import VersionAdmin
+
+from onadata.apps.api.models import OrganizationProfile, Team, TempToken
 
 
 # pylint: disable=too-few-public-methods
@@ -24,7 +27,7 @@ class TeamAdmin(FilterSuperuserMixin, admin.ModelAdmin):
 admin.site.register(Team, TeamAdmin)
 
 
-class OrganizationProfileAdmin(FilterSuperuserMixin, admin.ModelAdmin):
+class OrganizationProfileAdmin(FilterSuperuserMixin, VersionAdmin, admin.ModelAdmin):
     """Filter by request.user unless is_superuser."""
 
 

--- a/onadata/apps/api/models/organization_profile.py
+++ b/onadata/apps/api/models/organization_profile.py
@@ -11,6 +11,7 @@ from django.db import models
 from django.db.models.signals import post_delete, post_save
 from django.utils.translation import gettext_lazy as _
 
+import reversion
 from guardian.models import GroupObjectPermissionBase, UserObjectPermissionBase
 from guardian.shortcuts import assign_perm, get_perms_for_model
 from multidb.pinning import use_master
@@ -246,3 +247,6 @@ class OrgProfileGroupObjectPermission(GroupObjectPermissionBase):
     """Guardian model to create direct foreign keys."""
 
     content_object = models.ForeignKey(OrganizationProfile, on_delete=models.CASCADE)
+
+
+reversion.register(OrganizationProfile, follow=("userprofile_ptr",))

--- a/onadata/apps/api/tests/models/test_organization_profile.py
+++ b/onadata/apps/api/tests/models/test_organization_profile.py
@@ -3,7 +3,10 @@ from django.core.cache import cache
 from django.db import IntegrityError
 from django.test import override_settings
 
+import reversion
 from moto import mock_aws
+from reversion import revisions
+from reversion.models import Version
 
 from onadata.apps.api import tools
 from onadata.apps.api.models.organization_profile import OrganizationProfile
@@ -122,3 +125,26 @@ class TestOrganizationProfile(TestBase):
         )
 
         self.assertEqual(kms_key_qs.count(), 0)
+
+
+class OrganizationProfileReversionRegistrationTestCase(TestBase):
+    """Test OrganizationProfile is registered with django-reversion."""
+
+    def test_organization_profile_is_registered(self):
+        """OrganizationProfile is registered with django-reversion."""
+        self.assertTrue(reversion.is_registered(OrganizationProfile))
+
+    def test_revision_recorded_and_read(self):
+        """An OrganizationProfile saved in a revision is recorded and readable."""
+        profile = tools.create_organization_object(
+            "modilabs", self.user, {"name": "Modi Labs", "email": "info@modilabs.org"}
+        )
+        profile.save()
+
+        with revisions.create_revision():
+            revisions.add_to_revision(profile)
+
+        version = Version.objects.get_for_object(profile).first()
+        self.assertIsNotNone(version)
+        self.assertEqual(version.field_dict["email"], "info@modilabs.org")
+        self.assertEqual(version.field_dict["name"], "Modi Labs")

--- a/onadata/apps/api/tests/models/test_organization_profile.py
+++ b/onadata/apps/api/tests/models/test_organization_profile.py
@@ -126,10 +126,6 @@ class TestOrganizationProfile(TestBase):
 
         self.assertEqual(kms_key_qs.count(), 0)
 
-
-class OrganizationProfileReversionRegistrationTestCase(TestBase):
-    """Test OrganizationProfile is registered with django-reversion."""
-
     def test_organization_profile_is_registered(self):
         """OrganizationProfile is registered with django-reversion."""
         self.assertTrue(reversion.is_registered(OrganizationProfile))

--- a/onadata/apps/api/tests/models/test_organization_profile.py
+++ b/onadata/apps/api/tests/models/test_organization_profile.py
@@ -1,3 +1,4 @@
+from django.contrib.auth.models import User
 from django.contrib.contenttypes.models import ContentType
 from django.core.cache import cache
 from django.db import IntegrityError
@@ -132,10 +133,12 @@ class TestOrganizationProfile(TestBase):
 
     def test_revision_recorded_and_read(self):
         """An OrganizationProfile saved in a revision is recorded and readable."""
-        profile = tools.create_organization_object(
-            "modilabs", self.user, {"name": "Modi Labs", "email": "info@modilabs.org"}
+        profile = OrganizationProfile.objects.create(
+            user=User.objects.create(username="modilabs"),
+            creator=self.user,
+            name="Modi Labs",
+            email="info@modilabs.org",
         )
-        profile.save()
 
         with revisions.create_revision():
             revisions.add_to_revision(profile)

--- a/onadata/apps/api/tests/viewsets/test_organization_profile_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_organization_profile_viewset.py
@@ -90,8 +90,8 @@ class TestOrganizationProfileViewSet(TestAbstractViewSet):
             response.data["name"], ["Ensure this field has no more than 30 characters."]
         )
 
-    def test_require_auth_change_is_recorded(self):
-        """Changing require_auth records who changed it and the old and new value."""
+    def test_require_auth_change_is_audit_logged(self):
+        """Changing require_auth is audit logged."""
         self._org_create()
         request = self.factory.patch(
             "/",

--- a/onadata/apps/api/tests/viewsets/test_organization_profile_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_organization_profile_viewset.py
@@ -36,6 +36,7 @@ from onadata.apps.api.viewsets.user_profile_viewset import UserProfileViewSet
 from onadata.apps.logger.models.kms import KMSKey
 from onadata.apps.logger.models.project import Project
 from onadata.apps.main.models import UserProfile
+from onadata.apps.messaging.viewsets import MessagingViewSet
 from onadata.libs.exceptions import EncryptionError
 from onadata.libs.permissions import ROLES, DataEntryRole, OwnerRole
 from onadata.libs.utils.cache_tools import (
@@ -87,6 +88,44 @@ class TestOrganizationProfileViewSet(TestAbstractViewSet):
         self.assertEqual(response.status_code, 400)
         self.assertEqual(
             response.data["name"], ["Ensure this field has no more than 30 characters."]
+        )
+
+    def test_require_auth_change_is_recorded(self):
+        """Changing require_auth records who changed it and the old and new value."""
+        self._org_create()
+        request = self.factory.patch(
+            "/",
+            data=json.dumps({"require_auth": True}),
+            content_type="application/json",
+            **self.extra,
+        )
+        response = self.view(request, user="denoinc")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.data["require_auth"])
+
+        messaging_view = MessagingViewSet.as_view({"get": "list"})
+        request = self.factory.get(
+            "/messaging",
+            {
+                "target_type": "user",
+                "target_id": self.organization.user.pk,
+                "verb": "require_auth_changed",
+            },
+            **self.extra,
+        )
+        response = messaging_view(request)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 1)
+        message = response.data[0]
+        self.assertEqual(message["user"], "bob")
+        self.assertEqual(
+            json.loads(message["message"]),
+            {
+                "id": [self.organization.pk],
+                "description": "require_auth changed from False to True",
+            },
         )
 
     def test_orgs_list(self):

--- a/onadata/apps/api/tests/viewsets/test_organization_profile_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_organization_profile_viewset.py
@@ -17,6 +17,7 @@ from django.utils import timezone
 
 from guardian.shortcuts import get_perms
 from rest_framework import status
+from reversion.models import Version
 
 from onadata.apps.api.models.organization_profile import (
     OrganizationProfile,
@@ -71,6 +72,7 @@ class TestOrganizationProfileViewSet(TestAbstractViewSet):
 
     def test_partial_updates(self):
         self._org_create()
+        version_count = Version.objects.get_for_object(self.organization).count()
         metadata = {"computer": "mac"}
         json_metadata = json.dumps(metadata)
         data = {"metadata": json_metadata}
@@ -79,6 +81,11 @@ class TestOrganizationProfileViewSet(TestAbstractViewSet):
         profile = OrganizationProfile.objects.get(name="Dennis")
         self.assertEqual(response.status_code, 200)
         self.assertEqual(profile.metadata, metadata)
+
+        # reversion: partial update records a new version
+        versions = Version.objects.get_for_object(self.organization)
+        self.assertEqual(versions.count(), version_count + 1)
+        self.assertEqual(versions[0].revision.user, self.user)
 
     def test_partial_updates_invalid(self):
         self._org_create()
@@ -277,6 +284,11 @@ class TestOrganizationProfileViewSet(TestAbstractViewSet):
         self._org_create()
         self.assertTrue(self.organization.user.is_active)
         self.assertEqual(self.organization.email, "mail@mail-server.org")
+
+        # reversion: creating an organization records a version
+        versions = Version.objects.get_for_object(self.organization)
+        self.assertEqual(versions.count(), 1)
+        self.assertEqual(versions[0].revision.user, self.user)
 
     def test_orgs_create_without_name(self):
         data = {

--- a/onadata/apps/api/tests/viewsets/test_organization_profile_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_organization_profile_viewset.py
@@ -90,12 +90,12 @@ class TestOrganizationProfileViewSet(TestAbstractViewSet):
             response.data["name"], ["Ensure this field has no more than 30 characters."]
         )
 
-    def test_require_auth_change_is_audit_logged(self):
-        """Changing require_auth is audit logged."""
+    def test_organization_update_is_audit_logged(self):
+        """Updating an organization is audit logged."""
         self._org_create()
         request = self.factory.patch(
             "/",
-            data=json.dumps({"require_auth": True}),
+            data=json.dumps({"require_auth": True, "email": "info@denoinc.org"}),
             content_type="application/json",
             **self.extra,
         )
@@ -103,6 +103,7 @@ class TestOrganizationProfileViewSet(TestAbstractViewSet):
 
         self.assertEqual(response.status_code, 200)
         self.assertTrue(response.data["require_auth"])
+        self.assertEqual(response.data["email"], "info@denoinc.org")
 
         messaging_view = MessagingViewSet.as_view({"get": "list"})
         request = self.factory.get(
@@ -110,7 +111,7 @@ class TestOrganizationProfileViewSet(TestAbstractViewSet):
             {
                 "target_type": "user",
                 "target_id": self.organization.user.pk,
-                "verb": "require_auth_changed",
+                "verb": "profile_updated",
             },
             **self.extra,
         )
@@ -124,7 +125,10 @@ class TestOrganizationProfileViewSet(TestAbstractViewSet):
             json.loads(message["message"]),
             {
                 "id": [self.organization.pk],
-                "description": "require_auth changed from False to True",
+                "description": {
+                    "require_auth": {"old": False, "new": True},
+                    "email": {},
+                },
             },
         )
 

--- a/onadata/apps/api/tests/viewsets/test_user_profile_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_user_profile_viewset.py
@@ -22,6 +22,7 @@ from django_digest.test import DigestAuth
 from httmock import HTTMock, all_requests
 from registration.models import RegistrationProfile
 from rest_framework.authtoken.models import Token
+from reversion.models import Version
 from six.moves.urllib.parse import parse_qs, urlparse
 
 from onadata.apps.api.tests.viewsets.test_abstract_viewset import TestAbstractViewSet
@@ -288,6 +289,11 @@ class TestUserProfileViewSet(TestAbstractViewSet):
         user = User.objects.get(username="deno")
         self.assertTrue(user.is_active)
         self.assertTrue(user.check_password(password), password)
+
+        # reversion: creating a profile records a version
+        versions = Version.objects.get_for_object(profile)
+        self.assertEqual(versions.count(), 1)
+        self.assertEqual(versions[0].revision.user, self.user)
 
     @override_settings(DISABLE_CREATING_USERS=True)
     def test_block_profile_create(self):
@@ -586,6 +592,7 @@ class TestUserProfileViewSet(TestAbstractViewSet):
 
     def test_partial_updates(self):
         self.assertEqual(self.user.profile.country, "US")
+        version_count = Version.objects.get_for_object(self.user.profile).count()
         country = "KE"
         username = "george"
         metadata = {"computer": "mac"}
@@ -598,6 +605,11 @@ class TestUserProfileViewSet(TestAbstractViewSet):
         self.assertEqual(profile.country, country)
         self.assertEqual(profile.metadata, metadata)
         self.assertEqual(profile.user.username, username)
+
+        # reversion: partial update records a new version
+        versions = Version.objects.get_for_object(profile)
+        self.assertEqual(versions.count(), version_count + 1)
+        self.assertEqual(versions[0].revision.user, self.user)
 
     def test_profile_update_is_audit_logged(self):
         """Updating a profile is audit logged."""

--- a/onadata/apps/api/tests/viewsets/test_user_profile_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_user_profile_viewset.py
@@ -599,11 +599,11 @@ class TestUserProfileViewSet(TestAbstractViewSet):
         self.assertEqual(profile.metadata, metadata)
         self.assertEqual(profile.user.username, username)
 
-    def test_require_auth_change_is_audit_logged(self):
-        """Changing require_auth is audit logged."""
+    def test_profile_update_is_audit_logged(self):
+        """Updating a profile is audit logged."""
         request = self.factory.patch(
             "/",
-            data=json.dumps({"require_auth": True}),
+            data=json.dumps({"require_auth": True, "city": "Nairobi"}),
             content_type="application/json",
             **self.extra,
         )
@@ -611,6 +611,7 @@ class TestUserProfileViewSet(TestAbstractViewSet):
 
         self.assertEqual(response.status_code, 200)
         self.assertTrue(response.data["require_auth"])
+        self.assertEqual(response.data["city"], "Nairobi")
 
         messaging_view = MessagingViewSet.as_view({"get": "list"})
         request = self.factory.get(
@@ -618,7 +619,7 @@ class TestUserProfileViewSet(TestAbstractViewSet):
             {
                 "target_type": "user",
                 "target_id": self.user.pk,
-                "verb": "require_auth_changed",
+                "verb": "profile_updated",
             },
             **self.extra,
         )
@@ -632,7 +633,10 @@ class TestUserProfileViewSet(TestAbstractViewSet):
             json.loads(message["message"]),
             {
                 "id": [self.user.profile.pk],
-                "description": "require_auth changed from False to True",
+                "description": {
+                    "require_auth": {"old": False, "new": True},
+                    "city": {"old": "Bobville", "new": "Nairobi"},
+                },
             },
         )
 

--- a/onadata/apps/api/tests/viewsets/test_user_profile_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_user_profile_viewset.py
@@ -599,8 +599,8 @@ class TestUserProfileViewSet(TestAbstractViewSet):
         self.assertEqual(profile.metadata, metadata)
         self.assertEqual(profile.user.username, username)
 
-    def test_require_auth_change_is_recorded(self):
-        """Changing require_auth records who changed it and the old and new value."""
+    def test_require_auth_change_is_audit_logged(self):
+        """Changing require_auth is audit logged."""
         request = self.factory.patch(
             "/",
             data=json.dumps({"require_auth": True}),

--- a/onadata/apps/api/tests/viewsets/test_user_profile_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_user_profile_viewset.py
@@ -31,6 +31,7 @@ from onadata.apps.logger.models.instance import Instance
 from onadata.apps.logger.models.project_invitation import ProjectInvitation
 from onadata.apps.main.models import UserProfile
 from onadata.apps.main.models.user_profile import set_kpi_formbuilder_permissions
+from onadata.apps.messaging.viewsets import MessagingViewSet
 from onadata.libs.authentication import DigestAuthentication
 from onadata.libs.permissions import EditorRole
 from onadata.libs.serializers.user_profile_serializer import _get_first_last_names
@@ -597,6 +598,43 @@ class TestUserProfileViewSet(TestAbstractViewSet):
         self.assertEqual(profile.country, country)
         self.assertEqual(profile.metadata, metadata)
         self.assertEqual(profile.user.username, username)
+
+    def test_require_auth_change_is_recorded(self):
+        """Changing require_auth records who changed it and the old and new value."""
+        request = self.factory.patch(
+            "/",
+            data=json.dumps({"require_auth": True}),
+            content_type="application/json",
+            **self.extra,
+        )
+        response = self.view(request, user=self.user.username)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.data["require_auth"])
+
+        messaging_view = MessagingViewSet.as_view({"get": "list"})
+        request = self.factory.get(
+            "/messaging",
+            {
+                "target_type": "user",
+                "target_id": self.user.pk,
+                "verb": "require_auth_changed",
+            },
+            **self.extra,
+        )
+        response = messaging_view(request)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 1)
+        message = response.data[0]
+        self.assertEqual(message["user"], "bob")
+        self.assertEqual(
+            json.loads(message["message"]),
+            {
+                "id": [self.user.profile.pk],
+                "description": "require_auth changed from False to True",
+            },
+        )
 
     def test_partial_updates_empty_metadata(self):
         profile = UserProfile.objects.get(user=self.user)

--- a/onadata/apps/api/viewsets/organization_profile_viewset.py
+++ b/onadata/apps/api/viewsets/organization_profile_viewset.py
@@ -14,6 +14,7 @@ from rest_framework import status
 from rest_framework.decorators import action
 from rest_framework.response import Response
 from rest_framework.viewsets import ModelViewSet
+from reversion.views import RevisionMixin
 
 from onadata.apps.api import permissions
 from onadata.apps.api.models.organization_profile import OrganizationProfile
@@ -61,6 +62,7 @@ class OrganizationProfileViewSet(
     CacheControlMixin,
     ETagsMixin,
     ObjectLookupMixin,
+    RevisionMixin,
     BaseViewset,
     ModelViewSet,
 ):

--- a/onadata/apps/api/viewsets/user_profile_viewset.py
+++ b/onadata/apps/api/viewsets/user_profile_viewset.py
@@ -24,6 +24,7 @@ from rest_framework.filters import OrderingFilter
 from rest_framework.generics import get_object_or_404
 from rest_framework.response import Response
 from rest_framework.viewsets import ModelViewSet
+from reversion.views import RevisionMixin
 from six.moves.urllib.parse import urlencode
 
 from onadata.apps.api.constants import USERNAME_LOOKUP_REGEX
@@ -158,6 +159,7 @@ class UserProfileViewSet(
     CacheControlMixin,
     ETagsMixin,
     ObjectLookupMixin,
+    RevisionMixin,
     BaseViewset,
     ModelViewSet,
 ):

--- a/onadata/apps/main/models/user_profile.py
+++ b/onadata/apps/main/models/user_profile.py
@@ -2,6 +2,7 @@
 """
 UserProfile model class
 """
+
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.db import models
@@ -10,6 +11,7 @@ from django.utils.translation import gettext_lazy
 
 import jwt
 import requests
+import reversion
 from guardian.models import GroupObjectPermissionBase, UserObjectPermissionBase
 from guardian.shortcuts import assign_perm, get_perms_for_model
 from rest_framework.authtoken.models import Token
@@ -188,3 +190,6 @@ class UserProfileGroupObjectPermission(GroupObjectPermissionBase):
     """Guardian model to create direct foreign keys."""
 
     content_object = models.ForeignKey(UserProfile, on_delete=models.CASCADE)
+
+
+reversion.register(UserProfile)

--- a/onadata/apps/main/tests/test_user_profile.py
+++ b/onadata/apps/main/tests/test_user_profile.py
@@ -13,7 +13,12 @@ from django.test import RequestFactory
 from django.urls import reverse
 from django.urls.exceptions import NoReverseMatch
 
+import reversion
+from reversion import revisions
+from reversion.models import Version
+
 from onadata.apps.logger.xform_instance_parser import XLSFormError
+from onadata.apps.main.models import UserProfile
 from onadata.apps.main.tests.test_base import TestBase
 from onadata.apps.main.views import api_token, profile
 from onadata.libs.utils.common_tools import merge_dicts
@@ -250,3 +255,24 @@ class TestUserProfile(TestBase):
                 self.assertIn(username, unquote(url))
             except NoReverseMatch as e:
                 self.fail(f"URL reverse failed for Unicode username '{username}': {e}")
+
+
+class UserProfileReversionRegistrationTestCase(TestBase):
+    """Test UserProfile is registered with django-reversion."""
+
+    def test_user_profile_is_registered(self):
+        """UserProfile is registered with django-reversion."""
+        self.assertTrue(reversion.is_registered(UserProfile))
+
+    def test_revision_recorded_and_read(self):
+        """A UserProfile saved in a revision is recorded and readable."""
+        user_profile = self.user.profile
+        user_profile.city = "Nairobi"
+        user_profile.save()
+
+        with revisions.create_revision():
+            revisions.add_to_revision(user_profile)
+
+        version = Version.objects.get_for_object(user_profile).first()
+        self.assertIsNotNone(version)
+        self.assertEqual(version.field_dict["city"], "Nairobi")

--- a/onadata/apps/main/tests/test_user_profile.py
+++ b/onadata/apps/main/tests/test_user_profile.py
@@ -256,10 +256,6 @@ class TestUserProfile(TestBase):
             except NoReverseMatch as e:
                 self.fail(f"URL reverse failed for Unicode username '{username}': {e}")
 
-
-class UserProfileReversionRegistrationTestCase(TestBase):
-    """Test UserProfile is registered with django-reversion."""
-
     def test_user_profile_is_registered(self):
         """UserProfile is registered with django-reversion."""
         self.assertTrue(reversion.is_registered(UserProfile))

--- a/onadata/apps/messaging/constants.py
+++ b/onadata/apps/messaging/constants.py
@@ -35,6 +35,7 @@ FORM_UPDATED = "form_updated"
 KMS_KEY_ROTATED = "kmskey_rotated"
 ENTITY_LIST_IMPORTED = "entitylist_imported"
 ENTITY_LIST_DELETED = "entitylist_deleted"
+REQUIRE_AUTH_CHANGED = "require_auth_changed"
 MESSAGE_VERBS = [
     MESSAGE,
     SUBMISSION_REVIEWED,
@@ -47,6 +48,7 @@ MESSAGE_VERBS = [
     EXPORT_DOWNLOADED,
     ENTITY_LIST_IMPORTED,
     ENTITY_LIST_DELETED,
+    REQUIRE_AUTH_CHANGED,
 ]
 VERB_TOPIC_DICT = {
     SUBMISSION_CREATED: "submission/created",
@@ -57,4 +59,5 @@ VERB_TOPIC_DICT = {
     KMS_KEY_ROTATED: "kmskey/rotated",
     ENTITY_LIST_IMPORTED: "entitylist/imported",
     ENTITY_LIST_DELETED: "entitylist/deleted",
+    REQUIRE_AUTH_CHANGED: "require_auth/changed",
 }

--- a/onadata/apps/messaging/constants.py
+++ b/onadata/apps/messaging/constants.py
@@ -35,7 +35,7 @@ FORM_UPDATED = "form_updated"
 KMS_KEY_ROTATED = "kmskey_rotated"
 ENTITY_LIST_IMPORTED = "entitylist_imported"
 ENTITY_LIST_DELETED = "entitylist_deleted"
-REQUIRE_AUTH_CHANGED = "require_auth_changed"
+PROFILE_UPDATED = "profile_updated"
 MESSAGE_VERBS = [
     MESSAGE,
     SUBMISSION_REVIEWED,
@@ -48,7 +48,7 @@ MESSAGE_VERBS = [
     EXPORT_DOWNLOADED,
     ENTITY_LIST_IMPORTED,
     ENTITY_LIST_DELETED,
-    REQUIRE_AUTH_CHANGED,
+    PROFILE_UPDATED,
 ]
 VERB_TOPIC_DICT = {
     SUBMISSION_CREATED: "submission/created",
@@ -59,5 +59,5 @@ VERB_TOPIC_DICT = {
     KMS_KEY_ROTATED: "kmskey/rotated",
     ENTITY_LIST_IMPORTED: "entitylist/imported",
     ENTITY_LIST_DELETED: "entitylist/deleted",
-    REQUIRE_AUTH_CHANGED: "require_auth/changed",
+    PROFILE_UPDATED: "profile/updated",
 }

--- a/onadata/libs/serializers/organization_serializer.py
+++ b/onadata/libs/serializers/organization_serializer.py
@@ -20,15 +20,31 @@ from onadata.apps.api.tools import (
 from onadata.apps.logger.models import KMSKey
 from onadata.apps.main.forms import RegistrationFormUserProfile
 from onadata.apps.main.models.user_profile import UserProfile
-from onadata.apps.messaging.constants import REQUIRE_AUTH_CHANGED, USER
-from onadata.apps.messaging.serializers import send_message
 from onadata.libs.exceptions import EncryptionError
 from onadata.libs.kms.tools import rotate_key
 from onadata.libs.permissions import CAN_ADD_ORGANIZATION_PROJECT, get_role_in_org
 from onadata.libs.serializers.fields.json_field import JsonField
+from onadata.libs.serializers.user_profile_serializer import (
+    get_audit_values,
+    send_profile_updated_message,
+)
 
 # pylint: disable=invalid-name
 User = get_user_model()
+
+# Organization profile attributes whose changes are audit logged.
+ORGANIZATION_AUDIT_FIELDS = (
+    "name",
+    "email",
+    "city",
+    "country",
+    "home_page",
+    "twitter",
+    "description",
+    "require_auth",
+    "address",
+    "phonenumber",
+)
 
 
 class KMSKeyInlineSerializer(serializers.ModelSerializer):
@@ -99,6 +115,7 @@ class OrganizationSerializer(serializers.HyperlinkedModelSerializer):
 
     def update(self, instance, validated_data):
         """Update organization profile properties."""
+        old_values = get_audit_values(instance, ORGANIZATION_AUDIT_FIELDS)
         # update the user model
         if "name" in validated_data:
             first_name, last_name = _get_first_last_names(validated_data.get("name"))
@@ -109,21 +126,13 @@ class OrganizationSerializer(serializers.HyperlinkedModelSerializer):
             instance.email = validated_data.pop("email")
 
         instance.user.save()
-        old_require_auth = instance.require_auth
         instance = super().update(instance, validated_data)
-
-        if instance.require_auth != old_require_auth:
-            send_message(
-                instance_id=instance.pk,
-                target_id=instance.user.pk,
-                target_type=USER,
-                user=self.context["request"].user,
-                message_verb=REQUIRE_AUTH_CHANGED,
-                message_description=(
-                    f"require_auth changed from {old_require_auth} "
-                    f"to {instance.require_auth}"
-                ),
-            )
+        send_profile_updated_message(
+            instance,
+            old_values,
+            ORGANIZATION_AUDIT_FIELDS,
+            self.context["request"].user,
+        )
 
         return instance
 

--- a/onadata/libs/serializers/organization_serializer.py
+++ b/onadata/libs/serializers/organization_serializer.py
@@ -20,6 +20,8 @@ from onadata.apps.api.tools import (
 from onadata.apps.logger.models import KMSKey
 from onadata.apps.main.forms import RegistrationFormUserProfile
 from onadata.apps.main.models.user_profile import UserProfile
+from onadata.apps.messaging.constants import REQUIRE_AUTH_CHANGED, USER
+from onadata.apps.messaging.serializers import send_message
 from onadata.libs.exceptions import EncryptionError
 from onadata.libs.kms.tools import rotate_key
 from onadata.libs.permissions import CAN_ADD_ORGANIZATION_PROJECT, get_role_in_org
@@ -107,7 +109,23 @@ class OrganizationSerializer(serializers.HyperlinkedModelSerializer):
             instance.email = validated_data.pop("email")
 
         instance.user.save()
-        return super().update(instance, validated_data)
+        old_require_auth = instance.require_auth
+        instance = super().update(instance, validated_data)
+
+        if instance.require_auth != old_require_auth:
+            send_message(
+                instance_id=instance.pk,
+                target_id=instance.user.pk,
+                target_type=USER,
+                user=self.context["request"].user,
+                message_verb=REQUIRE_AUTH_CHANGED,
+                message_description=(
+                    f"require_auth changed from {old_require_auth} "
+                    f"to {instance.require_auth}"
+                ),
+            )
+
+        return instance
 
     def create(self, validated_data):
         """Create an organization profile."""

--- a/onadata/libs/serializers/user_profile_serializer.py
+++ b/onadata/libs/serializers/user_profile_serializer.py
@@ -5,6 +5,7 @@ UserProfile Serializers.
 
 import copy
 import re
+from operator import attrgetter
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
@@ -26,7 +27,7 @@ from onadata.apps.api.tasks import send_verification_email
 from onadata.apps.api.tools import get_host_domain
 from onadata.apps.main.forms import RegistrationFormUserProfile
 from onadata.apps.main.models import UserProfile
-from onadata.apps.messaging.constants import REQUIRE_AUTH_CHANGED, USER
+from onadata.apps.messaging.constants import PROFILE_UPDATED, USER
 from onadata.apps.messaging.serializers import send_message
 from onadata.libs.authentication import expired
 from onadata.libs.permissions import CAN_VIEW_PROFILE, is_organization
@@ -38,9 +39,61 @@ from onadata.libs.utils.email import get_verification_email_data, get_verificati
 RESERVED_NAMES = RegistrationFormUserProfile.RESERVED_USERNAMES
 LEGAL_USERNAMES_REGEX = RegistrationFormUserProfile.legal_usernames_re
 
+# Profile attributes whose changes are audit logged.
+USER_PROFILE_AUDIT_FIELDS = (
+    "user.username",
+    "user.first_name",
+    "user.last_name",
+    "user.email",
+    "name",
+    "city",
+    "country",
+    "organization",
+    "home_page",
+    "twitter",
+    "require_auth",
+)
+# Audited fields whose values are left out of the audit log.
+CONTACT_AUDIT_FIELDS = ("email", "phonenumber")
+
 
 # pylint: disable=invalid-name
 User = get_user_model()
+
+
+def get_audit_values(profile, fields):
+    """Returns the current values of the audited ``fields`` on ``profile``.
+
+    Each field is an attribute path on the profile, e.g. ``user.email``; the
+    values are keyed by the attribute name.
+    """
+    return {field.rsplit(".", 1)[-1]: attrgetter(field)(profile) for field in fields}
+
+
+def send_profile_updated_message(profile, old_values, fields, user):
+    """Audit logs the audited ``fields`` of ``profile`` that changed since ``old_values``.
+
+    Each changed field maps to its old and new value, except contact fields
+    which are recorded without their values.
+    """
+    changes = {}
+    for field, new_value in get_audit_values(profile, fields).items():
+        if new_value != old_values[field]:
+            changes[field] = (
+                {}
+                if field in CONTACT_AUDIT_FIELDS
+                else {"old": old_values[field], "new": new_value}
+            )
+
+    if changes:
+        send_message(
+            instance_id=profile.pk,
+            target_id=profile.user.pk,
+            target_type=USER,
+            user=user,
+            message_verb=PROFILE_UPDATED,
+            message_description=changes,
+        )
 
 
 def _get_first_last_names(name, limit=30):
@@ -223,6 +276,7 @@ class UserProfileSerializer(serializers.HyperlinkedModelSerializer):
 
     def update(self, instance, validated_data):
         """Update user properties."""
+        old_values = get_audit_values(instance, USER_PROFILE_AUDIT_FIELDS)
         params = validated_data
         password = params.get("password1")
         email = params.get("email")
@@ -258,21 +312,13 @@ class UserProfileSerializer(serializers.HyperlinkedModelSerializer):
             # force django-digest to regenerate its stored partial digests
             update_partial_digests(instance.user, password)
 
-        old_require_auth = instance.require_auth
         instance = super().update(instance, params)
-
-        if instance.require_auth != old_require_auth:
-            send_message(
-                instance_id=instance.pk,
-                target_id=instance.user.pk,
-                target_type=USER,
-                user=self.context["request"].user,
-                message_verb=REQUIRE_AUTH_CHANGED,
-                message_description=(
-                    f"require_auth changed from {old_require_auth} "
-                    f"to {instance.require_auth}"
-                ),
-            )
+        send_profile_updated_message(
+            instance,
+            old_values,
+            USER_PROFILE_AUDIT_FIELDS,
+            self.context["request"].user,
+        )
 
         return instance
 

--- a/onadata/libs/serializers/user_profile_serializer.py
+++ b/onadata/libs/serializers/user_profile_serializer.py
@@ -26,6 +26,8 @@ from onadata.apps.api.tasks import send_verification_email
 from onadata.apps.api.tools import get_host_domain
 from onadata.apps.main.forms import RegistrationFormUserProfile
 from onadata.apps.main.models import UserProfile
+from onadata.apps.messaging.constants import REQUIRE_AUTH_CHANGED, USER
+from onadata.apps.messaging.serializers import send_message
 from onadata.libs.authentication import expired
 from onadata.libs.permissions import CAN_VIEW_PROFILE, is_organization
 from onadata.libs.serializers.fields.json_field import JsonField
@@ -256,7 +258,23 @@ class UserProfileSerializer(serializers.HyperlinkedModelSerializer):
             # force django-digest to regenerate its stored partial digests
             update_partial_digests(instance.user, password)
 
-        return super().update(instance, params)
+        old_require_auth = instance.require_auth
+        instance = super().update(instance, params)
+
+        if instance.require_auth != old_require_auth:
+            send_message(
+                instance_id=instance.pk,
+                target_id=instance.user.pk,
+                target_type=USER,
+                user=self.context["request"].user,
+                message_verb=REQUIRE_AUTH_CHANGED,
+                message_description=(
+                    f"require_auth changed from {old_require_auth} "
+                    f"to {instance.require_auth}"
+                ),
+            )
+
+        return instance
 
     @TrackObjectEvent(
         user_field="user", properties={"name": "name", "country": "country"}

--- a/onadata/libs/serializers/user_profile_serializer.py
+++ b/onadata/libs/serializers/user_profile_serializer.py
@@ -71,7 +71,7 @@ def get_audit_values(profile, fields):
 
 
 def send_profile_updated_message(profile, old_values, fields, user):
-    """Audit logs the audited ``fields`` of ``profile`` that changed since ``old_values``.
+    """Audit logs the audited ``fields`` of ``profile`` changed since ``old_values``.
 
     Each changed field maps to its old and new value, except contact fields
     which are recorded without their values.


### PR DESCRIPTION
### Changes / Features implemented

- Changes to a user's or organization's profile are now recorded, capturing who made the change and which details changed, with the previous and new values. Contact details (email, phone number) are recorded as changed without their values. The record is available through the messaging endpoint.
- User and organization profiles are now version tracked, so earlier versions of a profile can be inspected and restored.

### Steps taken to verify this change does what is intended

- [x] Added tests

### Side effects of implementing this change

None.

**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  - [x] Updated documentation
