### PR TITLE
fix: make Enketo request timeout configurable and handle request failures

### DIFF
--- a/onadata/apps/api/tests/viewsets/test_data_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_data_viewset.py
@@ -68,6 +68,7 @@ from onadata.libs.serializers.submission_review_serializer import (
 )
 from onadata.libs.utils.common_tags import MONGO_STRFTIME
 from onadata.libs.utils.logger_tools import create_instance
+from onadata.libs.utils.viewer_tools import ENKETO_GENERIC_ERROR
 
 
 @urlmatch(netloc=r"(.*\.)?enketo\.ona\.io$")
@@ -1557,6 +1558,45 @@ class TestDataViewSet(SerializeMixin, TestBase):
             response = view(request, pk=formid, dataid=dataid)
             self.assertEqual(response.status_code, 400)
             self.assertEqual(response.get("Cache-Control"), None)
+
+    def test_enketo_edit_url_request_failure_returns_400(self):
+        """A failed request to Enketo returns 400 with the generic message.
+
+        Depends on get_enketo_urls translating RequestException into
+        EnketoError, which the endpoint reports as a parse error.
+        """
+        self._make_submissions()
+        view = DataViewSet.as_view({"get": "enketo"})
+        request = self.factory.get(
+            "/", data={"return_url": "http://test.io/test_url"}, **self.extra
+        )
+        formid = self.xform.pk
+        dataid = self.xform.instances.all().order_by("id")[0].pk
+        fake_event_id = "abc123def456"
+
+        with (
+            patch(
+                "onadata.libs.utils.viewer_tools.requests.post",
+                side_effect=requests.exceptions.ReadTimeout(
+                    "Read timed out. (read timeout=20)"
+                ),
+            ) as mock_post,
+            patch(
+                "onadata.libs.utils.viewer_tools.report_exception",
+                return_value=fake_event_id,
+            ),
+        ):
+            response = view(request, pk=formid, dataid=dataid)
+
+        self.assertTrue(mock_post.called)
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.data,
+            {
+                "detail": f"Enketo error: {ENKETO_GENERIC_ERROR}"
+                f" (reference: {fake_event_id})"
+            },
+        )
 
     def test_enketo_edit_url_names_the_submission(self):
         """The server URL sent to Enketo names the submission being edited.

--- a/onadata/libs/tests/utils/test_viewer_tools.py
+++ b/onadata/libs/tests/utils/test_viewer_tools.py
@@ -2,7 +2,7 @@
 
 import json
 import os
-from unittest.mock import Mock, patch
+from unittest.mock import ANY, Mock, patch
 
 from django.core.files.base import File
 from django.core.files.temp import NamedTemporaryFile
@@ -11,6 +11,9 @@ from django.test import SimpleTestCase
 from django.test.client import RequestFactory
 from django.test.utils import override_settings
 from django.utils import timezone
+
+from requests.exceptions import ConnectionError as RequestsConnectionError
+from requests.exceptions import ReadTimeout
 
 from onadata.apps.logger.models import Attachment, Instance, XForm
 from onadata.apps.main.tests.test_base import TestBase
@@ -23,6 +26,7 @@ from onadata.libs.utils.viewer_tools import (
     generate_enketo_form_defaults,
     get_client_ip,
     get_enketo_attachment_params,
+    get_enketo_urls,
     get_form,
     get_form_url,
     handle_enketo_error,
@@ -295,7 +299,7 @@ class TestGetEnketoAttachmentParams(TestBase):
 
 
 def _mock_response(status_code, content, text=None):
-    """Build a mock response for handle_enketo_error tests."""
+    """Build a mock HTTP response with the attributes the Enketo helpers read."""
     response = Mock()
     response.status_code = status_code
     response.content = content
@@ -378,6 +382,21 @@ class TestHandleEnketoError(SimpleTestCase):
 
         self.assertIn(ENKETO_GENERIC_ERROR, str(ctx.exception))
 
+    def test_valid_json_non_dict_body(self, mock_report):
+        """A JSON body that is not an object falls back to response.text."""
+        for body in (b'["not", "a", "dict"]', b"null", b"5", b'["message"]'):
+            with self.subTest(body=body):
+                mock_report.reset_mock()
+                mock_report.return_value = "sentry-id"
+                response = _mock_response(400, body, text="raw error text")
+
+                with self.assertRaises(EnketoError) as ctx:
+                    handle_enketo_error(response)
+
+                self.assertIn("raw error text", str(ctx.exception))
+                self.assertIn("sentry-id", str(ctx.exception))
+                mock_report.assert_called_once_with("HTTP Error 400", "raw error text")
+
     def test_error_message_includes_enketo_prefix(self, mock_report):
         """All raised errors include the Enketo error prefix."""
         mock_report.return_value = "sentry-id"
@@ -388,3 +407,73 @@ class TestHandleEnketoError(SimpleTestCase):
             handle_enketo_error(response)
 
         self.assertTrue(str(ctx.exception).startswith(ENKETO_ERROR_PREFIX))
+
+
+@override_settings(
+    ENKETO_URL="https://enketo.example.com/",
+    ENKETO_API_ALL_SURVEY_LINKS_PATH="/api_v2/survey/all",
+    ENKETO_API_INSTANCE_PATH="/api_v2/instance",
+    ENKETO_API_TOKEN="abc123",
+)
+@patch("onadata.libs.utils.viewer_tools.report_exception")
+@patch("onadata.libs.utils.viewer_tools.requests.post")
+class TestGetEnketoUrlsRequests(SimpleTestCase):
+    """How get_enketo_urls() makes and recovers from Enketo requests."""
+
+    def test_request_failure_raises_enketo_error(self, mock_post, mock_report):
+        """A failed request raises EnketoError with the generic message.
+
+        Both subclasses are exercised to pin the except clause at
+        RequestException breadth, not a single subclass.
+        """
+        errors = [
+            ReadTimeout("Read timed out. (read timeout=20)"),
+            RequestsConnectionError("Connection refused"),
+        ]
+        for error in errors:
+            with self.subTest(error=type(error).__name__):
+                mock_post.reset_mock()
+                mock_report.reset_mock()
+                mock_post.side_effect = error
+                mock_report.return_value = "sentry-id"
+
+                with self.assertRaises(EnketoError) as ctx:
+                    get_enketo_urls("https://example.com/enketo/1", "form_id")
+
+                message = str(ctx.exception)
+                self.assertTrue(mock_post.called)
+                self.assertIn(ENKETO_GENERIC_ERROR, message)
+                self.assertIn("sentry-id", message)
+                self.assertNotIn(str(error), message)
+                self.assertIs(ctx.exception.__cause__, error)
+                mock_report.assert_called_once_with(
+                    "Enketo request failed", str(error), ANY
+                )
+                self.assertIs(mock_report.call_args.args[2][1], error)
+
+    def test_non_dict_success_body_raises_enketo_error(self, mock_post, mock_report):
+        """A 2xx response whose JSON body is not an object raises EnketoError.
+
+        Callers immediately call .get() on the return value, so a non-dict
+        body must divert into the handled error path instead.
+        """
+        mock_post.return_value = _mock_response(200, b'["u1", "u2"]')
+        mock_report.return_value = "sentry-id"
+
+        with self.assertRaises(EnketoError) as ctx:
+            get_enketo_urls("https://example.com/enketo/1", "form_id")
+
+        self.assertIn(ENKETO_GENERIC_ERROR, str(ctx.exception))
+        self.assertIn("sentry-id", str(ctx.exception))
+
+    @override_settings(ENKETO_API_REQUEST_TIMEOUT=45)
+    def test_timeout_comes_from_settings(self, mock_post, _mock_report):
+        """The configured ENKETO_API_REQUEST_TIMEOUT is used for the request."""
+        mock_post.return_value = _mock_response(
+            200, b'{"url": "https://enketo.example.com/abc"}'
+        )
+
+        data = get_enketo_urls("https://example.com/enketo/1", "form_id")
+
+        self.assertEqual(data, {"url": "https://enketo.example.com/abc"})
+        self.assertEqual(mock_post.call_args.kwargs["timeout"], 45)

--- a/onadata/libs/tests/utils/test_viewer_tools.py
+++ b/onadata/libs/tests/utils/test_viewer_tools.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Test onadata.libs.utils.viewer_tools."""
 
 import json
