### PR TITLE
feat(2fa): complete audit coverage and failure alerting

### DIFF
--- a/onadata/apps/api/tests/viewsets/test_totp_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_totp_viewset.py
@@ -1094,6 +1094,138 @@ class TestTOTPViewSet(TestAbstractViewSet):
             "disabling a factor did not notify the account owner",
         )
 
+    def test_disabling_two_factor_is_written_to_the_security_audit_log(self):
+        device = self._enroll()
+
+        with self.assertLogs("audit_logger", level="DEBUG") as captured:
+            with next_totp_window():
+                response = self._post_with_api_key(
+                    "disable", {"code": current_code(device.key)}
+                )
+
+        self.assertEqual(response.status_code, 200)
+        actions = {
+            getattr(record, "formhub_action", None) for record in captured.records
+        }
+        self.assertIn("two-factor-disabled", actions)
+
+    def test_regenerating_recovery_codes_is_written_to_the_security_audit_log(self):
+        device = self._enroll()
+
+        with self.assertLogs("audit_logger", level="DEBUG") as captured:
+            with next_totp_window():
+                response = self._post_with_api_key(
+                    "recovery_generate", {"code": current_code(device.key)}
+                )
+
+        self.assertEqual(response.status_code, 201)
+        actions = {
+            getattr(record, "formhub_action", None) for record in captured.records
+        }
+        self.assertIn("two-factor-recovery-codes-generated", actions)
+
+    def test_viewing_recovery_codes_is_written_to_the_security_audit_log(self):
+        device = self._enroll()
+        with next_totp_window():
+            generated = self._post_with_api_key(
+                "recovery_generate", {"code": current_code(device.key)}
+            )
+        self.assertEqual(generated.status_code, 201)
+
+        with self.assertLogs("audit_logger", level="DEBUG") as captured:
+            with next_totp_window():
+                viewed = self._post_with_api_key(
+                    "recovery_view", {"code": current_code(device.key)}
+                )
+
+        self.assertEqual(viewed.status_code, 200)
+        actions = {
+            getattr(record, "formhub_action", None) for record in captured.records
+        }
+        self.assertIn("two-factor-recovery-codes-viewed", actions)
+
+    def test_regenerating_recovery_codes_notifies_the_account_owner(self):
+        device = self._enroll()
+        mail.outbox = []
+
+        with next_totp_window():
+            response = self._post_with_api_key(
+                "recovery_generate", {"code": current_code(device.key)}
+            )
+
+        self.assertEqual(response.status_code, 201)
+        self.assertTrue(
+            any(self.user.email in message.to for message in mail.outbox),
+            "replacing the recovery set did not notify the account owner",
+        )
+
+    def test_viewing_recovery_codes_does_not_notify_the_account_owner(self):
+        """Viewing is audited but deliberately not emailed -- re-reading the
+        unspent set is a supported flow, and mailing on every read would bury
+        the notifications that mark actual credential changes."""
+        device = self._enroll()
+        with next_totp_window():
+            generated = self._post_with_api_key(
+                "recovery_generate", {"code": current_code(device.key)}
+            )
+        self.assertEqual(generated.status_code, 201)
+        mail.outbox = []
+
+        with next_totp_window():
+            viewed = self._post_with_api_key(
+                "recovery_view", {"code": current_code(device.key)}
+            )
+
+        self.assertEqual(viewed.status_code, 200)
+        self.assertEqual(
+            [message for message in mail.outbox if self.user.email in message.to],
+            [],
+        )
+
+    @override_settings(
+        TWO_FACTOR_FAILURE_ALERT_THRESHOLD=3, TWO_FACTOR_FAILURE_ALERT_WINDOW=600
+    )
+    def test_repeated_failed_verifications_alert_the_account_owner(self):
+        # The failure counter lives in the cache, which the test runner does
+        # not roll back.
+        cache.clear()
+        self.addCleanup(cache.clear)
+        self._enroll()
+        mail.outbox = []
+
+        for _ in range(2):
+            self.assertEqual(self._verify({"code": "000000"}).status_code, 403)
+        self.assertEqual(
+            [message for message in mail.outbox if self.user.email in message.to],
+            [],
+            "alerted before the threshold was reached",
+        )
+
+        self.assertEqual(self._verify({"code": "000000"}).status_code, 403)
+        alerts = [message for message in mail.outbox if self.user.email in message.to]
+        self.assertEqual(
+            len(alerts), 1, "reaching the threshold did not alert the account owner"
+        )
+
+        # Failures past the threshold do not repeat the alert in this window.
+        self.assertEqual(self._verify({"code": "000000"}).status_code, 403)
+        self.assertEqual(len([m for m in mail.outbox if self.user.email in m.to]), 1)
+
+    @override_settings(TWO_FACTOR_FAILURE_ALERT_THRESHOLD=0)
+    def test_failure_alerting_can_be_disabled(self):
+        cache.clear()
+        self.addCleanup(cache.clear)
+        self._enroll()
+        mail.outbox = []
+
+        for _ in range(5):
+            self.assertEqual(self._verify({"code": "000000"}).status_code, 403)
+
+        self.assertEqual(
+            [message for message in mail.outbox if self.user.email in message.to],
+            [],
+        )
+
 
 @override_settings(ENABLE_TWO_FACTOR=False)
 class DisabledTOTPViewSetTestCase(TestAbstractViewSet):

