### PR TITLE
feat(2fa): audit second-factor events and notify the account owner

### DIFF
--- a/onadata/apps/api/tasks.py
+++ b/onadata/apps/api/tasks.py
@@ -138,6 +138,12 @@ def send_account_lockout_email(email, message_txt, subject):
 
 
 @app.task(base=AutoRetryTask)
+def send_two_factor_changed_email(email, message_txt, subject):
+    """Sends second-factor change notification email."""
+    send_generic_email(email, message_txt, subject)
+
+
+@app.task(base=AutoRetryTask)
 def send_account_deactivation_email(email, message_txt, subject):
     """Sends inactive-account deactivation warning email."""
     send_generic_email(email, message_txt, subject)

--- a/onadata/apps/api/tests/viewsets/test_totp_concurrency.py
+++ b/onadata/apps/api/tests/viewsets/test_totp_concurrency.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Concurrency tests for one-time-code verification.
 
 Threads here stand in for the deployment's uWSGI workers (``--workers 30
@@ -11,19 +10,24 @@ in parallel.
 transaction is never committed, so a second connection would not see the
 fixture at all.
 """
+
 import threading
 
+from django.conf import settings
 from django.contrib.auth.models import User
 from django.db import connection
 from django.test import TransactionTestCase, override_settings
 
+import jwt
 from django_otp.oath import totp
 from django_otp.plugins.otp_static.models import StaticDevice, StaticToken
 from django_otp.plugins.otp_totp.models import TOTPDevice
+from rest_framework.test import APIRequestFactory
 
 from onadata.apps.api.viewsets.totp_viewset import (
     RECOVERY_DEVICE_NAME,
     TOTP_DEVICE_NAME,
+    TOTPViewSet,
     _verify_recovery,
     _verify_totp,
 )
@@ -133,4 +137,73 @@ class TotpCodeConcurrencyTestCase(TransactionTestCase):
             sum(results),
             1,
             f"the code verified {sum(results)} times; one code, one use",
+        )
+
+
+@override_settings(ENABLE_TWO_FACTOR=True)
+class EnrolmentConfirmationConcurrencyTestCase(TransactionTestCase):
+    """A pending authenticator is confirmed by exactly one request.
+
+    Worse here than a double-spent code: confirmation mints the recovery set,
+    so every racing worker is handed one and each replaces the last. The user
+    is shown several sets and only the final one still works.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.user = User.objects.create_user(
+            "enrolmentrace", "enrolmentrace@example.com", "pw-9F3kz"
+        )
+        self.device = TOTPDevice.objects.create(
+            user=self.user, name=TOTP_DEVICE_NAME, confirmed=False
+        )
+
+    def test_one_pending_code_confirms_one_enrolment(self):
+        code = f"{totp(self.device.bin_key, self.device.step, self.device.t0):06d}"
+        config = settings.OPENID_CONNECT_VIEWSET_CONFIG
+        sso = jwt.encode(
+            {"email": self.user.email},
+            config["JWT_SECRET_KEY"],
+            algorithm=config["JWT_ALGORITHM"],
+        )
+        barrier = threading.Barrier(CONCURRENT)
+        responses = []
+        guard = threading.Lock()
+
+        def worker():
+            try:
+                request = APIRequestFactory().post(
+                    "/", data={"code": code}, HTTP_SSO=sso
+                )
+                barrier.wait(timeout=10)
+                response = TOTPViewSet.as_view({"post": "enroll_confirm"})(request)
+                with guard:
+                    responses.append(response)
+            finally:
+                connection.close()
+
+        threads = [threading.Thread(target=worker) for _ in range(CONCURRENT)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=30)
+
+        self.assertEqual(len(responses), CONCURRENT, "a worker did not finish")
+        # The losers find no pending row when the lock releases, rather than
+        # going on to spend the code: a double-click is a 409, not a "that
+        # code is not valid" on a code that was perfectly good.
+        self.assertEqual({response.status_code for response in responses}, {200, 409})
+        won = [response for response in responses if response.status_code == 200]
+        self.assertEqual(
+            len(won), 1, f"{len(won)} racing confirmations were each told they won"
+        )
+        # The half that bites: the set the winner was shown is the set that
+        # actually survived, so the codes on the user's screen are the live ones.
+        self.assertEqual(
+            set(won[0].data["codes"]),
+            set(
+                StaticToken.objects.filter(device__user=self.user).values_list(
+                    "token", flat=True
+                )
+            ),
         )