@@ -70,7 +69,7 @@ class TestViewerTools(TestBase):
         kwargs = {xform_variable_name: xform_variable_value}
         defaults = generate_enketo_form_defaults(self.xform, **kwargs)
 
-        key = "defaults[/data/transport/{}]".format(xform_variable_name)
+        key = f"defaults[/data/transport/{xform_variable_name}]"
         self.assertEqual(defaults, {key: xform_variable_value})
 
     # pylint: disable=C0103
@@ -91,13 +90,11 @@ class TestViewerTools(TestBase):
         }
         defaults = generate_enketo_form_defaults(self.xform, **kwargs)
 
-        transportation_types_key = "defaults[/data/transport/{}]".format(
-            transportation_types
-        )
+        transportation_types_key = f"defaults[/data/transport/{transportation_types}]"
         frequency_key = (
             "defaults[/data/transport/"
             "loop_over_transport_types_frequency/"
-            "{}/{}]".format(transportation_types_value, frequency)
+            f"{transportation_types_value}/{frequency}]"
         )
         self.assertIn(transportation_types_key, defaults)
         self.assertIn(frequency_key, defaults)
@@ -207,9 +204,11 @@ class TestViewerTools(TestBase):
             self.media_file,
         )
         self.instance = Instance.objects.all()[0]
