### PR TITLE
fix(messaging): record audit events for encryption keys and entity lists

### DIFF
--- a/onadata/apps/api/tests/viewsets/test_entity_list_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_entity_list_viewset.py
@@ -26,6 +26,7 @@ from onadata.apps.logger.models import (
     EntityListProperty,
     Project,
 )
+from onadata.apps.messaging.viewsets import MessagingViewSet
 from onadata.libs.exceptions import CSVImportError
 from onadata.libs.models.share_project import ShareProject
 from onadata.libs.pagination import StandardPageNumberPagination
@@ -614,19 +615,29 @@ class DeleteEntityListTestCase(TestAbstractViewSet):
             self.entity_list.name, f'trees{mocked_date.strftime("-deleted-at-%s")}'
         )
 
-    @patch("onadata.apps.api.viewsets.entity_list_viewset.send_message")
-    def test_audit_log_capture(self, mock_send_message):
+    def test_audit_log_capture(self):
         """Audit log is captured on deletion"""
         request = self.factory.delete("/", **self.extra)
         response = self.view(request, pk=self.entity_list.pk)
         self.assertEqual(response.status_code, 204)
-        mock_send_message.assert_called_once_with(
-            instance_id=self.entity_list.pk,
-            target_id=self.entity_list.pk,
-            target_type="entitylist",
-            user=self.user,
-            message_verb="entitylist_deleted",
+
+        messaging_view = MessagingViewSet.as_view({"get": "list"})
+        request = self.factory.get(
+            "/messaging",
+            {
+                "target_type": "entitylist",
+                "target_id": self.entity_list.pk,
+                "verb": "entitylist_deleted",
+            },
+            **self.extra,
         )
+        response = messaging_view(request)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 1)
+        message = response.data[0]
+        self.assertEqual(message["user"], "bob")
+        self.assertEqual(json.loads(message["message"]), {"id": [self.entity_list.pk]})
 
     def test_authentication_required(self):
         """Anonymous user cannot delete EntityList"""

--- a/onadata/apps/api/tests/viewsets/test_entity_list_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_entity_list_viewset.py
@@ -9,12 +9,14 @@ from datetime import datetime
 from datetime import timezone as tz
 from unittest.mock import Mock, patch
 
+from django.contrib.contenttypes.models import ContentType
 from django.core.cache import cache
 from django.core.files.uploadedfile import InMemoryUploadedFile, SimpleUploadedFile
 from django.test import override_settings
 from django.utils import timezone
 
 import boto3
+from actstream.models import Action
 from moto import mock_aws
 
 from onadata.apps.api.tests.viewsets.test_abstract_viewset import TestAbstractViewSet
@@ -26,7 +28,6 @@ from onadata.apps.logger.models import (
     EntityListProperty,
     Project,
 )
-from onadata.apps.messaging.viewsets import MessagingViewSet
 from onadata.libs.exceptions import CSVImportError
 from onadata.libs.models.share_project import ShareProject
 from onadata.libs.pagination import StandardPageNumberPagination
@@ -620,24 +621,13 @@ class DeleteEntityListTestCase(TestAbstractViewSet):
         request = self.factory.delete("/", **self.extra)
         response = self.view(request, pk=self.entity_list.pk)
         self.assertEqual(response.status_code, 204)
-
-        messaging_view = MessagingViewSet.as_view({"get": "list"})
-        request = self.factory.get(
-            "/messaging",
-            {
-                "target_type": "entitylist",
-                "target_id": self.entity_list.pk,
-                "verb": "entitylist_deleted",
-            },
-            **self.extra,
+        message = Action.objects.get(
+            target_content_type=ContentType.objects.get_for_model(EntityList),
+            target_object_id=self.entity_list.pk,
+            verb="entitylist_deleted",
         )
-        response = messaging_view(request)
-
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(response.data), 1)
-        message = response.data[0]
-        self.assertEqual(message["user"], "bob")
-        self.assertEqual(json.loads(message["message"]), {"id": [self.entity_list.pk]})
+        self.assertEqual(message.actor, self.user)
+        self.assertEqual(json.loads(message.description), {"id": [self.entity_list.pk]})
 
     def test_authentication_required(self):
         """Anonymous user cannot delete EntityList"""

