### PR TITLE
test: fix the ordering and encoding assumptions failing CI

### DIFF
--- a/onadata/libs/tests/utils/test_csv_builder.py
+++ b/onadata/libs/tests/utils/test_csv_builder.py
@@ -570,7 +570,8 @@ class TestCSVDataFrameBuilder(TestBase):
             self.xform.instances.all().order_by("id").values_list("json", flat=True)
         )
         csv_df_builder.export_to(temp_file.name, cursor)
-        csv_file = open(temp_file.name, "r")
+        # Explicit utf-8: utf-8-sig would eat the EF BB BF the assertion wants.
+        csv_file = open(temp_file.name, "r", encoding="utf-8")
         csv_reader = csv.reader(csv_file)
         header = next(csv_reader)
         self.assertEqual(len(header), 17 + len(csv_df_builder.extra_columns))

--- a/onadata/libs/tests/utils/test_logger_tools.py
+++ b/onadata/libs/tests/utils/test_logger_tools.py
@@ -1029,7 +1029,9 @@ class DeleteXFormSubmissionsTestCase(TestBase):
 
         self._publish_transportation_form()
         self._make_submissions()
-        self.instances = self.xform.instances.all()
+        # Ordered so the two reads of instances[0] in a test agree. Not list():
+        # it must stay unevaluated until the tests below read it, after mutating.
+        self.instances = self.xform.instances.order_by("pk")
 
     def test_soft_delete_all(self):
         """All submissions are soft deleted"""


### PR DESCRIPTION
### Changes / Features implemented

Two test-suite assumptions that make CI fail. No production code.

- **Ordering** — `DeleteXFormSubmissionsTestCase` reads `self.instances[0]` twice in a test on an unordered queryset, so once one row has been soft-deleted the two reads can return different rows. `test_action_recorded` then compares a pk against its neighbour.
- **Encoding** — `test_windows_excel_compatible_csv_export` reads a file starting with `EF BB BF` using the platform default encoding, which raises `UnicodeDecodeError` wherever that default is not UTF-8. This is what has had `main` red since 2026-08-18.

### Steps taken to verify this change does what is intended

Both tests pass under `LC_ALL=C` — which reproduces the runner — and under a UTF-8 locale. Before the encoding fix, `LC_ALL=C` reproduces the CI error exactly.

### Side effects of implementing this change

None outside the two test modules.

**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  - [ ] Updated documentation

Closes #