-        self.attachment = Attachment.objects.create(
-            instance=self.instance, media_file=File(open(media_file, "rb"), media_file)
-        )
+        with open(media_file, "rb") as media_file_handle:
+            self.attachment = Attachment.objects.create(
+                instance=self.instance,
+                media_file=File(media_file_handle, media_file),
+            )
         with NamedTemporaryFile() as zip_file:
             create_attachments_zipfile(Attachment.objects.all(), zip_file)
 

--- a/onadata/libs/utils/viewer_tools.py
+++ b/onadata/libs/utils/viewer_tools.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Utility functions for data views."""
 
 import json
@@ -6,7 +5,6 @@ import os
 import sys
 import zipfile
 from json.decoder import JSONDecodeError
-from typing import Dict
 
 from django.conf import settings
 from django.core.files.storage import storages
@@ -141,7 +139,7 @@ def get_client_ip(request):
     return request.META.get("REMOTE_ADDR")
 
 
-def get_enketo_attachment_params(request, instance) -> Dict[str, str]:
+def get_enketo_attachment_params(request, instance) -> dict[str, str]:
     """Return the `instance_attachments[<filename>]` params for a submission.
 
     The instance XML records only the file name of each attachment, so these
@@ -171,7 +169,7 @@ def get_enketo_attachment_params(request, instance) -> Dict[str, str]:
 
 def get_enketo_urls(
     form_url, id_string, instance_xml=None, instance_id=None, return_url=None, **kwargs
-) -> Dict[str, str]:
+) -> dict[str, str]:
     """Return Enketo URLs."""
     if (
         not hasattr(settings, "ENKETO_URL")
@@ -257,6 +255,8 @@ def handle_enketo_error(response):
             ) from enketo_error
         message = response.text
     else:
+        # Not data.get("message", response.text): the fallback must stay
+        # lazy because response.text decodes the whole body on access.
         message = data["message"] if "message" in data else response.text
 
     if not event_id:
@@ -307,7 +307,7 @@ def create_attachments_zipfile(attachments, zip_file):
                             )
                             break
                         z_file.writestr(attachment.media_file.name, a_file.read())
-                except IOError as io_error:
+                except OSError as io_error:
                     report_exception("Create attachment zip exception", io_error)
                     break
 