--- a/onadata/apps/api/tests/viewsets/test_organization_profile_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_organization_profile_viewset.py
@@ -1655,20 +1655,30 @@ class RotateKeyTestCase(TestAbstractViewSet):
         self.assertEqual(response.status_code, 400)
         self.assertIn("Key is disabled", str(response.data["id"]))
 
-    @patch("onadata.apps.api.viewsets.organization_profile_viewset.send_message")
-    def test_audit_log_capture(self, mock_send_message, mock_rotate_key):
+    def test_audit_log_capture(self, mock_rotate_key):
         """Audit log is captured."""
         request = self.factory.post("/", data=self.data, **self.extra)
         response = self.view(request, user="denoinc")
 
         self.assertEqual(response.status_code, 200)
-        mock_send_message.assert_called_once_with(
-            instance_id=self.kms_key.id,
-            target_id=self.kms_key.id,
-            target_type="kmskey",
-            user=self.user,
-            message_verb="kmskey_rotated",
+
+        messaging_view = MessagingViewSet.as_view({"get": "list"})
+        request = self.factory.get(
+            "/messaging",
+            {
+                "target_type": "kmskey",
+                "target_id": self.kms_key.id,
+                "verb": "kmskey_rotated",
+            },
+            **self.extra,
         )
+        response = messaging_view(request)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 1)
+        message = response.data[0]
+        self.assertEqual(message["user"], "bob")
+        self.assertEqual(json.loads(message["message"]), {"id": [self.kms_key.id]})
 
     def test_rotation_reason_optional(self, mock_rotate_key):
         """Rotation reason is optional."""

--- a/onadata/apps/api/tests/viewsets/test_organization_profile_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_organization_profile_viewset.py
@@ -15,6 +15,7 @@ from django.core.cache import cache
 from django.test.utils import override_settings
 from django.utils import timezone
 
+from actstream.models import Action
 from guardian.shortcuts import get_perms
 from rest_framework import status
 from reversion.models import Version
@@ -1661,24 +1662,13 @@ class RotateKeyTestCase(TestAbstractViewSet):
         response = self.view(request, user="denoinc")
 
         self.assertEqual(response.status_code, 200)
-
-        messaging_view = MessagingViewSet.as_view({"get": "list"})
-        request = self.factory.get(
-            "/messaging",
-            {
-                "target_type": "kmskey",
-                "target_id": self.kms_key.id,
-                "verb": "kmskey_rotated",
-            },
-            **self.extra,
+        message = Action.objects.get(
+            target_content_type=ContentType.objects.get_for_model(KMSKey),
+            target_object_id=self.kms_key.id,
+            verb="kmskey_rotated",
         )
-        response = messaging_view(request)
-
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(response.data), 1)
-        message = response.data[0]
-        self.assertEqual(message["user"], "bob")
-        self.assertEqual(json.loads(message["message"]), {"id": [self.kms_key.id]})
+        self.assertEqual(message.actor, self.user)
+        self.assertEqual(json.loads(message.description), {"id": [self.kms_key.id]})
 
     def test_rotation_reason_optional(self, mock_rotate_key):
         """Rotation reason is optional."""

--- a/onadata/apps/logger/tests/test_tasks.py
+++ b/onadata/apps/logger/tests/test_tasks.py
@@ -1,5 +1,6 @@
 """Tests for module onadata.apps.logger.tasks"""
 
+import json
 import sys
 from io import StringIO
 from types import SimpleNamespace
@@ -10,6 +11,7 @@ from django.db import DatabaseError, OperationalError
 from django.utils import timezone
 
 from celery.exceptions import MaxRetriesExceededError
