### PR TITLE
feat: make the Enketo API request timeout configurable

### DIFF
--- a/onadata/libs/tests/utils/test_viewer_tools.py
+++ b/onadata/libs/tests/utils/test_viewer_tools.py
@@ -24,6 +24,7 @@ from onadata.libs.utils.viewer_tools import (
     generate_enketo_form_defaults,
     get_client_ip,
     get_enketo_attachment_params,
+    get_enketo_urls,
     get_form,
     get_form_url,
     handle_enketo_error,
@@ -111,6 +112,31 @@ class TestViewerTools(TestBase):
         kwargs = {"name": "bla"}
         defaults = generate_enketo_form_defaults(self.xform, **kwargs)
         self.assertEqual(defaults, {})
+
+    @override_settings(ENKETO_API_TOKEN="abc", ENKETO_API_TIMEOUT=5)
+    @patch("onadata.libs.utils.viewer_tools.requests.post")
+    def test_get_enketo_urls_uses_configured_timeout(self, mock_post):
+        """get_enketo_urls() sends the ENKETO_API_TIMEOUT setting to Enketo."""
+        mock_post.return_value = Mock(
+            status_code=200, content=b'{"url": "https://enketo.ona.io/::abc"}'
+        )
+
+        data = get_enketo_urls("https://example.com/enketo/1", "test_form")
+
+        self.assertEqual(data, {"url": "https://enketo.ona.io/::abc"})
+        self.assertEqual(mock_post.call_args.kwargs["timeout"], 5)
+
+    @override_settings(ENKETO_API_TOKEN="abc")
+    @patch("onadata.libs.utils.viewer_tools.requests.post")
+    def test_get_enketo_urls_default_timeout(self, mock_post):
+        """get_enketo_urls() defaults to a 20 second timeout."""
+        mock_post.return_value = Mock(
+            status_code=200, content=b'{"url": "https://enketo.ona.io/::abc"}'
+        )
+
+        get_enketo_urls("https://example.com/enketo/1", "test_form")
+
+        self.assertEqual(mock_post.call_args.kwargs["timeout"], 20)
 
     def test_get_form(self):
         """Test get_form()."""

--- a/onadata/libs/utils/viewer_tools.py
+++ b/onadata/libs/utils/viewer_tools.py
@@ -205,7 +205,7 @@ def get_enketo_urls(
         data=values,
         auth=(settings.ENKETO_API_TOKEN, ""),
         verify=getattr(settings, "VERIFY_SSL", True),
-        timeout=20,
+        timeout=getattr(settings, "ENKETO_API_TIMEOUT", 20),
     )
     resp_content = response.content
     resp_content = (

--- a/onadata/settings/common.py
+++ b/onadata/settings/common.py
@@ -102,6 +102,8 @@ ENKETO_URL = "https://enketo.ona.io/"
 ENKETO_API_ALL_SURVEY_LINKS_PATH = "/api_v2/survey/all"
 ENKETO_API_INSTANCE_PATH = "/api_v2/instance"
 ENKETO_API_TOKEN = ""
+# seconds to wait for Enketo API responses before failing
+ENKETO_API_TIMEOUT = 20
 ENKETO_API_INSTANCE_IFRAME_URL = ENKETO_URL + "api_v2/instance/iframe"
 ENKETO_API_SALT = "secretsalt"
 VERIFY_SSL = True


### PR DESCRIPTION
### Changes / Features implemented

`get_enketo_urls()` hardcoded a 20 second timeout on requests to the Enketo API. The timeout is now read from a new `ENKETO_API_TIMEOUT` setting (default 20, so behaviour is unchanged unless a deployment overrides it). This lets deployments tune how long to wait for Enketo before failing, e.g. when Enketo is under load.

### Steps taken to verify this change does what is intended

Added two unit tests in `test_viewer_tools.py`: one asserting the configured `ENKETO_API_TIMEOUT` value is sent to Enketo (written first and confirmed failing against the hardcoded value), and one asserting the default remains 20 when the setting is absent.

### Side effects of implementing this change

None — the default matches the previous hardcoded value.

**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  - [ ] Updated documentation

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/onaio/codesmith/onadata/pr/3236"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790352696&installation_model_id=422582&pr_number=3236&repository=onaio%2Fonadata&return_to=https%3A%2F%2Fgithub.com%2Fonaio%2Fonadata%2Fpull%2F3236&signature=95e1c1b14236a8ef12d93c7cd5dc86dd1117848dd92af0295396e4a3a3a21d6a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->