### PR TITLE
fix: scope submission edit URLs to the submission

### DIFF
--- a/onadata/apps/api/tests/viewsets/test_data_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_data_viewset.py
@@ -1558,6 +1558,32 @@ class TestDataViewSet(SerializeMixin, TestBase):
             self.assertEqual(response.status_code, 400)
             self.assertEqual(response.get("Cache-Control"), None)
 
+    def test_enketo_edit_url_names_the_submission(self):
+        """The server URL sent to Enketo names the submission being edited.
+
+        Enketo derives the form list and submission endpoints from it, so
+        naming the submission is what routes the edit to the endpoint that
+        supersedes it instead of the one that creates a new submission.
+        """
+        self._make_submissions()
+        instance = self.xform.instances.all().order_by("id")[0]
+        view = DataViewSet.as_view({"get": "enketo"})
+        request = self.factory.get(
+            "/", data={"return_url": "http://test.io/test_url"}, **self.extra
+        )
+
+        captured = {}
+
+        with HTTMock(enketo_edit_capture_mock(captured)):
+            view(request, pk=self.xform.pk, dataid=instance.pk)
+
+        posted = parse_qs(captured["body"])
+
+        self.assertEqual(
+            posted["server_url"],
+            [f"https://testserver.com/enketo/{self.xform.pk}/{instance.pk}"],
+        )
+
     def test_enketo_edit_url_sends_instance_attachments(self):
         """The edit link request carries the submission's attachments.
 

--- a/onadata/apps/api/viewsets/data_viewset.py
+++ b/onadata/apps/api/viewsets/data_viewset.py
@@ -343,6 +343,7 @@ class DataViewSet(
                     self.object.xform.user.username,
                     xform_pk=self.object.xform.id,
                     generate_consistent_urls=True,
+                    submission_pk=self.object.pk,
                 )
                 if not return_url:
                     raise ParseError(_("return_url not provided."))

--- a/onadata/apps/logger/tests/test_webforms.py
+++ b/onadata/apps/logger/tests/test_webforms.py
@@ -106,6 +106,35 @@ class TestWebforms(TestBase):
             ],
         )
 
+    def test_edit_url_names_the_submission(self):
+        """The server URL sent to Enketo names the submission being edited.
+
+        Enketo derives the form list and submission endpoints from it, so
+        naming the submission is what routes the edit to the endpoint that
+        supersedes it instead of the one that creates a new submission.
+        """
+        instance = Instance.objects.order_by("id").reverse()[0]
+        edit_url = reverse(
+            edit_data,
+            kwargs={
+                "username": self.user.username,
+                "id_string": self.xform.id_string,
+                "data_id": instance.id,
+            },
+        )
+
+        captured = {}
+
+        with HTTMock(enketo_edit_capture_mock(captured)):
+            self.client.get(edit_url)
+
+        posted = parse_qs(captured["body"])
+
+        self.assertEqual(
+            posted["server_url"],
+            [f"https://testserver.com/enketo/{self.xform.pk}/{instance.pk}"],
+        )
+
     def test_inject_instanceid(self):
         """
         Test that 1 and only 1 instance id exists or is injected

--- a/onadata/apps/logger/views.py
+++ b/onadata/apps/logger/views.py
@@ -636,7 +636,13 @@ def edit_data(request, username, id_string, data_id):
         + "#/"
         + str(instance.id)
     )
-    form_url = get_form_url(request, username)
+    form_url = get_form_url(
+        request,
+        username,
+        xform_pk=xform.pk,
+        generate_consistent_urls=True,
+        submission_pk=instance.pk,
+    )
 
     try:
         url = get_enketo_urls(

--- a/onadata/libs/tests/utils/test_viewer_tools.py
+++ b/onadata/libs/tests/utils/test_viewer_tools.py
@@ -178,6 +178,17 @@ class TestViewerTools(TestBase):
         )
         self.assertEqual(url, "https://ona.io/enketo/492")
 
+    @override_settings(TESTING_MODE=False, ENKETO_PROTOCOL="http")
+    def test_get_form_url_submission_pk(self):
+        """The submission pk is appended to the form specific URL."""
+        request = RequestFactory().get("/")
+
+        url = get_form_url(
+            request, xform_pk=492, submission_pk=6, generate_consistent_urls=True
+        )
+
+        self.assertEqual(url, "http://ona.io/enketo/492/6")
+
     @override_settings(ZIP_REPORT_ATTACHMENT_LIMIT=8)
     @patch("onadata.libs.utils.viewer_tools.report_exception")
     def test_create_attachments_zipfile_file_too_big(self, rpt_mock):

--- a/onadata/libs/utils/viewer_tools.py
+++ b/onadata/libs/utils/viewer_tools.py
@@ -339,6 +339,7 @@ def get_form_url(
     preview=False,
     xform_pk=None,
     generate_consistent_urls=False,
+    submission_pk=None,
 ):
     """
     Return a form list url endpoint to be used to make a request to Enketo.
@@ -348,6 +349,9 @@ def get_form_url(
     provided then Enketo will request the form list from
     https://example.com/[username]/formList. Same applies for preview if
     preview is True and also to a single form when xform_pk is provided.
+    When submission_pk is provided the url is scoped to that submission, so
+    that Enketo requests the form list from and posts the edit to the
+    submission specific endpoints.
 
     When *protocol* is ``None`` (the default) it is read from the
     ``ENKETO_PROTOCOL`` Django setting, falling back to ``"https"``.
@@ -368,6 +372,9 @@ def get_form_url(
 
     if xform_pk and generate_consistent_urls:
         url += f"/enketo/{xform_pk}"
+
+        if submission_pk:
+            url += f"/{submission_pk}"
     elif username:
         url += f"/{username}/{xform_pk}" if xform_pk else f"/{username}"
 


### PR DESCRIPTION
### Changes / Features implemented

An edit link now points Enketo at the specific submission being edited rather than at the form as a whole.

Before this change, an edit came back to the server without saying which response it replaced. The server worked that out by reading the submitted response, which it cannot do for a form with managed encryption. Those edits were saved as brand new responses, so the form ended up holding both the original and the edit, and nothing reported a problem.

Edits now replace the original response, with the previous version kept in its history. This covers both the edit link the API hands out and the older webform edit page.

### Steps taken to verify this change does what is intended

- [x] Added tests

### Side effects of implementing this change

Edits to forms without managed encryption now travel the same route. They behave exactly as before.


**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  - [ ] Updated documentation

Closes #3221

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/onaio/codesmith/onadata/pr/3222"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789813876&installation_model_id=422582&pr_number=3222&repository=onaio%2Fonadata&return_to=https%3A%2F%2Fgithub.com%2Fonaio%2Fonadata%2Fpull%2F3222&signature=f4da91bdfcf4978fefc97a12deabd77e896f38a321d5fdc353272f44f5678c03"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->