+from rest_framework.test import APIRequestFactory, force_authenticate
 from valigetta.exceptions import ConnectionException as ValigettaConnectionException
 
 from onadata.apps.logger.models import EntityList
@@ -27,6 +29,7 @@ from onadata.apps.logger.tasks import (
     set_entity_list_perms_async,
 )
 from onadata.apps.main.tests.test_base import TestBase
+from onadata.apps.messaging.viewsets import MessagingViewSet
 from onadata.libs.exceptions import NotAllMediaReceivedError
 from onadata.libs.utils.cache_tools import PROJECT_DATE_MODIFIED_CACHE
 from onadata.libs.utils.user_auth import get_user_default_project
@@ -582,8 +585,7 @@ class ImportEntitiesFromCSVAsyncTestCase(TestBase):
             uuid_column="uuid",
         )
 
-    @patch("onadata.apps.logger.tasks.send_message")
-    def test_audit_log_created(self, mock_send_message, mock_import, mock_open):
+    def test_audit_log_created(self, mock_import, mock_open):
         """Creates an audit log when entities are imported"""
         mock_open.return_value = self.csv_file
 
@@ -591,11 +593,20 @@ class ImportEntitiesFromCSVAsyncTestCase(TestBase):
             "csv_file.csv", self.entity_list.pk, user_id=self.user.pk
         )
 
-        mock_import.assert_called_once()
-        mock_send_message.assert_called_once_with(
-            instance_id=self.entity_list.pk,
-            target_id=self.entity_list.pk,
-            target_type="entitylist",
-            user=self.user,
-            message_verb="entitylist_imported",
+        view = MessagingViewSet.as_view({"get": "list"})
+        request = APIRequestFactory().get(
+            "/messaging",
+            {
+                "target_type": "entitylist",
+                "target_id": self.entity_list.pk,
+                "verb": "entitylist_imported",
+            },
         )
+        force_authenticate(request, user=self.user)
+        response = view(request)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 1)
+        message = response.data[0]
+        self.assertEqual(message["user"], "bob")
+        self.assertEqual(json.loads(message["message"]), {"id": [self.entity_list.pk]})

--- a/onadata/apps/logger/tests/test_tasks.py
+++ b/onadata/apps/logger/tests/test_tasks.py
@@ -6,12 +6,13 @@ from io import StringIO
 from types import SimpleNamespace
 from unittest.mock import patch
 
+from django.contrib.contenttypes.models import ContentType
 from django.core.cache import cache
 from django.db import DatabaseError, OperationalError
 from django.utils import timezone
 
+from actstream.models import Action
 from celery.exceptions import MaxRetriesExceededError
-from rest_framework.test import APIRequestFactory, force_authenticate
 from valigetta.exceptions import ConnectionException as ValigettaConnectionException
 
 from onadata.apps.logger.models import EntityList
@@ -29,7 +30,6 @@ from onadata.apps.logger.tasks import (
     set_entity_list_perms_async,
 )
 from onadata.apps.main.tests.test_base import TestBase
-from onadata.apps.messaging.viewsets import MessagingViewSet
 from onadata.libs.exceptions import NotAllMediaReceivedError
 from onadata.libs.utils.cache_tools import PROJECT_DATE_MODIFIED_CACHE
 from onadata.libs.utils.user_auth import get_user_default_project
@@ -593,20 +593,10 @@ class ImportEntitiesFromCSVAsyncTestCase(TestBase):
             "csv_file.csv", self.entity_list.pk, user_id=self.user.pk
         )
 
