### PR TITLE
chore: bump minor versions of pinned dependencies

### DIFF
--- a/requirements/azure.pip
+++ b/requirements/azure.pip
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements/azure.pip requirements/azure.in
 #
-asgiref==3.11.1
+asgiref==3.12.1
     # via django
 azure-core==1.41.0
     # via
@@ -12,11 +12,11 @@ azure-core==1.41.0
     #   django-storages
 azure-storage-blob==12.30.0
     # via django-storages
-certifi==2026.6.17
+certifi==2026.7.22
     # via requests
-cffi==2.0.0
+cffi==2.1.1
     # via cryptography
-charset-normalizer==3.4.7
+charset-normalizer==3.5.1
     # via requests
 cryptography==49.0.0
     # via
@@ -38,9 +38,9 @@ pycparser==3.0
     # via cffi
 requests==2.34.2
     # via azure-core
-sqlparse==0.5.5
+sqlparse==0.6.0
     # via django
-typing-extensions==4.15.0
+typing-extensions==4.16.0
     # via
     #   azure-core
     #   azure-storage-blob

--- a/requirements/base.pip
+++ b/requirements/base.pip
@@ -12,7 +12,7 @@ analytics-python==1.4.post1
     # via onadata
 appoptics-metrics==5.1.0
     # via onadata
-asgiref==3.11.1
+asgiref==3.12.1
     # via
     #   django
     #   django-cors-headers
@@ -37,17 +37,17 @@ cached-property==2.0.1
     # via tableschema
 celery==5.6.3
     # via onadata
-certifi==2026.6.17
+certifi==2026.7.22
     # via
     #   requests
     #   sentry-sdk
-cffi==2.0.0
+cffi==2.1.1
     # via cryptography
-chardet==7.4.3
+chardet==7.6.0
     # via
     #   dataflows-tabulator
     #   datapackage
-charset-normalizer==3.4.7
+charset-normalizer==3.5.1
     # via requests
 click==8.4.2
     # via
@@ -114,7 +114,7 @@ django-cors-headers==4.9.0
     # via onadata
 django-csp==4.0
     # via onadata
-django-debug-toolbar==7.0.0
+django-debug-toolbar==7.1.1
     # via onadata
 django-digest @ git+https://github.com/onaio/django-digest.git@6bf61ec08502fd3545d4f2c0838b6cb15e7ffa92
     # via -r requirements/base.in
@@ -130,7 +130,7 @@ django-multidb-router @ git+https://github.com/onaio/django-multidb-router.git@f
     # via -r requirements/base.in
 django-nose==1.4.7
     # via onadata
-django-oauth-toolkit==3.3.0
+django-oauth-toolkit==3.4.0
     # via onadata
 django-ordered-model==3.7.4
     # via onadata
@@ -182,7 +182,7 @@ future==1.0.0
     # via python-json2xlsclient
 geojson==3.3.0
     # via onadata
-google-auth==2.55.0
+google-auth==2.56.3
     # via
     #   google-auth-oauthlib
     #   onadata
@@ -192,7 +192,7 @@ greenlet==3.5.2
     # via sqlalchemy
 hiredis==3.4.0
     # via redis
-httplib2==0.31.2
+httplib2==0.32.0
     # via onadata
 idna==3.18
     # via
@@ -251,13 +251,13 @@ openpyxl==3.1.5
     #   dataflows-tabulator
     #   onadata
     #   pyxform
-packaging==26.2
+packaging==26.3
     # via
     #   django-csp
     #   kombu
 paho-mqtt==2.1.0
     # via onadata
-pillow==12.2.0
+pillow==12.3.0
     # via
     #   elaphe3
     #   onadata
@@ -299,7 +299,7 @@ python-json2xlsclient @ git+https://github.com/onaio/python-json2xlsclient.git@6
     # via -r requirements/base.in
 python-memcached==1.62
     # via onadata
-pytz==2026.2
+pytz==2026.3.post1
     # via
     #   django-query-builder
     #   fleming
@@ -332,13 +332,13 @@ requests-oauthlib==2.0.0
     # via google-auth-oauthlib
 rfc3986==2.0.0
     # via tableschema
-rpds-py==2026.5.1
+rpds-py==2026.6.3
     # via
     #   jsonschema
     #   referencing
 s3transfer==0.19.0
     # via boto3
