### PR TITLE
5.22.2 20260826

### DIFF
--- a/onadata/apps/api/tests/viewsets/test_charts_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_charts_viewset.py
@@ -2,6 +2,7 @@
 """
 Test ChartsViewSet.
 """
+
 import json
 import os
 from unittest.mock import patch
@@ -23,7 +24,7 @@ from onadata.libs.utils.timing import calculate_duration
 from onadata.libs.utils.user_auth import get_user_default_project
 
 
-def raise_data_error(a):
+def raise_data_error(*args, **kwargs):
     raise DataError
 
 

--- a/onadata/apps/api/tests/viewsets/test_dataview_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_dataview_viewset.py
@@ -18,17 +18,12 @@ from openpyxl import load_workbook
 from onadata.apps.api.tests.viewsets.test_abstract_viewset import TestAbstractViewSet
 from onadata.apps.api.viewsets.attachment_viewset import AttachmentViewSet
 from onadata.apps.api.viewsets.dataview_viewset import DataViewViewSet
-from onadata.libs.utils.dataview_filters import (
-    apply_filters,
-    filter_to_field_lookup,
-    get_field_lookup,
-    get_filter_kwargs,
-)
 from onadata.apps.api.viewsets.note_viewset import NoteViewSet
 from onadata.apps.api.viewsets.project_viewset import ProjectViewSet
 from onadata.apps.api.viewsets.xform_viewset import XFormViewSet
 from onadata.apps.logger.models import Attachment, Instance
-from onadata.apps.logger.models.data_view import DataView
+from onadata.apps.logger.models.data_view import FILTERABLE_METADATA_COLUMNS, DataView
+from onadata.apps.logger.models.xform import XForm
 from onadata.apps.viewer.models.export import Export
 from onadata.libs.permissions import ReadOnlyRole
 from onadata.libs.serializers.attachment_serializer import AttachmentSerializer
@@ -42,6 +37,13 @@ from onadata.libs.utils.common_tags import EDITED, MONGO_STRFTIME
 from onadata.libs.utils.common_tools import (
     filename_from_disposition,
     get_response_content,
+)
+from onadata.libs.utils.dataview_filters import (
+    apply_filters,
+    filter_to_field_lookup,
+    get_field_lookup,
+    get_filter_kwargs,
+    is_safe_column,
 )
 
 
@@ -112,6 +114,56 @@ class TestDataViewViewSet(TestAbstractViewSet):
         instance.save()
         self.assertEqual(apply_filters(self.xform.instances, filters).first().xml, xml)
         # delete instance
+        instance.delete()
+
+    def test_is_safe_column(self):
+        """Only string columns free of the ``__`` lookup separator are safe."""
+        self.assertTrue(is_safe_column("age"))
+        self.assertTrue(is_safe_column("a_group/grouped"))
+        self.assertTrue(is_safe_column("_submission_time"))
+        # A form field literally named with ``__`` is not safe even though it
+        # could otherwise reach the allow-list.
+        self.assertFalse(is_safe_column("age__gt"))
+        self.assertFalse(is_safe_column([]))
+        self.assertFalse(is_safe_column(None))
+
+    def test_get_filter_kwargs_drops_lookup_separator_column(self):
+        """A column carrying ``__`` never reaches the ORM lookup."""
+        self.assertEqual(
+            get_filter_kwargs([{"value": 2, "column": "age__gt", "filter": "="}]),
+            {},
+        )
+
+    def test_get_filter_kwargs_drops_non_string_column(self):
+        """A non-string column is dropped rather than raising a TypeError."""
+        self.assertEqual(
+            get_filter_kwargs([{"value": 2, "column": [], "filter": "="}]),
+            {},
+        )
+
+    def test_apply_filters_ignores_hostile_stored_dataview(self):
+        """A hostile column stored directly is handled safely at consumption.
+
+        DataViews created via the ORM bypass serializer validation; a column
+        with ``__`` must not reach ``filter(**kwargs)``. The filter is dropped
+        so the query runs without error and simply applies no constraint.
+        """
+        xml = '<data id="a"><fruit>orange</fruit></data>'
+        instance = Instance(xform=self.xform, xml=xml)
+        instance.save()
+
+        data_view = DataView.objects.create(
+            name="Hostile DataView",
+            project=self.project,
+            xform=self.xform,
+            columns=["fruit"],
+            query=[{"column": "fruit__gt", "filter": "=", "value": "x"}],
+        )
+
+        queryset = apply_filters(self.xform.instances, data_view.query)
+        # No exception, and the hostile filter applied no constraint.
+        self.assertIn(instance, list(queryset))
+
         instance.delete()
 
     # pylint: disable=invalid-name
@@ -360,6 +412,176 @@ class TestDataViewViewSet(TestAbstractViewSet):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data["name"], "My DataView updated")
+
+    def _dataview_data(self, **overrides):
+        data = {
+            "name": "Allow-list DataView",
+            "xform": f"http://testserver/api/v1/forms/{self.xform.pk}",
+            "project": f"http://testserver/api/v1/projects/{self.project.pk}",
+            "columns": '["name", "age", "gender"]',
+            "query": '[{"column":"age","filter":">","value":"20"}]',
+        }
+        data.update(overrides)
+        return data
+
+    def test_create_dataview_rejects_unknown_column(self):
+        """A query column absent from the form is rejected on create."""
+        data = self._dataview_data(
+            query='[{"column":"nonexistent_field","filter":"=","value":"x"}]'
+        )
+        request = self.factory.post("/", data=data, **self.extra)
+        response = self.view(request)
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("query", response.data)
+
+    def test_create_dataview_rejects_lookup_path_column(self):
+        """A Django lookup-separator column (``__``) is rejected on create."""
+        data = self._dataview_data(
+            query='[{"column":"age__gt","filter":"=","value":"20"}]'
+        )
+        request = self.factory.post("/", data=data, **self.extra)
+        response = self.view(request)
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("query", response.data)
+
+    def test_create_dataview_accepts_supported_metadata_column(self):
+        """A supported metadata column (``_submission_time``) is accepted."""
+        data = self._dataview_data(
+            query='[{"column":"_submission_time","filter":">","value":"2015-01-01"}]'
+        )
+        request = self.factory.post("/", data=data, **self.extra)
+        response = self.view(request)
+
+        self.assertEqual(response.status_code, 201)
+
+    def test_create_dataview_accepts_nested_xpath_column(self):
+        """A valid nested form XPath (containing ``/``) is accepted."""
+        data = self._dataview_data(
+            columns='["name", "a_group/grouped"]',
+            query='[{"column":"a_group/grouped","filter":"=","value":"Yes"}]',
+        )
+        request = self.factory.post("/", data=data, **self.extra)
+        response = self.view(request)
+
+        self.assertEqual(response.status_code, 201)
+
+    def test_update_dataview_rejects_unknown_column(self):
+        """A full update (PUT) with an unknown query column is rejected."""
+        self._create_dataview()
+
+        data = self._dataview_data(
+            name="My DataView updated",
+            query='[{"column":"nonexistent_field","filter":"=","value":"x"}]',
+        )
+        request = self.factory.put("/", data=data, **self.extra)
+        response = self.view(request, pk=self.data_view.pk)
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("query", response.data)
+
+    def test_patch_dataview_query_rejects_unknown_column(self):
+        """A partial update (PATCH) that sets an unknown query column fails."""
+        self._create_dataview()
+
+        data = {"query": '[{"column":"nonexistent_field","filter":"=","value":"x"}]'}
+        request = self.factory.patch("/", data=data, **self.extra)
+        response = self.view(request, pk=self.data_view.pk)
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("query", response.data)
+
+    def test_patch_unrelated_keeps_legacy_column(self):
+        """An unrelated PATCH is not failed by a pre-existing legacy column."""
+        data_view = DataView.objects.create(
+            name="Legacy DataView",
+            project=self.project,
+            xform=self.xform,
+            columns=["name"],
+            query=[{"column": "legacy_gone", "filter": "=", "value": "x"}],
+        )
+
+        request = self.factory.patch("/", data={"name": "Renamed"}, **self.extra)
+        response = self.view(request, pk=data_view.pk)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["name"], "Renamed")
+
+    def test_form_change_validates_retained_query(self):
+        """Changing the form re-validates the retained query against it."""
+        # Query column ``gender`` is valid on the tutorial form.
+        self._create_dataview(
+            data=self._dataview_data(
+                name="Gender DataView",
+                columns='["name", "gender"]',
+                query='[{"column":"gender","filter":"=","value":"male"}]',
+            )
+        )
+        data_view_pk = self.data_view.pk
+
+        # Publish a second form that has no ``gender`` field.
+        path = os.path.join(
+            settings.PROJECT_ROOT,
+            "libs",
+            "tests",
+            "utils",
+            "fixtures",
+            "age_decimal",
+            "age_decimal.xlsx",
+        )
+        self._publish_xls_form_to_project(xlsform_path=path)
+
+        data = {"xform": f"http://testserver/api/v1/forms/{self.xform.pk}"}
+        request = self.factory.patch("/", data=data, **self.extra)
+        response = self.view(request, pk=data_view_pk)
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("query", response.data)
+
+    def test_create_dataview_rejects_non_string_column(self):
+        """A non-string query column yields a 400, not a 500 (TypeError)."""
+        data = self._dataview_data(query='[{"column":[],"filter":"=","value":"x"}]')
+        request = self.factory.post("/", data=data, **self.extra)
+        response = self.view(request)
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("query", response.data)
+
+    def test_create_dataview_rejects_form_field_with_lookup_separator(self):
+        """A form field literally named with ``__`` is still rejected.
+
+        Even when the field enters the allow-list via the form, the ``__``
+        lookup separator is rejected before the membership check so it can
+        never reach ``get_field_lookup``.
+        """
+        fields = self.xform.get_field_name_xpaths_only() + ["age__gt"]
+        data = self._dataview_data(
+            query='[{"column":"age__gt","filter":"=","value":"20"}]'
+        )
+        with patch.object(XForm, "get_field_name_xpaths_only", return_value=fields):
+            request = self.factory.post("/", data=data, **self.extra)
+            response = self.view(request)
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("query", response.data)
+
+    def test_create_dataview_accepts_all_supported_metadata_columns(self):
+        """Every supported filter metadata column is accepted on create."""
+        for column in FILTERABLE_METADATA_COLUMNS:
+            # ``_submission_time`` casts to a timestamp; other metadata compare
+            # as text and ``_id`` as an integer, so an int-like value is safe.
+            value = "2015-01-01" if column == "_submission_time" else "1"
+            query = json.dumps([{"column": column, "filter": "=", "value": value}])
+            data = self._dataview_data(name=f"Meta {column}", query=query)
+            request = self.factory.post("/", data=data, **self.extra)
+            response = self.view(request)
+
+            self.assertEqual(
+                response.status_code,
+                201,
+                f"metadata column {column} rejected: {response.data}",
+            )
 
     def test_soft_delete_dataview(self):
         """

--- a/onadata/apps/api/tests/viewsets/test_merged_xform_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_merged_xform_viewset.py
@@ -54,6 +54,13 @@ NOT_MATCHING = """
 |         | fruits            | mango  | Mango  |
 """
 
+TRIGGER_MD = """
+| survey  |
+|         | type    | name  | label | trigger  | calculation |
+|         | integer | fruit | Fruit |          |             |
+|         | text    | note  | Note  | ${fruit} | 1 + 1       |
+"""
+
 # https://github.com/onaio/onadata/issues/1153
 REFERENCE_ISSUE = """
 | survey  |