-        view = MessagingViewSet.as_view({"get": "list"})
-        request = APIRequestFactory().get(
-            "/messaging",
-            {
-                "target_type": "entitylist",
-                "target_id": self.entity_list.pk,
-                "verb": "entitylist_imported",
-            },
+        message = Action.objects.get(
+            target_content_type=ContentType.objects.get_for_model(EntityList),
+            target_object_id=self.entity_list.pk,
+            verb="entitylist_imported",
         )
-        force_authenticate(request, user=self.user)
-        response = view(request)
-
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(response.data), 1)
-        message = response.data[0]
-        self.assertEqual(message["user"], "bob")
-        self.assertEqual(json.loads(message["message"]), {"id": [self.entity_list.pk]})
+        self.assertEqual(message.actor, self.user)
+        self.assertEqual(json.loads(message.description), {"id": [self.entity_list.pk]})

--- a/onadata/apps/messaging/apps.py
+++ b/onadata/apps/messaging/apps.py
@@ -27,3 +27,5 @@ class MessagingConfig(AppConfig):
         registry.register(apps.get_model(model_name="User", app_label="auth"))
         registry.register(apps.get_model(model_name="XForm", app_label="logger"))
         registry.register(apps.get_model(model_name="Project", app_label="logger"))
+        registry.register(apps.get_model(model_name="KMSKey", app_label="logger"))
+        registry.register(apps.get_model(model_name="EntityList", app_label="logger"))

--- a/onadata/apps/messaging/serializers.py
+++ b/onadata/apps/messaging/serializers.py
@@ -46,6 +46,8 @@ class MessageSerializer(serializers.ModelSerializer):
         ("xform", "XForm"),
         ("project", "Project"),
         ("user", "User"),
+        ("kmskey", "KMSKey"),
+        ("entitylist", "EntityList"),
     )  # yapf: disable
 
     message = serializers.CharField(source="description", allow_blank=False)
