### PR TITLE
feat: allow replacing managed encrypted forms

### DIFF
--- a/onadata/apps/api/tests/viewsets/test_xform_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_xform_viewset.py
@@ -58,6 +58,7 @@ from onadata.apps.api.tests.viewsets.test_abstract_viewset import (
 from onadata.apps.api.viewsets.project_viewset import ProjectViewSet
 from onadata.apps.api.viewsets.xform_viewset import XFormViewSet
 from onadata.apps.logger.models import Attachment, EntityList, Instance, Project, XForm
+from onadata.apps.logger.models.kms import KMSKey
 from onadata.apps.logger.models.xform_version import XFormVersion
 from onadata.apps.logger.views import delete_xform
 from onadata.apps.logger.xform_instance_parser import XLSFormError
@@ -65,6 +66,7 @@ from onadata.apps.main.models import MetaData
 from onadata.apps.messaging.constants import FORM_UPDATED, XFORM
 from onadata.apps.viewer.models import Export
 from onadata.libs.exceptions import EncryptionError
+from onadata.libs.kms.tools import encrypt_xform
 from onadata.libs.models.share_project import ShareProject
 from onadata.libs.permissions import (
     ROLES_ORDERED,
@@ -6219,6 +6221,55 @@ nhMo+jI88L3qfm4/rtWKuQ9/a268phlNj34uQeoDDHuRViQo00L5meE/pFptm
             self.assertEqual(version, self.xform.version)
             self.assertEqual(xform_json, self.xform.json)
             self.assertEqual(xform_xml, self.xform.xml)
+
+    def test_update_managed_encrypted_xform(self):
+        """Replacing a managed encrypted form keeps it encrypted with the managed key."""
+        with HTTMock(enketo_mock):
+            self._publish_xls_form_to_project()
+            org = self._create_organization(
+                username="valigetta", name="Valigetta Inc", created_by=self.user
+            )
+            kms_key = KMSKey.objects.create(
+                key_id="fake-key-id",
+                description="Key-2025-04-03",
+                public_key="fake-pub-key",
+                content_type=ContentType.objects.get_for_model(org),
+                object_id=org.pk,
+                provider=KMSKey.KMSProvider.AWS,
+            )
+            self.xform.user = org.user
+            self.xform.save()
+            encrypt_xform(self.xform, encrypted_by=self.user)
+            version = self.xform.version
+
+            view = XFormViewSet.as_view({"patch": "partial_update"})
+            path = os.path.join(
+                settings.PROJECT_ROOT,
+                "apps",
+                "main",
+                "tests",
+                "fixtures",
+                "transportation",
+                "transportation_updated.xlsx",
+            )
+            with open(path, "rb") as xls_file:
+                post_data = {"xls_file": xls_file}
+                request = self.factory.patch("/", data=post_data, **self.extra)
+                response = view(request, pk=self.xform.pk)
+
+            self.assertEqual(response.status_code, 200)
+            self.xform = XForm.objects.get(pk=self.xform.pk)
+            self.assertNotEqual(version, self.xform.version)
+            self.assertIn(
+                "preferred_means", [e.name for e in self.xform.survey_elements]
+            )
+            self.assertTrue(self.xform.encrypted)
+            self.assertEqual(self.xform.json["public_key"], kms_key.public_key)
+            self.assertTrue(
+                self.xform.kms_keys.filter(
+                    version=self.xform.version, kms_key=kms_key, encrypted_by=self.user
+                ).exists()
+            )
 
 
 class ExportAsyncTestCase(XFormViewSetBaseTestCase):

--- a/onadata/apps/api/viewsets/xform_viewset.py
+++ b/onadata/apps/api/viewsets/xform_viewset.py
@@ -1000,7 +1000,7 @@ class XFormViewSet(
         if request.FILES or set(["xls_url", "dropbox_xls_url", "text_xls_form"]) & set(
             request.data
         ):
-            if self.object.encrypted:
+            if self.object.encrypted and not self.object.is_managed:
                 return Response(
                     {"message": _("This form is encrypted and cannot be replaced.")},
                     status=status.HTTP_400_BAD_REQUEST,

--- a/onadata/apps/main/tests/test_form_show.py
+++ b/onadata/apps/main/tests/test_form_show.py
@@ -7,6 +7,8 @@ import os
 from unittest import skip
 from unittest.mock import patch
 
+from django.contrib.contenttypes.models import ContentType
+from django.contrib.messages import get_messages
 from django.core.exceptions import MultipleObjectsReturned
 from django.core.files.base import ContentFile
 from django.test.utils import override_settings
@@ -16,6 +18,7 @@ from httmock import HTTMock
 
 from onadata.apps.api.tests.mocked_data import enketo_urls_mock
 from onadata.apps.logger.models import XForm
+from onadata.apps.logger.models.kms import KMSKey
 from onadata.apps.logger.views import (
     delete_xform,
     download_jsonform,
@@ -541,6 +544,77 @@ class TestFormShow(TestBase):
             > 0
         )
         self.assertTrue(is_updated_form)
+
+    def test_cannot_replace_encrypted_form(self):
+        """A form encrypted with a custom key cannot be replaced."""
+        XForm.objects.filter(pk=self.xform.pk).update(
+            encrypted=True, public_key="fake-pub-key"
+        )
+        version = self.xform.version
+        xform_update_url = reverse(
+            update_xform,
+            kwargs={"username": self.user.username, "id_string": self.xform.id_string},
+        )
+        xls_path = os.path.join(
+            self.this_directory,
+            "fixtures",
+            "transportation",
+            "transportation_updated.xlsx",
+        )
+
+        with open(xls_path, "rb") as xls_file:
+            post_data = {"xls_file": xls_file}
+            response = self.client.post(xform_update_url, post_data)
+
+        self.assertEqual(response.status_code, 302)
+        xform = XForm.objects.get(pk=self.xform.pk)
+        self.assertEqual(xform.version, version)
+        # preferred_means is only in the replacement XLSForm
+        self.assertNotIn("preferred_means", [e.name for e in xform.survey_elements])
+        self.assertIn(
+            "This form is encrypted and cannot be replaced.",
+            [str(message) for message in get_messages(response.wsgi_request)],
+        )
+
+    def test_can_replace_managed_encrypted_form(self):
+        """A form encrypted with a managed key can be replaced."""
+        org = self._create_organization(
+            username="valigetta", name="Valigetta Inc", created_by=self.user
+        )
+        kms_key = KMSKey.objects.create(
+            key_id="fake-key-id",
+            description="Key-2025-04-03",
+            public_key="fake-pub-key",
+            content_type=ContentType.objects.get_for_model(org),
+            object_id=org.pk,
+            provider=KMSKey.KMSProvider.AWS,
+        )
+        XForm.objects.filter(pk=self.xform.pk).update(
+            encrypted=True, is_managed=True, public_key=kms_key.public_key
+        )
+        self.xform.kms_keys.create(
+            version=self.xform.version, kms_key=kms_key, encrypted_by=self.user
+        )
+        xform_update_url = reverse(
+            update_xform,
+            kwargs={"username": self.user.username, "id_string": self.xform.id_string},
+        )
+        xls_path = os.path.join(
+            self.this_directory,
+            "fixtures",
+            "transportation",
+            "transportation_updated.xlsx",
+        )
+
+        with open(xls_path, "rb") as xls_file:
+            post_data = {"xls_file": xls_file}
+            self.client.post(xform_update_url, post_data)
+
+        xform = XForm.objects.get(pk=self.xform.pk)
+        # preferred_means is only in the replacement XLSForm
+        self.assertIn("preferred_means", [e.name for e in xform.survey_elements])
+        self.assertTrue(xform.encrypted)
+        self.assertEqual(xform.json["public_key"], kms_key.public_key)
 
     def test_update_form_doesnt_truncate_to_50_chars(self):
         count = XForm.objects.count()

--- a/onadata/apps/main/views.py
+++ b/onadata/apps/main/views.py
@@ -1548,6 +1548,19 @@ def update_xform(request, username, id_string):
 
     xform = get_form(xform_kwargs)
     owner = xform.user
+    show_url = reverse(show, kwargs={"username": username, "id_string": id_string})
+
+    # Forms encrypted with a custom key lose the key when the XLSForm is
+    # re-read, since the key is not part of the XLSForm
+    if xform.encrypted and not xform.is_managed:
+        messages.add_message(
+            request,
+            messages.INFO,
+            _("This form is encrypted and cannot be replaced."),
+            extra_tags="alert-error",
+        )
+
+        return HttpResponseRedirect(show_url)
 
     def set_form():
         """Publishes the XLSForm"""
@@ -1580,9 +1593,7 @@ def update_xform(request, username, id_string):
         request, messages.INFO, message["text"], extra_tags=message["type"]
     )
 
-    return HttpResponseRedirect(
-        reverse(show, kwargs={"username": username, "id_string": id_string})
-    )
+    return HttpResponseRedirect(show_url)
 
 
 @is_owner

--- a/onadata/apps/viewer/models/data_dictionary.py
+++ b/onadata/apps/viewer/models/data_dictionary.py
@@ -199,6 +199,11 @@ class DataDictionary(XForm):  # pylint: disable=too-many-instance-attributes
             else:
                 survey["id_string"] = self.id_string
                 workbook_json["id_string"] = self.id_string
+            if self.is_managed:
+                # Managed encryption is applied after publishing, so the
+                # key lives in the stored form rather than the XLSForm
+                survey.public_key = self.public_key
+                workbook_json["public_key"] = self.public_key
             self.json = workbook_json
             self.xml = survey.to_xml()
             self.version = survey.get("version")

--- a/onadata/apps/viewer/tests/test_data_dictionary.py
+++ b/onadata/apps/viewer/tests/test_data_dictionary.py
@@ -2,6 +2,7 @@
 
 from django.contrib.contenttypes.models import ContentType
 from django.core.cache import cache
+from django.core.files.base import ContentFile
 from django.test import override_settings
 from django.utils import timezone
 
@@ -17,6 +18,7 @@ from onadata.apps.logger.models.xform import XForm
 from onadata.apps.main.models.meta_data import MetaData
 from onadata.apps.main.tests.test_base import TestBase
 from onadata.apps.viewer.models.data_dictionary import DataDictionary
+from onadata.libs.kms.tools import encrypt_xform
 from onadata.libs.permissions import ROLES
 from onadata.libs.utils.user_auth import get_user_default_project
 
@@ -873,6 +875,48 @@ class DataDictionaryTestCase(TestBase):
             xform.refresh_from_db()
 
             self.assertFalse(xform.encrypted)
+
+    def test_replace_managed_form_keeps_managed_key(self):
+        """Re-reading the XLSForm of a managed form keeps the managed public key."""
+        org = self._create_organization(
+            username="valigetta", name="Valigetta Inc", created_by=self.user
+        )
+        kms_key = KMSKey.objects.create(
+            key_id="fake-key-id",
+            description="Key-2025-04-03",
+            public_key="fake-pub-key",
+            content_type=ContentType.objects.get_for_model(org),
+            object_id=org.pk,
+            provider=KMSKey.KMSProvider.AWS,
+        )
+        text_xls_form = (
+            "survey\r\n"
+            ",type,name,label\r\n"
+            ",text,fruit,Fruit\r\n"
+            "settings\r\n"
+            ",form_title,id_string\r\n"
+            ",Fruits,fruits\r\n"
+        )
+        data_dict = DataDictionary.objects.create(
+            created_by=self.user,
+            user=org.user,
+            xls=ContentFile(text_xls_form.encode(), name="fruits.csv"),
+            project=get_user_default_project(org.user),
+        )
+        encrypt_xform(XForm.objects.get(pk=data_dict.pk), encrypted_by=self.user)
+        data_dict = DataDictionary.objects.get(pk=data_dict.pk)
+        data_dict.num_of_submissions = 1
+        updated_text_xls_form = text_xls_form.replace(",Fruits,", ",Fruits updated,")
+        data_dict.xls = ContentFile(updated_text_xls_form.encode(), name="fruits.csv")
+
+        data_dict.save()
+
+        xform = XForm.objects.get(pk=data_dict.pk)
+        self.assertEqual(xform.title, "Fruits updated")
+        self.assertTrue(xform.encrypted)
+        self.assertEqual(xform.json["public_key"], kms_key.public_key)
+        self.assertIn(f'base64RsaPublicKey="{kms_key.public_key}"', xform.xml)
+        self.assertEqual(xform.hash, xform.get_hash())
 
     def test_str_includes_deletion_suffix(self):
         """String representation includes the deletion suffix if missing"""

--- a/onadata/libs/tests/utils/test_logger_tools.py
+++ b/onadata/libs/tests/utils/test_logger_tools.py
@@ -1555,3 +1555,50 @@ class PublishXLSFormTestCase(TestBase):
                 version=xform.version, kms_key=kms_key, encrypted_by=self.user
             ).exists()
         )
+
+    def test_replace_managed_form_without_registered_key(self):
+        """Replacing a managed form whose version has no key is logged."""
+        org = self._create_organization(
+            username="valigetta", name="Valigetta Inc", created_by=self.user
+        )
+        KMSKey.objects.create(
+            key_id="fake-key-id",
+            description="Key-2025-04-03",
+            public_key="fake-pub-key",
+            content_type=ContentType.objects.get_for_model(org),
+            object_id=org.pk,
+            provider=KMSKey.KMSProvider.AWS,
+        )
+        project = get_user_default_project(org.user)
+        text_xls_form = (
+            "survey\r\n"
+            ",type,name,label\r\n"
+            ",text,fruit,Fruit\r\n"
+            "settings\r\n"
+            ",form_title,id_string\r\n"
+            ",Fruits,fruits\r\n"
+        )
+        xls_file = ContentFile(text_xls_form.encode(), name="fruits.csv")
+        dd = publish_xls_form(xls_file, org.user, project, None, self.user)
+        encrypt_xform(XForm.objects.get(pk=dd.pk), encrypted_by=self.user)
+        encrypted_version = XForm.objects.get(pk=dd.pk).version
+        # Simulate a managed form whose current version was never registered
+        # against the key that encrypts it
+        dd.kms_keys.all().delete()
+        updated_text_xls_form = text_xls_form.replace(",Fruits,", ",Fruits updated,")
+        xls_file = ContentFile(updated_text_xls_form.encode(), name="fruits.csv")
+
+        with self.assertLogs(
+            "onadata.libs.utils.logger_tools", level="ERROR"
+        ) as log_context:
+            updated_dd = publish_xls_form(
+                xls_file, org.user, project, "fruits", self.user
+            )
+
+        xform = XForm.objects.get(pk=updated_dd.pk)
+        # The replacement goes ahead, unregistered
+        self.assertEqual(xform.title, "Fruits updated")
+        self.assertFalse(xform.kms_keys.exists())
+        self.assertEqual(len(log_context.output), 1)
+        self.assertIn(str(xform.pk), log_context.output[0])
+        self.assertIn(encrypted_version, log_context.output[0])

--- a/onadata/libs/tests/utils/test_logger_tools.py
+++ b/onadata/libs/tests/utils/test_logger_tools.py
@@ -10,6 +10,7 @@ from io import BytesIO
 from unittest.mock import Mock, patch
 
 from django.conf import settings
+from django.contrib.contenttypes.models import ContentType
 from django.core.cache import cache
 from django.core.exceptions import PermissionDenied
 from django.core.files.base import ContentFile
@@ -23,11 +24,13 @@ from defusedxml.ElementTree import ParseError
 
 from onadata.apps.logger.import_tools import django_file
 from onadata.apps.logger.models import Instance, InstanceHistory
+from onadata.apps.logger.models.kms import KMSKey
 from onadata.apps.logger.models.survey_type import SurveyType
 from onadata.apps.logger.models.xform import XForm
 from onadata.apps.logger.models.xform_version import XFormVersion
 from onadata.apps.logger.xform_instance_parser import AttachmentNameError
 from onadata.apps.main.tests.test_base import TestBase
+from onadata.libs.kms.tools import encrypt_xform
 from onadata.libs.test_utils.pyxform_test_case import PyxformTestCase
 from onadata.libs.utils.common_tags import MEDIA_ALL_RECEIVED, MEDIA_COUNT, TOTAL_MEDIA
 from onadata.libs.utils.logger_tools import (
@@ -1514,3 +1517,41 @@ class PublishXLSFormTestCase(TestBase):
         self.assertEqual(updated_dd.pk, active_xform.pk)
         active_xform.refresh_from_db()
         self.assertEqual(active_xform.title, "Fruits updated")
+
+    def test_replace_managed_form_registers_new_version_key(self):
+        """Replacing a managed form registers the new version against its key."""
+        org = self._create_organization(
+            username="valigetta", name="Valigetta Inc", created_by=self.user
+        )
+        kms_key = KMSKey.objects.create(
+            key_id="fake-key-id",
+            description="Key-2025-04-03",
+            public_key="fake-pub-key",
+            content_type=ContentType.objects.get_for_model(org),
+            object_id=org.pk,
+            provider=KMSKey.KMSProvider.AWS,
+        )
+        project = get_user_default_project(org.user)
+        text_xls_form = (
+            "survey\r\n"
+            ",type,name,label\r\n"
+            ",text,fruit,Fruit\r\n"
+            "settings\r\n"
+            ",form_title,id_string\r\n"
+            ",Fruits,fruits\r\n"
+        )
+        xls_file = ContentFile(text_xls_form.encode(), name="fruits.csv")
+        dd = publish_xls_form(xls_file, org.user, project, None, self.user)
+        encrypt_xform(XForm.objects.get(pk=dd.pk), encrypted_by=self.user)
+        updated_text_xls_form = text_xls_form.replace(",Fruits,", ",Fruits updated,")
+        xls_file = ContentFile(updated_text_xls_form.encode(), name="fruits.csv")
+
+        updated_dd = publish_xls_form(xls_file, org.user, project, "fruits", self.user)
+
+        xform = XForm.objects.get(pk=updated_dd.pk)
+        self.assertEqual(xform.title, "Fruits updated")
+        self.assertTrue(
+            xform.kms_keys.filter(
+                version=xform.version, kms_key=kms_key, encrypted_by=self.user
+            ).exists()
+        )

--- a/onadata/libs/utils/logger_tools.py
+++ b/onadata/libs/utils/logger_tools.py
@@ -1120,8 +1120,19 @@ def publish_xls_form(xls_file, user, project, id_string=None, created_by=None):
         dd = DataDictionary.objects.get(
             user=user, id_string=id_string, project=project, deleted_at__isnull=True
         )
+        # The managed key encrypting the current version carries over to
+        # the new version
+        kms_key = (
+            dd.kms_keys.filter(version=dd.version).latest("date_created").kms_key
+            if dd.is_managed
+            else None
+        )
         dd.xls = xls_file
         dd.save()
+        if kms_key is not None:
+            dd.kms_keys.create(
+                version=dd.version, kms_key=kms_key, encrypted_by=created_by
+            )
     else:
         dd = DataDictionary.objects.create(
             created_by=created_by or user, user=user, xls=xls_file, project=project

--- a/onadata/libs/utils/logger_tools.py
+++ b/onadata/libs/utils/logger_tools.py
@@ -1120,15 +1120,24 @@ def publish_xls_form(xls_file, user, project, id_string=None, created_by=None):
         dd = DataDictionary.objects.get(
             user=user, id_string=id_string, project=project, deleted_at__isnull=True
         )
-        # The managed key encrypting the current version carries over to
-        # the new version
-        kms_key = (
-            dd.kms_keys.filter(version=dd.version).latest("date_created").kms_key
-            if dd.is_managed
-            else None
-        )
+        kms_key = None
+
+        if dd.is_managed:
+            xform_key_qs = dd.kms_keys.filter(version=dd.version)
+
+            if xform_key_qs.exists():
+                # The managed key encrypting the current version carries over to
+                # the new version
+                kms_key = xform_key_qs.latest("date_created").kms_key
+
+            else:
+                logger.error(
+                    "Managed key not found for XForm %s version %s", dd.pk, dd.version
+                )
+
         dd.xls = xls_file
         dd.save()
+
         if kms_key is not None:
             dd.kms_keys.create(
                 version=dd.version, kms_key=kms_key, encrypted_by=created_by


### PR DESCRIPTION
### Changes / Features implemented

Forms encrypted with managed keys can now be replaced with an updated XLSForm. The replaced form stays encrypted with the same managed key, and submissions made against the new version can be decrypted as before. Forms using custom (non-managed) encryption are still rejected from replacement.

### Steps taken to verify this change does what is intended

- [x] Added tests

### Side effects of implementing this change

None.


**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  - [ ] Updated documentation

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/onaio/codesmith/onadata/pr/3229"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790249441&installation_model_id=422582&pr_number=3229&repository=onaio%2Fonadata&return_to=https%3A%2F%2Fgithub.com%2Fonaio%2Fonadata%2Fpull%2F3229&signature=fd9644384ded4fbd23d24d241084a8959b1c04beddbb9922346f963dfbc2bc9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->