### PR TITLE
fix: handle expired Enketo JWTs

### DIFF
--- a/onadata/apps/api/tests/viewsets/test_xform_submission_viewset.py
+++ b/onadata/apps/api/tests/viewsets/test_xform_submission_viewset.py
@@ -5,6 +5,7 @@ Test XFormSubmissionViewSet module.
 
 import os
 from builtins import open  # pylint: disable=redefined-builtin
+from datetime import timedelta
 from io import BytesIO
 from unittest.mock import patch
 
@@ -17,6 +18,7 @@ from django.test import TransactionTestCase, override_settings
 from django.urls.exceptions import NoReverseMatch
 from django.utils import timezone
 
+import jwt
 import simplejson as json
 from django_digest.test import DigestAuth
 from rest_framework import status
@@ -32,6 +34,7 @@ from onadata.apps.logger.models.instance import InstanceHistory
 from onadata.apps.restservice.models import RestService
 from onadata.apps.restservice.services.textit import ServiceDefinition
 from onadata.libs.permissions import DataEntryRole
+from onadata.libs.utils.common_tags import API_TOKEN
 from onadata.libs.utils.common_tools import get_uuid
 
 
@@ -937,6 +940,30 @@ class TestXFormSubmissionViewSet(TestAbstractViewSet, TransactionTestCase):
                 self.assertEqual(
                     Instance.objects.filter(xform=self.xform).count(), count + 1
                 )
+
+    def test_post_submission_with_expired_enketo_jwt(self):
+        """An expired raw Enketo JWT is rejected instead of treated anonymously."""
+        payload = {
+            API_TOKEN: self.user.auth_token.key,
+            "exp": timezone.now() - timedelta(seconds=1),
+        }
+        cookie_jwt = jwt.encode(
+            payload,
+            settings.JWT_SECRET_KEY,
+            algorithm=settings.JWT_ALGORITHM,
+        )
+        request = self.factory.post(f"/enketo/{self.xform.pk}/submission")
+        request.COOKIES[settings.ENKETO_AUTH_COOKIE] = cookie_jwt
+        count = Instance.objects.filter(xform=self.xform).count()
+
+        response = self.view(request, xform_pk=self.xform.pk)
+
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(response.data, "Token expired")
+        self.assertTrue(response.has_header("X-OpenRosa-Version"))
+        self.assertTrue(response.has_header("X-OpenRosa-Accept-Content-Length"))
+        self.assertTrue(response.has_header("Date"))
+        self.assertEqual(Instance.objects.filter(xform=self.xform).count(), count)
 
     def test_head_submission_request_w_no_auth(self):
         """

--- a/onadata/libs/authentication.py
+++ b/onadata/libs/authentication.py
@@ -228,8 +228,12 @@ def get_api_token(cookie_jwt):
         return api_token
     except BadSignature as e:
         raise exceptions.AuthenticationFailed(_(f"Bad Signature: {e}")) from e
+    except jwt.ExpiredSignatureError as e:
+        raise exceptions.AuthenticationFailed(_("Token expired")) from e
     except jwt.DecodeError as e:
         raise exceptions.AuthenticationFailed(_(f"JWT DecodeError: {e}")) from e
+    except jwt.InvalidTokenError as e:
+        raise exceptions.AuthenticationFailed(_("Invalid token")) from e
     except Token.DoesNotExist as e:
         raise exceptions.AuthenticationFailed(_("Invalid token")) from e
 

--- a/onadata/libs/tests/test_authentication.py
+++ b/onadata/libs/tests/test_authentication.py
@@ -36,6 +36,21 @@ JWT_ALGORITHM = getattr(settings, "JWT_ALGORITHM", "HS256")
 
 
 class TestGetAPIToken(TestCase):
+    def test_expired_token(self):
+        with self.assertRaisesRegex(AuthenticationFailed, "Token expired"):
+            data = {
+                API_TOKEN: "somekey",
+                "exp": timezone.now() - timedelta(seconds=1),
+            }
+            jwt_data = jwt.encode(data, JWT_SECRET_KEY, algorithm=JWT_ALGORITHM)
+            get_api_token(jwt_data)
+
+    def test_invalid_token(self):
+        with self.assertRaisesRegex(AuthenticationFailed, "Invalid token"):
+            data = {API_TOKEN: "somekey", "aud": "unexpected-audience"}
+            jwt_data = jwt.encode(data, JWT_SECRET_KEY, algorithm=JWT_ALGORITHM)
+            get_api_token(jwt_data)
+
     def test_non_existent_token(self):
         with self.assertRaisesRegex(AuthenticationFailed, "Invalid token"):
             data = {API_TOKEN: "nonexistenttoken"}


### PR DESCRIPTION
### Changes / Features implemented

- Convert expired Enketo JWTs into HTTP 401 responses with the message Token expired.
- Convert other PyJWT validation failures into HTTP 401 responses with the message Invalid token.
- Preserve the existing malformed-JWT DecodeError response and support for unsigned cross-service JWT cookies.
- Add unit and endpoint regression coverage, including assertions that failed authentication keeps OpenRosa headers and does not create a submission.

### Steps taken to verify this change does what is intended

- Verified expired and non-expiry invalid JWTs return controlled authentication failures.
- Verified an expired Enketo JWT returns HTTP 401 with Token expired, includes the OpenRosa response headers, and creates no submission.
- All 98 targeted authentication and submission-viewset tests pass.

### Side effects of implementing this change

Expired or otherwise invalid Enketo credentials are now rejected as authentication failures instead of escaping as server errors. This does not change token issuance, cookie lifetime, token refresh behavior, or anonymous submission rules.


**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  - [x] Updated documentation (not applicable; no user-facing configuration or workflow changed)

Closes #3251

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/onaio/codesmith/onadata/pr/3252"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790951396&installation_model_id=422582&pr_number=3252&repository=onaio%2Fonadata&return_to=https%3A%2F%2Fgithub.com%2Fonaio%2Fonadata%2Fpull%2F3252&signature=83e79a46386af7a8f5cadd545ee8b3eae7bafb79a3544dc0fad5b08b747ded30"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