--- a/onadata/apps/api/viewsets/totp_viewset.py
+++ b/onadata/apps/api/viewsets/totp_viewset.py
@@ -33,15 +33,14 @@ from rest_framework.response import Response
 from rest_framework.viewsets import ViewSet
 from two_factor.utils import default_device
 
-from onadata.apps.api.tasks import send_two_factor_changed_email
 from onadata.libs.authentication import (
     SSOHeaderAuthentication,
     add_login_attempt,
     assert_not_locked_out,
     get_client_ip,
 )
-from onadata.libs.utils.email import get_two_factor_email_data
 from onadata.libs.utils.log import Actions, audit_log
+from onadata.libs.utils.two_factor import notify_owner, record_verification_failure
 
 RECOVERY_CODE_COUNT = 10
 
@@ -211,32 +210,6 @@ def _regenerate_recovery_codes(user) -> list:
         ]
 
 
-def _audit_verification_failure(request, audit: dict):
-    """Record a failed second-factor check where an operator can see it."""
-    audit_log(
-        Actions.TWO_FACTOR_VERIFICATION_FAILED,
-        request.user,
-        request.user,
-        _("Two-factor verification failed."),
-        audit,
-        request,
-    )
-
-
-def _notify_owner(user, enabled: bool):
-    """Tell the account owner their second factor changed.
-
-    Whoever made the change -- owner or intruder -- the owner finds out.
-    Skipped when the account has no address to reach.
-    """
-    if not user.email:
-        return
-    email_data = get_two_factor_email_data(user.username, enabled)
-    send_two_factor_changed_email.apply_async(
-        args=[user.email, email_data["message_txt"], email_data["subject"]]
-    )
-
-
 def _enrollment_payload(device) -> dict:
     """One secret in three renderings: QR, URI, and base32 to type by hand.
 
@@ -305,7 +278,7 @@ class TOTPViewSet(ViewSet):
             return None
         if _verify_code(request.user, str(request.data.get("code", "")).strip()):
             return None
-        _audit_verification_failure(request, {"audience": audience})
+        record_verification_failure(request, request.user, {"audience": audience})
         return Response(
             {
                 "error": "That code is not valid. Enter a current code from your "
@@ -496,7 +469,7 @@ class TOTPViewSet(ViewSet):
             {},
             request,
         )
-        _notify_owner(request.user, enabled=True)
+        notify_owner(request.user, "enabled")
         return Response({"enrolled": True, "codes": codes})
 
     @action(detail=False, methods=["post"], url_path="disable")
@@ -514,7 +487,15 @@ class TOTPViewSet(ViewSet):
             # standing that nothing here can verify, so never removable.
             for device in devices_for_user(request.user, confirmed=None):
                 device.delete()
-        _notify_owner(request.user, enabled=False)
+        audit_log(
+            Actions.TWO_FACTOR_DISABLED,
+            request.user,
+            request.user,
+            _("Two-factor authentication disabled."),
+            {},
+            request,
+        )
+        notify_owner(request.user, "disabled")
         return Response({"enrolled": False})
 
     @action(detail=False, methods=["post"], url_path="recovery/generate")
@@ -528,11 +509,20 @@ class TOTPViewSet(ViewSet):
         refusal = self._require_code(request, "recovery-generate")
         if refusal is not None:
             return refusal
-        # The only time these are readable.
-        return Response(
-            {"codes": _regenerate_recovery_codes(request.user)},
-            status=status.HTTP_201_CREATED,
+        codes = _regenerate_recovery_codes(request.user)
+        audit_log(
+            Actions.TWO_FACTOR_RECOVERY_CODES_GENERATED,
+            request.user,
+            request.user,
+            _("Two-factor recovery codes replaced."),
+            {},
+            request,
         )
+        # The previous set died with the new one's arrival, which is worth an
+        # email; enrolment's initial set is covered by the enrolment notice.
+        notify_owner(request.user, "recovery_generated")
+        # The only time these are readable.
+        return Response({"codes": codes}, status=status.HTTP_201_CREATED)
 
     @action(detail=False, methods=["post"], url_path="recovery")
     def recovery_view(self, request):
@@ -550,6 +540,17 @@ class TOTPViewSet(ViewSet):
                 {"error": "No recovery codes have been generated."},
                 status=status.HTTP_404_NOT_FOUND,
             )
+        # Audited but not emailed: re-reading the unspent set is a supported
+        # flow, and mailing every read would bury the notices that mark
+        # actual credential changes.
+        audit_log(
+            Actions.TWO_FACTOR_RECOVERY_CODES_VIEWED,
+            request.user,
+            request.user,
+            _("Two-factor recovery codes viewed."),
+            {},
+            request,
+        )
         return Response(
             {"codes": list(recovery.token_set.values_list("token", flat=True))}
         )
@@ -580,8 +581,8 @@ class TOTPViewSet(ViewSet):
                 status=status.HTTP_400_BAD_REQUEST,
             )
         if not _verify_code(request.user, code, method):
-            _audit_verification_failure(
-                request, {"audience": audience, "method": method}
+            record_verification_failure(
+                request, request.user, {"audience": audience, "method": method}
             )
             return Response(
                 {"error": "That code is not valid."},

--- a/onadata/apps/main/tests/test_accounts_login_lockout.py
+++ b/onadata/apps/main/tests/test_accounts_login_lockout.py
@@ -209,6 +209,37 @@ class EnrolledUserWizardTestCase(WizardLogin, TestBase):
         self.assertNotIn("_auth_user_id", self.client.session)
 
 
+class WizardVerificationAuditTestCase(WizardLogin, TestBase):
+    """A failed wizard token entry reaches the security audit log.
+
+    The same action the API's failed checks record: one event, both doors.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.device = self.enrol_device()
+
+    def test_failed_token_is_written_to_the_security_audit_log(self):
+        self.submit_credentials()
+
+        with self.assertLogs("audit_logger", level="DEBUG") as captured:
+            response = self.submit_token("000000")
+
+        self.assertNotEqual(response.status_code, 302)
+        actions = {
+            getattr(record, "formhub_action", None) for record in captured.records
+        }
+        self.assertIn("two-factor-verification-failed", actions)
+
+    def test_a_valid_token_is_not_recorded_as_a_failure(self):
+        self.submit_credentials()
+
+        with self.assertNoLogs("audit_logger", level="DEBUG"):
+            response = self.submit_token(self.current_token(self.device))
+
+        self.assertEqual(response.status_code, 302)
+
+
 @override_settings(MAX_LOGIN_ATTEMPTS=3, LOCKOUT_TIME=1800)
 class TokenStepLockoutTestCase(WizardLogin, TestBase):
     """The lockout covers the token step, not the credentials step alone.

--- a/onadata/apps/main/two_factor_views.py
+++ b/onadata/apps/main/two_factor_views.py
@@ -25,7 +25,7 @@ def _default_remember_to_off(form):
         remember.initial = False
 
 
-def _enforce_lockout(form, request):
+def _enforce_lockout(form, request, step):
     """Count token failures against onadata's login lockout.
 
     Upstream covers the credentials step alone, leaving whoever holds the