--- a/onadata/apps/api/tests/viewsets/test_totp_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_totp_viewset.py
@@ -23,10 +23,12 @@ from two_factor.utils import default_device
 
 from onadata.apps.api.tests.viewsets.test_abstract_viewset import TestAbstractViewSet
 from onadata.apps.api.viewsets.totp_viewset import (
+    RECOVERY_CODE_ALPHABET,
     RECOVERY_CODE_COUNT,
     RECOVERY_DEVICE_NAME,
     TOTP_DEVICE_NAME,
     TOTPViewSet,
+    _verify_recovery,
 )
 
 #: Any test spending two codes must move between windows: django-otp records
@@ -354,6 +356,50 @@ class TestTOTPViewSet(TestAbstractViewSet):
             self._get_status().data["recoveryCodes"],
             {"generated": True, "remaining": RECOVERY_CODE_COUNT},
         )
+
+    def test_recovery_codes_carry_at_least_64_bits_of_randomness(self):
+        """Base32 spends 5 bits a character, so 64 bits needs 13 of them.
+
+        Rate limiting is what actually makes these unguessable -- see the
+        throttling test below -- but the entropy is the half that holds if
+        the throttle is ever turned off.
+        """
+        device = self._enroll()
+        with next_totp_window():
+            response = self._post_with_api_key(
+                "recovery_generate", {"code": current_code(device.key)}
+            )
+        self.assertEqual(response.status_code, 201)
+
+        for code in response.data["codes"]:
+            self.assertGreaterEqual(len(code), 13, code)
+            self.assertTrue(set(code) <= set(RECOVERY_CODE_ALPHABET), code)
+
+    def test_wrong_recovery_codes_are_throttled(self):
+        """The entropy above is sized against a throttled attacker.
+
+        django-otp backs off by ``factor * 2 ** (failures - 1)`` seconds and
+        the factor is a setting, so a deployment can switch this off. Asserted
+        here because turning it off changes what the code length has to be.
+        """
+        self._enroll()
+        with next_totp_window():
+            self._post_with_api_key(
+                "recovery_generate",
+                {"code": current_code(default_device(self.user).key)},
+            )
+        device = StaticDevice.objects.get(user=self.user, name=RECOVERY_DEVICE_NAME)
+        self.assertTrue(device.throttling_enabled, "backoff is off; codes stand alone")
+
+        # Five misses rather than one: the delay doubles each time, so this
+        # leaves ~16 seconds rather than racing a 1-second window.
+        for miss in range(5):
+            self.assertFalse(_verify_recovery(self.user, f"not-a-code{miss}"))
+
+        # A real code, refused only because the misses started the backoff.
+        spendable = device.token_set.first().token
+        self.assertFalse(_verify_recovery(self.user, spendable))
+        self.assertTrue(device.token_set.filter(token=spendable).exists())
 
     def test_regenerating_replaces_rather_than_appends(self):
         """Spent codes left behind would make the remaining count a lie."""

--- a/onadata/apps/api/tests/viewsets/test_totp_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_totp_viewset.py
@@ -11,6 +11,7 @@ from unittest.mock import patch
 
 from django.conf import settings
 from django.contrib.auth.models import User
+from django.core import mail
 from django.core.cache import cache
 from django.test import RequestFactory, override_settings
 from django.views.debug import SafeExceptionReporterFilter
@@ -1047,6 +1048,51 @@ class TestTOTPViewSet(TestAbstractViewSet):
             )
 
         self.assertEqual(response.status_code, 404)
