### PR TITLE
feat: audit log form replacement

### DIFF
--- a/onadata/apps/api/tests/viewsets/test_xform_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_xform_viewset.py
@@ -62,7 +62,7 @@ from onadata.apps.logger.models.kms import KMSKey
 from onadata.apps.logger.models.xform_version import XFormVersion
 from onadata.apps.logger.views import delete_xform
 from onadata.apps.logger.xform_instance_parser import XLSFormError
-from onadata.apps.main.models import MetaData
+from onadata.apps.main.models import AuditLog, MetaData
 from onadata.apps.messaging.constants import FORM_UPDATED, XFORM
 from onadata.apps.viewer.models import Export
 from onadata.libs.exceptions import EncryptionError
@@ -102,6 +102,7 @@ from onadata.libs.utils.common_tools import (
     filename_from_disposition,
     get_response_content,
 )
+from onadata.libs.utils.log import Actions
 from onadata.libs.utils.xform_utils import get_xform_users
 
 ROLES = [ReadOnlyRole, DataEntryRole, EditorRole, ManagerRole, OwnerRole]
@@ -3114,6 +3115,80 @@ nhMo+jI88L3qfm4/rtWKuQ9/a268phlNj34uQeoDDHuRViQo00L5meE/pFptm
             self.assertNotEqual(title_old, self.xform.title)
             self.assertEqual(form_id, self.xform.pk)
             self.assertEqual(id_string, self.xform.id_string)
+
+    def test_update_xform_xls_file_audit_logged(self):
+        """Replacing a form is recorded in the audit log"""
+        with HTTMock(enketo_mock):
+            self._publish_xls_form_to_project()
+
+            view = XFormViewSet.as_view(
+                {
+                    "patch": "partial_update",
+                }
+            )
+
+            path = os.path.join(
+                settings.PROJECT_ROOT,
+                "apps",
+                "main",
+                "tests",
+                "fixtures",
+                "transportation",
+                "transportation_version.xlsx",
+            )
+            with open(path, "rb") as xls_file:
+                post_data = {"xls_file": xls_file}
+                request = self.factory.patch("/", data=post_data, **self.extra)
+                response = view(request, pk=self.xform.pk)
+                self.assertEqual(response.status_code, 200)
+
+            records = list(
+                AuditLog.query_data(
+                    self.xform.user.username, sort="-created_on", start=0, limit=1
+                )
+            )
+            self.assertEqual(len(records), 1)
+            record = records[0]
+            self.assertEqual(record["action"], Actions.FORM_XLS_UPDATED)
+            self.assertEqual(record["user"], self.user.username)
+            self.assertEqual(record["account"], self.xform.user.username)
+            self.assertEqual(record["audit"], {"xform": self.xform.id_string})
+
+    def test_update_xform_xls_bad_file_not_audit_logged(self):
+        """A failed form replacement is not recorded in the audit log"""
+        with HTTMock(enketo_mock):
+            self._publish_xls_form_to_project()
+
+            view = XFormViewSet.as_view(
+                {
+                    "patch": "partial_update",
+                }
+            )
+
+            path = os.path.join(
+                settings.PROJECT_ROOT,
+                "apps",
+                "main",
+                "tests",
+                "fixtures",
+                "transportation",
+                "transportation.bad_id.xlsx",
+            )
+            with open(path, "rb") as xls_file:
+                post_data = {"xls_file": xls_file}
+                request = self.factory.patch("/", data=post_data, **self.extra)
+                response = view(request, pk=self.xform.pk)
+                self.assertEqual(response.status_code, 400)
+
+            records = AuditLog.query_data(self.xform.user.username)
+            self.assertEqual(
+                [
+                    record
+                    for record in records
+                    if record["action"] == Actions.FORM_XLS_UPDATED
+                ],
+                [],
+            )
 
     def test_manager_can_update_xform_xls_file(self):
         """Manager Role can replace xlsform"""

--- a/onadata/apps/api/viewsets/xform_viewset.py
+++ b/onadata/apps/api/viewsets/xform_viewset.py
@@ -107,6 +107,7 @@ from onadata.libs.utils.csv_import import (
     submit_csv_async,
 )
 from onadata.libs.utils.export_tools import parse_request_export_options
+from onadata.libs.utils.log import Actions, audit_log
 from onadata.libs.utils.logger_tools import publish_form
 from onadata.libs.utils.string import str2bool
 from onadata.libs.utils.upload_validation import (
@@ -269,6 +270,15 @@ def _try_update_xlsform(request, xform, owner):
             target_type=XFORM,
             user=request.user or owner,
             message_verb=FORM_UPDATED,
+        )
+
+        audit_log(
+            Actions.FORM_XLS_UPDATED,
+            request.user,
+            owner,
+            _("XLS for '%(id_string)s' updated.") % {"id_string": xform.id_string},
+            {"xform": xform.id_string},
+            request,
         )
 
         return Response(serializer.data, status=status.HTTP_200_OK)


### PR DESCRIPTION
### Changes / Features implemented

Replacing a form is now recorded in the account's activity trail no matter how it is done.

Previously only replacements made from the web interface were recorded. Replacing the same form through the API left no trace at all, so a form could change without anyone reviewing the activity trail being able to see who did it or when. Both routes now record the same entry.

The entry is only recorded once the replacement actually succeeds, so a rejected form leaves nothing behind.

### Steps taken to verify this change does what is intended

- [x] Added tests

### Side effects of implementing this change

None.


**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  - [ ] Updated documentation

Closes #3240

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/onaio/codesmith/onadata/pr/3241"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790516304&installation_model_id=422582&pr_number=3241&repository=onaio%2Fonadata&return_to=https%3A%2F%2Fgithub.com%2Fonaio%2Fonadata%2Fpull%2F3241&signature=3075e220c5527679efae7ada15cd2ae3d8448e4a0264ccf6b3fa034187be7c9e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->