@@ -51,6 +51,10 @@ def _enforce_lockout(form, request):
         try:
             return inner_clean()
         except forms.ValidationError:
+            # Lazy for the same reason as above. Recorded before the lockout
+            # counter so hitting the threshold cannot skip the audit entry.
+            two_factor = importlib.import_module("onadata.libs.utils.two_factor")
+            two_factor.record_verification_failure(request, form.user, {"step": step})
             # Re-raised so the user sees the library's wrong-token message,
             # until add_login_attempt raises at the threshold instead.
             try:
@@ -116,7 +120,8 @@ class LockoutLoginView(LoginView):
         class named there is discarded before it is ever instantiated.
         """
         form = super().get_form(step=step, **kwargs)
-        if (step or self.steps.current) in (self.TOKEN_STEP, self.BACKUP_STEP):
+        current = step or self.steps.current
+        if current in (self.TOKEN_STEP, self.BACKUP_STEP):
             _default_remember_to_off(form)
-            _enforce_lockout(form, self.request)
+            _enforce_lockout(form, self.request, current)
         return form

--- a/onadata/libs/templates/two_factor/failed_attempts.txt
+++ b/onadata/libs/templates/two_factor/failed_attempts.txt
@@ -1,0 +1,12 @@
+{% load i18n %}
+{% blocktranslate %}
+Hi {{ username }},
+
+There have been {{ failure_count }} failed attempts to pass two-factor verification on your Ona account in the last {{ window_minutes }} minutes.
+
+If this was not you, someone else may hold your password or an active session. Sign in, change your password, and reach out to our support team, {{ support_email }}.
+
+Thank you for choosing Ona!
+
+The Team at Ona
+{% endblocktranslate %}

--- a/onadata/libs/templates/two_factor/failed_attempts_email_subject.txt
+++ b/onadata/libs/templates/two_factor/failed_attempts_email_subject.txt
@@ -1,0 +1,1 @@
+{% load i18n %}{% blocktranslate %}Ona Two-Factor Verification Failures{% endblocktranslate %}

--- a/onadata/libs/templates/two_factor/recovery_generated.txt
+++ b/onadata/libs/templates/two_factor/recovery_generated.txt
@@ -1,0 +1,12 @@
+{% load i18n %}
+{% blocktranslate %}
+Hi {{ username }},
+
+A new set of two-factor recovery codes was just generated for your Ona account. Your previous recovery codes no longer work.
+
+If this was not you, sign in, change your password, generate a fresh set of recovery codes, and reach out to our support team, {{ support_email }}.
+
+Thank you for choosing Ona!
+
+The Team at Ona
+{% endblocktranslate %}

--- a/onadata/libs/templates/two_factor/recovery_generated_email_subject.txt
+++ b/onadata/libs/templates/two_factor/recovery_generated_email_subject.txt
@@ -1,0 +1,1 @@
+{% load i18n %}{% blocktranslate %}Ona Recovery Codes Replaced{% endblocktranslate %}

--- a/onadata/libs/utils/email.py
+++ b/onadata/libs/utils/email.py
@@ -85,17 +85,21 @@ def get_account_lockout_email_data(username, ip_address, end=False):
     return email_data
 
 
-def get_two_factor_email_data(username, enabled):
-    """Generates the email notifying a change to the account's second factor"""
-    state = "enabled" if enabled else "disabled"
+def get_two_factor_email_data(username, event, **context):
+    """Generates the email notifying a two-factor account event.
+
+    ``event`` names the template pair under ``two_factor/``; extra context
+    reaches the message template.
+    """
     ctx_dict = {
         "username": username,
         "support_email": getattr(settings, "SUPPORT_EMAIL", "support@example.com"),
+        **context,
     }
 
     return {
-        "subject": render_to_string(f"two_factor/{state}_email_subject.txt"),
-        "message_txt": render_to_string(f"two_factor/{state}.txt", ctx_dict),
+        "subject": render_to_string(f"two_factor/{event}_email_subject.txt"),
+        "message_txt": render_to_string(f"two_factor/{event}.txt", ctx_dict),
     }
 
 