@@ -183,7 +185,7 @@ def send_message(
     Send a message.
     :param id: A single ID or list of IDs that have been affected by an action
     :param target_id: id of the target_type
-    :param target_type: any of these three ['xform', 'project', 'user']
+    :param target_type: any of ['xform', 'project', 'user', 'kmskey', 'entitylist']
     :param request: http request object
     :return:
     """

--- a/onadata/apps/messaging/tests/test_messaging_viewset.py
+++ b/onadata/apps/messaging/tests/test_messaging_viewset.py
@@ -69,7 +69,6 @@ class TestMessagingViewSet(TestCase):
         """
         self._create_message()
 
-    @override_settings(FULL_MESSAGE_PAYLOAD=True)
     def test_create_message_for_kmskey(self):
         """
         POST /messaging adds a new message for a KMS key.
@@ -93,9 +92,13 @@ class TestMessagingViewSet(TestCase):
         force_authenticate(request, user=user)
         response = view(request=request)
         self.assertEqual(response.status_code, 201, response.data)
-        self.assertLessEqual(data.items(), response.data.items())
+        message = Action.objects.get(
+            target_content_type=ContentType.objects.get_for_model(KMSKey),
+            target_object_id=kms_key.pk,
+        )
+        self.assertEqual(message.actor, user)
+        self.assertEqual(message.description, "Hello World!")
 
-    @override_settings(FULL_MESSAGE_PAYLOAD=True)
     def test_create_message_for_entitylist(self):
         """
         POST /messaging adds a new message for an entity list.
@@ -115,7 +118,12 @@ class TestMessagingViewSet(TestCase):
         force_authenticate(request, user=user)
         response = view(request=request)
         self.assertEqual(response.status_code, 201, response.data)
-        self.assertLessEqual(data.items(), response.data.items())
+        message = Action.objects.get(
+            target_content_type=ContentType.objects.get_for_model(EntityList),
+            target_object_id=entity_list.pk,
+        )
+        self.assertEqual(message.actor, user)
+        self.assertEqual(message.description, "Hello World!")
 
     def test_target_does_not_exist(self):
         """

--- a/onadata/apps/messaging/tests/test_messaging_viewset.py
+++ b/onadata/apps/messaging/tests/test_messaging_viewset.py
@@ -8,6 +8,8 @@ from __future__ import unicode_literals
 from builtins import str as text
 from datetime import datetime, timedelta, timezone as dt_timezone
 
+from django.contrib.auth import get_user_model
+from django.contrib.contenttypes.models import ContentType
 from django.core.cache import cache
 from django.test import TestCase
 from django.test.utils import override_settings
@@ -19,9 +21,13 @@ from actstream.signals import action
 from guardian.shortcuts import assign_perm
 from rest_framework.test import APIRequestFactory, force_authenticate
 
+from onadata.apps.logger.models import EntityList, KMSKey
 from onadata.apps.messaging.constants import EXPORT_CREATED, SUBMISSION_CREATED
 from onadata.apps.messaging.tests.test_base import _create_user
 from onadata.apps.messaging.viewsets import MessagingViewSet
+from onadata.libs.utils.user_auth import get_user_default_project
+
+User = get_user_model()
 
 
 class TestMessagingViewSet(TestCase):
@@ -62,6 +68,54 @@ class TestMessagingViewSet(TestCase):
         Test POST /messaging adding a new message for a specific form.
         """
         self._create_message()
+
+    @override_settings(FULL_MESSAGE_PAYLOAD=True)
+    def test_create_message_for_kmskey(self):
+        """
+        POST /messaging adds a new message for a KMS key.
+        """
+        user = _create_user()
+        kms_key = KMSKey.objects.create(
+            key_id="fake-key-id",
+            public_key="fake-pub-key",
+            content_type=ContentType.objects.get_for_model(User),
+            object_id=user.pk,
+            provider=KMSKey.KMSProvider.AWS,
+        )
+        assign_perm("logger.change_kmskey", user, kms_key)
+        view = MessagingViewSet.as_view({"post": "create"})
+        data = {
+            "message": "Hello World!",
+            "target_id": kms_key.pk,
+            "target_type": "kmskey",
+        }
+        request = self.factory.post("/messaging", data)
+        force_authenticate(request, user=user)
+        response = view(request=request)
+        self.assertEqual(response.status_code, 201, response.data)
+        self.assertLessEqual(data.items(), response.data.items())
+
+    @override_settings(FULL_MESSAGE_PAYLOAD=True)
+    def test_create_message_for_entitylist(self):
+        """
+        POST /messaging adds a new message for an entity list.
+        """
+        user = _create_user()
+        entity_list = EntityList.objects.create(
+            name="trees", project=get_user_default_project(user)
+        )
+        assign_perm("logger.change_entitylist", user, entity_list)
+        view = MessagingViewSet.as_view({"post": "create"})
+        data = {
+            "message": "Hello World!",
+            "target_id": entity_list.pk,
+            "target_type": "entitylist",
+        }
+        request = self.factory.post("/messaging", data)
+        force_authenticate(request, user=user)
+        response = view(request=request)
+        self.assertEqual(response.status_code, 201, response.data)
+        self.assertLessEqual(data.items(), response.data.items())
 
     def test_target_does_not_exist(self):
         """


### PR DESCRIPTION
### Changes / Features implemented

- Rotating an organization's encryption key, importing entities and deleting an entity list now leave an audit record. These events were previously being sent but silently discarded, so the messaging endpoint returned nothing for them. The records are now available through the messaging endpoint, filtered by the `kmskey` and `entitylist` target types.

### Steps taken to verify this change does what is intended

- [x] Added tests

### Side effects of implementing this change

None.

**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  - [x] Updated documentation

Closes #3216

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/onaio/codesmith/onadata/pr/3219"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789657416&installation_model_id=422582&pr_number=3219&repository=onaio%2Fonadata&return_to=https%3A%2F%2Fgithub.com%2Fonaio%2Fonadata%2Fpull%2F3219&signature=3f63dcb7afafb6283270b7e88f4183f83e3243f5c92df717126c0da875795754"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->