@@ -160,6 +167,36 @@ class TestMergedXFormViewSet(TestAbstractViewSet):
     def test_create_merged_dataset(self):
         """Test creating a merged dataset"""
         self._create_merged_dataset()
+
+    def test_create_merged_dataset_trigger_column(self):
+        """Creating a merged dataset from forms with a trigger column"""
+        view = MergedXFormViewSet.as_view(
+            {
+                "post": "create",
+            }
+        )
+        # pylint: disable=attribute-defined-outside-init
+        self.project = get_user_default_project(self.user)
+        xform1 = self._publish_markdown(TRIGGER_MD, self.user, id_string="a")
+        xform2 = self._publish_markdown(TRIGGER_MD, self.user, id_string="b")
+
+        data = {
+            "xforms": [
+                "http://testserver/api/v1/forms/%s" % xform1.pk,
+                "http://testserver/api/v1/forms/%s" % xform2.pk,
+            ],
+            "name": "Merged Dataset",
+            "project": f"http://testserver/api/v1/projects/{self.project.pk}",
+        }
+        request = self.factory.post("/", data=data, **self.extra)
+        response = view(request)
+        self.assertEqual(response.status_code, 201)
+
+        # the merged form's survey rebuilds from its stored JSON
+        merged_xform = MergedXForm.objects.get(pk=response.data["id"])
+        self.assertIn(
+            'event="xforms-value-changed"', merged_xform.get_survey().to_xml()
+        )
 
     def test_merged_datasets_list(self):
         """Test list endpoint of a merged dataset"""

--- a/onadata/apps/api/tests/viewsets/test_metadata_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_metadata_viewset.py
@@ -348,7 +348,15 @@ class TestMetaDataViewSet(TestAbstractViewSet):
         )
 
     def test_add_media_dataview_link(self):
-        self._create_dataview()
+        data = {
+            "name": "My DataView",
+            "xform": f"http://testserver/api/v1/forms/{self.xform.pk}",
+            "project": f"http://testserver/api/v1/projects/{self.project.pk}",
+            "columns": '["name", "age", "gender"]',
+            "query": '[{"column":"_submission_time","filter":">",'
+            '"value":"1900-01-01"}]',
+        }
+        self._create_dataview(data)
         data_type = "media"
         data_value = "dataview {} transportation".format(self.data_view.pk)
         self._add_form_metadata(self.xform, data_type, data_value)

--- a/onadata/apps/api/tests/viewsets/test_project_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_project_viewset.py
@@ -419,7 +419,15 @@ class TestProjectViewSet(TestAbstractViewSet):
     # pylint: disable=invalid-name
     def test_none_empty_forms_and_dataview_properties_in_returned_json(self):
         self._publish_xls_form_to_project()
-        self._create_dataview()
+        data = {
+            "name": "My DataView",
+            "xform": f"http://testserver/api/v1/forms/{self.xform.pk}",
+            "project": f"http://testserver/api/v1/projects/{self.project.pk}",
+            "columns": '["name", "age", "gender"]',
+            "query": '[{"column":"_submission_time","filter":">",'
+            '"value":"1900-01-01"}]',
+        }
+        self._create_dataview(data)
 
         view = ProjectViewSet.as_view({"get": "retrieve"})
         request = self.factory.get("/", **self.extra)
@@ -2837,8 +2845,9 @@ class TestProjectViewSet(TestAbstractViewSet):
             "xform": f"http://testserver/api/v1/forms/{self.xform.pk}",
             "project": f"http://testserver/api/v1/projects/{project2.pk}",
             "columns": '["name", "age", "gender"]',
-            "query": '[{"column":"age","filter":">","value":"20"},'
-            '{"column":"age","filter":"<","value":"50"}]',
+            "query": '[{"column":"_submission_time","filter":">",'
+            '"value":"1900-01-01"},'
+            '{"column":"_submission_time","filter":"<","value":"2100-01-01"}]',
         }
 
         self._create_dataview(data)

--- a/onadata/apps/api/tests/viewsets/test_widget_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_widget_viewset.py
@@ -586,6 +586,25 @@ class TestWidgetViewSet(TestAbstractViewSet):
         self.assertEqual(count, Widget.objects.all().count())
         self.assertEqual(response.data["column"], ["'doesnotexists' not in the form."])
 
+    def test_create_group_by_not_in_form(self):
+        """A widget whose group_by is not a form field is rejected."""
+        data = {
+            "content_object": "http://testserver/api/v1/forms/%s" % self.xform.pk,
+            "widget_type": "charts",
+            "view_type": "horizontal-bar",
+            "column": "_submission_time",
+            "group_by": "doesnotexists",
+        }
+
+        count = Widget.objects.all().count()
+
+        request = self.factory.post("/", data=data, **self.extra)
+        response = self.view(request)
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(count, Widget.objects.all().count())
+        self.assertEqual(response.data["group_by"], ["'doesnotexists' not in the form."])
+
     def test_create_widget_with_xform_no_perms(self):
         data = {
             "content_object": "http://testserver/api/v1/forms/%s" % self.xform.pk,

--- a/onadata/apps/logger/migrations/0039_restore_flipped_encryption.py
+++ b/onadata/apps/logger/migrations/0039_restore_flipped_encryption.py
@@ -1,0 +1,66 @@
+"""Restore encryption status for forms wrongly flipped to unencrypted."""
+
+from django.db import migrations
+
+
+def restore_flipped_encryption(apps, schema_editor):
+    """Restore forms whose post-publish public key was dropped from json.
+
+    Encryption enabled after publishing — via managed (KMS) keys or the
+    API ``public_key`` field — exists only in a form's stored json and
+    xml; the XLSForm file has no record of it. For forms whose stored
+    json predates the pyxform 4.1.0 upgrade (skipped by migration 0031),
+    ``XForm._get_survey()`` rebuilt the json from the XLSForm without
+    the key and a later full save recomputed ``encrypted`` as False.
+
+    The flip never touched the form xml, so wrongly flipped forms still
+    carry the key in their xml — unlike forms legitimately unencrypted
+    by an XLSForm replacement, whose replaced xml has no key.
+    """
+    # Use live model for get_survey_and_json_from_xlsform. This is
+    # needed because apps.get_model("logger", "XForm") returns a frozen
+    # version of XForm that has only the fields known at this migration
+    from onadata.apps.logger.models.xform import XForm as LiveXForm
+
+    # pylint: disable=invalid-name
+    XForm = apps.get_model("logger", "XForm")
+    candidates = (
+        XForm.objects.filter(deleted_at__isnull=True, encrypted=False)
+        .exclude(public_key="")
+        .exclude(public_key__isnull=True)
+        .only("id", "xml")
+    )
+
+    eta = candidates.count()
+
+    for xform in candidates.iterator(chunk_size=100):
+        eta -= 1
+        print("eta", eta)
+
+        if "base64RsaPublicKey" not in (xform.xml or ""):
+            continue
+
+        try:
+            live_xform = LiveXForm.objects.get(id=xform.id)
+            _, workbook_json = live_xform.get_survey_and_json_from_xlsform()
+            workbook_json["public_key"] = live_xform.public_key
+            XForm.objects.filter(id=xform.id).update(json=workbook_json, encrypted=True)
+            print(f"Restored encryption for XForm {xform.id}")
+
+        # pylint: disable=broad-exception-caught
+        except Exception as e:
+            # Best-effort repair; leave the form for manual follow-up
+            print(f"Restoring encryption for XForm {xform.id} failed: {e}")
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("logger", "0038_instance_last_edited_by"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            restore_flipped_encryption,
+            reverse_code=migrations.RunPython.noop,  # migration is irreversible
+        ),
+    ]

--- a/onadata/apps/logger/migrations/0042_decrypt_swept_encrypted_submissions.py
+++ b/onadata/apps/logger/migrations/0042_decrypt_swept_encrypted_submissions.py
@@ -1,0 +1,63 @@
+"""Decrypt submissions whose ciphertext was swept by the attachment sweep."""
+
+from django.db import migrations
+
+
+# pylint: disable=unused-argument
+def decrypt_swept_encrypted_submissions(apps, schema_editor):
+    """Restore and decrypt submissions whose ciphertext was wrongly swept.
+
+    While a managed form's ``encrypted`` flag was False — flipped by the
+    stale-json bug repaired in logger.0039, or turned off while devices
+    still held an encrypted form version — ``get_expected_media`` did not
+    recognise incoming encrypted envelopes, so the attachment sweep in
+    ``save_attachments`` soft-deleted their ciphertext right after
+    creation and decryption failed with no files.
+    """
+    from onadata.apps.logger.models import Instance
+    from onadata.libs.kms.tools import decrypt_instance
+
+    candidates = Instance.objects.filter(
+        deleted_at__isnull=True,
+        is_encrypted=True,
+        decryption_status=Instance.DecryptionStatus.FAILED,
+    )
+    decrypted_count = 0
+    failed_count = 0
+    skipped_count = 0
+
+    for instance in candidates.iterator(chunk_size=100):
+        if (instance.json or {}).get("_decryption_error") != "INVALID_SUBMISSION":
+            skipped_count += 1
+            continue
+
+        instance.attachments.filter(deleted_at__isnull=False).update(deleted_at=None)
+
+        try:
+            decrypt_instance(instance)
+            decrypted_count += 1
+            print(f"Decrypted Instance {instance.id}")
+
+        # pylint: disable=broad-exception-caught
+        except Exception as e:
+            # Best-effort repair; leave the submission for manual follow-up
+            failed_count += 1
+            print(f"Decrypting Instance {instance.id} failed: {e}")
+
+    print(
+        f"Decrypted {decrypted_count} submissions,"
+        f" {failed_count} failed, {skipped_count} skipped"
+    )
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("logger", "0041_project_date_created_indexes"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            decrypt_swept_encrypted_submissions,
+            reverse_code=migrations.RunPython.noop,
+        ),
+    ]