-sentry-sdk==2.63.0
+sentry-sdk==2.68.0
     # via onadata
 simplejson==4.1.1
     # via onadata
@@ -353,17 +353,17 @@ six==1.17.0
     #   tableschema
 sqlalchemy==2.0.51
     # via dataflows-tabulator
-sqlparse==0.5.5
+sqlparse==0.6.0
     # via
     #   django
     #   django-debug-toolbar
 tableschema==1.21.0
     # via datapackage
-typing-extensions==4.15.0
+typing-extensions==4.16.0
     # via
     #   jwcrypto
     #   sqlalchemy
-tzdata==2026.2
+tzdata==2026.3
     # via kombu
 tzlocal==5.4.3
     # via celery
@@ -392,7 +392,7 @@ vine==5.1.0
     #   kombu
 wcwidth==0.8.1
     # via prompt-toolkit
-wrapt==2.2.2
+wrapt==2.3.0
     # via deprecated
 xlrd==2.0.1
     # via

--- a/requirements/dev.pip
+++ b/requirements/dev.pip
@@ -12,7 +12,7 @@ analytics-python==1.4.post1
     # via onadata
 appoptics-metrics==5.1.0
     # via onadata
-asgiref==3.11.1
+asgiref==3.12.1
     # via
     #   django
     #   django-cors-headers
@@ -46,19 +46,19 @@ cached-property==2.0.1
     # via tableschema
 celery==5.6.3
     # via onadata
-certifi==2026.6.17
+certifi==2026.7.22
     # via
     #   requests
     #   sentry-sdk
-cffi==2.0.0
+cffi==2.1.1
     # via cryptography
 cfgv==3.5.0
     # via pre-commit
-chardet==7.4.3
+chardet==7.6.0
     # via
     #   dataflows-tabulator
     #   datapackage
-charset-normalizer==3.4.7
+charset-normalizer==3.5.1
     # via requests
 click==8.4.2
     # via
@@ -135,7 +135,7 @@ django-cors-headers==4.9.0
     # via onadata
 django-csp==4.0
     # via onadata
-django-debug-toolbar==7.0.0
+django-debug-toolbar==7.1.1
     # via onadata
 django-digest @ git+https://github.com/onaio/django-digest.git@6bf61ec08502fd3545d4f2c0838b6cb15e7ffa92
     # via -r requirements/base.in
@@ -153,7 +153,7 @@ django-multidb-router @ git+https://github.com/onaio/django-multidb-router.git@f
     # via -r requirements/base.in
 django-nose==1.4.7
     # via onadata
-django-oauth-toolkit==3.3.0
+django-oauth-toolkit==3.4.0
     # via onadata
 django-ordered-model==3.7.4
     # via onadata
@@ -219,7 +219,7 @@ future==1.0.0
     # via python-json2xlsclient
 geojson==3.3.0
     # via onadata
-google-auth==2.55.0
+google-auth==2.56.3
     # via
     #   google-auth-oauthlib
     #   onadata
@@ -231,7 +231,7 @@ hiredis==3.4.0
     # via redis
 httmock==1.4.0
     # via -r requirements/dev.in
-httplib2==0.31.2
+httplib2==0.32.0
     # via onadata
 identify==2.6.19
     # via pre-commit
@@ -317,7 +317,7 @@ openpyxl==3.1.5
     #   dataflows-tabulator
     #   onadata
     #   pyxform
-packaging==26.2
+packaging==26.3
     # via
     #   django-csp
     #   kombu
@@ -331,7 +331,7 @@ pep8-naming==0.10.0
     # via prospector
 pexpect==4.9.0
     # via ipython
-pillow==12.2.0
+pillow==12.3.0
     # via
     #   elaphe3
     #   onadata
@@ -424,7 +424,7 @@ python-json2xlsclient @ git+https://github.com/onaio/python-json2xlsclient.git@6
     # via -r requirements/base.in
 python-memcached==1.62
     # via onadata
-pytz==2026.2
+pytz==2026.3.post1
     # via
     #   django-query-builder
     #   fleming
@@ -472,7 +472,7 @@ responses==0.26.1
     # via moto
 rfc3986==2.0.0
     # via tableschema
-rpds-py==2026.5.1
+rpds-py==2026.6.3
     # via
     #   jsonschema
     #   referencing