--- a/onadata/libs/utils/viewer_tools.py
+++ b/onadata/libs/utils/viewer_tools.py
@@ -198,13 +198,17 @@ def get_enketo_urls(
         # kwargs = {'defaults[/widgets/text_widgets/my_string]': "Hey Mark"}
         values.update(kwargs)
 
-    response = requests.post(
-        url,
-        data=values,
-        auth=(settings.ENKETO_API_TOKEN, ""),
-        verify=getattr(settings, "VERIFY_SSL", True),
-        timeout=20,
-    )
+    try:
+        response = requests.post(
+            url,
+            data=values,
+            auth=(settings.ENKETO_API_TOKEN, ""),
+            verify=getattr(settings, "VERIFY_SSL", True),
+            timeout=getattr(settings, "ENKETO_API_REQUEST_TIMEOUT", 20),
+        )
+    except requests.exceptions.RequestException as error:
+        event_id = report_exception("Enketo request failed", str(error), sys.exc_info())
+        raise EnketoError(_enketo_error_msg(ENKETO_GENERIC_ERROR, event_id)) from error
     resp_content = response.content
     resp_content = (
         resp_content.decode("utf-8")
@@ -217,7 +221,7 @@ def get_enketo_urls(
         except ValueError:
             pass
         else:
-            if data:
+            if isinstance(data, dict) and data:
                 return data
 
     handle_enketo_error(response)
@@ -257,7 +261,11 @@ def handle_enketo_error(response):
     else:
         # Not data.get("message", response.text): the fallback must stay
         # lazy because response.text decodes the whole body on access.
-        message = data["message"] if "message" in data else response.text
+        message = (
+            data["message"]
+            if isinstance(data, dict) and "message" in data
+            else response.text
+        )
 
     if not event_id:
         event_id = report_exception(f"HTTP Error {response.status_code}", message)

--- a/onadata/settings/common.py
+++ b/onadata/settings/common.py
@@ -102,6 +102,8 @@ ENKETO_URL = "https://enketo.ona.io/"
 ENKETO_API_ALL_SURVEY_LINKS_PATH = "/api_v2/survey/all"
 ENKETO_API_INSTANCE_PATH = "/api_v2/instance"
 ENKETO_API_TOKEN = ""
+# Seconds to wait for a response on requests to the Enketo API
+ENKETO_API_REQUEST_TIMEOUT = 20
 ENKETO_API_INSTANCE_IFRAME_URL = ENKETO_URL + "api_v2/instance/iframe"
 ENKETO_API_SALT = "secretsalt"
 VERIFY_SSL = True


### PR DESCRIPTION
### Changes / Features implemented

Production requests to Enketo (e.g. generating a submission edit URL) can exceed the hardcoded 20s timeout; the resulting `ReadTimeout` propagates uncaught and clients get a 500 ([Sentry event](https://ona-systems.sentry.io/issues/124831738/events/1548f7be8a4d4d18bd7b4b765f8ee079/)).

- New `ENKETO_API_REQUEST_TIMEOUT` setting (default 20s) replaces the hardcoded timeout, so slow Enketo deployments can raise it without a code change.
- `get_enketo_urls()` now reports request failures (timeout, connection error) to Sentry and raises `EnketoError`, which callers already handle — clients get the friendly "Sorry, we cannot load your form right now" message instead of a 500.
- Non-object JSON bodies from Enketo (in error or success responses) also divert into the `EnketoError` path instead of crashing on `.get()`.

The first commit is lint/format churn (pre-commit hooks had not previously run on these files).

### Steps taken to verify this change does what is intended

Mocked `SimpleTestCase` tests: `ReadTimeout` and `ConnectionError` raise `EnketoError` with the generic message and Sentry reference, and the configured timeout is passed to the request. Verified via CI.

### Side effects of implementing this change

Enketo network failures now surface as a 400 with the generic Enketo error message rather than a 500.

Note for reviewers: since #3213 the ruff and isort pre-commit hooks disagree on Django import sorting and undo each other on any file with Django imports. This branch keeps the repo-standard isort layout; aligning ruff's isort config is left for a separate PR.

**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  - [ ] Updated documentation


