### PR TITLE
feat(api): include is_managed on project forms

### DIFF
--- a/docs/projects.rst
+++ b/docs/projects.rst
@@ -74,6 +74,7 @@ Response
                     "id_string": "Community_Health_Check",
                     "is_merged_dataset": false,
                     "encrypted": true,
+                    "is_managed": true,
                     "contributes_entities_to": [],
                     "consumes_entities_from": []
                 }
@@ -115,6 +116,7 @@ Response
                     "id_string": "Animal_Sighting_Log",
                     "is_merged_dataset": false,
                     "encrypted": false,
+                    "is_managed": false,
                     "contributes_entities_to": [],
                     "consumes_entities_from": []
                 }
@@ -258,6 +260,7 @@ Response
                     "num_of_submissions":7,
                     "downloadable":true,
                     "encrypted":false,
+                    "is_managed":false,
                     "published_by_formbuilder":null,
                     "last_submission_time":"2024-06-18T14:34:57.987361Z",
                     "date_created":"2024-05-28T12:08:07.993820Z",
@@ -280,6 +283,7 @@ Response
                     "num_of_submissions":0,
                     "downloadable":true,
                     "encrypted":false,
+                    "is_managed":false,
                     "published_by_formbuilder":null,
                     "last_submission_time":null,
                     "date_created":"2024-05-28T12:08:39.909235Z",

--- a/onadata/apps/api/tests/viewsets/test_project_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_project_viewset.py
@@ -518,26 +518,6 @@ class TestProjectViewSet(TestAbstractViewSet):
         )
         self.assertEqual(response.status_code, 200)
 
-    def test_project_forms_include_is_managed(self):
-        """A form encrypted with a managed key reports is_managed on the
-        project list and detail endpoints."""
-        self._publish_xls_form_to_project()
-        self.xform.is_managed = True
-        self.xform.save()
-
-        request = self.factory.get("/", **self.extra)
-        response = self.view(request)
-
-        self.assertEqual(response.status_code, 200)
-        self.assertTrue(response.data[0]["forms"][0]["is_managed"])
-
-        view = ProjectViewSet.as_view({"get": "retrieve"})
-        request = self.factory.get("/", **self.extra)
-        response = view(request, pk=self.project.pk)
-
-        self.assertEqual(response.status_code, 200)
-        self.assertTrue(response.data["forms"][0]["is_managed"])
-
     def test_projects_tags(self):
         self._project_create()
         view = ProjectViewSet.as_view(

--- a/onadata/apps/api/tests/viewsets/test_project_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_project_viewset.py
@@ -208,6 +208,7 @@ class TestProjectViewSet(TestAbstractViewSet):
                                     ("id_string", "transportation_2011_07_25"),
                                     ("is_merged_dataset", False),
                                     ("encrypted", False),
+                                    ("is_managed", False),
                                     ("contributes_entities_to", []),
                                     ("consumes_entities_from", []),
                                 ]
@@ -488,6 +489,7 @@ class TestProjectViewSet(TestAbstractViewSet):
                 "encrypted",
                 "formid",
                 "id_string",
+                "is_managed",
                 "is_merged_dataset",
                 "last_submission_time",
                 "last_updated_at",
@@ -515,6 +517,26 @@ class TestProjectViewSet(TestAbstractViewSet):
             sorted(data_view_obj_keys),
         )
         self.assertEqual(response.status_code, 200)
+
+    def test_project_forms_include_is_managed(self):
+        """A form encrypted with a managed key reports is_managed on the
+        project list and detail endpoints."""
+        self._publish_xls_form_to_project()
+        self.xform.is_managed = True
+        self.xform.save()
+
+        request = self.factory.get("/", **self.extra)
+        response = self.view(request)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.data[0]["forms"][0]["is_managed"])
+
+        view = ProjectViewSet.as_view({"get": "retrieve"})
+        request = self.factory.get("/", **self.extra)
+        response = view(request, pk=self.project.pk)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.data["forms"][0]["is_managed"])
 
     def test_projects_tags(self):
         self._project_create()

--- a/onadata/apps/api/tests/viewsets/v2/test_project_viewset.py
+++ b/onadata/apps/api/tests/viewsets/v2/test_project_viewset.py
@@ -159,6 +159,7 @@ class RetrieveProjectTestCase(TestAbstractViewSet):
                     "num_of_submissions": 0,
                     "downloadable": True,
                     "encrypted": False,
+                    "is_managed": False,
                     "published_by_formbuilder": None,
                     "last_submission_time": None,
                     "date_created": xform.date_created.isoformat().replace(

--- a/onadata/libs/serializers/project_serializer.py
+++ b/onadata/libs/serializers/project_serializer.py
@@ -275,6 +275,7 @@ class BaseProjectXFormSerializer(
             "id_string",
             "is_merged_dataset",
             "encrypted",
+            "is_managed",
             "contributes_entities_to",
             "consumes_entities_from",
         )
@@ -303,6 +304,7 @@ class ProjectXFormSerializer(BaseProjectXFormSerializer):
             "num_of_submissions",
             "downloadable",
             "encrypted",
+            "is_managed",
             "published_by_formbuilder",
             "last_submission_time",
             "date_created",


### PR DESCRIPTION
### Changes / Features implemented

Forms listed under a project, on both the project list and project detail endpoints, now report whether they are encrypted with a managed key, the same way the single-form endpoint already does. Previously project forms only said whether a form was encrypted, so a client listing a project's forms could not tell managed-key encryption from custom-key encryption.

### Steps taken to verify this change does what is intended

- [x] Updated tests

### Side effects of implementing this change

None.


**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  - [x] Updated documentation

Closes #3247