@@ -480,7 +480,7 @@ s3transfer==0.19.0
     # via boto3
 semver==3.0.4
     # via requirements-detector
-sentry-sdk==2.63.0
+sentry-sdk==2.68.0
     # via onadata
 setoptconf-tmp==0.3.1
     # via prospector
@@ -499,7 +499,7 @@ snowballstemmer==3.1.1
     # via pydocstyle
 sqlalchemy==2.0.51
     # via dataflows-tabulator
-sqlparse==0.5.5
+sqlparse==0.6.0
     # via
     #   django
     #   django-debug-toolbar
@@ -517,11 +517,11 @@ traitlets==5.15.1
     # via
     #   ipython
     #   matplotlib-inline
-typing-extensions==4.15.0
+typing-extensions==4.16.0
     # via
     #   jwcrypto
     #   sqlalchemy
-tzdata==2026.2
+tzdata==2026.3
     # via kombu
 tzlocal==5.4.3
     # via celery
@@ -555,7 +555,7 @@ wcwidth==0.8.1
     # via prompt-toolkit
 werkzeug==3.1.8
     # via moto
-wrapt==2.2.2
+wrapt==2.3.0
     # via deprecated
 xlrd==2.0.1
     # via

--- a/requirements/docs.pip
+++ b/requirements/docs.pip
@@ -8,9 +8,9 @@ alabaster==1.0.0
     # via sphinx
 babel==2.18.0
     # via sphinx
-certifi==2026.6.17
+certifi==2026.7.22
     # via requests
-charset-normalizer==3.4.7
+charset-normalizer==3.5.1
     # via requests
 docutils==0.22.4
     # via sphinx
@@ -24,7 +24,7 @@ jinja2==3.1.6
     # via sphinx
 markupsafe==3.0.3
     # via jinja2
-packaging==26.2
+packaging==26.3
     # via sphinx
 pygments==2.20.0
     # via sphinx

--- a/requirements/s3.pip
+++ b/requirements/s3.pip
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements/s3.pip requirements/s3.in
 #
-asgiref==3.11.1
+asgiref==3.12.1
     # via django
 boto3==1.43.36
     # via -r requirements/s3.in
@@ -28,7 +28,7 @@ s3transfer==0.19.0
     # via boto3
 six==1.17.0
     # via python-dateutil
-sqlparse==0.5.5
+sqlparse==0.6.0
     # via django
 urllib3==2.7.0
     # via

--- a/requirements/ses.pip
+++ b/requirements/ses.pip
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements/ses.pip requirements/ses.in
 #
-asgiref==3.11.1
+asgiref==3.12.1
     # via django
 boto==2.49.0
     # via -r requirements/ses.in
@@ -30,7 +30,7 @@ s3transfer==0.19.0
     # via boto3
 six==1.17.0
     # via python-dateutil
-sqlparse==0.5.5
+sqlparse==0.6.0
     # via django
 urllib3==2.7.0
     # via


### PR DESCRIPTION
### Changes / Features implemented

Bumps 19 pinned dependencies to their latest minor releases (same major version) across the compiled requirements files. Only versions published more than a week ago were selected; newer releases such as django-oauth-toolkit 3.4.1, google-auth 2.57.0, and sentry-sdk 2.68.1 were deliberately skipped as too recent.

Notable bumps: djangorestframework 3.17.1 → 3.18.0, django-oauth-toolkit 3.3.0 → 3.4.0, sentry-sdk 2.63.0 → 2.68.0, Pillow 12.2.0 → 12.3.0, sqlparse 0.5.5 → 0.6.0. The rest are transitive/infrastructure pins (asgiref, certifi, cffi, chardet, charset-normalizer, django-debug-toolbar, google-auth, httplib2, packaging, pytz, rpds-py, typing-extensions, tzdata, wrapt).

### Steps taken to verify this change does what is intended

Verified each new version against PyPI (release exists, not yanked, not a pre-release, published on or before 2026-08-18) and that no setup.cfg or transitive constraints block the bumps. Relying on CI to run the test suite.

### Side effects of implementing this change

None expected; all bumps stay within the current major version.

**Before submitting this PR for review, please make sure you have:**

  - [ ] Included tests (N/A — version pins only)
  - [ ] Updated documentation (N/A — version pins only)

Closes #