### PR TITLE
fix(api): keep format suffix out of email usernames

### DIFF
--- a/onadata/apps/api/constants.py
+++ b/onadata/apps/api/constants.py
@@ -10,12 +10,20 @@ API constants module.
 # DRF's format_suffix_patterns will handle them
 # Note: No ^ or $ anchors as Django URL routing provides boundaries
 # Note: \w in Python 3 matches Unicode word characters (letters, digits, underscore)
+# Format suffixes must stay out of the username so DRF's format-suffix
+# routes (``users/<username>.json``) split them off. Applied to every
+# alternative that can end in letters, including email usernames.
+_NOT_FORMAT_SUFFIX = (
+    r"(?<!\.json)(?<!\.xml)(?<!\.csv)(?<!\.jsonp)" + r"(?<!\.yaml)(?<!\.html)(?<!\.api)"
+)
 USERNAME_LOOKUP_REGEX = (
     r"(?:[\w.-]+"
-    r"(?<!\.json)(?<!\.xml)(?<!\.csv)(?<!\.jsonp)"
-    r"(?<!\.yaml)(?<!\.html)(?<!\.api))|"
-    r"\+?[\d.\-]+|"
-    r"[\w.%+-]+@[\w.-]+\.[a-zA-Z]{2,}"
+    + _NOT_FORMAT_SUFFIX
+    + r")"
+    + r"|\+?[\d.\-]+"
+    + r"|(?:[\w.%+-]+@[\w.-]+\.[a-zA-Z]{2,}"
+    + _NOT_FORMAT_SUFFIX
+    + r")"
 )
 
 # Username validation regex for form/serializer validation

--- a/onadata/apps/api/tests/viewsets/test_project_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_project_viewset.py
@@ -888,6 +888,31 @@ class TestProjectViewSet(TestAbstractViewSet):
             self.assertEqual(self.user, project.created_by)
             self.assertEqual(self.user, project.organization)
 
+    def test_projects_create_with_format_suffix_in_email_owner_url(self):
+        """A user whose username is an email address can create a project
+        when the owner URL carries a ``.json`` format suffix."""
+        self._login_user_and_profile(
+            extra_post_data={
+                "username": "jane@example.com",
+                "email": "jane@example.com",
+            }
+        )
+        data = {
+            "name": "demo_email_owner",
+            "owner": "http://testserver/api/v1/users/jane@example.com.json",
+            "public": False,
+        }
+        view = ProjectViewSet.as_view({"post": "create"})
+        request = self.factory.post(
+            "/", data=json.dumps(data), content_type="application/json", **self.extra
+        )
+        response = view(request, owner=self.user.username)
+
+        self.assertEqual(response.status_code, 201, response.data)
+        self.assertEqual(
+            response.data["owner"], "http://testserver/api/v1/users/jane@example.com"
+        )
+
     # pylint: disable=invalid-name
     def test_projects_create_many_users(self):
         self._project_create()

--- a/onadata/apps/main/tests/test_urls_without_admin.py
+++ b/onadata/apps/main/tests/test_urls_without_admin.py
@@ -5,13 +5,7 @@ import importlib
 
 from django.conf import settings
 from django.test import SimpleTestCase, override_settings
-from django.urls import (
-    NoReverseMatch,
-    Resolver404,
-    clear_url_caches,
-    resolve,
-    reverse,
-)
+from django.urls import NoReverseMatch, clear_url_caches, resolve, reverse
 
 from onadata.apps.api.urls import v1_urls as api_v1_urls_module
 from onadata.apps.main import urls as main_urls_module
@@ -84,75 +78,3 @@ class TestUrlsAdminToggle(SimpleTestCase):
             self._reload_urlconfs()
             # Should not raise.
             reverse("admin:index")