--- a/onadata/apps/logger/models/data_view.py
+++ b/onadata/apps/logger/models/data_view.py
@@ -29,6 +29,8 @@ from onadata.libs.utils.cache_tools import (  # noqa pylint: disable=unused-impo
 )
 from onadata.libs.utils.common_tags import (
     ATTACHMENTS,
+    DATE_MODIFIED,
+    DURATION,
     EDITED,
     GEOLOCATION,
     ID,
@@ -36,12 +38,22 @@ from onadata.libs.utils.common_tags import (
     MONGO_STRFTIME,
     NOTES,
     SUBMISSION_TIME,
+    SUBMITTED_BY,
 )
 from onadata.libs.utils.common_tools import get_abbreviated_xpath
 
 SUPPORTED_FILTERS = ["=", ">", "<", ">=", "<=", "<>", "!="]
 ATTACHMENT_TYPES = ["photo", "audio", "video"]
 DEFAULT_COLUMNS = [ID, SUBMISSION_TIME, EDITED, LAST_EDITED, NOTES]
+# Metadata columns a DataView ``query`` filter may reference in addition to the
+# form's own fields. Extends the auto-returned DEFAULT_COLUMNS with the
+# submission metadata the chart/stats and filter paths treat as first-class
+# (see chart_tools.FIELD_DATA_MAP). DEFAULT_COLUMNS alone omits these.
+FILTERABLE_METADATA_COLUMNS = DEFAULT_COLUMNS + [
+    DATE_MODIFIED,
+    SUBMITTED_BY,
+    DURATION,
+]
 
 
 def _json_sql_str(key, known_integers=None, known_dates=None, known_decimals=None):

--- a/onadata/apps/logger/models/instance.py
+++ b/onadata/apps/logger/models/instance.py
@@ -768,7 +768,7 @@ class Instance(models.Model, InstanceBaseClass):
         if self.check_encrypted():
             self.is_encrypted = True
 
-            if self.xform.is_managed:
+            if self.xform.is_was_managed:
                 self.decryption_status = Instance.DecryptionStatus.PENDING
         else:
             self.is_encrypted = False
@@ -781,7 +781,9 @@ class Instance(models.Model, InstanceBaseClass):
             # pylint: disable=no-member
             data = self.get_dict()
             media_list = []
-            if "encryptedXmlFile" in data and self.xform.encrypted:
+            if "encryptedXmlFile" in data and (
+                self.xform.encrypted or self.xform.is_was_managed
+            ):
                 media_list.append(data["encryptedXmlFile"])
                 if "media" in data:
                     # pylint: disable=no-member

--- a/onadata/apps/logger/models/xform.py
+++ b/onadata/apps/logger/models/xform.py
@@ -525,7 +525,15 @@ class XFormMixin:
             if (is_itemset_error or is_trigger_error) and self.xls:
                 # Use get_survey_and_json_from_xlsform to get workbook_json
                 survey, workbook_json = self.get_survey_and_json_from_xlsform()
-                # Persist the workbook_json to avoid repeated XLS parsing
+                # Encryption enabled post-publish (e.g. via managed keys)
+                # exists only in the stored json, not the XLSForm
+                if self.public_key:
+                    survey.public_key = self.public_key
+                    workbook_json["public_key"] = self.public_key
+                # Persist the workbook_json to avoid repeated XLS parsing;
+                # updating the in-memory json keeps an enclosing save()
+                # from writing the stale json back
+                self.json = workbook_json
                 XForm.objects.filter(pk=self.pk).update(json=workbook_json)
                 return survey
             if is_trigger_error:

--- a/onadata/apps/logger/models/xform.py
+++ b/onadata/apps/logger/models/xform.py
@@ -140,6 +140,20 @@ def get_survey_from_file_object(
     return survey, xlsform_json
 
 
+def _convert_triggers_to_tuples(node):
+    """Recursively convert question ``trigger`` values from lists to tuples.
+
+    pyxform processes trigger references into tuples; storing the survey as
+    JSON turns them into lists, which ``SurveyElementBuilder`` rejects.
+    """
+    if isinstance(node, dict):
+        if isinstance(node.get("trigger"), list):
+            node["trigger"] = tuple(node["trigger"])
+        for child in node.get("children", []):
+            _convert_triggers_to_tuples(child)
+    return node
+
+
 def question_types_to_exclude(_type):
     """Returns True if ``_type`` is in QUESTION_TYPES_TO_EXCLUDE."""
     return _type in QUESTION_TYPES_TO_EXCLUDE
@@ -514,6 +528,16 @@ class XFormMixin:
                 # Persist the workbook_json to avoid repeated XLS parsing
                 XForm.objects.filter(pk=self.pk).update(json=workbook_json)
                 return survey
+            if is_trigger_error:
+                # Merged datasets have no XLSForm to rebuild from; the
+                # stored json is valid except triggers became lists in
+                # the JSON round-trip
+                survey_dict = (
+                    json.loads(self.json) if isinstance(self.json, str) else self.json
+                )
+                return SurveyElementBuilder().create_survey_element_from_dict(
+                    _convert_triggers_to_tuples(survey_dict)
+                )
             raise
 
         return bytes(bytearray(self.xml, encoding="utf-8"))

--- a/onadata/apps/logger/tests/models/test_instance.py
+++ b/onadata/apps/logger/tests/models/test_instance.py
@@ -1283,8 +1283,12 @@ class TestInstance(TestBase):
         self.assertEqual(instance.decryption_status, Instance.DecryptionStatus.PENDING)
 
         # Encrypted Instance whose encryption is not by managed keys (custom encryption)
-        self.xform.is_managed = False
-        self.xform.save(update_fields=["is_managed"])
+        md = """
+        | survey |
+        |        | type  | name   | label                |
+        |        | photo | sunset | Take photo of sunset |
+        """
+        custom_xform = self._publish_markdown(md, self.user, id_string="custom")
         manifest_xml = """
         <data xmlns="http://opendatakit.org/submissions" encrypted="yes"
             id="test_valigetta" version="202502131337">
@@ -1302,7 +1306,7 @@ class TestInstance(TestBase):
         """.strip()
         survey_type, _ = SurveyType.objects.get_or_create(slug="slug-foo")
         instance = Instance.objects.create(
-            xform=self.xform,
+            xform=custom_xform,
             xml=manifest_xml,
             user=self.user,
             survey_type=survey_type,
@@ -1322,6 +1326,18 @@ class TestInstance(TestBase):
         self.assertEqual(
             instance.decryption_status, Instance.DecryptionStatus.UNMANAGED
         )
+
+    def test_decryption_pending_encryption_disabled(self):
+        """decryption_status is PENDING for encrypted Instance received after
+        managed encryption is disabled."""
+        self._publish_managed_form()
+        # Disabled encryption
+        XForm.objects.filter(pk=self.xform.pk).update(encrypted=False, is_managed=False)
+        self.xform.refresh_from_db()
+        instance = self._submit_encrypted_instance()
+
+        self.assertTrue(instance.is_encrypted)
+        self.assertEqual(instance.decryption_status, Instance.DecryptionStatus.PENDING)
 
     @patch(
         "onadata.apps.logger.tasks.adjust_xform_num_of_decrypted_submissions_async.delay"
@@ -1401,3 +1417,61 @@ class TestInstance(TestBase):
         # Returns False if XML invalid
         with patch("xml.etree.ElementTree.fromstring", side_effect=ParseError):
             self.assertFalse(instance.check_encrypted())
+
+
+class GetExpectedMediaTestCase(TestBase):
+    """Tests for `Instance.get_expected_media`"""
+
+    def setUp(self):
+        super().setUp()
+
+        self._publish_managed_form()
+
+    def test_encrypted_flag_off(self):
+        """Ciphertext files are expected media when a managed form's encrypted flag is off."""
+        XForm.objects.filter(pk=self.xform.pk).update(encrypted=False)
+        self.xform.refresh_from_db()
+        instance = self._submit_encrypted_instance()
+
+        self.assertCountEqual(
+            instance.get_expected_media(),
+            ["submission.xml.enc", "sunset.png.enc", "forest.mp4.enc"],
+        )
+
+    def test_encryption_disabled(self):
+        """Ciphertext files are expected media after managed encryption is disabled."""
+        XForm.objects.filter(pk=self.xform.pk).update(encrypted=False, is_managed=False)
+        self.xform.refresh_from_db()
+        instance = self._submit_encrypted_instance()
+
+        self.assertCountEqual(
+            instance.get_expected_media(),
+            ["submission.xml.enc", "sunset.png.enc", "forest.mp4.enc"],
+        )
+
+    def test_single_media_file(self):
+        """A lone ciphertext media file is expected media when the encrypted flag is off."""
+        XForm.objects.filter(pk=self.xform.pk).update(encrypted=False)
+        self.xform.refresh_from_db()
+        xml = f"""
+        <data xmlns="http://opendatakit.org/submissions" encrypted="yes"
+            id="{self.xform.id_string}" version="{self.xform.version}">
+            <base64EncryptedKey>fake-key</base64EncryptedKey>
+            <meta xmlns="http://openrosa.org/xforms">
+                <instanceID>uuid:8780874c-fe70-4060-ab6e-c8e5228ed85f</instanceID>
+            </meta>
+            <media>
+                <file>sunset.png.enc</file>
+            </media>
+            <encryptedXmlFile>submission.xml.enc</encryptedXmlFile>
+            <base64EncryptedElementSignature>fake-signature</base64EncryptedElementSignature>
+        </data>
+        """.strip()
+        survey_type, _ = SurveyType.objects.get_or_create(slug="slug-foo")
+        instance = Instance.objects.create(
+            xform=self.xform, xml=xml, user=self.user, survey_type=survey_type
+        )
+
+        self.assertCountEqual(
+            instance.get_expected_media(), ["submission.xml.enc", "sunset.png.enc"]
+        )

--- a/onadata/apps/logger/tests/models/test_xform.py
+++ b/onadata/apps/logger/tests/models/test_xform.py
@@ -589,6 +589,96 @@ class TestXForm(TestBase):
         # The json should now be workbook_json, not the old survey.to_json_dict() format
         self.assertEqual(xform.json, original_workbook_json)
 
+    def _make_stale_managed_xform(self, public_key):
+        """Publish a form and recreate a stale managed encrypted state.
+
+        Managed (KMS) encryption injects the public key into the stored
+        ``json`` after publishing; the XLSForm file has no record of it.
+        Stored json that predates the pyxform 4.1.0 upgrade — a select
+        question with inline children and no itemset — fails parsing,
+        making ``_get_survey`` fall back to rebuilding from the XLSForm.
+        Migration logger.0031 skipped encrypted forms, so such forms
+        exist in production.
+        """
+        self._publish_transportation_form()
+        xform = XForm.objects.get(pk=self.xform.pk)
+        self.publish_time_workbook_json = xform.json.copy()
+        stale_json = {
+            "name": self.publish_time_workbook_json["name"],
+            "title": xform.title,
+            "id_string": xform.id_string,
+            "sms_keyword": xform.id_string,
+            "type": "survey",
+            "default_language": "default",
+            "public_key": public_key,
+            "children": [
+                {
+                    "name": "fruit",
+                    "type": "select one",
+                    "label": "Fruit",
+                    "children": [
+                        {"name": "mango", "label": "Mango"},
+                        {"name": "orange", "label": "Orange"},
+                    ],
+                },
+                {
+                    "name": "meta",
+                    "type": "group",
+                    "control": {"bodyless": True},
+                    "children": [
+                        {
+                            "name": "instanceID",
+                            "type": "calculate",
+                            "bind": {"readonly": "true()", "jr:preload": "uid"},
+                        }
+                    ],
+                },
+            ],
+        }
+        XForm.objects.filter(pk=xform.pk).update(
+            json=stale_json,
+            encrypted=True,
+            is_managed=True,
+            public_key=public_key,
+            # The form has data, so _set_public_key_field does not
+            # re-inject the key on save
+            num_of_submissions=1,
+        )
+        xform.refresh_from_db()
+        return xform
+
+    def test_save_preserves_managed_encryption_on_stale_json(self):
+        """A full save keeps a managed form encrypted when its json is stale.
+
+        The XLSForm-rebuilt survey must retain the injected public key,
+        otherwise the save recomputes ``encrypted`` as False.
+        """
+        public_key = "fake-managed-public-key"
+        xform = self._make_stale_managed_xform(public_key)
+
+        xform.save()
+
+        xform.refresh_from_db()
+        self.assertTrue(xform.encrypted)
+
+    def test_save_heals_stale_json_of_managed_form(self):
+        """A full save persists the rebuilt json, key included.
+
+        The stale json should be replaced by the XLSForm-rebuilt workbook
+        json with the injected public key retained, so later saves do not
+        re-parse the XLSForm.
+        """
+        public_key = "fake-managed-public-key"
+        xform = self._make_stale_managed_xform(public_key)
+
+        xform.save()
+
+        xform.refresh_from_db()
+        self.assertEqual(
+            xform.json,
+            {**self.publish_time_workbook_json, "public_key": public_key},
+        )
+
     def test_is_was_managed_when_managed(self):
         """is_was_managed returns True when is_managed is True"""
         self._publish_transportation_form()

--- a/onadata/apps/logger/tests/test_parsing.py
+++ b/onadata/apps/logger/tests/test_parsing.py
@@ -237,6 +237,58 @@ class TestXFormInstanceParser(TestBase):
         ]
         self.assertEqual(flat_dict.get("media"), expected_flat_list)
 
+    def _encrypted_envelope_single_media(self):
+        return f"""
+        <data xmlns="http://opendatakit.org/submissions" encrypted="yes"
+            id="{self.xform.id_string}" version="{self.xform.version}">
+            <base64EncryptedKey>fake-key</base64EncryptedKey>
+            <meta xmlns="http://openrosa.org/xforms">
+                <instanceID>uuid:8780874c-fe70-4060-ab6e-c8e5228ed85f</instanceID>
+            </meta>
+            <media>
+                <file>sunset.png.enc</file>
+            </media>
+            <encryptedXmlFile>submission.xml.enc</encryptedXmlFile>
+            <base64EncryptedElementSignature>fake-signature</base64EncryptedElementSignature>
+        </data>
+        """.strip()
+
+    def test_media_list_on_managed_form_encrypted_flag_off(self):
+        """A single media file parses as a list when a managed form's
+        encrypted flag is off."""
+        self._publish_managed_form()
+        XForm.objects.filter(pk=self.xform.pk).update(encrypted=False)
+        self.xform.refresh_from_db()
+
+        parser = XFormInstanceParser(
+            self._encrypted_envelope_single_media(), self.xform
+        )
+
+        self.assertEqual(
+            parser.to_dict().get("data").get("media"), [{"file": "sunset.png.enc"}]
+        )
+        self.assertEqual(
+            parser.to_flat_dict().get("media"), [{"media/file": "sunset.png.enc"}]
+        )
+
+    def test_media_list_after_encryption_disabled(self):
+        """A single media file parses as a list after managed encryption
+        is disabled."""
+        self._publish_managed_form()
+        XForm.objects.filter(pk=self.xform.pk).update(encrypted=False, is_managed=False)
+        self.xform.refresh_from_db()
+
+        parser = XFormInstanceParser(
+            self._encrypted_envelope_single_media(), self.xform
+        )
+
+        self.assertEqual(
+            parser.to_dict().get("data").get("media"), [{"file": "sunset.png.enc"}]
+        )
+        self.assertEqual(
+            parser.to_flat_dict().get("media"), [{"media/file": "sunset.png.enc"}]
+        )
+
     def test_xml_repeated_nodes_to_dict(self):
         xml_file = os.path.join(
             os.path.dirname(os.path.abspath(__file__)), "../fixtures/repeated_nodes.xml"

--- a/onadata/apps/logger/xform_instance_parser.py
+++ b/onadata/apps/logger/xform_instance_parser.py
@@ -359,7 +359,9 @@ class XFormInstanceParser:
         ]
 
         self._dict = _xml_node_to_dict(
-            self._root_node, repeats, self.data_dicionary.encrypted
+            self._root_node,
+            repeats,
+            self.data_dicionary.encrypted or self.data_dicionary.is_was_managed,
         )
         self._flat_dict = {}
 

--- a/onadata/apps/viewer/parsed_instance_tools.py
+++ b/onadata/apps/viewer/parsed_instance_tools.py
@@ -162,7 +162,8 @@ def get_where_clause(query, form_integer_fields=None, form_decimal_fields=None):
                             continue
 
                         if value is None:
-                            or_where.extend([f"logger_instance.json->>'{key}' IS NULL"])
+                            or_where.extend(["logger_instance.json->>%s IS NULL"])
+                            or_params.extend([key])
                         elif isinstance(value, list):
                             for item in value:
                                 or_where.extend(["logger_instance.json->>%s = %s"])

--- a/onadata/libs/data/query.py
+++ b/onadata/libs/data/query.py
@@ -49,7 +49,8 @@ def _additional_data_view_filters(data_view):
         data_view_where = " AND " + " AND ".join(where)
 
     for param in where_params:
-        data_view_where = data_view_where.replace("%s", f"'{param}'", 1)
+        escaped_param = str(param).replace("'", "''")
+        data_view_where = data_view_where.replace("%s", f"'{escaped_param}'", 1)
 
     return data_view_where
 
@@ -62,6 +63,11 @@ def _json_query(field):
     _field = field.replace("'", "''")
 
     return f"json->>'{_field}'"
+
+
+def _escape_identifier(value):
+    """Escape a value used as a double-quoted SQL identifier/alias."""
+    return value.replace('"', '""') if isinstance(value, str) else value
 
 
 def _postgres_count_group_field_n_group_by(field, name, xform, group_by, data_view):
@@ -196,7 +202,7 @@ def _query_args(field, name, xform, group_by=None):
     qargs = {
         "table": "logger_instance",
         "json": _json_query(field),
-        "name": name,
+        "name": _escape_identifier(name),
         "restrict_field": "xform_id",
         "restrict_value": xform.pk,
         "join": "",
@@ -213,10 +219,10 @@ def _query_args(field, name, xform, group_by=None):
 
     if isinstance(group_by, list):
         for index, value in enumerate(group_by):
-            qargs[f"group_name{index}"] = value
+            qargs[f"group_name{index}"] = _escape_identifier(value)
             qargs[f"group_by{index}"] = _json_query(value)
     else:
-        qargs["group_name"] = group_by
+        qargs["group_name"] = _escape_identifier(group_by)
         qargs["group_by"] = _json_query(group_by)
 
     return qargs

--- a/onadata/libs/data/query.py
+++ b/onadata/libs/data/query.py
@@ -22,9 +22,11 @@ def _dictfetchall(cursor):
     return [dict(zip([col[0] for col in desc], row)) for row in cursor.fetchall()]
 
 
-def _execute_query(query, to_dict=True):
+def _execute_query(query, params=None, to_dict=True):
     cursor = connection.cursor()
-    cursor.execute(query)
+    # Pass ``None`` (not an empty list) when there are no parameters so the
+    # driver sends the query verbatim and does not attempt ``%`` interpolation.
+    cursor.execute(query, params or None)
 
     return _dictfetchall(cursor) if to_dict else cursor
 
@@ -41,18 +43,20 @@ def _get_fields_of_type(xform, types):
 
 
 def _additional_data_view_filters(data_view):
+    """Return a DataView's filter SQL fragment and its bound parameters.
+
+    The fragment keeps the ``%s`` placeholders emitted by
+    ``DataView._get_where_clause`` and the parameters are returned untouched so
+    the caller can hand them to ``cursor.execute`` as bound values. No
+    request-derived filter column or value is ever rendered into the SQL text.
+    """
     # pylint: disable=protected-access
     where, where_params = DataView._get_where_clause(data_view)
 
-    data_view_where = ""
-    if where:
-        data_view_where = " AND " + " AND ".join(where)
+    if not where:
+        return "", []
 
-    for param in where_params:
-        escaped_param = str(param).replace("'", "''")
-        data_view_where = data_view_where.replace("%s", f"'{escaped_param}'", 1)
-
-    return data_view_where
+    return " AND " + " AND ".join(where), list(where_params)
 
 
 def _json_query(field):
@@ -77,9 +81,10 @@ def _postgres_count_group_field_n_group_by(field, name, xform, group_by, data_vi
             "to_char(to_date(%(json)s, 'YYYY-MM-DD'), 'YYYY" "-MM-DD')" % string_args
         )
 
-    additional_filters = ""
+    additional_filters, additional_params = "", []
     if data_view:
-        additional_filters = _additional_data_view_filters(data_view)
+        additional_filters, additional_params = _additional_data_view_filters(data_view)
+    string_args["additional_filters"] = additional_filters
 
     restricted_string = _restricted_query(xform)
     query = (
@@ -89,13 +94,13 @@ def _postgres_count_group_field_n_group_by(field, name, xform, group_by, data_vi
         "FROM %(table)s WHERE "
         + restricted_string
         + " AND deleted_at IS NULL "
-        + additional_filters
+        + "%(additional_filters)s"
         + " GROUP BY %(json)s, %(group_by)s"
         + " ORDER BY %(json)s, %(group_by)s"
     )
     query = query % string_args
 
-    return query
+    return query, additional_params
 
 
 def _postgres_count_group(field, name, xform, data_view=None):
@@ -105,9 +110,10 @@ def _postgres_count_group(field, name, xform, data_view=None):
             "to_char(to_date(%(json)s, 'YYYY-MM-DD'), 'YYYY" "-MM-DD')" % string_args
         )
 
-    additional_filters = ""
+    additional_filters, additional_params = "", []
     if data_view:
-        additional_filters = _additional_data_view_filters(data_view)
+        additional_filters, additional_params = _additional_data_view_filters(data_view)
+    string_args["additional_filters"] = additional_filters
 
     # Use left join to the auth user model for better performance.
     if field == SUBMITTED_BY:
@@ -120,13 +126,13 @@ def _postgres_count_group(field, name, xform, data_view=None):
         "%(table)s %(join)s WHERE "
         + restricted_string
         + " AND deleted_at IS NULL "
-        + additional_filters
+        + "%(additional_filters)s"
         + " GROUP BY %(json)s"
         " ORDER BY %(json)s"
     )
     sql_query = sql_query % string_args
 
-    return sql_query
+    return sql_query, additional_params
 
 
 def _postgres_aggregate_group_by(field, name, xform, group_by, data_view=None):
@@ -136,9 +142,10 @@ def _postgres_aggregate_group_by(field, name, xform, group_by, data_view=None):
             "to_char(to_date(%(json)s, 'YYYY-MM-DD'), 'YYYY" "-MM-DD')" % string_args
         )
 
-    additional_filters = ""
+    additional_filters, additional_params = "", []
     if data_view:
-        additional_filters = _additional_data_view_filters(data_view)
+        additional_filters, additional_params = _additional_data_view_filters(data_view)
+    string_args["additional_filters"] = additional_filters
 
     group_by_select = ""
     group_by_group_by = ""
@@ -170,14 +177,14 @@ def _postgres_aggregate_group_by(field, name, xform, group_by, data_view=None):
         + "FROM %(table)s WHERE "
         + restricted_string
         + " AND deleted_at IS NULL "
-        + additional_filters
+        + "%(additional_filters)s"
         + " GROUP BY "
         + group_by_group_by
         + " ORDER BY "
         + group_by_group_by
     )
 
-    return query % string_args
+    return query % string_args, additional_params
 
 
 def _postgres_select_key(field, name, xform):
@@ -259,7 +266,9 @@ def get_form_submissions_grouped_by_field(xform, field, name=None, data_view=Non
     if not name:
         name = field
 
-    return _execute_query(_postgres_count_group(field, name, xform, data_view))
+    query, params = _postgres_count_group(field, name, xform, data_view)
+
+    return _execute_query(query, params)
 
 
 # pylint: disable=invalid-name
@@ -269,9 +278,11 @@ def get_form_submissions_aggregated_by_select_one(
     """Number of submissions grouped and aggregated by select_one field"""
     if not name:
         name = field
-    return _execute_query(
-        _postgres_aggregate_group_by(field, name, xform, group_by, data_view)
+    query, params = _postgres_aggregate_group_by(
+        field, name, xform, group_by, data_view
     )
+
+    return _execute_query(query, params)
 
 
 # pylint: disable=invalid-name
@@ -281,9 +292,11 @@ def get_form_submissions_grouped_by_select_one(
     """Number of submissions disaggregated by select_one field"""
     if not name:
         name = field
-    return _execute_query(
-        _postgres_count_group_field_n_group_by(field, name, xform, group_by, data_view)
+    query, params = _postgres_count_group_field_n_group_by(
+        field, name, xform, group_by, data_view
     )
+
+    return _execute_query(query, params)
 
 
 def get_numeric_fields(xform):

--- a/onadata/libs/serializers/dataview_serializer.py
+++ b/onadata/libs/serializers/dataview_serializer.py
@@ -10,7 +10,11 @@ from django.utils.translation import gettext as _
 from rest_framework import serializers
 from rest_framework.exceptions import ParseError
 
-from onadata.apps.logger.models.data_view import SUPPORTED_FILTERS, DataView
+from onadata.apps.logger.models.data_view import (
+    FILTERABLE_METADATA_COLUMNS,
+    SUPPORTED_FILTERS,
+    DataView,
+)
 from onadata.apps.logger.models.project import Project
 from onadata.apps.logger.models.xform import XForm
 from onadata.libs.serializers.fields.json_field import JsonField
@@ -22,6 +26,7 @@ from onadata.libs.utils.cache_tools import (
     safe_cache_set,
 )
 from onadata.libs.utils.common_tags import DATE_FORMAT, MONGO_STRFTIME
+from onadata.libs.utils.dataview_filters import is_safe_column
 from onadata.libs.utils.model_tools import get_columns_with_hxl
 
 LAST_SUBMISSION_TIME = "_submission_time"
@@ -43,6 +48,18 @@ def validate_datetime(value):
     except ValueError:
         return False
     return True
+
+
+def _allowed_query_columns(xform):
+    """Columns a DataView ``query`` filter may reference on ``xform``.
+
+    Combines the form's own field XPaths with the submission metadata columns
+    DataView filtering treats as first-class (``FILTERABLE_METADATA_COLUMNS``).
+    Nested form XPaths (containing ``/``) are preserved because they are
+    returned verbatim by the form; Django lookup separators such as ``__`` never
+    appear here and are rejected separately by ``is_safe_column``.
+    """
+    return set(xform.get_field_name_xpaths_only()) | set(FILTERABLE_METADATA_COLUMNS)
 
 
 def match_columns(data, instance=None):
@@ -196,12 +213,53 @@ class DataViewSerializer(serializers.HyperlinkedModelSerializer):
                 ):
                     raise serializers.ValidationError(
                         _(
-                            f"Date value in {column} should be yyyy-mm-ddThh:m:s or "
-                            "yyyy-mm-dd"
+                            "Date value in %(column)s should be yyyy-mm-ddThh:m:s "
+                            "or yyyy-mm-dd"
                         )
+                        % {"column": column}
                     )
 
+        self._validate_query_columns(attrs)
+
         return super().validate(attrs)
+
+    def _validate_query_columns(self, attrs):
+        """Reject unsafe or unknown ``query`` columns for the target form.
+
+        Each column must be a string free of the ORM lookup separator ``__``
+        (``is_safe_column``) and must appear in the form's allow-list. Validates
+        when the query is being set, or when the form is being changed under a
+        retained query. An update that touches neither the query nor the form is
+        left alone so a pre-existing legacy column does not fail an unrelated
+        change. The effective form is the incoming ``xform`` (create or form
+        change) otherwise the instance's form.
+        """
+        query_supplied = "query" in attrs
+        form_changed = "xform" in attrs and attrs.get("xform")
+        if not (query_supplied or form_changed):
+            return
+
+        xform = attrs.get("xform") or (
+            self.instance.xform if self.instance is not None else None
+        )
+        if xform is None:
+            return
+
+        query = attrs.get("query")
+        if query is None and self.instance is not None:
+            query = self.instance.query
+
+        allowed_columns = _allowed_query_columns(xform)
+        for query_item in query or []:
+            column = query_item.get("column")
+            if not is_safe_column(column):
+                raise serializers.ValidationError(
+                    {"query": _("Unsupported column '%(column)s'") % {"column": column}}
+                )
+            if column not in allowed_columns:
+                raise serializers.ValidationError(
+                    {"query": _("Unknown column '%(column)s'") % {"column": column}}
+                )
 
     def get_count(self, obj):
         """Returns the submission count for the data view,"""

--- a/onadata/libs/serializers/widget_serializer.py
+++ b/onadata/libs/serializers/widget_serializer.py
@@ -181,6 +181,16 @@ class WidgetSerializer(serializers.HyperlinkedModelSerializer):
                     {"column": f"'{column}' not in the form."}
                 ) from e
 
+            group_by = attrs.get("group_by")
+            if group_by:
+                try:
+                    # Check if group_by column exists in xform
+                    get_field_from_field_xpath(group_by, xform)
+                except Http404 as e:
+                    raise serializers.ValidationError(
+                        {"group_by": f"'{group_by}' not in the form."}
+                    ) from e
+
         order = attrs.get("order")
 
         # Set the order

--- a/onadata/libs/tests/data/test_tools.py
+++ b/onadata/libs/tests/data/test_tools.py
@@ -261,3 +261,132 @@ class TestTools(TestBase):
         # The value is treated as a literal that matches no submission; if it
         # were injected the trailing OR '1'='1' would match every row.
         self.assertEqual(result, [])
+
+    def _executed_group_by_query(self, field, data_view=None):
+        """Run the public group-by path with a mocked cursor and return the
+        ``(sql, params)`` handed to ``cursor.execute``.
+
+        Asserting here checks the real psycopg2 hand-off — the SQL text the
+        driver receives and the values bound alongside it — without reaching
+        into the private query builders.
+        """
+        with patch("onadata.libs.data.query.connection") as mock_connection:
+            cursor = mock_connection.cursor.return_value
+            cursor.description = []
+            cursor.fetchall.return_value = []
+            get_form_submissions_grouped_by_field(
+                self.xform, field, data_view=data_view
+            )
+        sql, params = cursor.execute.call_args.args
+        return sql, params
+
+    def test_group_by_field_binds_hostile_filter_as_params(self):
+        """Hostile filter column/value are bound as params, never in SQL text.
+
+        Covers a literal ``%s``, a single quote and a backslash across two AND
+        filters, and asserts the placeholder count equals the parameter count.
+        """
+        data_view = DataView(
+            query=[
+                {
+                    "column": ") OR 1=1 --",
+                    "filter": "=",
+                    "value": "A%s",
+                    "condition": "and",
+                },
+                {
+                    "column": "name",
+                    "filter": "=",
+                    "value": "b\\c' OR '1'='1",
+                    "condition": "and",
+                },
+            ]
+        )
+
+        sql, params = self._executed_group_by_query("_submission_time", data_view)
+
+        # No request-derived filter token is rendered into the SQL text.
+        self.assertNotIn(") OR 1=1 --", sql)
+        self.assertNotIn("A%s", sql)
+        self.assertNotIn("b\\c", sql)
+        self.assertNotIn("OR '1'='1", sql)
+        # Every placeholder is backed by exactly one bound parameter, in order.
+        self.assertEqual(sql.count("%s"), len(params))
+        self.assertEqual(params, [") OR 1=1 --", "A%s", "name", "b\\c' OR '1'='1"])
+
+    def test_group_by_field_percent_s_shift_preserves_param_order(self):
+        """A literal ``%s`` in an earlier value cannot shift a later column out.
+
+        This is the prior-escaping-bypass primitive: a one-at-a-time replace
+        loop re-scanned inserted text, so a ``%s`` in an earlier value shifted
+        the following column outside its quotes. With bound parameters the
+        column and value are never rendered into SQL, so ordering is preserved.
+        """
+        data_view = DataView(
+            query=[
+                {"column": "age", "filter": "=", "value": "A%s", "condition": "and"},
+                {
+                    "column": ") OR 1=1 --",
+                    "filter": "=",
+                    "value": "B",
+                    "condition": "and",
+                },
+            ]
+        )
+
+        sql, params = self._executed_group_by_query("_submission_time", data_view)
+
+        self.assertNotIn(") OR 1=1 --", sql)
+        self.assertNotIn("OR 1=1", sql)
+        self.assertEqual(sql.count("%s"), len(params))
+        self.assertEqual(params, ["age", "A%s", ") OR 1=1 --", "B"])
+
+    def test_group_by_field_or_condition_param_order(self):
+        """OR filters keep their column/value parameters in emitted order."""
+        data_view = DataView(
+            query=[
+                {"column": "age", "filter": "=", "value": "1", "condition": "or"},
+                {"column": "name", "filter": "=", "value": "2", "condition": "or"},
+            ]
+        )
+
+        sql, params = self._executed_group_by_query("_submission_time", data_view)
+
+        self.assertIn(" OR ", sql)
+        self.assertEqual(sql.count("%s"), len(params))
+        self.assertEqual(params, ["age", "1", "name", "2"])
+
+    def test_group_by_field_without_data_view_binds_no_params(self):
+        """Without a DataView the driver receives the query with no bound params."""
+        sql, params = self._executed_group_by_query("_submission_time")
+
+        # ``params or None`` sends ``None`` so the driver skips ``%`` interpolation.
+        self.assertIsNone(params)
+        self.assertEqual(sql.count("%s"), 0)
+
+    def test_group_by_field_percent_s_shift_returns_no_rows(self):
+        """End-to-end: the %s-shift payload binds as data and matches nothing."""
+        self._make_submissions()
+        data_view = DataView.objects.create(
+            name="dv-shift",
+            project=self.xform.project,
+            xform=self.xform,
+            columns=["name"],
+            query=[
+                {"column": "name", "filter": "=", "value": "A%s", "condition": "and"},
+                {
+                    "column": ") OR 1=1 --",
+                    "filter": "=",
+                    "value": "B",
+                    "condition": "and",
+                },
+            ],
+        )
+
+        result = get_form_submissions_grouped_by_field(
+            self.xform, "_submission_time", data_view=data_view
+        )
+
+        # If the column injected, ") OR 1=1 --" would match every row; bound as
+        # a JSON key it matches nothing.
+        self.assertEqual(result, [])

--- a/onadata/libs/tests/data/test_tools.py
+++ b/onadata/libs/tests/data/test_tools.py
@@ -7,6 +7,7 @@ import os
 from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
 
+from onadata.apps.logger.models.data_view import DataView
 from onadata.apps.logger.models.instance import Instance
 from onadata.apps.main.tests.test_base import TestBase
 from onadata.libs.data.query import (
@@ -223,3 +224,40 @@ class TestTools(TestBase):
         field = "age"
         records = get_field_records(field, self.xform)
         self.assertEqual(sorted(records), sorted([23, 23, 35]))
+
+    def test_group_by_field_name_with_double_quote(self):
+        """A group name containing a double quote is grouped safely as an alias."""
+        self._make_submissions()
+        field = "_submission_time"
+        name = 'a"b'
+
+        result = get_form_submissions_grouped_by_field(self.xform, field, name)[0]
+
+        self.assertEqual(sorted([name, "count"]), sorted(list(result)))
+        self.assertEqual(result["count"], len(self.xform.instances.all()))
+
+    def test_group_by_field_with_quoted_data_view_filter(self):
+        """A single quote in a data view filter value is compared as a literal."""
+        self._make_submissions()
+        data_view = DataView.objects.create(
+            name="dv",
+            project=self.xform.project,
+            xform=self.xform,
+            columns=["name"],
+            query=[
+                {
+                    "column": "name",
+                    "filter": "=",
+                    "value": "x' OR '1'='1",
+                    "condition": "and",
+                }
+            ],
+        )
+
+        result = get_form_submissions_grouped_by_field(
+            self.xform, "_submission_time", data_view=data_view
+        )
+
+        # The value is treated as a literal that matches no submission; if it
+        # were injected the trailing OR '1'='1' would match every row.
+        self.assertEqual(result, [])

--- a/onadata/libs/utils/dataview_filters.py
+++ b/onadata/libs/utils/dataview_filters.py
@@ -19,6 +19,18 @@ def filter_to_field_lookup(filter_string):
     return "__gt"
 
 
+def is_safe_column(column):
+    """Return ``True`` if ``column`` is a safe DataView filter reference.
+
+    A safe column is a string that does not contain the Django ORM lookup
+    separator ``__``. Nested form fields use ``/`` as their path separator, so
+    ``__`` never appears in a legitimate column; left unchecked it would be
+    interpreted as a relation/lookup traversal by ``filter(**kwargs)`` via
+    ``get_field_lookup``.
+    """
+    return isinstance(column, str) and "__" not in column
+
+
 def get_field_lookup(column, filter_string):
     """
     Convert filter_string + column into a field lookup expression
@@ -28,13 +40,21 @@ def get_field_lookup(column, filter_string):
 
 def get_filter_kwargs(filters):
     """
-    Apply filters on a queryset
+    Build ORM filter kwargs from DataView ``query`` filters.
+
+    Columns that are not safe json key references (non-strings, or values
+    containing the ``__`` lookup separator) are dropped rather than applied.
+    The serializer rejects these on write, but DataViews created directly or
+    stored before that guard must not reach ``filter(**kwargs)`` with a column
+    that escapes the json key boundary.
     """
     kwargs = {}
     if filters:
         for f in filters:
-            value = f"{f['value']}"
             column = f["column"]
+            if not is_safe_column(column):
+                continue
+            value = f"{f['value']}"
             filter_kwargs = {get_field_lookup(column, f["filter"]): value}
             kwargs = {**kwargs, **filter_kwargs}
     return kwargs

--- a/requirements/azure.pip
+++ b/requirements/azure.pip
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements/azure.pip requirements/azure.in
 #
-asgiref==3.11.1
+asgiref==3.12.1
     # via django
 azure-core==1.41.0
     # via
@@ -12,23 +12,23 @@ azure-core==1.41.0
     #   django-storages
 azure-storage-blob==12.30.0
     # via django-storages
-certifi==2026.6.17
+certifi==2026.7.22
     # via requests
-cffi==2.0.0
+cffi==2.1.1
     # via cryptography
-charset-normalizer==3.4.7
+charset-normalizer==3.5.1
     # via requests
-cryptography==49.0.0
+cryptography==50.0.0
     # via
     #   -r requirements/azure.in
     #   azure-storage-blob
-django==5.2.15
+django==5.2.17
     # via
     #   -r requirements/azure.in
     #   django-storages
 django-storages[azure]==1.14.6
     # via -r requirements/azure.in
-idna==3.18
+idna==3.19
     # via
     #   -r requirements/azure.in
     #   requests
@@ -38,9 +38,9 @@ pycparser==3.0
     # via cffi
 requests==2.34.2
     # via azure-core
-sqlparse==0.5.5
+sqlparse==0.6.0
     # via django
-typing-extensions==4.15.0
+typing-extensions==4.16.0
     # via
     #   azure-core
     #   azure-storage-blob

--- a/requirements/base.pip
+++ b/requirements/base.pip
@@ -12,7 +12,7 @@ analytics-python==1.4.post1
     # via onadata
 appoptics-metrics==5.1.0
     # via onadata
-asgiref==3.11.1
+asgiref==3.12.1
     # via
     #   django
     #   django-cors-headers
@@ -25,11 +25,11 @@ backoff==1.10.0
     # via analytics-python
 billiard==4.2.4
     # via celery
-boto3==1.43.36
+boto3==1.43.79
     # via
     #   dataflows-tabulator
     #   valigetta
-botocore==1.43.36
+botocore==1.43.79
     # via
     #   boto3
     #   s3transfer
@@ -37,17 +37,17 @@ cached-property==2.0.1
     # via tableschema
 celery==5.6.3
     # via onadata
-certifi==2026.6.17
+certifi==2026.7.22
     # via
     #   requests
     #   sentry-sdk
-cffi==2.0.0
+cffi==2.1.1
     # via cryptography
-chardet==7.4.3
+chardet==7.6.0
     # via
     #   dataflows-tabulator
     #   datapackage
-charset-normalizer==3.4.7
+charset-normalizer==3.5.1
     # via requests
 click==8.4.2
     # via
@@ -66,7 +66,7 @@ click-repl==0.3.0
     # via celery
 codetiming==1.4.0
     # via -r requirements/base.in
-cryptography==49.0.0
+cryptography==50.0.0
     # via
     #   google-auth
     #   jwcrypto
@@ -88,7 +88,7 @@ deprecated==1.3.1
     # via onadata
 dict2xml==1.7.8
     # via onadata
-django==5.2.15
+django==5.2.17
     # via
     #   django-activity-stream
     #   django-cors-headers
@@ -114,7 +114,7 @@ django-cors-headers==4.9.0
     # via onadata
 django-csp==4.0
     # via onadata
-django-debug-toolbar==7.0.0
+django-debug-toolbar==7.1.1
     # via onadata
 django-digest @ git+https://github.com/onaio/django-digest.git@6bf61ec08502fd3545d4f2c0838b6cb15e7ffa92
     # via -r requirements/base.in
@@ -122,7 +122,7 @@ django-filter==25.2
     # via
     #   djangorestframework-gis
     #   onadata
-django-guardian==3.3.2
+django-guardian==3.3.3
     # via
     #   djangorestframework-guardian
     #   onadata
@@ -130,7 +130,7 @@ django-multidb-router @ git+https://github.com/onaio/django-multidb-router.git@f
     # via -r requirements/base.in
 django-nose==1.4.7
     # via onadata
-django-oauth-toolkit==3.3.0
+django-oauth-toolkit==3.4.1
     # via onadata
 django-ordered-model==3.7.4
     # via onadata
@@ -148,7 +148,7 @@ django-taggit==6.1.0
     # via onadata
 django-templated-email==3.1.1
     # via onadata
-djangorestframework==3.17.1
+djangorestframework==3.17.2
     # via
     #   djangorestframework-csv
     #   djangorestframework-gis
@@ -182,23 +182,24 @@ future==1.0.0
     # via python-json2xlsclient
 geojson==3.3.0
     # via onadata
-google-auth==2.55.0
+google-auth==2.57.0
     # via
     #   google-auth-oauthlib
     #   onadata
-google-auth-oauthlib==1.4.0
+google-auth-oauthlib==1.4.1
     # via onadata
-greenlet==3.5.2
+greenlet==3.5.5
     # via sqlalchemy
-hiredis==3.4.0
+hiredis==3.4.1
     # via redis
-httplib2==0.31.2
+httplib2==0.32.0
     # via onadata
-idna==3.18
+idna==3.19
     # via
     #   -r requirements/base.in
+    #   onadata
     #   requests
-ijson==3.5.0
+ijson==3.5.1
     # via dataflows-tabulator
 inflection==0.5.1
     # via djangorestframework-jsonapi
@@ -228,9 +229,9 @@ lark==1.3.1
     # via pyxform
 linear-tsv==1.1.0
     # via dataflows-tabulator
-lxml==6.1.1
+lxml==6.1.2
     # via onadata
-markdown==3.10.2
+markdown==3.10.3
     # via onadata
 modilabs-python-utils==0.1.5
     # via onadata
@@ -238,7 +239,7 @@ monotonic==1.6
     # via analytics-python
 nose==1.3.7
     # via django-nose
-numpy==2.5.0
+numpy==2.5.2
     # via onadata
 oauthlib==3.3.1
     # via
@@ -251,21 +252,21 @@ openpyxl==3.1.5
     #   dataflows-tabulator
     #   onadata
     #   pyxform
-packaging==26.2
+packaging==26.3
     # via
     #   django-csp
     #   kombu
 paho-mqtt==2.1.0
     # via onadata
-pillow==12.2.0
+pillow==12.3.0
     # via
     #   elaphe3
     #   onadata
-prompt-toolkit==3.0.52
+prompt-toolkit==3.0.53
     # via click-repl
 psycopg2-binary==2.9.12
     # via onadata
-pyasn1==0.6.3
+pyasn1==0.6.4
     # via pyasn1-modules
 pyasn1-modules==0.4.2
     # via google-auth
@@ -299,7 +300,7 @@ python-json2xlsclient @ git+https://github.com/onaio/python-json2xlsclient.git@6
     # via -r requirements/base.in
 python-memcached==1.62
     # via onadata
-pytz==2026.2
+pytz==2026.3.post1
     # via
     #   django-query-builder
     #   fleming
@@ -309,7 +310,7 @@ pyxform==4.4.1
     #   pyfloip
 recaptcha-client==1.0.6
     # via onadata
-redis[hiredis]==8.0.1
+redis[hiredis]==8.1.0
     # via
     #   django-redis
     #   onadata
@@ -332,13 +333,13 @@ requests-oauthlib==2.0.0
     # via google-auth-oauthlib
 rfc3986==2.0.0
     # via tableschema
-rpds-py==2026.5.1
+rpds-py==2026.6.3
     # via
     #   jsonschema
     #   referencing
-s3transfer==0.19.0
+s3transfer==0.19.2
     # via boto3
-sentry-sdk==2.63.0
+sentry-sdk==2.68.1
     # via onadata
 simplejson==4.1.1
     # via onadata
@@ -351,21 +352,21 @@ six==1.17.0
     #   linear-tsv
     #   python-dateutil
     #   tableschema
-sqlalchemy==2.0.51
+sqlalchemy==2.0.52
     # via dataflows-tabulator
-sqlparse==0.5.5
+sqlparse==0.6.0
     # via
     #   django
     #   django-debug-toolbar
 tableschema==1.21.0
     # via datapackage
-typing-extensions==4.15.0
+typing-extensions==4.16.0
     # via
     #   jwcrypto
     #   sqlalchemy
-tzdata==2026.2
+tzdata==2026.3
     # via kombu
-tzlocal==5.4.3
+tzlocal==5.4.4
     # via celery
 ujson==5.13.0
     # via onadata
@@ -379,6 +380,8 @@ urllib3==2.7.0
     # via
     #   -r requirements/base.in
     #   botocore
+    #   django-oauth-toolkit
+    #   onadata
     #   requests
     #   sentry-sdk
 uwsgi==2.0.31
@@ -390,9 +393,9 @@ vine==5.1.0
     #   amqp
     #   celery
     #   kombu
-wcwidth==0.8.1
+wcwidth==0.8.2
     # via prompt-toolkit
-wrapt==2.2.2
+wrapt==2.3.0
     # via deprecated
 xlrd==2.0.1
     # via

--- a/requirements/dev.pip
+++ b/requirements/dev.pip
@@ -12,7 +12,7 @@ analytics-python==1.4.post1
     # via onadata
 appoptics-metrics==5.1.0
     # via onadata
-asgiref==3.11.1
+asgiref==3.12.1
     # via
     #   django
     #   django-cors-headers
@@ -21,7 +21,7 @@ astroid==4.0.4
     #   pylint
     #   pylint-celery
     #   requirements-detector
-asttokens==3.0.1
+asttokens==3.0.2
     # via stack-data
 attrs==26.1.0
     # via
@@ -32,12 +32,12 @@ backoff==1.10.0
     # via analytics-python
 billiard==4.2.4
     # via celery
-boto3==1.43.36
+boto3==1.43.79
     # via
     #   dataflows-tabulator
     #   moto
     #   valigetta
-botocore==1.43.36
+botocore==1.43.79
     # via
     #   boto3
     #   moto
@@ -46,19 +46,19 @@ cached-property==2.0.1
     # via tableschema
 celery==5.6.3
     # via onadata
-certifi==2026.6.17
+certifi==2026.7.22
     # via
     #   requests
     #   sentry-sdk
-cffi==2.0.0
+cffi==2.1.1
     # via cryptography
 cfgv==3.5.0
     # via pre-commit
-chardet==7.4.3
+chardet==7.6.0
     # via
     #   dataflows-tabulator
     #   datapackage
-charset-normalizer==3.4.7
+charset-normalizer==3.5.1
     # via requests
 click==8.4.2
     # via
@@ -77,7 +77,7 @@ click-repl==0.3.0
     # via celery
 codetiming==1.4.0
     # via -r requirements/base.in
-cryptography==49.0.0
+cryptography==50.0.0
     # via
     #   google-auth
     #   jwcrypto
@@ -92,9 +92,7 @@ dataflows-tabulator==1.54.3
 datapackage==1.15.4
     # via pyfloip
 decorator==5.3.1
-    # via
-    #   ipdb
-    #   ipython
+    # via ipdb
 defusedxml==0.7.1
     # via
     #   djangorestframework-xml
@@ -108,7 +106,7 @@ dill==0.4.1
     # via pylint
 distlib==0.4.3
     # via virtualenv
-django==5.2.15
+django==5.2.17
     # via
     #   django-activity-stream
     #   django-cors-headers
@@ -135,7 +133,7 @@ django-cors-headers==4.9.0
     # via onadata
 django-csp==4.0
     # via onadata
-django-debug-toolbar==7.0.0
+django-debug-toolbar==7.1.1
     # via onadata
 django-digest @ git+https://github.com/onaio/django-digest.git@6bf61ec08502fd3545d4f2c0838b6cb15e7ffa92
     # via -r requirements/base.in
@@ -145,7 +143,7 @@ django-filter==25.2
     # via
     #   djangorestframework-gis
     #   onadata
-django-guardian==3.3.2
+django-guardian==3.3.3
     # via
     #   djangorestframework-guardian
     #   onadata
@@ -153,7 +151,7 @@ django-multidb-router @ git+https://github.com/onaio/django-multidb-router.git@f
     # via -r requirements/base.in
 django-nose==1.4.7
     # via onadata
-django-oauth-toolkit==3.3.0
+django-oauth-toolkit==3.4.1
     # via onadata
 django-ordered-model==3.7.4
     # via onadata
@@ -171,7 +169,7 @@ django-taggit==6.1.0
     # via onadata
 django-templated-email==3.1.1
     # via onadata
-djangorestframework==3.17.1
+djangorestframework==3.17.2
     # via
     #   djangorestframework-csv
     #   djangorestframework-gis
@@ -203,7 +201,7 @@ et-xmlfile==2.0.0
     # via openpyxl
 executing==2.2.1
     # via stack-data
-filelock==3.29.4
+filelock==3.32.4
     # via
     #   python-discovery
     #   virtualenv
@@ -219,33 +217,34 @@ future==1.0.0
     # via python-json2xlsclient
 geojson==3.3.0
     # via onadata
-google-auth==2.55.0
+google-auth==2.57.0
     # via
     #   google-auth-oauthlib
     #   onadata
-google-auth-oauthlib==1.4.0
+google-auth-oauthlib==1.4.1
     # via onadata
-greenlet==3.5.2
+greenlet==3.5.5
     # via sqlalchemy
-hiredis==3.4.0
+hiredis==3.4.1
     # via redis
 httmock==1.4.0
     # via -r requirements/dev.in
-httplib2==0.31.2
+httplib2==0.32.0
     # via onadata
 identify==2.6.19
     # via pre-commit
-idna==3.18
+idna==3.19
     # via
     #   -r requirements/base.in
+    #   onadata
     #   requests
-ijson==3.5.0
+ijson==3.5.1
     # via dataflows-tabulator
 inflection==0.5.1
     # via djangorestframework-jsonapi
 ipdb==0.13.13
     # via -r requirements/dev.in
-ipython==9.14.1
+ipython==9.16.1
     # via ipdb
 ipython-pygments-lexers==1.1.1
     # via ipython
@@ -281,9 +280,9 @@ lark==1.3.1
     # via pyxform
 linear-tsv==1.1.0
     # via dataflows-tabulator
-lxml==6.1.1
+lxml==6.1.2
     # via onadata
-markdown==3.10.2
+markdown==3.10.3
     # via onadata
 markupsafe==3.0.3
     # via werkzeug
@@ -298,13 +297,13 @@ modilabs-python-utils==0.1.5
     # via onadata
 monotonic==1.6
     # via analytics-python
-moto==5.2.2
+moto==5.2.3
     # via -r requirements/dev.in
 nodeenv==1.10.0
     # via pre-commit
 nose==1.3.7
     # via django-nose
-numpy==2.5.0
+numpy==2.5.2
     # via onadata
 oauthlib==3.3.1
     # via
@@ -317,7 +316,7 @@ openpyxl==3.1.5
     #   dataflows-tabulator
     #   onadata
     #   pyxform
-packaging==26.2
+packaging==26.3
     # via
     #   django-csp
     #   kombu
@@ -331,23 +330,22 @@ pep8-naming==0.10.0
     # via prospector
 pexpect==4.9.0
     # via ipython
-pillow==12.2.0
+pillow==12.3.0
     # via
     #   elaphe3
     #   onadata
-platformdirs==4.10.0
+platformdirs==4.11.4
     # via
     #   pylint
-    #   python-discovery
     #   virtualenv
     #   yapf
-pre-commit==4.6.0
+pre-commit==4.6.2
     # via -r requirements/dev.in
-prompt-toolkit==3.0.52
+prompt-toolkit==3.0.53
     # via
     #   click-repl
     #   ipython
-prospector==1.19.0
+prospector==1.19.1
     # via -r requirements/dev.in
 psutil==7.2.2
     # via ipython
@@ -357,7 +355,7 @@ ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.3
     # via stack-data
-pyasn1==0.6.3
+pyasn1==0.6.4
     # via pyasn1-modules
 pyasn1-modules==0.4.2
     # via google-auth
@@ -377,7 +375,7 @@ pyflakes==3.4.0
     #   prospector
 pyfloip @ git+https://github.com/onaio/floip-py.git@3c980eb184069ae7c3c9136b18441978237cd41d
     # via -r requirements/base.in
-pygments==2.20.0
+pygments==2.21.0
     # via
     #   ipython
     #   ipython-pygments-lexers
@@ -387,7 +385,7 @@ pyjwt[crypto]==2.13.0
     #   onadata
 pylibmc==1.6.3
     # via onadata
-pylint==4.0.6
+pylint==4.0.7
     # via
     #   -r requirements/dev.in
     #   prospector
@@ -396,7 +394,7 @@ pylint==4.0.6
     #   pylint-plugin-utils
 pylint-celery==0.3
     # via prospector
-pylint-django==2.7.0
+pylint-django==2.8.0
     # via
     #   -r requirements/dev.in
     #   prospector
@@ -418,13 +416,13 @@ python-dateutil==2.9.0.post0
     #   tableschema
 python-digest @ git+https://github.com/onaio/python-digest.git@08267ca8afc1a52f91352ebb5385e8e6d074fc36
     # via -r requirements/base.in
-python-discovery==1.4.2
+python-discovery==1.5.3
     # via virtualenv
 python-json2xlsclient @ git+https://github.com/onaio/python-json2xlsclient.git@62b4645f7b4f2684421a13ce98da0331a9dd66a0
     # via -r requirements/base.in
 python-memcached==1.62
     # via onadata
-pytz==2026.2
+pytz==2026.3.post1
     # via
     #   django-query-builder
     #   fleming
@@ -439,7 +437,7 @@ pyyaml==6.0.3
     #   responses
 recaptcha-client==1.0.6
     # via onadata
-redis[hiredis]==8.0.1
+redis[hiredis]==8.1.0
     # via
     #   django-redis
     #   onadata
@@ -466,21 +464,21 @@ requests-mock==1.12.1
     # via -r requirements/dev.in
 requests-oauthlib==2.0.0
     # via google-auth-oauthlib
-requirements-detector==1.5.0
+requirements-detector==1.6.0
     # via prospector
-responses==0.26.1
+responses==0.26.2
     # via moto
 rfc3986==2.0.0
     # via tableschema
-rpds-py==2026.5.1
+rpds-py==2026.6.3
     # via
     #   jsonschema
     #   referencing
-s3transfer==0.19.0
+s3transfer==0.19.2
     # via boto3
 semver==3.0.4
     # via requirements-detector
-sentry-sdk==2.63.0
+sentry-sdk==2.68.1
     # via onadata
 setoptconf-tmp==0.3.1
     # via prospector
@@ -497,9 +495,9 @@ six==1.17.0
     #   tableschema
 snowballstemmer==3.1.1
     # via pydocstyle
-sqlalchemy==2.0.51
+sqlalchemy==2.0.52
     # via dataflows-tabulator
-sqlparse==0.5.5
+sqlparse==0.6.0
     # via
     #   django
     #   django-debug-toolbar
@@ -511,19 +509,19 @@ tblib==3.2.2
     # via -r requirements/dev.in
 toml==0.10.2
     # via prospector
-tomlkit==0.15.0
+tomlkit==0.15.1
     # via pylint
-traitlets==5.15.1
+traitlets==5.16.1
     # via
     #   ipython
     #   matplotlib-inline
-typing-extensions==4.15.0
+typing-extensions==4.16.0
     # via
     #   jwcrypto
     #   sqlalchemy
-tzdata==2026.2
+tzdata==2026.3
     # via kombu
-tzlocal==5.4.3
+tzlocal==5.4.4
     # via celery
 ujson==5.13.0
     # via onadata
@@ -537,6 +535,8 @@ urllib3==2.7.0
     # via
     #   -r requirements/base.in
     #   botocore
+    #   django-oauth-toolkit
+    #   onadata
     #   requests
     #   responses
     #   sentry-sdk
@@ -549,13 +549,13 @@ vine==5.1.0
     #   amqp
     #   celery
     #   kombu
-virtualenv==21.5.1
+virtualenv==21.7.5
     # via pre-commit
-wcwidth==0.8.1
+wcwidth==0.8.2
     # via prompt-toolkit
 werkzeug==3.1.8
     # via moto
-wrapt==2.2.2
+wrapt==2.3.0
     # via deprecated
 xlrd==2.0.1
     # via

--- a/requirements/docs.pip
+++ b/requirements/docs.pip
@@ -8,25 +8,25 @@ alabaster==1.0.0
     # via sphinx
 babel==2.18.0
     # via sphinx
-certifi==2026.6.17
+certifi==2026.7.22
     # via requests
-charset-normalizer==3.4.7
+charset-normalizer==3.5.1
     # via requests
 docutils==0.22.4
     # via sphinx
-idna==3.18
+idna==3.19
     # via
     #   -r requirements/docs.in
     #   requests
-imagesize==2.0.0
+imagesize==2.0.1
     # via sphinx
 jinja2==3.1.6
     # via sphinx
 markupsafe==3.0.3
     # via jinja2
-packaging==26.2
+packaging==26.3
     # via sphinx
-pygments==2.20.0
+pygments==2.21.0
     # via sphinx
 requests==2.34.2
     # via sphinx

--- a/requirements/s3.pip
+++ b/requirements/s3.pip
@@ -4,15 +4,15 @@
 #
 #    pip-compile --output-file=requirements/s3.pip requirements/s3.in
 #
-asgiref==3.11.1
+asgiref==3.12.1
     # via django
-boto3==1.43.36
+boto3==1.43.79
     # via -r requirements/s3.in
-botocore==1.43.36
+botocore==1.43.79
     # via
     #   boto3
     #   s3transfer
-django==5.2.15
+django==5.2.17
     # via
     #   -r requirements/s3.in
     #   django-storages
@@ -24,11 +24,11 @@ jmespath==1.1.0
     #   botocore
 python-dateutil==2.9.0.post0
     # via botocore
-s3transfer==0.19.0
+s3transfer==0.19.2
     # via boto3
 six==1.17.0
     # via python-dateutil
-sqlparse==0.5.5
+sqlparse==0.6.0
     # via django
 urllib3==2.7.0
     # via

--- a/requirements/ses.pip
+++ b/requirements/ses.pip
@@ -4,17 +4,17 @@
 #
 #    pip-compile --output-file=requirements/ses.pip requirements/ses.in
 #
-asgiref==3.11.1
+asgiref==3.12.1
     # via django
 boto==2.49.0
     # via -r requirements/ses.in
-boto3==1.43.36
+boto3==1.43.79
     # via django-ses
-botocore==1.43.36
+botocore==1.43.79
     # via
     #   boto3
     #   s3transfer
-django==5.2.15
+django==5.2.17
     # via
     #   -r requirements/ses.in
     #   django-ses
@@ -26,11 +26,11 @@ jmespath==1.1.0
     #   botocore
 python-dateutil==2.9.0.post0
     # via botocore
-s3transfer==0.19.0
+s3transfer==0.19.2
     # via boto3
 six==1.17.0
     # via python-dateutil
-sqlparse==0.5.5
+sqlparse==0.6.0
     # via django
 urllib3==2.7.0
     # via


### PR DESCRIPTION
### Changes / Features implemented

Release branch for 5.22.2 (2026-08-26). Contains seven commits: SQL injection hardening in DataView chart/stats filters and related raw-SQL sinks (widget group_by, data view filters, stats alias, `$or` null-value handling in `get_where_clause`), three encryption fixes (preserving managed encryption status and encrypted submission ciphertext when rebuilding or reconfiguring forms, and trigger-list coercion when rebuilding surveys from JSON), and the pinned-dependency minor bumps also proposed in #3230.

### Steps taken to verify this change does what is intended

Full CI (unit tests, static analysis, security scans) passes on this branch content, and the Docker image builds successfully for amd64 and arm64.

### Side effects of implementing this change

The dependency bump commit overlaps with #3230; merging either first leaves the other a trivial rebase.

**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  - [ ] Updated documentation (N/A)

Closes #

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/onaio/codesmith/onadata/pr/3231"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790267423&installation_model_id=422582&pr_number=3231&repository=onaio%2Fonadata&return_to=https%3A%2F%2Fgithub.com%2Fonaio%2Fonadata%2Fpull%2F3231&signature=9b728eb5c4665fc0ae6307cfa70405aa2f94df5cdac4675551b57112477b2656"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->