--- a/onadata/libs/utils/log.py
+++ b/onadata/libs/utils/log.py
@@ -61,7 +61,10 @@ Actions = Enum(  # pylint: disable=invalid-name
     SMS_SUPPORT_ACTIVATED="sms-support-activated",
     SMS_SUPPORT_DEACTIVATED="sms-support-deactivated",
     TWO_FACTOR_ENROLLED="two-factor-enrolled",
+    TWO_FACTOR_DISABLED="two-factor-disabled",
     TWO_FACTOR_VERIFICATION_FAILED="two-factor-verification-failed",
+    TWO_FACTOR_RECOVERY_CODES_GENERATED="two-factor-recovery-codes-generated",
+    TWO_FACTOR_RECOVERY_CODES_VIEWED="two-factor-recovery-codes-viewed",
 )
 
 

--- a/onadata/libs/utils/two_factor.py
+++ b/onadata/libs/utils/two_factor.py
@@ -1,0 +1,69 @@
+"""Recording and notification of two-factor account events.
+
+Shared by the API viewset and the login wizard, so both doors onto the second
+factor report through one funnel.
+"""
+
+from django.conf import settings
+from django.core.cache import cache
+from django.utils.translation import gettext as _
+
+from onadata.libs.utils.log import Actions, audit_log
+
+FAILURE_COUNT_CACHE_PREFIX = "two-factor-failures"
+
+
+def notify_owner(user, event, **context):
+    """Email the account owner about a change to their second factor.
+
+    Whoever made the change -- owner or intruder -- the owner finds out.
+    Skipped when the account has no address to reach.
+    """
+    if not user.email:
+        return
+    # Lazy: the login wizard reaches this module, and the task module imports
+    # back into the apps the wizard belongs to.
+    # pylint: disable=import-outside-toplevel
+    from onadata.apps.api.tasks import send_two_factor_changed_email
+    from onadata.libs.utils.email import get_two_factor_email_data
+
+    email_data = get_two_factor_email_data(user.username, event, **context)
+    send_two_factor_changed_email.apply_async(
+        args=[user.email, email_data["message_txt"], email_data["subject"]]
+    )
+
+
+def record_verification_failure(request, user, audit):
+    """Audit a failed second-factor check and alert the owner on repetition."""
+    audit_log(
+        Actions.TWO_FACTOR_VERIFICATION_FAILED,
+        user,
+        user,
+        _("Two-factor verification failed."),
+        audit,
+        request,
+    )
+    _alert_on_repeated_failures(user)
+
+
+def _alert_on_repeated_failures(user):
+    """One owner email per window once failures reach the threshold.
+
+    The window opens at the first failure: ``cache.add`` sets the expiry only
+    when the key is absent, and ``incr`` preserves it. Alerting on the exact
+    threshold count keeps it to one email per window however long the run of
+    failures continues.
+    """
+    threshold = getattr(settings, "TWO_FACTOR_FAILURE_ALERT_THRESHOLD", 10)
+    if not threshold:
+        return
+    window = getattr(settings, "TWO_FACTOR_FAILURE_ALERT_WINDOW", 1800)
+    key = f"{FAILURE_COUNT_CACHE_PREFIX}:{user.pk}"
+    cache.add(key, 0, window)
+    if cache.incr(key) == threshold:
+        notify_owner(
+            user,
+            "failed_attempts",
+            failure_count=threshold,
+            window_minutes=max(1, window // 60),
+        )

--- a/onadata/settings/common.py
+++ b/onadata/settings/common.py
@@ -165,6 +165,13 @@ TWO_FACTOR_STEP_UP_AUDIENCES = frozenset(
 # password hashes nobody knows, and demanding one there would bar enrolment
 # outright. Deployments where the password is the account's own turn it on.
 TWO_FACTOR_ENROLMENT_REQUIRES_PASSWORD = False
+
+# Email the account owner after this many failed second-factor checks within
+# TWO_FACTOR_FAILURE_ALERT_WINDOW seconds -- one email per window. 0 disables
+# the alert.
+TWO_FACTOR_FAILURE_ALERT_THRESHOLD = 10
+TWO_FACTOR_FAILURE_ALERT_WINDOW = 1800
+
 LOGIN_REDIRECT_URL = "/login_redirect/"
 
 # URL prefix for admin static files -- CSS, JavaScript and images.


### PR DESCRIPTION
### Changes / Features implemented

Completes the audit trail and owner notifications for second-factor changes. Disabling, regenerating recovery codes, and viewing recovery codes now write audit entries; regenerating the recovery set emails the owner (viewing is audited but deliberately not emailed). Failed wizard token entries write the same `two-factor-verification-failed` action the API records, through a shared funnel in `onadata/libs/utils/two_factor.py`. Repeated failures now alert the owner: after `TWO_FACTOR_FAILURE_ALERT_THRESHOLD` failed checks within `TWO_FACTOR_FAILURE_ALERT_WINDOW` seconds (both configurable, threshold 0 disables), one email per window.

### Steps taken to verify this change does what is intended

Red-checked on the local docker stack: at the tests-only first commit the six feature tests fail (missing audit entries, no emails, no alert) and the three negative guards pass; at the branch tip all 95 tests across the TOTP viewset, wizard lockout, and concurrency modules pass.

### Side effects of implementing this change

None on API responses. The failure counter lives in the cache alongside the login lockout's.

**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  - [ ] Updated documentation