-
-
-class TestHyphenatedUsernameUrls(SimpleTestCase):
-    """Username-scoped URLs must reverse for usernames containing a hyphen."""
-
-    def test_download_xform_reverse_with_hyphenated_username(self):
-        """download_xform reverses for a hyphenated username (id_string and pk)."""
-        url = reverse(
-            "download_xform",
-            kwargs={"username": "alpha-project", "id_string": "myform"},
-        )
-        self.assertIn("alpha-project", url)
-
-        url_pk = reverse(
-            "download_xform",
-            kwargs={"username": "alpha-project", "pk": 885480},
-        )
-        self.assertIn("alpha-project", url_pk)
-
-    def test_username_scoped_urls_reverse_with_hyphenated_username(self):
-        """A representative set of username-scoped URLs reverse with a hyphen."""
-        username = "alpha-project"
-        cases = [
-            ("form-list", {"username": username}),
-            ("submissions", {"username": username}),
-            ("download_xlsform", {"username": username, "id_string": "myform"}),
-            ("download_jsonform", {"username": username, "id_string": "myform"}),
-            ("enter_data", {"username": username, "id_string": "myform"}),
-            ("data-view", {"username": username, "id_string": "myform"}),
-            ("manifest-url", {"username": username, "pk": 885480}),
-            (
-                "export-download",
-                {
-                    "username": username,
-                    "id_string": "myform",
-                    "export_type": "csv",
-                    "filename": "data.csv",
-                },
-            ),
-        ]
-        for name, kwargs in cases:
-            with self.subTest(url=name):
-                self.assertIn(username, reverse(name, kwargs=kwargs))
-
-    def test_metacharacter_username_does_not_match_routes(self):
-        """Usernames with HTML metacharacters do not match username routes.
-
-        The username group uses USERNAME_LOOKUP_REGEX (not the looser
-        ``[^/]+``), so characters such as ``<>"'`` that cannot appear in a
-        valid username never reach the underlying views.
-        """
-        for path in ("/<script>/formList", '/a"b/submission', "/a'b/formUpload"):
-            with self.subTest(path=path):
-                with self.assertRaises(Resolver404):
-                    resolve(path)
-
-
-class TestUsernameFormatSuffixUrls(SimpleTestCase):
-    """Format suffixes split off email usernames like any other username."""
-
-    def test_format_suffix_splits_off_email_username(self):
-        """``users/<email>.<format>`` resolves to the email plus a ``format``
-        kwarg, and the bare email still resolves as the whole username."""
-        email = "jane@mail.example.com"
-        for suffix in ("json", "xml", "csv", "jsonp", "yaml", "html", "api"):
-            with self.subTest(suffix=suffix):
-                match = resolve(f"/api/v1/users/{email}.{suffix}")
-                self.assertEqual(match.view_name, "user-detail")
-                self.assertEqual(match.kwargs, {"username": email, "format": suffix})
-
-        match = resolve(f"/api/v1/users/{email}")
-        self.assertEqual(match.kwargs, {"username": email})

--- a/onadata/apps/main/tests/test_urls_without_admin.py
+++ b/onadata/apps/main/tests/test_urls_without_admin.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Tests for URL configuration when django.contrib.admin toggles in INSTALLED_APPS."""
+
 import importlib
 
 from django.conf import settings
@@ -134,7 +135,24 @@ class TestHyphenatedUsernameUrls(SimpleTestCase):
         ``[^/]+``), so characters such as ``<>"'`` that cannot appear in a
         valid username never reach the underlying views.
         """
-        for path in ("/<script>/formList", "/a\"b/submission", "/a'b/formUpload"):
+        for path in ("/<script>/formList", '/a"b/submission', "/a'b/formUpload"):
             with self.subTest(path=path):
                 with self.assertRaises(Resolver404):
                     resolve(path)
+
+
+class TestUsernameFormatSuffixUrls(SimpleTestCase):
+    """Format suffixes split off email usernames like any other username."""
+
+    def test_format_suffix_splits_off_email_username(self):
+        """``users/<email>.<format>`` resolves to the email plus a ``format``
+        kwarg, and the bare email still resolves as the whole username."""
+        email = "jane@mail.example.com"
+        for suffix in ("json", "xml", "csv", "jsonp", "yaml", "html", "api"):
+            with self.subTest(suffix=suffix):
+                match = resolve(f"/api/v1/users/{email}.{suffix}")
+                self.assertEqual(match.view_name, "user-detail")
+                self.assertEqual(match.kwargs, {"username": email, "format": suffix})
+
+        match = resolve(f"/api/v1/users/{email}")
+        self.assertEqual(match.kwargs, {"username": email})