+
+    def test_enrolment_is_written_to_the_security_audit_log(self):
+        with self.assertLogs("audit_logger", level="DEBUG") as captured:
+            self._enroll()
+
+        actions = {
+            getattr(record, "formhub_action", None) for record in captured.records
+        }
+        self.assertIn("two-factor-enrolled", actions)
+
+    def test_failed_verification_is_written_to_the_security_audit_log(self):
+        self._enroll()
+
+        with self.assertLogs("audit_logger", level="DEBUG") as captured:
+            response = self._verify({"code": "000000", "method": "totp"})
+
+        self.assertEqual(response.status_code, 403)
+        actions = {
+            getattr(record, "formhub_action", None) for record in captured.records
+        }
+        self.assertIn("two-factor-verification-failed", actions)
+
+    def test_enrolment_notifies_the_account_owner(self):
+        mail.outbox = []
+
+        self._enroll()
+
+        self.assertTrue(
+            any(self.user.email in message.to for message in mail.outbox),
+            "enrolling a factor did not notify the account owner",
+        )
+
+    def test_disabling_two_factor_notifies_the_account_owner(self):
+        device = self._enroll()
+        mail.outbox = []
+        with next_totp_window():
+            response = self._post_with_api_key(
+                "disable", {"code": current_code(device.key)}
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(
+            any(self.user.email in message.to for message in mail.outbox),
+            "disabling a factor did not notify the account owner",
+        )
 
 
 @override_settings(ENABLE_TWO_FACTOR=False)

--- a/onadata/apps/api/viewsets/totp_viewset.py
+++ b/onadata/apps/api/viewsets/totp_viewset.py
@@ -41,6 +41,14 @@ from onadata.libs.authentication import (
 
 RECOVERY_CODE_COUNT = 10
 
+#: Lowercase base32, matching what the codes are encoded with.
+RECOVERY_CODE_ALPHABET = "abcdefghijklmnopqrstuvwxyz234567"
+
+#: 64 bits, which base32 renders as 13 characters. django-otp's own generator
+#: draws 5 bytes; that is unguessable against the per-device backoff, but the
+#: backoff is a setting and this leaves the codes standing on their own.
+RECOVERY_CODE_BYTES = 8
+
 #: Not free-form labels. two_factor matches "default" to decide whether to
 #: ask for a second factor at all; "backup" is this module's own, and only has
 #: to agree between the code that writes the recovery set and the code that
@@ -173,6 +181,16 @@ def _verify_code(user, code: str, method: str = "") -> bool:
     return any(check(user, code) for check in VERIFY_METHODS.values())
 
 
+def _recovery_token() -> str:
+    """A recovery code, lowercase to match how they are compared."""
+    return (
+        base64.b32encode(secrets.token_bytes(RECOVERY_CODE_BYTES))
+        .decode()
+        .rstrip("=")
+        .lower()
+    )
+
+
 def _regenerate_recovery_codes(user) -> list:
     """Replace the recovery set and return the new codes.
 
@@ -185,9 +203,7 @@ def _regenerate_recovery_codes(user) -> list:
             user=user, name=RECOVERY_DEVICE_NAME, confirmed=True
         )
         return [
-            StaticToken.objects.create(
-                device=device, token=StaticToken.random_token()
-            ).token
+            StaticToken.objects.create(device=device, token=_recovery_token()).token
             for _ in range(RECOVERY_CODE_COUNT)
         ]
 

--- a/onadata/apps/api/viewsets/totp_viewset.py
+++ b/onadata/apps/api/viewsets/totp_viewset.py
@@ -16,6 +16,7 @@ from django.conf import settings
 from django.core.cache import cache
 from django.db import transaction
 from django.utils.decorators import method_decorator
+from django.utils.translation import gettext as _
 from django.views.decorators.debug import sensitive_post_parameters, sensitive_variables
 
 import qrcode
@@ -32,12 +33,15 @@ from rest_framework.response import Response
 from rest_framework.viewsets import ViewSet
 from two_factor.utils import default_device
 
+from onadata.apps.api.tasks import send_two_factor_changed_email
 from onadata.libs.authentication import (
     SSOHeaderAuthentication,
     add_login_attempt,
     assert_not_locked_out,
     get_client_ip,
 )
+from onadata.libs.utils.email import get_two_factor_email_data
+from onadata.libs.utils.log import Actions, audit_log
 
 RECOVERY_CODE_COUNT = 10
 
@@ -207,6 +211,32 @@ def _regenerate_recovery_codes(user) -> list:
         ]
 
 
+def _audit_verification_failure(request, audit: dict):
+    """Record a failed second-factor check where an operator can see it."""
+    audit_log(
+        Actions.TWO_FACTOR_VERIFICATION_FAILED,
+        request.user,
+        request.user,
+        _("Two-factor verification failed."),
+        audit,
+        request,
+    )
+
+
+def _notify_owner(user, enabled: bool):
+    """Tell the account owner their second factor changed.
+
+    Whoever made the change -- owner or intruder -- the owner finds out.
+    Skipped when the account has no address to reach.
+    """
+    if not user.email:
+        return
+    email_data = get_two_factor_email_data(user.username, enabled)
+    send_two_factor_changed_email.apply_async(
+        args=[user.email, email_data["message_txt"], email_data["subject"]]
+    )
+
+
 def _enrollment_payload(device) -> dict:
     """One secret in three renderings: QR, URI, and base32 to type by hand.
 
@@ -275,6 +305,7 @@ class TOTPViewSet(ViewSet):
             return None
         if _verify_code(request.user, str(request.data.get("code", "")).strip()):
             return None
+        _audit_verification_failure(request, {"audience": audience})
         return Response(
             {
                 "error": "That code is not valid. Enter a current code from your "
@@ -455,6 +486,17 @@ class TOTPViewSet(ViewSet):
             device.confirmed = True
             device.save(update_fields=["confirmed"])
             codes = _regenerate_recovery_codes(request.user)
+        # After the transaction: neither the log entry nor the email can be
+        # rolled back, so neither may describe an enrolment that was.
+        audit_log(
+            Actions.TWO_FACTOR_ENROLLED,
+            request.user,
+            request.user,
+            _("Two-factor authentication enabled."),
+            {},
+            request,
+        )
+        _notify_owner(request.user, enabled=True)
         return Response({"enrolled": True, "codes": codes})
 
     @action(detail=False, methods=["post"], url_path="disable")
@@ -472,6 +514,7 @@ class TOTPViewSet(ViewSet):
             # standing that nothing here can verify, so never removable.
             for device in devices_for_user(request.user, confirmed=None):
                 device.delete()
+        _notify_owner(request.user, enabled=False)
         return Response({"enrolled": False})
 
     @action(detail=False, methods=["post"], url_path="recovery/generate")
@@ -537,6 +580,9 @@ class TOTPViewSet(ViewSet):
                 status=status.HTTP_400_BAD_REQUEST,
             )
         if not _verify_code(request.user, code, method):
+            _audit_verification_failure(
+                request, {"audience": audience, "method": method}
+            )
             return Response(
                 {"error": "That code is not valid."},
                 status=status.HTTP_403_FORBIDDEN,

--- a/onadata/apps/api/viewsets/totp_viewset.py
+++ b/onadata/apps/api/viewsets/totp_viewset.py
@@ -111,9 +111,13 @@ def _totp_device(user, confirmed=True, lock=False):
     )
 
 
-def _recovery_device(user):
-    """The user's recovery-code set, or None."""
-    return StaticDevice.objects.filter(user=user, name=RECOVERY_DEVICE_NAME).first()
+def _recovery_device(user, lock=False):
+    """The user's recovery-code set, or None.
+
+    ``lock`` as in ``_totp_device``.
+    """
+    devices = StaticDevice.objects.select_for_update() if lock else StaticDevice.objects
+    return devices.filter(user=user, name=RECOVERY_DEVICE_NAME).first()
 
 
 def _has_second_factor(user) -> bool:
@@ -135,12 +139,7 @@ def _verify_totp(user, code: str) -> bool:
     ``--threads 1`` does not serialise them.
     """
     with transaction.atomic():
-        device = (
-            TOTPDevice.objects.select_for_update()
-            .filter(user=user, name=TOTP_DEVICE_NAME, confirmed=True)
-            .order_by("-id")
-            .first()
-        )
+        device = _totp_device(user, lock=True)
         return device is not None and device.verify_token(code)
 
 
@@ -154,11 +153,7 @@ def _verify_recovery(user, code: str) -> bool:
     exactly, so the login wizard and this path would otherwise disagree.
     """
     with transaction.atomic():
-        recovery = (
-            StaticDevice.objects.select_for_update()
-            .filter(user=user, name=RECOVERY_DEVICE_NAME)
-            .first()
-        )
+        recovery = _recovery_device(user, lock=True)
         return recovery is not None and recovery.verify_token(code.lower())
 
 

--- a/onadata/apps/api/viewsets/totp_viewset.py
+++ b/onadata/apps/api/viewsets/totp_viewset.py
@@ -94,14 +94,18 @@ def _known_audiences() -> frozenset:
     return frozenset(getattr(settings, "TWO_FACTOR_STEP_UP_AUDIENCES", ()))
 
 
-def _totp_device(user, confirmed=True):
+def _totp_device(user, confirmed=True, lock=False):
     """The user's authenticator, or None.
 
     Newest first, so the answer cannot depend on the order Postgres returns
     rows in should a second confirmed device ever survive.
+
+    ``lock`` holds the row until the transaction ends, for callers that go on
+    to spend the code or change the device.
     """
+    devices = TOTPDevice.objects.select_for_update() if lock else TOTPDevice.objects
     return (
-        TOTPDevice.objects.filter(user=user, name=TOTP_DEVICE_NAME, confirmed=confirmed)
+        devices.filter(user=user, name=TOTP_DEVICE_NAME, confirmed=confirmed)
         .order_by("-id")
         .first()
     )
@@ -420,24 +424,29 @@ class TOTPViewSet(ViewSet):
         refusal = self._require_login_session(request)
         if refusal is not None:
             return refusal
-        device = _totp_device(request.user, confirmed=False)
-        if device is None:
-            return Response(
-                {"error": "Start setting up an authenticator before confirming it."},
-                status=status.HTTP_409_CONFLICT,
-            )
         code = str(request.data.get("code", "")).strip()
-        if not device.verify_token(code):
-            return Response(
-                {
-                    "error": "That code is not valid. Check the time on your device "
-                    "and try the current code."
-                },
-                status=status.HTTP_403_FORBIDDEN,
-            )
-        # One transaction: an authenticator that confirmed but whose recovery
-        # codes did not is one lost phone away from a locked account.
+        # One transaction, with the pending row locked before the code is
+        # spent: a device that confirmed but whose recovery codes did not is
+        # one lost phone from a locked account, and racing callers would each
+        # be handed a set of which only the last survives.
         with transaction.atomic():
+            device = _totp_device(request.user, confirmed=False, lock=True)
+            if device is None:
+                return Response(
+                    {
+                        "error": "Start setting up an authenticator before "
+                        "confirming it."
+                    },
+                    status=status.HTTP_409_CONFLICT,
+                )
+            if not device.verify_token(code):
+                return Response(
+                    {
+                        "error": "That code is not valid. Check the time on your "
+                        "device and try the current code."
+                    },
+                    status=status.HTTP_403_FORBIDDEN,
+                )
             # default_device() answers with the first confirmed device named
             # "default", not the newest, so an incumbent left behind stays the
             # device the login wizard challenges on. Matched by name across

--- a/onadata/libs/templates/two_factor/disabled.txt
+++ b/onadata/libs/templates/two_factor/disabled.txt
@@ -1,0 +1,12 @@
+{% load i18n %}
+{% blocktranslate %}
+Hi {{ username }},
+
+Two-factor authentication was just turned off on your Ona account.
+
+If this was not you, sign in, change your password, set up your authenticator again, and reach out to our support team, {{ support_email }}.
+
+Thank you for choosing Ona!
+
+The Team at Ona
+{% endblocktranslate %}

--- a/onadata/libs/templates/two_factor/disabled_email_subject.txt
+++ b/onadata/libs/templates/two_factor/disabled_email_subject.txt
@@ -1,0 +1,1 @@
+{% load i18n %}{% blocktranslate %}Ona Two-Factor Authentication Disabled{% endblocktranslate %}

--- a/onadata/libs/templates/two_factor/enabled.txt
+++ b/onadata/libs/templates/two_factor/enabled.txt
@@ -1,0 +1,12 @@
+{% load i18n %}
+{% blocktranslate %}
+Hi {{ username }},
+
+An authenticator app was just set up for two-factor authentication on your Ona account.
+
+If this was not you, sign in, remove the authenticator, change your password, and reach out to our support team, {{ support_email }}.
+
+Thank you for choosing Ona!
+
+The Team at Ona
+{% endblocktranslate %}

--- a/onadata/libs/templates/two_factor/enabled_email_subject.txt
+++ b/onadata/libs/templates/two_factor/enabled_email_subject.txt
@@ -1,0 +1,1 @@
+{% load i18n %}{% blocktranslate %}Ona Two-Factor Authentication Enabled{% endblocktranslate %}

--- a/onadata/libs/utils/email.py
+++ b/onadata/libs/utils/email.py
@@ -85,6 +85,20 @@ def get_account_lockout_email_data(username, ip_address, end=False):
     return email_data
 
 
+def get_two_factor_email_data(username, enabled):
+    """Generates the email notifying a change to the account's second factor"""
+    state = "enabled" if enabled else "disabled"
+    ctx_dict = {
+        "username": username,
+        "support_email": getattr(settings, "SUPPORT_EMAIL", "support@example.com"),
+    }
+
+    return {
+        "subject": render_to_string(f"two_factor/{state}_email_subject.txt"),
+        "message_txt": render_to_string(f"two_factor/{state}.txt", ctx_dict),
+    }
+
+
 def get_account_deactivation_email_data(
     email, username, days_remaining, deactivation_date
 ):

--- a/onadata/libs/utils/log.py
+++ b/onadata/libs/utils/log.py
@@ -60,6 +60,8 @@ Actions = Enum(  # pylint: disable=invalid-name
     BAMBOO_LINK_DELETED="bamboo-link-deleted",
     SMS_SUPPORT_ACTIVATED="sms-support-activated",
     SMS_SUPPORT_DEACTIVATED="sms-support-deactivated",
+    TWO_FACTOR_ENROLLED="two-factor-enrolled",
+    TWO_FACTOR_VERIFICATION_FAILED="two-factor-verification-failed",
 )
 
 


### PR DESCRIPTION
### Changes / Features implemented

Second-factor lifecycle events now leave a trace. Confirming an enrolment writes a `two-factor-enrolled` entry to the security audit log, and a failed code check — on `verify` or on any code-guarded action — writes `two-factor-verification-failed`. Enrolling and disabling both email the account owner, so whoever made the change, the owner finds out. Notification templates follow the account-lockout ones.

### Steps taken to verify this change does what is intended

Adopted the four tests from the outstanding-security-issues review, which were run and failing against this branch before the change. Template rendering verified locally through `get_two_factor_email_data`.

### Side effects of implementing this change

None on API responses — audit entries and emails are added after the existing transactions commit, and the email is skipped for accounts with no address.

**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  - [ ] Updated documentation

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/onaio/codesmith/onadata/pr/3237"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790408813&installation_model_id=422582&pr_number=3237&repository=onaio%2Fonadata&return_to=https%3A%2F%2Fgithub.com%2Fonaio%2Fonadata%2Fpull%2F3237&signature=ac50132447d8d8934a01108731d4f42607726e4714fa26a9dc8a2b6977c8a7ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->