--- a/onadata/apps/main/tests/test_username_urls.py
+++ b/onadata/apps/main/tests/test_username_urls.py
@@ -1,0 +1,82 @@
+# -*- coding: utf-8 -*-
+"""Tests for username-scoped URL routing.
+
+The ``username`` group in ``main/urls.py`` and the API ``users``/``profiles``
+routes share ``USERNAME_LOOKUP_REGEX``; these tests pin which usernames the
+routes accept and how format suffixes are split off.
+"""
+
+from django.test import SimpleTestCase
+from django.urls import Resolver404, resolve, reverse
+
+
+class TestHyphenatedUsernameUrls(SimpleTestCase):
+    """Username-scoped URLs must reverse for usernames containing a hyphen."""
+
+    def test_download_xform_reverse_with_hyphenated_username(self):
+        """download_xform reverses for a hyphenated username (id_string and pk)."""
+        url = reverse(
+            "download_xform",
+            kwargs={"username": "alpha-project", "id_string": "myform"},
+        )
+        self.assertIn("alpha-project", url)
+
+        url_pk = reverse(
+            "download_xform",
+            kwargs={"username": "alpha-project", "pk": 885480},
+        )
+        self.assertIn("alpha-project", url_pk)
+
+    def test_username_scoped_urls_reverse_with_hyphenated_username(self):
+        """A representative set of username-scoped URLs reverse with a hyphen."""
+        username = "alpha-project"
+        cases = [
+            ("form-list", {"username": username}),
+            ("submissions", {"username": username}),
+            ("download_xlsform", {"username": username, "id_string": "myform"}),
+            ("download_jsonform", {"username": username, "id_string": "myform"}),
+            ("enter_data", {"username": username, "id_string": "myform"}),
+            ("data-view", {"username": username, "id_string": "myform"}),
+            ("manifest-url", {"username": username, "pk": 885480}),
+            (
+                "export-download",
+                {
+                    "username": username,
+                    "id_string": "myform",
+                    "export_type": "csv",
+                    "filename": "data.csv",
+                },
+            ),
+        ]
+        for name, kwargs in cases:
+            with self.subTest(url=name):
+                self.assertIn(username, reverse(name, kwargs=kwargs))
+
+    def test_metacharacter_username_does_not_match_routes(self):
+        """Usernames with HTML metacharacters do not match username routes.
+
+        The username group uses USERNAME_LOOKUP_REGEX (not the looser
+        ``[^/]+``), so characters such as ``<>"'`` that cannot appear in a
+        valid username never reach the underlying views.
+        """
+        for path in ("/<script>/formList", '/a"b/submission', "/a'b/formUpload"):
+            with self.subTest(path=path):
+                with self.assertRaises(Resolver404):
+                    resolve(path)
+
+
+class TestUsernameFormatSuffixUrls(SimpleTestCase):
+    """Format suffixes split off email usernames like any other username."""
+
+    def test_format_suffix_splits_off_email_username(self):
+        """``users/<email>.<format>`` resolves to the email plus a ``format``
+        kwarg, and the bare email still resolves as the whole username."""
+        email = "jane@mail.example.com"
+        for suffix in ("json", "xml", "csv", "jsonp", "yaml", "html", "api"):
+            with self.subTest(suffix=suffix):
+                match = resolve(f"/api/v1/users/{email}.{suffix}")
+                self.assertEqual(match.view_name, "user-detail")
+                self.assertEqual(match.kwargs, {"username": email, "format": suffix})
+
+        match = resolve(f"/api/v1/users/{email}")
+        self.assertEqual(match.kwargs, {"username": email})

--- a/onadata/apps/main/tests/test_username_urls.py
+++ b/onadata/apps/main/tests/test_username_urls.py
@@ -10,8 +10,9 @@ from django.test import SimpleTestCase
 from django.urls import Resolver404, resolve, reverse
 
 
-class TestHyphenatedUsernameUrls(SimpleTestCase):
-    """Username-scoped URLs must reverse for usernames containing a hyphen."""
+class TestUsernameUrls(SimpleTestCase):
+    """Username-scoped URLs accept every username shape the lookup pattern
+    allows, reject metacharacters, and split off format suffixes."""
 
     def test_download_xform_reverse_with_hyphenated_username(self):
         """download_xform reverses for a hyphenated username (id_string and pk)."""
@@ -63,10 +64,6 @@ class TestHyphenatedUsernameUrls(SimpleTestCase):
             with self.subTest(path=path):
                 with self.assertRaises(Resolver404):
                     resolve(path)
-
-
-class TestUsernameFormatSuffixUrls(SimpleTestCase):
-    """Format suffixes split off email usernames like any other username."""
 
     def test_format_suffix_splits_off_email_username(self):
         """``users/<email>.<format>`` resolves to the email plus a ``format``


### PR DESCRIPTION
### Changes / Features implemented

Users whose username is an email address could not create projects when the owner link ends in `.json`, as API clients using format-suffixed URLs send it. The username lookup treated that suffix as part of the email, so the API replied "Invalid hyperlink - Object does not exist."

The suffix is now split off email usernames the same way it already is for every other username shape.

### Steps taken to verify this change does what is intended

- Added a test that creates a project with an email-username owner link ending in `.json`. It failed with the reported error before the change and passes after.
- Added a test that every routed format suffix (`.json`, `.xml`, `.csv`, `.jsonp`, `.yaml`, `.html`, `.api`) is split off an email username, and that a bare email still resolves as the whole username.
- Ran the user, profile and project viewset suites; no new failures.

### Side effects of implementing this change

None.


**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  - [ ] Updated documentation

Closes #3244